### PR TITLE
Docs fixes for shell compatibility

### DIFF
--- a/dhctl/README.md
+++ b/dhctl/README.md
@@ -119,8 +119,8 @@ For example, use a docker image from the Flant docker registry:
   * `config.yaml` - configuration file for the cluster bootstrap as described above.
      ```bash
      docker run -it \
-       -v $(pwd)/config.yaml:/config.yaml \
-       -v $HOME/.ssh/:/tmp/.ssh/ \
+       -v "$(pwd)/config.yaml:/config.yaml" \
+       -v "$HOME/.ssh/:/tmp/.ssh/" \
        registry.deckhouse.io/fe/install:alpha \
        bash
      ```

--- a/dhctl/README.md
+++ b/dhctl/README.md
@@ -119,7 +119,7 @@ For example, use a docker image from the Flant docker registry:
   * `config.yaml` - configuration file for the cluster bootstrap as described above.
      ```bash
      docker run -it \
-       -v "$(pwd)/config.yaml:/config.yaml" \
+       -v "$PWD/config.yaml:/config.yaml" \
        -v "$HOME/.ssh/:/tmp/.ssh/" \
        registry.deckhouse.io/fe/install:alpha \
        bash

--- a/docs/documentation/pages/internal/DEVELOPMENT.md
+++ b/docs/documentation/pages/internal/DEVELOPMENT.md
@@ -746,11 +746,11 @@ Local development
 --------------------
 Create the following symlink to make the development process more convenient:
 ```bash
-sudo ln -s "$(pwd)" /deckhouse
+sudo ln -s "$PWD" /deckhouse
 ```
 In macOS, if the root filesystem is in a Read-only mode, use the following command to create a symlink:
 ```bash
-echo "deckhouse\t$(pwd)" >> /etc/synthetic.conf
+echo "deckhouse\t$PWD" >> /etc/synthetic.conf
 ```
 and reboot the OS.
 

--- a/docs/documentation/pages/internal/DEVELOPMENT.md
+++ b/docs/documentation/pages/internal/DEVELOPMENT.md
@@ -746,7 +746,7 @@ Local development
 --------------------
 Create the following symlink to make the development process more convenient:
 ```bash
-sudo ln -s $(pwd) /deckhouse
+sudo ln -s "$(pwd)" /deckhouse
 ```
 In macOS, if the root filesystem is in a Read-only mode, use the following command to create a symlink:
 ```bash

--- a/docs/site/_includes/getting_started/STEP2.md
+++ b/docs/site/_includes/getting_started/STEP2.md
@@ -7,18 +7,18 @@ The commands below pull the Docker image of the Deckhouse installer and pass the
 -  For CE installations:
 
    ```shell
-docker run -it -v "$(pwd)/config.yml:/config.yml" -v "$HOME/.ssh/:/tmp/.ssh/"
-{%- if include.mode == "existing" %} -v "$(pwd)/kubeconfig:/kubeconfig" {% endif %}
-{%- if include.mode == "cloud" %} -v "$(pwd)/dhctl-tmp:/tmp" {% endif %} registry.deckhouse.io/deckhouse/ce/install:beta bash
+docker run -it -v "$PWD/config.yml:/config.yml" -v "$HOME/.ssh/:/tmp/.ssh/"
+{%- if include.mode == "existing" %} -v "$PWD/kubeconfig:/kubeconfig" {% endif %}
+{%- if include.mode == "cloud" %} -v "$PWD/dhctl-tmp:/tmp" {% endif %} registry.deckhouse.io/deckhouse/ce/install:beta bash
 ```
 
 -  For EE installations:
 
    ```shell
 docker login -u license-token -p <LICENSE_TOKEN> registry.deckhouse.io
-docker run -it -v "$(pwd)/config.yml:/config.yml" -v "$HOME/.ssh/:/tmp/.ssh/"
-{%- if include.mode == "existing" %} -v "$(pwd)/kubeconfig:/kubeconfig" {% endif %}
-{%- if include.mode == "cloud" %} -v "$(pwd)/dhctl-tmp:/tmp" {% endif %} registry.deckhouse.io/deckhouse/ee/install:beta bash
+docker run -it -v "$PWD/config.yml:/config.yml" -v "$HOME/.ssh/:/tmp/.ssh/"
+{%- if include.mode == "existing" %} -v "$PWD/kubeconfig:/kubeconfig" {% endif %}
+{%- if include.mode == "cloud" %} -v "$PWD/dhctl-tmp:/tmp" {% endif %} registry.deckhouse.io/deckhouse/ee/install:beta bash
 ```
 
 {%- if include.mode == "existing" %}
