### PR TITLE
Increase pod deletion timeout in Upmeter scheduler monitoring

### DIFF
--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_pod.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_pod.go
@@ -80,7 +80,7 @@ func (c *podLifecycleChecker) Check() check.Error {
 /*
 1. check control-plane
 2. collect garbage
-2. crate pod                    (podCreationTimeout)
+2. create pod                   (podCreationTimeout)
 3. see the pod is scheduled     (podScheduledTimeout)
 4. delete the pod               (podDeletionTimeout)
 	+ensure the pod is not listed

--- a/modules/500-upmeter/images/upmeter/pkg/probe/controlplane.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/controlplane.go
@@ -88,7 +88,7 @@ func ControlPlane(access kubernetes.Access) []runnerConfig {
 				Node:                     os.Getenv("NODE_NAME"),
 				CreationTimeout:          5 * time.Second,
 				SchedulingTimeout:        20 * time.Second,
-				DeletionTimeout:          5 * time.Second,
+				DeletionTimeout:          20 * time.Second,
 				GarbageCollectionTimeout: gcTimeout,
 			},
 		},


### PR DESCRIPTION
Failing to delete pod doesn't indicate that there is a problem with scheduler so test shouldn't fail in this case.

I've increased deletion timeout to 20 seconds because that what we have left before next round of test is executed in worst case scenario:

5s of creation + 20s of scheduling + 20s of deletion + 10s of GC + 5s just in case = 60s

Fixes #35 