### PR TITLE
Fix documentation for creating access binding on Yandex Cloud

### DIFF
--- a/docs/site/_includes/getting_started/yandex/STEP_ENV.md
+++ b/docs/site/_includes/getting_started/yandex/STEP_ENV.md
@@ -10,7 +10,7 @@ name: candi
 ```
 - Assign the `editor` role to the newly created user:
   ```yaml
-yc resource-manager folder add-access-binding <cloudname> --role editor --subject serviceAccount:<userId>
+yc resource-manager folder add-access-binding <foldername> --role editor --subject serviceAccount:<userId>
 ```
 - Create a JSON file containing the parameters for user authorization in the cloud. These parameters will be used to log in to the cloud:
   ```yaml

--- a/docs/site/_includes/getting_started/yandex/STEP_ENV_RU.md
+++ b/docs/site/_includes/getting_started/yandex/STEP_ENV_RU.md
@@ -10,7 +10,7 @@ name: candi
 ```
 - Назначьте роль `editor` вновь созданному пользователю для своего облака:
   ```yaml
-yc resource-manager folder add-access-binding <cloudname> --role editor --subject serviceAccount:<userId>
+yc resource-manager folder add-access-binding <foldername> --role editor --subject serviceAccount:<userId>
 ```
 - Создайте JSON-файл с параметрами авторизации пользователя в облаке. В дальнейшем с помощью этих данных будем авторизовываться в облаке:
   ```yaml


### PR DESCRIPTION
Argument for add-access-binding command is folder name, not cloud name

We can check that in command help:
```sh
$ yc resource-manager folder add-access-binding --help
Add access binding for the specified folder

Usage:
  yc resource-manager folder add-access-binding <FOLDER-NAME>|<FOLDER-ID> [Flags...] [Global Flags...]
...
```