@@ -60,7 +60,7 @@ dhctl bootstrap \
 
 Notes:
 {%- if include.mode == "cloud" %}
-- The `-v "$(pwd)/dhctl-tmp:/tmp"` parameter enables saving the state of the Terraform installer to a temporary directory on the startup host. It allows the installation to continue correctly in case of a failure of the installer's container.
+- The `-v "$PWD/dhctl-tmp:/tmp"` parameter enables saving the state of the Terraform installer to a temporary directory on the startup host. It allows the installation to continue correctly in case of a failure of the installer's container.
 {%- endif %}
 - If any problems {% if include.mode="cloud" %}on the cloud provider side {% endif %}occur, you can stop the process of installation using the following command (the configuration file should be the same you’ve used to initiate the installation):
 

--- a/docs/site/_includes/getting_started/STEP2.md
+++ b/docs/site/_includes/getting_started/STEP2.md
@@ -9,7 +9,7 @@ The commands below pull the Docker image of the Deckhouse installer and pass the
    ```shell
 docker run -it -v $(pwd)/config.yml:/config.yml -v $HOME/.ssh/:/tmp/.ssh/
 {%- if include.mode == "existing" %} -v $(pwd)/kubeconfig:/kubeconfig {% endif %}
-{%- if include.mode == "cloud" %} -v ./dhctl-tmp:/tmp {% endif %} registry.deckhouse.io/deckhouse/ce/install:beta bash
+{%- if include.mode == "cloud" %} -v $(pwd)/dhctl-tmp:/tmp {% endif %} registry.deckhouse.io/deckhouse/ce/install:beta bash
 ```
 
 -  For EE installations:
@@ -18,7 +18,7 @@ docker run -it -v $(pwd)/config.yml:/config.yml -v $HOME/.ssh/:/tmp/.ssh/
 docker login -u license-token -p <LICENSE_TOKEN> registry.deckhouse.io
 docker run -it -v $(pwd)/config.yml:/config.yml -v $HOME/.ssh/:/tmp/.ssh/
 {%- if include.mode == "existing" %} -v $(pwd)/kubeconfig:/kubeconfig {% endif %}
-{%- if include.mode == "cloud" %} -v ./dhctl-tmp:/tmp {% endif %} registry.deckhouse.io/deckhouse/ee/install:beta bash
+{%- if include.mode == "cloud" %} -v $(pwd)/dhctl-tmp:/tmp {% endif %} registry.deckhouse.io/deckhouse/ee/install:beta bash
 ```
 
 {%- if include.mode == "existing" %}
@@ -60,7 +60,7 @@ dhctl bootstrap \
 
 Notes:
 {%- if include.mode == "cloud" %}
-- The `-v ./dhctl-tmp:/tmp` parameter enables saving the state of the Terraform installer to a temporary directory on the startup host. It allows the installation to continue correctly in case of a failure of the installer's container.
+- The `-v $(pwd)/dhctl-tmp:/tmp` parameter enables saving the state of the Terraform installer to a temporary directory on the startup host. It allows the installation to continue correctly in case of a failure of the installer's container.
 {%- endif %}
 - If any problems {% if include.mode="cloud" %}on the cloud provider side {% endif %}occur, you can stop the process of installation using the following command (the configuration file should be the same you’ve used to initiate the installation):
 

--- a/docs/site/_includes/getting_started/STEP2.md
+++ b/docs/site/_includes/getting_started/STEP2.md
@@ -7,18 +7,18 @@ The commands below pull the Docker image of the Deckhouse installer and pass the
 -  For CE installations:
 
    ```shell
-docker run -it -v $(pwd)/config.yml:/config.yml -v $HOME/.ssh/:/tmp/.ssh/
-{%- if include.mode == "existing" %} -v $(pwd)/kubeconfig:/kubeconfig {% endif %}
-{%- if include.mode == "cloud" %} -v $(pwd)/dhctl-tmp:/tmp {% endif %} registry.deckhouse.io/deckhouse/ce/install:beta bash
+docker run -it -v "$(pwd)/config.yml:/config.yml" -v "$HOME/.ssh/:/tmp/.ssh/"
+{%- if include.mode == "existing" %} -v "$(pwd)/kubeconfig:/kubeconfig" {% endif %}
+{%- if include.mode == "cloud" %} -v "$(pwd)/dhctl-tmp:/tmp" {% endif %} registry.deckhouse.io/deckhouse/ce/install:beta bash
 ```
 
 -  For EE installations:
 
    ```shell
 docker login -u license-token -p <LICENSE_TOKEN> registry.deckhouse.io
