### PR TITLE
[upmeter] Node selector and toleration settings for server

### DIFF
--- a/modules/500-upmeter/openapi/config-values.yaml
+++ b/modules/500-upmeter/openapi/config-values.yaml
@@ -301,3 +301,40 @@ properties:
 
               This secret must have the [kubernetes.io/tls](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#tls-secrets) format.
             default: "false"
+  nodeSelector:
+    type: object
+    additionalProperties:
+      type: string
+    x-kubernetes-preserve-unknown-fields: true
+    x-examples:
+      - disktype: ssd
+    description: |
+      Node selector for Upmeter server. The same as in the Pods' `spec.nodeSelector` parameter in Kubernetes.
+
+      If the parameter is omitted or `false`, it will be determined [automatically](https://deckhouse.io/en/documentation/v1/#advanced-scheduling).
+  tolerations:
+    type: array
+    items:
+      type: object
+      properties:
+        effect:
+          type: string
+        key:
+          type: string
+        operator:
+          type: string
+        tolerationSeconds:
+          type: integer
+          format: int64
+        value:
+          type: string
+    x-examples:
+      -
+        - key: "key1"
+          operator: "Equal"
+          value: "value1"
+          effect: "NoSchedule"
+    description: |
+      Node tolerations for Upmeter server. The same as in the Pods' `spec.tolerations` parameter in Kubernetes;
+
+      If the parameter is omitted or `false`, it will be determined [automatically](https://deckhouse.io/en/documentation/v1/#advanced-scheduling).

--- a/modules/500-upmeter/openapi/doc-ru-config-values.yaml
+++ b/modules/500-upmeter/openapi/doc-ru-config-values.yaml
@@ -6,7 +6,7 @@ properties:
     oneOf:
       - type: string
       - type: boolean
-        enum: [ false ]
+        enum: [false]
     description: |
       Имя storageClass'а, который использовать.
 
@@ -15,7 +15,7 @@ properties:
       * Если указать `false` — будет форсироваться использование emptyDir'а.
   auth:
     type: object
-    default: { }
+    default: {}
     description: |
       Доступ к web-интерфейсу
     required:
@@ -26,7 +26,7 @@ properties:
         type: object
         description: |
           Настройки доступа к web-интерфейсу.
-        default: { }
+        default: {}
         properties:
           externalAuthentication:
             type: object
@@ -61,14 +61,14 @@ properties:
             items:
               type: string
             x-examples:
-              - [ "1.1.1.1/32" ]
+              - ["1.1.1.1/32"]
             description: |
               Список CIDR, которым разрешено проходить аутентификацию. Если параметр не указан, аутентификацию разрешено проходить без ограничения по IP-адресу.
       webui:
         type: object
         description: |
           Натсройки доступа к web-интерфейсу.
-        default: { }
+        default: {}
         properties:
           externalAuthentication:
             type: object
@@ -103,12 +103,12 @@ properties:
             items:
               type: string
             x-examples:
-              - [ "1.1.1.1/32" ]
+              - ["1.1.1.1/32"]
             description: |
               Список CIDR, которым разрешено проходить аутентификацию. Если параметр не указан, аутентификацию разрешено проходить без ограничения по IP-адресу.
   smokeMini:
     type: object
-    default: { }
+    default: {}
     required:
       - auth
     properties:
@@ -116,7 +116,7 @@ properties:
         type: object
         description: |
           Натсройки доступа к web-интерфейсу.
-        default: { }
+        default: {}
         properties:
           externalAuthentication:
             type: object
@@ -151,14 +151,14 @@ properties:
             items:
               type: string
             x-examples:
-              - [ "1.1.1.1/32" ]
+              - ["1.1.1.1/32"]
             description: |
               Список CIDR, которым разрешено проходить аутентификацию. Если параметр не указан, аутентификацию разрешено проходить без ограничения по IP-адресу.
       storageClass:
         oneOf:
           - type: string
           - type: boolean
-            enum: [ false ]
+            enum: [false]
         description: |
           storageClass для использования при проверке работоспособности дисков.
 
@@ -199,7 +199,7 @@ properties:
                   Секрет должен быть в формате [kubernetes.io/tls](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#tls-secrets).
   disabledProbes:
     type: array
-    default: [ ]
+    default: []
     items:
       type: string
     description: |
@@ -250,3 +250,14 @@ properties:
               Имя secret'а в namespace `d8-system`, который будет использоваться для webui/status.
 
               Секрет должен быть в формате [kubernetes.io/tls](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#tls-secrets).
+  nodeSelector:
+    description: |
+      Структура, аналогичная `spec.nodeSelector` Kubernetes Pod.
+
+      Если ничего не указано или указано `false` — будет [использоваться автоматика](https://deckhouse.io/ru/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).
+  tolerations:
+    type: array
+    description: |
+      Структура, аналогичная  `spec.tolerations` в Kubernetes Pod.
+
+      Если ничего не указано или указано `false` — будет [использоваться автоматика](https://deckhouse.io/ru/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).

--- a/modules/500-upmeter/templates/upmeter/statefulset.yaml
+++ b/modules/500-upmeter/templates/upmeter/statefulset.yaml
@@ -67,8 +67,8 @@ spec:
       terminationGracePeriodSeconds: 5
       enableServiceLinks: false
       serviceAccountName: upmeter
-{{- include "helm_lib_node_selector" (tuple . "system") | indent 6 }}
-{{- include "helm_lib_tolerations" (tuple . "system") | indent 6 }}
+{{- include "helm_lib_node_selector" (tuple . "monitoring") | indent 6 }}
+{{- include "helm_lib_tolerations" (tuple . "monitoring") | indent 6 }}
 {{- include "helm_lib_priority_class" (tuple . "cluster-low") | indent 6 }}
 {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | indent 6 }}
 {{- $storageClass := .Values.upmeter.internal.effectiveStorageClass }}


### PR DESCRIPTION
## Description

Allows to configure exact node where upmeter statefulset will schedule. 

## Why we need it and what problem does it solve?

Useful when e.g. system nodes are places in multiple availability zones and at the same time disks are not multi-zonal (#347).

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: upmeter
type: feature
description: Assign more specific nodes for the server pod
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
