### PR TITLE
Changelog: fix github syntax quotes

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -62,7 +62,7 @@ jobs:
       ok: steps.pr.outputs.ok
 
   milestones:
-    if: needs.filter.outputs.ok == 'ok'
+    if: needs.filter.outputs.ok
     name: Open Milestones
     runs-on: ubuntu-latest
     needs: filter

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           # We expect the number of simultaneously open milestones will not exceed 10.
           # https://docs.github.com/en/rest/reference/issues#milestones
-          milestones="$(gh api 'repos/${{ github.repository }}/milestones?state=open&per_page=100'
+          milestones="$(gh api 'repos/${{ github.repository }}/milestones?state=open&per_page=100')"
 
           count="$(echo $milestones | jq '. | length')"
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -62,7 +62,7 @@ jobs:
       ok: steps.pr.outputs.ok
 
   milestones:
-    if: needs.filter.outputs.ok == "ok"
+    if: needs.filter.outputs.ok == 'ok'
     name: Open Milestones
     runs-on: ubuntu-latest
     needs: filter


### PR DESCRIPTION
## Description

There is a double quote issue that we encounter when PRs are merged. 

See https://github.com/actions/runner/issues/866

## Why we need it and what problem does it solve?

Fixes the changelog workflow results