-docker run -it -v $(pwd)/config.yml:/config.yml -v $HOME/.ssh/:/tmp/.ssh/
-{%- if include.mode == "existing" %} -v $(pwd)/kubeconfig:/kubeconfig {% endif %}
-{%- if include.mode == "cloud" %} -v $(pwd)/dhctl-tmp:/tmp {% endif %} registry.deckhouse.io/deckhouse/ee/install:beta bash
+docker run -it -v "$(pwd)/config.yml:/config.yml" -v "$HOME/.ssh/:/tmp/.ssh/"
+{%- if include.mode == "existing" %} -v "$(pwd)/kubeconfig:/kubeconfig" {% endif %}
+{%- if include.mode == "cloud" %} -v "$(pwd)/dhctl-tmp:/tmp" {% endif %} registry.deckhouse.io/deckhouse/ee/install:beta bash
 ```
 
 {%- if include.mode == "existing" %}
@@ -60,7 +60,7 @@ dhctl bootstrap \
 
 Notes:
 {%- if include.mode == "cloud" %}
-- The `-v $(pwd)/dhctl-tmp:/tmp` parameter enables saving the state of the Terraform installer to a temporary directory on the startup host. It allows the installation to continue correctly in case of a failure of the installer's container.
+- The `-v "$(pwd)/dhctl-tmp:/tmp"` parameter enables saving the state of the Terraform installer to a temporary directory on the startup host. It allows the installation to continue correctly in case of a failure of the installer's container.
 {%- endif %}
 - If any problems {% if include.mode="cloud" %}on the cloud provider side {% endif %}occur, you can stop the process of installation using the following command (the configuration file should be the same you’ve used to initiate the installation):
 

--- a/docs/site/_includes/getting_started/STEP2_RU.md
+++ b/docs/site/_includes/getting_started/STEP2_RU.md
@@ -7,18 +7,18 @@
 -  Для редакции CE:
 
    ```shell
-docker run -it -v $(pwd)/config.yml:/config.yml -v $HOME/.ssh/:/tmp/.ssh/
-{%- if include.mode == "existing" %} -v $(pwd)/kubeconfig:/kubeconfig {% endif %}
-{%- if include.mode == "cloud" %} -v $(pwd)/dhctl-tmp:/tmp {% endif %} registry.deckhouse.io/deckhouse/ce/install:beta bash
+docker run -it -v "$(pwd)/config.yml:/config.yml" -v "$HOME/.ssh/:/tmp/.ssh/"
+{%- if include.mode == "existing" %} -v "$(pwd)/kubeconfig:/kubeconfig" {% endif %}
+{%- if include.mode == "cloud" %} -v "$(pwd)/dhctl-tmp:/tmp" {% endif %} registry.deckhouse.io/deckhouse/ce/install:beta bash
 ```
 
 -  Для редакции EE:
 
    ```shell
 docker login -u license-token -p <LICENSE_TOKEN> registry.deckhouse.io
-docker run -it -v $(pwd)/config.yml:/config.yml -v $HOME/.ssh/:/tmp/.ssh/
-{%- if include.mode == "existing" %} -v $(pwd)/kubeconfig:/kubeconfig {% endif %}
-{%- if include.mode == "cloud" %} -v $(pwd)/dhctl-tmp:/tmp {% endif %} registry.deckhouse.io/deckhouse/ee/install:beta bash
+docker run -it -v "$(pwd)/config.yml:/config.yml" -v "$HOME/.ssh/:/tmp/.ssh/"
+{%- if include.mode == "existing" %} -v "$(pwd)/kubeconfig:/kubeconfig" {% endif %}
+{%- if include.mode == "cloud" %} -v "$(pwd)/dhctl-tmp:/tmp" {% endif %} registry.deckhouse.io/deckhouse/ee/install:beta bash
 ```
 
 {%- if include.mode == "existing" %}
@@ -60,7 +60,7 @@ dhctl bootstrap \
 
 Примечания:
 {%- if include.mode == "cloud" %}
-- Благодаря использованию параметра `-v $(pwd)/dhctl-tmp:/tmp` состояние данных Terraform-инстяллятора будет сохранено во временной директории на хосте запуска, что позволит корректно продолжить установку в случае прерывания работы контейнера с инсталлятором.
+- Благодаря использованию параметра `-v "$(pwd)/dhctl-tmp:/tmp"` состояние данных Terraform-инстяллятора будет сохранено во временной директории на хосте запуска, что позволит корректно продолжить установку в случае прерывания работы контейнера с инсталлятором.
 {%- endif %}
 - В случае возникновения проблем во время разворачивания кластера {% if include.mode="cloud" %}в одном из облачных провайдеров {% endif %}для остановки процесса установки следует воспользоваться следующей командой (файл конфигурации должен совпадать с тем, с которым производилось разворачивание кластера):
 

--- a/docs/site/_includes/getting_started/STEP2_RU.md
+++ b/docs/site/_includes/getting_started/STEP2_RU.md
@@ -7,18 +7,18 @@
 -  Для редакции CE:
 
    ```shell
