### PR TITLE
[upmeter] HTTP checker: fail when cannot dial

### DIFF
--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/http.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/http.go
@@ -41,12 +41,14 @@ func newHTTPChecker(client *http.Client, verifier httpVerifier) check.Checker {
 
 func (c *httpChecker) Check() check.Error {
 	c.req = c.verifier.Request()
+
+	// The request body is closed inside
 	body, err := doRequest(c.client, c.req)
 	if err != nil {
 		return err
 	}
-	err = c.verifier.Verify(body)
-	return err
+
+	return c.verifier.Verify(body)
 }
 
 func (c *httpChecker) BusyWith() string {
@@ -82,7 +84,7 @@ func newGetRequest(endpoint, authToken string) (*http.Request, check.Error) {
 func doRequest(client *http.Client, req *http.Request) ([]byte, check.Error) {
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, check.ErrUnknown("cannot dial %q: %v", req.URL, err)
+		return nil, check.ErrFail("cannot dial %q: %v", req.URL, err)
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
## Description

Return fail probe status when cannot dial endpoint.

## Why we need it and what problem does it solve?

Unknown check status is false positive. When something is unavailable, the check should fail. Before the change, the HTTP checker fails on non-200 status code or when body cannot be read. Network unavailability was treated differently.

Resolves #348 

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: upmeter
type: fix 
description: HTTP probe status is "down" when it cannot connect to endpoint, instead of "unknown"
note: Unavailable Prometheus is not considered "up" anymore, like everything else that depends on it
```

