### PR TITLE
Fix NodeGroup apiVersion conversion on bare metal clusters

### DIFF
--- a/modules/040-node-manager/webhooks/conversion/node_group
+++ b/modules/040-node-manager/webhooks/conversion/node_group
@@ -99,7 +99,7 @@ EOF
 
 
 function __on_conversion::alpha2_to_v1() {
-  cluster_config_json="$(context::jq '.snapshots.cluster_config[0].filterResult' | base64 -d | yq eval -I0 -j)"
+  cluster_config_json="$(context::jq -r '.snapshots.cluster_config[0].filterResult' | base64 -d | yq eval -I0 -j)"
   # shellcheck disable=SC2016
   if converted=$(context::jq -r --argjson config "$cluster_config_json" '.review.request.objects//[] | map(
      if .apiVersion == "deckhouse.io/v1alpha2" then


### PR DESCRIPTION
### Problem

Error `Invalid character in input stream.` during v1alpha → v1 convervion for NodeGroup. The issue can be reproduced only on bare metal clusters where no `kube-system/d8-provider-cluster-configuration` secret exists.

### Reason

`jq '.snapshots.cluster_config[0].filterResult'` returns `""` which can't be base64 decoded and script fails.

### Solution

Use `-r` flag to return empty string as no symbols instead fo `""`