-docker run -it -v "$(pwd)/config.yml:/config.yml" -v "$HOME/.ssh/:/tmp/.ssh/"
-{%- if include.mode == "existing" %} -v "$(pwd)/kubeconfig:/kubeconfig" {% endif %}
-{%- if include.mode == "cloud" %} -v "$(pwd)/dhctl-tmp:/tmp" {% endif %} registry.deckhouse.io/deckhouse/ce/install:beta bash
+docker run -it -v "$PWD/config.yml:/config.yml" -v "$HOME/.ssh/:/tmp/.ssh/"
+{%- if include.mode == "existing" %} -v "$PWD/kubeconfig:/kubeconfig" {% endif %}
+{%- if include.mode == "cloud" %} -v "$PWD/dhctl-tmp:/tmp" {% endif %} registry.deckhouse.io/deckhouse/ce/install:beta bash
 ```
 
 -  Для редакции EE:
 
    ```shell
 docker login -u license-token -p <LICENSE_TOKEN> registry.deckhouse.io
-docker run -it -v "$(pwd)/config.yml:/config.yml" -v "$HOME/.ssh/:/tmp/.ssh/"
-{%- if include.mode == "existing" %} -v "$(pwd)/kubeconfig:/kubeconfig" {% endif %}
-{%- if include.mode == "cloud" %} -v "$(pwd)/dhctl-tmp:/tmp" {% endif %} registry.deckhouse.io/deckhouse/ee/install:beta bash
+docker run -it -v "$PWD/config.yml:/config.yml" -v "$HOME/.ssh/:/tmp/.ssh/"
+{%- if include.mode == "existing" %} -v "$PWD/kubeconfig:/kubeconfig" {% endif %}
+{%- if include.mode == "cloud" %} -v "$PWD/dhctl-tmp:/tmp" {% endif %} registry.deckhouse.io/deckhouse/ee/install:beta bash
 ```
 
 {%- if include.mode == "existing" %}
@@ -60,7 +60,7 @@ dhctl bootstrap \
 
 Примечания:
 {%- if include.mode == "cloud" %}
-- Благодаря использованию параметра `-v "$(pwd)/dhctl-tmp:/tmp"` состояние данных Terraform-инстяллятора будет сохранено во временной директории на хосте запуска, что позволит корректно продолжить установку в случае прерывания работы контейнера с инсталлятором.
+- Благодаря использованию параметра `-v "$PWD/dhctl-tmp:/tmp"` состояние данных Terraform-инстяллятора будет сохранено во временной директории на хосте запуска, что позволит корректно продолжить установку в случае прерывания работы контейнера с инсталлятором.
 {%- endif %}
 - В случае возникновения проблем во время разворачивания кластера {% if include.mode="cloud" %}в одном из облачных провайдеров {% endif %}для остановки процесса установки следует воспользоваться следующей командой (файл конфигурации должен совпадать с тем, с которым производилось разворачивание кластера):
 

--- a/docs/site/_includes/getting_started/STEP2_RU.md
+++ b/docs/site/_includes/getting_started/STEP2_RU.md
@@ -9,7 +9,7 @@
    ```shell
 docker run -it -v $(pwd)/config.yml:/config.yml -v $HOME/.ssh/:/tmp/.ssh/
 {%- if include.mode == "existing" %} -v $(pwd)/kubeconfig:/kubeconfig {% endif %}
-{%- if include.mode == "cloud" %} -v ./dhctl-tmp:/tmp {% endif %} registry.deckhouse.io/deckhouse/ce/install:beta bash
+{%- if include.mode == "cloud" %} -v $(pwd)/dhctl-tmp:/tmp {% endif %} registry.deckhouse.io/deckhouse/ce/install:beta bash
 ```
 
 -  Для редакции EE:
@@ -18,7 +18,7 @@ docker run -it -v $(pwd)/config.yml:/config.yml -v $HOME/.ssh/:/tmp/.ssh/
 docker login -u license-token -p <LICENSE_TOKEN> registry.deckhouse.io
 docker run -it -v $(pwd)/config.yml:/config.yml -v $HOME/.ssh/:/tmp/.ssh/
 {%- if include.mode == "existing" %} -v $(pwd)/kubeconfig:/kubeconfig {% endif %}
-{%- if include.mode == "cloud" %} -v ./dhctl-tmp:/tmp {% endif %} registry.deckhouse.io/deckhouse/ee/install:beta bash
+{%- if include.mode == "cloud" %} -v $(pwd)/dhctl-tmp:/tmp {% endif %} registry.deckhouse.io/deckhouse/ee/install:beta bash
 ```
 
 {%- if include.mode == "existing" %}
@@ -60,7 +60,7 @@ dhctl bootstrap \
 
 Примечания:
 {%- if include.mode == "cloud" %}
-- Благодаря использованию параметра `-v ./dhctl-tmp:/tmp` состояние данных Terraform-инстяллятора будет сохранено во временной директории на хосте запуска, что позволит корректно продолжить установку в случае прерывания работы контейнера с инсталлятором.
+- Благодаря использованию параметра `-v $(pwd)/dhctl-tmp:/tmp` состояние данных Terraform-инстяллятора будет сохранено во временной директории на хосте запуска, что позволит корректно продолжить установку в случае прерывания работы контейнера с инсталлятором.
 {%- endif %}
 - В случае возникновения проблем во время разворачивания кластера {% if include.mode="cloud" %}в одном из облачных провайдеров {% endif %}для остановки процесса установки следует воспользоваться следующей командой (файл конфигурации должен совпадать с тем, с которым производилось разворачивание кластера):
 

--- a/modules/402-ingress-nginx/internal/README.md
+++ b/modules/402-ingress-nginx/internal/README.md
@@ -4,6 +4,6 @@
 2. Set LB address in `load.yaml` `phantom.address` parameter.
 3. Start the container.
 ```shell
-docker run -v $(pwd):/var/loadtest -it direvius/yandex-tank
+docker run -v "$(pwd):/var/loadtest" -it direvius/yandex-tank
 ```
 4. Follow the given `Web:` url to see online graphs. 

--- a/modules/402-ingress-nginx/internal/README.md
+++ b/modules/402-ingress-nginx/internal/README.md
@@ -4,6 +4,6 @@
 2. Set LB address in `load.yaml` `phantom.address` parameter.
 3. Start the container.
 ```shell
-docker run -v "$(pwd):/var/loadtest" -it direvius/yandex-tank
+docker run -v "$PWD:/var/loadtest" -it direvius/yandex-tank
 ```
 4. Follow the given `Web:` url to see online graphs. 

--- a/testing/cloud_layouts/README.md
+++ b/testing/cloud_layouts/README.md
@@ -8,8 +8,8 @@ docker run \
   -ti \
   --entrypoint /bin/bash \
   -v /deckhouse:/deckhouse \
-  -v "$(pwd)/testing/cloud_layouts:/deckhouse/testing/cloud_layouts" \
-  -v "$(pwd)/layouts-tests-tmp:/tmp" \
+  -v "$PWD/testing/cloud_layouts:/deckhouse/testing/cloud_layouts" \
+  -v "$PWD/layouts-tests-tmp:/tmp" \
   -w /deckhouse dev-registry.deckhouse.io/sys/deckhouse-oss/dev/install:master
 ```
 ```bash


### PR DESCRIPTION
## 1. Use absolute path to dhctl-tmp directory otherwise `docker run` fails

### Problem

`docker run` fails with error `Error response from daemon: create ./dhctl-tmp: "./dhctl-tmp" includes i
nvalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a h
ost directory, use absolute path.
See 'docker run --help'.`. I have reproduced the problem on Linux and macOS


### Solution

Use absolute path like error message suggests

## 2. Use `$PWD` environment variable instead of `$(pwd)` to make scripts compatible with fish shell

### Problem

Fish shell uses different syntax for inline commands so command can't be copy-pasted

bash: `echo "$(pwd)"`
fish: `echo "(pwd)"`

It's not a big deal because all fish users know it but it would be nice to use $PWD instead of $(pwd) to make fish users life a litter easier

### Solution

Use $PWD instead of $(pwd)

## 3. Enclose directories names with quotation marks to avoid issues when path contains spaces

### Problem

Weird error message when current directory or $HOME contains space characters

```sh
$ pwd
/Users/user/Desktop/deckhouse test

$ docker run -it -v $(pwd)/config.yml:/config.yml -v $HOME/.ssh/:/tmp/.ssh/ -v $(pwd)/dhctl-tmp:/tmp registry.de
ckhouse.io/deckhouse/ee/install:alpha bash
Unable to find image 'with:latest' locally
```

### Solution

Enclose directories names in quotation marks