### PR TITLE
[dhctl][deckhouse] Control plane node readiness check before converge node

### DIFF
--- a/dhctl/cmd/dhctl/commands/control-plane.go
+++ b/dhctl/cmd/dhctl/commands/control-plane.go
@@ -1,0 +1,100 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"fmt"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/infra/hook/controlplane"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
+)
+
+func DefineTestControlPlaneManagerReadyCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
+	cmd := parent.Command("manager", "Test control plane manager is ready.")
+	app.DefineSSHFlags(cmd)
+	app.DefineBecomeFlags(cmd)
+	app.DefineKubeFlags(cmd)
+	app.DefineControlPlaneFlags(cmd, false)
+
+	cmd.Action(func(c *kingpin.ParseContext) error {
+		sshClient, err := ssh.NewInitClientFromFlags(true)
+		if err != nil {
+			return err
+		}
+
+		kubeCl := client.NewKubernetesClient().WithSSHClient(sshClient)
+		// auto init
+		err = kubeCl.Init(client.AppKubernetesInitParams())
+		if err != nil {
+			return fmt.Errorf("open kubernetes connection: %v", err)
+		}
+
+		checker := controlplane.NewManagerReadinessChecker(kubeCl)
+		ready, err := checker.IsReady(app.ControlPlaneHostname)
+		if err != nil {
+			return fmt.Errorf("Control plane manager is not ready: %s", err)
+		}
+
+		if ready {
+			log.InfoLn("Control plane manager is ready")
+		} else {
+			log.WarnLn("Control plane manager is not ready")
+		}
+
+		return nil
+	})
+	return cmd
+}
+
+func DefineTestControlPlaneNodeReadyCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
+	cmd := parent.Command("node", "Test control plane node is ready.")
+	app.DefineSSHFlags(cmd)
+	app.DefineBecomeFlags(cmd)
+	app.DefineKubeFlags(cmd)
+	app.DefineControlPlaneFlags(cmd, true)
+
+	cmd.Action(func(c *kingpin.ParseContext) error {
+		sshClient, err := ssh.NewInitClientFromFlags(true)
+		if err != nil {
+			return err
+		}
+
+		kubeCl := client.NewKubernetesClient().WithSSHClient(sshClient)
+		// auto init
+		err = kubeCl.Init(client.AppKubernetesInitParams())
+		if err != nil {
+			return fmt.Errorf("open kubernetes connection: %v", err)
+		}
+
+		checker := controlplane.NewHook(kubeCl, map[string]string{
+			app.ControlPlaneHostname: app.ControlPlaneIP,
+		}, "").WithSourceCommandName("test")
+
+		err = checker.IsReady()
+		if err != nil {
+			return fmt.Errorf("Control plane node is not ready: %v", err)
+		}
+
+		log.InfoLn("Control plane manager node is ready")
+
+		return nil
+	})
+	return cmd
+}

--- a/dhctl/cmd/dhctl/commands/converge.go
+++ b/dhctl/cmd/dhctl/commands/converge.go
@@ -16,6 +16,7 @@ package commands
 
 import (
 	"fmt"
+	"time"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -108,6 +109,8 @@ func DefineAutoConvergeCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 		inLockRunner := converge.NewInLockRunner(kubeCl, converge.AutoConvergerIdentity).
 			// never force lock
 			WithForceLock(false)
+
+		app.DeckhouseTimeout = 1 * time.Hour
 
 		runner := converge.NewRunner(kubeCl, inLockRunner).
 			WithChangeSettings(&terraform.ChangeActionSettings{

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -99,13 +99,19 @@ func main() {
 		}
 	}
 
-	testCmd := kpApp.Command("test", "Commands to test the parts of bootstrap process.")
+	testCmd := kpApp.Command("test", "Commands to test the parts of bootstrap and converge process.")
 	{
 		commands.DefineTestSSHConnectionCommand(testCmd)
 		commands.DefineTestKubernetesAPIConnectionCommand(testCmd)
 		commands.DefineTestSCPCommand(testCmd)
 		commands.DefineTestUploadExecCommand(testCmd)
 		commands.DefineTestBundle(testCmd)
+
+		controlPlaneCmd := testCmd.Command("control-plane", "Commands to test control plane nodes.")
+		{
+			commands.DefineTestControlPlaneManagerReadyCommand(controlPlaneCmd)
+			commands.DefineTestControlPlaneNodeReadyCommand(controlPlaneCmd)
+		}
 	}
 
 	deckhouseCmd := testCmd.Command("deckhouse", "Install and uninstall deckhouse.")

--- a/dhctl/pkg/app/control-plane.go
+++ b/dhctl/pkg/app/control-plane.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	ControlPlaneHostname = ""
+	ControlPlaneIP       = ""
+)
+
+func DefineControlPlaneFlags(cmd *kingpin.CmdClause, ipRequired bool) {
+	cmd.Flag("control-plane-node-hostname", "Control plane node hostname to check").
+		Envar(configEnvName("CONTROL_PLANE_NODE_HOSTNAME")).
+		Required().
+		StringVar(&ControlPlaneHostname)
+
+	ipFlag := cmd.Flag("control-plane-node-ip", "Control plane node ip to check").
+		Envar(configEnvName("CONTROL_PLANE_NODE_IP"))
+
+	if ipRequired {
+		ipFlag.Required()
+	}
+
+	ipFlag.StringVar(&ControlPlaneIP)
+}

--- a/dhctl/pkg/kubernetes/actions/converge/check.go
+++ b/dhctl/pkg/kubernetes/actions/converge/check.go
@@ -202,10 +202,10 @@ func CheckState(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig) 
 		}
 
 		nodeGroup := NodeGroupGroupOptions{
-			Name:     nodeGroupName,
-			Step:     step,
-			Replicas: replicas,
-			State:    nodeGroupState.State,
+			Name:            nodeGroupName,
+			Step:            step,
+			DesiredReplicas: replicas,
+			State:           nodeGroupState.State,
 		}
 
 		for name := range nodeGroupState.State {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -353,6 +353,10 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *Config) erro
 }
 
 func WaitForReadiness(kubeCl *client.KubernetesClient) error {
+	return WaitForReadinessNotOnNode(kubeCl, "")
+}
+
+func WaitForReadinessNotOnNode(kubeCl *client.KubernetesClient, excludeNode string) error {
 	return log.Process("default", "Waiting for Deckhouse to become Ready", func() error {
 		ctx, cancel := context.WithTimeout(context.Background(), app.DeckhouseTimeout)
 		defer cancel()
@@ -361,7 +365,11 @@ func WaitForReadiness(kubeCl *client.KubernetesClient) error {
 			case <-ctx.Done():
 				return ErrTimedOut
 			default:
-				ok, err := NewLogPrinter(kubeCl).WaitPodBecomeReady().Print(ctx)
+				ok, err := NewLogPrinter(kubeCl).
+					WaitPodBecomeReady().
+					WithExcludeNode(excludeNode).
+					Print(ctx)
+
 				if err != nil {
 					if errors.Is(err, ErrTimedOut) {
 						return err

--- a/dhctl/pkg/kubernetes/actions/deckhouse/pod.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/pod.go
@@ -1,0 +1,65 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deckhouse
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+)
+
+func GetPod(kubeCl *client.KubernetesClient) (*v1.Pod, error) {
+	pods, err := kubeCl.CoreV1().Pods("d8-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "app=deckhouse"})
+	if err != nil {
+		return nil, ErrListPods
+	}
+
+	if len(pods.Items) != 1 {
+		return nil, ErrListPods
+	}
+
+	pod := pods.Items[0]
+
+	return &pod, nil
+}
+
+func GetRunningPod(kubeCl *client.KubernetesClient) (*v1.Pod, error) {
+	pod, err := GetPod(kubeCl)
+	if err != nil {
+		return nil, err
+	}
+
+	phase := pod.Status.Phase
+	message := fmt.Sprintf("Deckhouse pod found: %s (%s)", pod.Name, pod.Status.Phase)
+
+	if phase != v1.PodRunning {
+		return nil, fmt.Errorf(message)
+	}
+
+	return pod, nil
+}
+
+func DeletePod(kubeCl *client.KubernetesClient) error {
+	pod, err := GetPod(kubeCl)
+	if err != nil {
+		return err
+	}
+
+	return kubeCl.CoreV1().Pods("d8-system").Delete(context.TODO(), pod.GetName(), metav1.DeleteOptions{})
+}

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -41,6 +41,8 @@ const (
 	deployServiceHostEnvVarName = "KUBERNETES_SERVICE_HOST"
 	deployServicePortEnvVarName = "KUBERNETES_SERVICE_PORT"
 	deployTimeEnvVarFormat      = time.RFC3339
+
+	ConvergeLabel = "dhctl.deckhouse.io/node-for-converge"
 )
 
 type DeckhouseDeploymentParams struct {
@@ -220,6 +222,22 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 					Name: "kube",
 					VolumeSource: apiv1.VolumeSource{
 						EmptyDir: &apiv1.EmptyDirVolumeSource{Medium: apiv1.StorageMediumMemory},
+					},
+				},
+			},
+			Affinity: &apiv1.Affinity{
+				NodeAffinity: &apiv1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &apiv1.NodeSelector{
+						NodeSelectorTerms: []apiv1.NodeSelectorTerm{
+							{
+								MatchExpressions: []apiv1.NodeSelectorRequirement{
+									{
+										Key:      ConvergeLabel,
+										Operator: apiv1.NodeSelectorOpDoesNotExist,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/dhctl/pkg/kubernetes/client/lease-lock.go
+++ b/dhctl/pkg/kubernetes/client/lease-lock.go
@@ -312,6 +312,7 @@ func LockInfo(lease *coordinationv1.Lease) (string, *LockUserInfo) {
   lastRenewTime: %v
   leaseDuration: %vs
   user: %s@%s
+  additionalInfo:
     %s
 `
 	return fmt.Sprintf(format,

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/cp-manager.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/cp-manager.go
@@ -1,0 +1,76 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+)
+
+type ManagerReadinessChecker struct {
+	kubeCl *client.KubernetesClient
+}
+
+func NewManagerReadinessChecker(kubeCl *client.KubernetesClient) *ManagerReadinessChecker {
+	return &ManagerReadinessChecker{
+		kubeCl: kubeCl,
+	}
+}
+
+func (c *ManagerReadinessChecker) IsReady(nodeName string) (bool, error) {
+	cpmPodsList, err := c.kubeCl.CoreV1().Pods("kube-system").List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "app=d8-control-plane-manager",
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+	})
+
+	if err != nil {
+		return false, err
+	}
+
+	if len(cpmPodsList.Items) == 0 {
+		return false, fmt.Errorf("Not found control plane manage pod")
+	}
+
+	if len(cpmPodsList.Items) > 1 {
+		return false, fmt.Errorf("Found multiple control plane manager pods for one node")
+	}
+
+	cpmPod := cpmPodsList.Items[0]
+	podName := cpmPod.GetName()
+	phase := cpmPod.Status.Phase
+
+	if cpmPod.Status.Phase != corev1.PodRunning {
+		return false, fmt.Errorf("Control plane manager pod %s is not running (%s)", podName, phase)
+	}
+
+	for _, status := range cpmPod.Status.ContainerStatuses {
+		if status.Name != "control-plane-manager" {
+			continue
+		}
+
+		return status.Ready, nil
+	}
+
+	return false, fmt.Errorf("Not found control-plane-manager container in pod %s", podName)
+}
+
+func (c *ManagerReadinessChecker) Name() string {
+	return "Control plane manager readiness"
+}

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/hook.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/hook.go
@@ -1,0 +1,185 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/deckhouse"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/manifests"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/infra/hook"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
+)
+
+type Hook struct {
+	nodesNamesToCheck []string
+	checkers          []hook.NodeChecker
+	sourceCommandName string
+	kubeCl            *client.KubernetesClient
+	nodeToConverge    string
+	runAfterAction    bool
+}
+
+func NewHook(kubeCl *client.KubernetesClient, nodesToCheckWithIPs map[string]string, clusterUUID string) *Hook {
+	proxyChecker := NewKubeProxyChecker().
+		WithExternalIPs(nodesToCheckWithIPs).
+		WithClusterUUID(clusterUUID)
+
+	checkers := []hook.NodeChecker{
+		hook.NewKubeNodeReadinessChecker(kubeCl),
+		proxyChecker,
+		NewManagerReadinessChecker(kubeCl),
+	}
+
+	nodes := make([]string, 0)
+	for nodeName := range nodesToCheckWithIPs {
+		nodes = append(nodes, nodeName)
+	}
+
+	return &Hook{
+		nodesNamesToCheck: nodes,
+		checkers:          checkers,
+		kubeCl:            kubeCl,
+	}
+}
+
+func (h *Hook) WithSourceCommandName(name string) *Hook {
+	h.sourceCommandName = name
+	return h
+}
+
+func (h *Hook) WithNodeToConverge(nodeToConverge string) *Hook {
+	h.nodeToConverge = nodeToConverge
+	return h
+}
+
+func (h *Hook) convergeLabelToNode(shouldExist bool) error {
+	node, err := h.kubeCl.CoreV1().Nodes().Get(context.TODO(), h.nodeToConverge, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	labels := node.GetLabels()
+
+	if shouldExist {
+		if _, ok := labels[manifests.ConvergeLabel]; ok {
+			return nil
+		}
+
+		labels[manifests.ConvergeLabel] = ""
+	} else {
+		if _, ok := labels[manifests.ConvergeLabel]; !ok {
+			return nil
+		}
+
+		delete(labels, manifests.ConvergeLabel)
+	}
+
+	node.SetLabels(labels)
+
+	_, err = h.kubeCl.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+
+	return err
+}
+
+func (h *Hook) BeforeAction() (bool, error) {
+	err := log.Process(h.sourceCommandName, "Check deckhouse pod is not on converged node", func() error {
+		var pod *v1.Pod
+		err := retry.NewSilentLoop("Get deckhouse pod", 10, 3*time.Second).Run(func() error {
+			var err error
+			pod, err = deckhouse.GetRunningPod(h.kubeCl)
+
+			return err
+		})
+
+		if err != nil {
+			return fmt.Errorf("Deckhouse pod did not get: %s", err)
+		}
+
+		if pod.Spec.NodeName != h.nodeToConverge {
+			h.runAfterAction = false
+			return nil
+		}
+
+		confirm := input.NewConfirmation().
+			WithMessage("Deckhouse pod is located on node to converge. Do you want to move pod in another node?")
+
+		if !confirm.Ask() {
+			log.WarnLn("Skip moving deckhouse pod")
+			h.runAfterAction = false
+			return nil
+		}
+
+		title := fmt.Sprintf("Set label '%s' on converged node", manifests.ConvergeLabel)
+		err = retry.NewLoop(title, 10, 3*time.Second).Run(func() error {
+			return h.convergeLabelToNode(true)
+		})
+
+		if err != nil {
+			return fmt.Errorf("Cannot set label '%s' to node: %v", manifests.ConvergeLabel, err)
+		}
+
+		err = retry.NewLoop("Evict deckhouse pod from node", 10, 3*time.Second).Run(func() error {
+			return deckhouse.DeletePod(h.kubeCl)
+		})
+
+		if err != nil {
+			return err
+		}
+
+		h.runAfterAction = true
+
+		return nil
+	})
+
+	if err != nil {
+		return false, err
+	}
+
+	return h.runAfterAction, err
+}
+
+func (h *Hook) AfterAction() error {
+	if !h.runAfterAction {
+		return nil
+	}
+
+	title := fmt.Sprintf("Delete label '%s' from converged node", manifests.ConvergeLabel)
+	return retry.NewLoop(title, 10, 3*time.Second).Run(func() error {
+		return h.convergeLabelToNode(false)
+	})
+}
+
+func (h *Hook) IsReady() error {
+	excludeNode := h.nodeToConverge
+	if !h.runAfterAction {
+		excludeNode = ""
+	}
+
+	err := deckhouse.WaitForReadinessNotOnNode(h.kubeCl, excludeNode)
+	if err != nil {
+		return err
+	}
+
+	return hook.IsAllNodesReady(h.checkers, h.nodesNamesToCheck, h.sourceCommandName, "Control plane nodes are ready")
+}

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/kube-proxy.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/kube-proxy.go
@@ -1,0 +1,145 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"context"
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
+)
+
+type KubeProxyChecker struct {
+	initParams       *client.KubernetesInitParams
+	logCheckResult   bool
+	askPassword      bool
+	stopProxy        bool
+	nodesExternalIPs map[string]string
+	clusterUUID      string
+}
+
+func NewKubeProxyChecker() *KubeProxyChecker {
+	return &KubeProxyChecker{
+		stopProxy: true,
+	}
+}
+
+func (c *KubeProxyChecker) WithInitParams(p *client.KubernetesInitParams) *KubeProxyChecker {
+	c.initParams = p
+	return c
+}
+
+func (c *KubeProxyChecker) WithLogResult(f bool) *KubeProxyChecker {
+	c.logCheckResult = f
+	return c
+}
+
+func (c *KubeProxyChecker) WithAskPassword(f bool) *KubeProxyChecker {
+	c.askPassword = f
+	return c
+}
+
+func (c *KubeProxyChecker) WithStopProxy(f bool) *KubeProxyChecker {
+	c.stopProxy = f
+	return c
+}
+
+func (c *KubeProxyChecker) WithClusterUUID(uuid string) *KubeProxyChecker {
+	c.clusterUUID = uuid
+	return c
+}
+
+func (c *KubeProxyChecker) WithExternalIPs(ips map[string]string) *KubeProxyChecker {
+	c.nodesExternalIPs = ips
+	return c
+}
+
+func (c *KubeProxyChecker) IsReady(nodeName string) (bool, error) {
+	sshClient := ssh.NewClientFromFlags()
+
+	if len(c.nodesExternalIPs) > 0 {
+		ip, ok := c.nodesExternalIPs[nodeName]
+		if !ok {
+			return false, fmt.Errorf("Not found external ip for node %s", nodeName)
+		}
+
+		sshClient.Settings.SetAvailableHosts([]string{ip})
+	}
+
+	var err error
+	sshClient, err = sshClient.Start()
+	if err != nil {
+		return false, err
+	}
+
+	kubeCl := client.NewKubernetesClient().WithSSHClient(sshClient)
+	err = kubeCl.Init(client.AppKubernetesInitParams())
+	if err != nil {
+		return false, fmt.Errorf("open kubernetes connection: %v", err)
+	}
+
+	defer func() {
+		if !c.stopProxy {
+			return
+		}
+
+		if kubeCl.KubeProxy != nil {
+			kubeCl.KubeProxy.Stop()
+		}
+
+		if kubeCl.SSHClient != nil {
+			kubeCl.SSHClient.Stop()
+		}
+	}()
+
+	// d8-cluster-uuid
+	ns, err := kubeCl.CoreV1().ConfigMaps("kube-system").Get(context.TODO(), "d8-cluster-uuid", v1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	c.printNs(ns)
+
+	uuidInCluster := ns.Data["cluster-uuid"]
+	if c.clusterUUID != "" && c.clusterUUID != uuidInCluster {
+		return false, fmt.Errorf("Incorrect cluster uuid. In cluster %s != %s passed.", uuidInCluster, c.clusterUUID)
+	}
+
+	return true, nil
+}
+
+func (c *KubeProxyChecker) Name() string {
+	return "Ssh access and kube-proxy availability"
+}
+
+func (c *KubeProxyChecker) printNs(cm *apiv1.ConfigMap) {
+	if !c.logCheckResult {
+		return
+	}
+
+	yamlRepr, err := yaml.Marshal(cm)
+	if err != nil {
+		log.ErrorF("ConfigMap marshal error %v\n", err)
+		return
+	}
+
+	log.InfoF("Cluster UUID ConfigMap:\n%s\n", string(yamlRepr))
+}

--- a/dhctl/pkg/operations/converge/infra/hook/node.go
+++ b/dhctl/pkg/operations/converge/infra/hook/node.go
@@ -1,0 +1,128 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hook
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
+)
+
+var (
+	ErrNotReady = fmt.Errorf("Not ready.")
+)
+
+type NodeChecker interface {
+	IsReady(nodeName string) (bool, error)
+	Name() string
+}
+
+func IsAllNodesReady(checkers []NodeChecker, nodes []string, sourceCommandName, processName string) error {
+	if checkers == nil {
+		return nil
+	}
+
+	if len(nodes) == 0 {
+		return fmt.Errorf("Do not have nodes for %s.", processName)
+	}
+
+	return log.Process(sourceCommandName, processName, func() error {
+		for _, nodeName := range nodes {
+			ready, err := IsNodeReady(checkers, nodeName, sourceCommandName)
+			if err != nil {
+				return err
+			}
+
+			if !ready {
+				return ErrNotReady
+			}
+		}
+
+		return nil
+	})
+}
+
+func IsNodeReady(checkers []NodeChecker, nodeName, sourceCommandName string) (bool, error) {
+	title := fmt.Sprintf("Node %s is ready", nodeName)
+	var lastErr error
+
+	err := retry.NewLoop(title, 30, 10*time.Second).Run(func() error {
+		for _, check := range checkers {
+			err := log.Process(sourceCommandName, check.Name(), func() error {
+				isReady, err := check.IsReady(nodeName)
+				if err != nil {
+					return err
+				}
+
+				if !isReady {
+					return ErrNotReady
+				}
+
+				return err
+			})
+
+			if err != nil {
+				lastErr = err
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return false, fmt.Errorf("Node %s is not ready. last error: %v/%v", nodeName, err, lastErr)
+	}
+
+	return true, nil
+}
+
+type KubeNodeReadinessChecker struct {
+	kubeCl *client.KubernetesClient
+}
+
+func NewKubeNodeReadinessChecker(kubeCl *client.KubernetesClient) *KubeNodeReadinessChecker {
+	return &KubeNodeReadinessChecker{
+		kubeCl: kubeCl,
+	}
+}
+
+func (c *KubeNodeReadinessChecker) IsReady(nodeName string) (bool, error) {
+	node, err := c.kubeCl.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	for _, c := range node.Status.Conditions {
+		if c.Type == apiv1.NodeReady {
+			if c.Status == apiv1.ConditionTrue {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+func (c *KubeNodeReadinessChecker) Name() string {
+	return "Kube node is ready"
+}

--- a/dhctl/pkg/state/cache/init.go
+++ b/dhctl/pkg/state/cache/init.go
@@ -24,8 +24,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/util"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/cache"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/stringsutil"
 )
 
 var once sync.Once
@@ -39,7 +39,7 @@ var (
 var globalCache state.Cache = &cache.DummyCache{}
 
 func choiceCache(identity string) (state.Cache, error) {
-	tmpDir := filepath.Join(app.CacheDir, util.Sha256Encode(identity))
+	tmpDir := filepath.Join(app.CacheDir, stringsutil.Sha256Encode(identity))
 	log.DebugF("Cache dir %s\n", tmpDir)
 	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
 		return nil, fmt.Errorf("can't create cache directory: %w", err)

--- a/dhctl/pkg/system/ssh/client.go
+++ b/dhctl/pkg/system/ssh/client.go
@@ -16,10 +16,43 @@ package ssh
 
 import (
 	"fmt"
+	"sync"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh/frontend"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh/session"
 )
+
+var (
+	agentInstanceSingleton sync.Once
+	agentInstance          *frontend.Agent
+)
+
+func initAgentInstance() (*frontend.Agent, error) {
+	var err error
+
+	agentInstanceSingleton.Do(func() {
+		if agentInstance == nil {
+			inst := frontend.NewAgent(&session.AgentSettings{
+				PrivateKeys: app.SSHPrivateKeys,
+			})
+
+			err = inst.Start()
+			if err != nil {
+				return
+			}
+			tomb.RegisterOnShutdown("Stop ssh-agent", func() {
+				agentInstance.Stop()
+			})
+
+			agentInstance = inst
+		}
+	})
+
+	return agentInstance, err
+}
 
 type Client struct {
 	Settings *session.Session
@@ -30,8 +63,15 @@ func (s *Client) Start() (*Client, error) {
 	if s.Settings == nil {
 		return nil, fmt.Errorf("possible bug in ssh client: session should be created before start")
 	}
-	s.Agent = frontend.NewAgent(s.Settings)
-	return s, s.Agent.Start()
+
+	a, err := initAgentInstance()
+	if err != nil {
+		return nil, err
+	}
+	s.Agent = a
+	s.Settings.AgentSettings = s.Agent.AgentSettings
+
+	return s, nil
 }
 
 // Easy access to frontends
@@ -64,4 +104,10 @@ func (s *Client) UploadScript(scriptPath string, args ...string) *frontend.Uploa
 // UploadScript is used to upload script and execute it on remote server
 func (s *Client) Check() *frontend.Check {
 	return frontend.NewCheck(s.Settings)
+}
+
+// Stop stop client
+func (s *Client) Stop() {
+	// do nothing
+	// stop agent on shutdown because agent is singleton
 }

--- a/dhctl/pkg/system/ssh/cmd/scp.go
+++ b/dhctl/pkg/system/ssh/cmd/scp.go
@@ -78,7 +78,7 @@ func (s *SCP) WithPreserve(preserve bool) *SCP {
 
 func (s *SCP) SCP() *SCP {
 	// env := append(os.Environ(), s.Env...)
-	env := append(os.Environ(), s.Session.AuthSockEnv())
+	env := append(os.Environ(), s.Session.AgentSettings.AuthSockEnv())
 
 	args := []string{
 		// ssh args for bastion here

--- a/dhctl/pkg/system/ssh/cmd/ssh-add.go
+++ b/dhctl/pkg/system/ssh/cmd/ssh-add.go
@@ -27,11 +27,11 @@ import (
 const SSHAddPath = "ssh-add"
 
 type SSHAdd struct {
-	Session *session.Session
+	AgentSettings *session.AgentSettings
 }
 
-func NewSSHAdd(sess *session.Session) *SSHAdd {
-	return &SSHAdd{Session: sess}
+func NewSSHAdd(sess *session.AgentSettings) *SSHAdd {
+	return &SSHAdd{AgentSettings: sess}
 }
 
 func (s *SSHAdd) KeyCmd(keyPath string) *exec.Cmd {
@@ -39,7 +39,7 @@ func (s *SSHAdd) KeyCmd(keyPath string) *exec.Cmd {
 		keyPath,
 	}
 	env := []string{
-		s.Session.AuthSockEnv(),
+		s.AgentSettings.AuthSockEnv(),
 	}
 	cmd := exec.Command(SSHAddPath, args...)
 	cmd.Env = append(os.Environ(), env...)
@@ -48,7 +48,7 @@ func (s *SSHAdd) KeyCmd(keyPath string) *exec.Cmd {
 
 func (s *SSHAdd) ListCmd() *exec.Cmd {
 	env := []string{
-		s.Session.AuthSockEnv(),
+		s.AgentSettings.AuthSockEnv(),
 	}
 	cmd := exec.Command(SSHAddPath, "-l")
 	cmd.Env = append(os.Environ(), env...)
@@ -62,7 +62,7 @@ func (s *SSHAdd) AddKeys(keys []string) error {
 			k,
 		}
 		env := []string{
-			s.Session.AuthSockEnv(),
+			s.AgentSettings.AuthSockEnv(),
 		}
 		cmd := exec.Command(SSHAddPath, args...)
 		cmd.Env = append(os.Environ(), env...)
@@ -81,7 +81,7 @@ func (s *SSHAdd) AddKeys(keys []string) error {
 	if app.IsDebug {
 		log.DebugLn("list added keys")
 		env := []string{
-			s.Session.AuthSockEnv(),
+			s.AgentSettings.AuthSockEnv(),
 		}
 		cmd := exec.Command(SSHAddPath, "-l")
 		cmd.Env = append(os.Environ(), env...)

--- a/dhctl/pkg/system/ssh/cmd/ssh-agent.go
+++ b/dhctl/pkg/system/ssh/cmd/ssh-agent.go
@@ -34,7 +34,7 @@ const SSHAgentPath = "ssh-agent"
 type SSHAgent struct {
 	*process.Executor
 
-	Session *session.Session
+	AgentSettings *session.AgentSettings
 
 	agentCmd *exec.Cmd
 
@@ -104,7 +104,7 @@ func (a *SSHAgent) Start() error {
 	}
 
 	// save auth sock in session to access it from other cmds and frontends
-	a.Session.AuthSock = a.AuthSock
+	a.AgentSettings.AuthSock = a.AuthSock
 	tomb.RegisterOnShutdown("Delete SSH agent temporary directory", func() {
 		_ = os.RemoveAll(filepath.Dir(a.AuthSock))
 	})

--- a/dhctl/pkg/system/ssh/cmd/ssh.go
+++ b/dhctl/pkg/system/ssh/cmd/ssh.go
@@ -57,7 +57,7 @@ func (s *SSH) WithCommand(name string, arg ...string) *SSH {
 // TODO move connection settings from ExecuteCmd
 func (s *SSH) Cmd() *exec.Cmd {
 	env := append(os.Environ(), s.Env...)
-	env = append(env, s.Session.AuthSockEnv())
+	env = append(env, s.Session.AgentSettings.AuthSockEnv())
 
 	// ssh connection settings
 	//   ANSIBLE_SSH_ARGS="${ANSIBLE_SSH_ARGS:-"-C

--- a/dhctl/pkg/system/ssh/frontend/agent.go
+++ b/dhctl/pkg/system/ssh/frontend/agent.go
@@ -25,26 +25,26 @@ import (
 )
 
 type Agent struct {
-	Session *session.Session
+	AgentSettings *session.AgentSettings
 
 	Agent *cmd.SSHAgent
 }
 
-func NewAgent(sess *session.Session) *Agent {
-	return &Agent{Session: sess}
+func NewAgent(sess *session.AgentSettings) *Agent {
+	return &Agent{AgentSettings: sess}
 }
 
 func (a *Agent) Start() error {
-	if len(a.Session.PrivateKeys) == 0 {
+	if len(a.AgentSettings.PrivateKeys) == 0 {
 		a.Agent = &cmd.SSHAgent{
-			Session:  a.Session,
-			AuthSock: os.Getenv("SSH_AUTH_SOCK"),
+			AgentSettings: a.AgentSettings,
+			AuthSock:      os.Getenv("SSH_AUTH_SOCK"),
 		}
 		return nil
 	}
 
 	a.Agent = &cmd.SSHAgent{
-		Session: a.Session,
+		AgentSettings: a.AgentSettings,
 	}
 
 	log.DebugLn("agent: start ssh-agent")
@@ -64,9 +64,9 @@ func (a *Agent) Start() error {
 
 // TODO replace with x/crypto/ssh/agent ?
 func (a *Agent) AddKeys() error {
-	for _, k := range a.Session.PrivateKeys {
+	for _, k := range a.AgentSettings.PrivateKeys {
 		log.DebugF("add key %s\n", k)
-		sshAdd := cmd.NewSSHAdd(a.Session).KeyCmd(k)
+		sshAdd := cmd.NewSSHAdd(a.AgentSettings).KeyCmd(k)
 		output, err := sshAdd.CombinedOutput()
 		if err != nil {
 			werr := "signal: interrupt"
@@ -84,7 +84,7 @@ func (a *Agent) AddKeys() error {
 
 	if app.IsDebug {
 		log.DebugLn("list added keys")
-		listCmd := cmd.NewSSHAdd(a.Session).ListCmd()
+		listCmd := cmd.NewSSHAdd(a.AgentSettings).ListCmd()
 
 		output, err := listCmd.CombinedOutput()
 		if err != nil {

--- a/dhctl/pkg/system/ssh/frontend/kube-proxy.go
+++ b/dhctl/pkg/system/ssh/frontend/kube-proxy.go
@@ -23,7 +23,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh/session"
 )
 
-var LocalAPIPort = 22322
+const DefaultLocalAPIPort = 22322
 
 type KubeProxy struct {
 	Session *session.Session
@@ -43,7 +43,7 @@ func NewKubeProxy(sess *session.Session) *KubeProxy {
 	return &KubeProxy{
 		Session:   sess,
 		port:      "0",
-		localPort: LocalAPIPort,
+		localPort: DefaultLocalAPIPort,
 	}
 }
 
@@ -172,7 +172,7 @@ func (k *KubeProxy) upTunnel(kubeProxyPort string, useLocalPort int, tunnelError
 	localPort = useLocalPort
 
 	if useLocalPort < 1 {
-		localPort = LocalAPIPort
+		localPort = DefaultLocalAPIPort
 		rewriteLocalPort = true
 	}
 
@@ -204,6 +204,7 @@ func (k *KubeProxy) upTunnel(kubeProxyPort string, useLocalPort int, tunnelError
 			}
 		} else {
 			go tun.HealthMonitor(tunnelErrorCh)
+			lastError = nil
 			break
 		}
 	}

--- a/dhctl/pkg/system/ssh/frontend/tunnel.go
+++ b/dhctl/pkg/system/ssh/frontend/tunnel.go
@@ -104,8 +104,8 @@ func (t *Tunnel) Up() error {
 }
 
 func (t *Tunnel) HealthMonitor(errorOutCh chan<- error) {
-	defer log.DebugF("Tunnel health monitor stopped")
-	log.DebugF("Tunnel health monitor started")
+	defer log.DebugF("Tunnel health monitor stopped\n")
+	log.DebugF("Tunnel health monitor started\n")
 
 	t.stopCh = make(chan struct{}, 1)
 

--- a/dhctl/pkg/terraform/hook.go
+++ b/dhctl/pkg/terraform/hook.go
@@ -1,0 +1,35 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terraform
+
+type InfraActionHook interface {
+	BeforeAction() (runAfterAction bool, err error)
+	IsReady() error
+	AfterAction() error
+}
+
+type DummyHook struct{}
+
+func (c *DummyHook) BeforeAction() (runPostAction bool, err error) {
+	return false, nil
+}
+
+func (c *DummyHook) IsReady() error {
+	return nil
+}
+
+func (c *DummyHook) AfterAction() error {
+	return nil
+}

--- a/dhctl/pkg/terraform/pipeline_test.go
+++ b/dhctl/pkg/terraform/pipeline_test.go
@@ -206,7 +206,7 @@ func TestDestroyPipeline(t *testing.T) {
 
 			err := DestroyPipeline(runner, "test")
 			if tc.expectedErr != nil {
-				require.EqualError(t, err, tc.expectedErr.Error())
+				require.Contains(t, err.Error(), tc.expectedErr.Error())
 			} else {
 				require.NoError(t, err)
 			}

--- a/dhctl/pkg/terraform/runner_test.go
+++ b/dhctl/pkg/terraform/runner_test.go
@@ -160,7 +160,7 @@ func TestCheckRunnerHandleChanges(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			skip, err := tc.runner.handleChanges()
+			skip, err := tc.runner.isSkipChanges()
 			require.Equal(t, tc.skip, skip)
 			if tc.err != nil {
 				require.Error(t, err)

--- a/dhctl/pkg/util/cache/cache.go
+++ b/dhctl/pkg/util/cache/cache.go
@@ -25,12 +25,12 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/util"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/stringsutil"
 )
 
 // NewTempStateCache creates new cache instance in tmp directory
 func NewTempStateCache(identity string) (*StateCache, error) {
-	cacheDir := filepath.Join(app.CacheDir, util.Sha256Encode(identity))
+	cacheDir := filepath.Join(app.CacheDir, stringsutil.Sha256Encode(identity))
 	return NewStateCache(cacheDir)
 }
 

--- a/dhctl/pkg/util/maputil/maputil.go
+++ b/dhctl/pkg/util/maputil/maputil.go
@@ -1,0 +1,43 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maputil
+
+func ExcludeKeys(m map[string]string, excludeKeys ...string) map[string]string {
+	excludeKeysSet := make(map[string]struct{})
+	for _, k := range excludeKeys {
+		excludeKeysSet[k] = struct{}{}
+	}
+
+	res := make(map[string]string)
+
+	for k, v := range m {
+		if _, ok := excludeKeysSet[k]; ok {
+			continue
+		}
+
+		res[k] = v
+	}
+
+	return res
+}
+
+func Values(m map[string]string) []string {
+	keysList := make([]string, 0, len(m))
+	for _, v := range m {
+		keysList = append(keysList, v)
+	}
+
+	return keysList
+}

--- a/dhctl/pkg/util/maputil/maputil_test.go
+++ b/dhctl/pkg/util/maputil/maputil_test.go
@@ -1,0 +1,98 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maputil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExcludeKeys(t *testing.T) {
+	cases := []struct {
+		name     string
+		mp       map[string]string
+		excluded []string
+		res      map[string]string
+	}{
+		{
+			name:     "Empty map and empty keys returns empty map",
+			mp:       make(map[string]string),
+			excluded: make([]string, 0),
+			res:      make(map[string]string),
+		},
+
+		{
+			name:     "Not empty map and empty keys returns map with all keys",
+			mp:       map[string]string{"k": "v"},
+			excluded: make([]string, 0),
+			res:      map[string]string{"k": "v"},
+		},
+
+		{
+			name:     "Empty map and not empty keys return empty map",
+			mp:       make(map[string]string),
+			excluded: []string{"k"},
+			res:      make(map[string]string),
+		},
+
+		{
+			name: "Exclude one key",
+			mp: map[string]string{
+				"k1": "v1",
+				"k2": "v2",
+				"k3": "v3",
+			},
+			excluded: []string{"k2"},
+			res: map[string]string{
+				"k1": "v1",
+				"k3": "v3",
+			},
+		},
+
+		{
+			name: "Exclude multiple keys, but one key is not in map. Must exclude all exists keys",
+			mp: map[string]string{
+				"k1": "v1",
+				"k2": "v2",
+				"k3": "v3",
+			},
+			excluded: []string{"k2", "m1"},
+			res: map[string]string{
+				"k1": "v1",
+				"k3": "v3",
+			},
+		},
+
+		{
+			name: "Exclude all keys",
+			mp: map[string]string{
+				"k1": "v1",
+				"k2": "v2",
+				"k3": "v3",
+			},
+			excluded: []string{"k1", "k2", "k3", "m1"},
+			res:      make(map[string]string),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res := ExcludeKeys(c.mp, c.excluded...)
+
+			require.Equal(t, res, c.res)
+		})
+	}
+}

--- a/dhctl/pkg/util/stringsutil/strings.go
+++ b/dhctl/pkg/util/stringsutil/strings.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package stringsutil
 
 import (
 	"crypto/sha256"
@@ -32,7 +32,7 @@ func RandomStrElement(list []string) (string, int) {
 	return list[indx], indx
 }
 
-func ExcludeElementFromSlice(list []string, elem string) []string {
+func Index(list []string, elem string) int {
 	indx := -1
 	for i, v := range list {
 		if v == elem {
@@ -40,6 +40,12 @@ func ExcludeElementFromSlice(list []string, elem string) []string {
 			break
 		}
 	}
+
+	return indx
+}
+
+func ExcludeElementFromSlice(list []string, elem string) []string {
+	indx := Index(list, elem)
 
 	if indx >= 0 {
 		var res []string

--- a/modules/020-deckhouse/templates/deployment.yaml
+++ b/modules/020-deckhouse/templates/deployment.yaml
@@ -55,7 +55,14 @@ spec:
       annotations:
         checksum/registry: {{ include (print $.Template.BasePath "/registry.yaml") . | sha256sum }}
     spec:
-      {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: dhctl.deckhouse.io/node-for-converge
+                    operator: DoesNotExist
+{{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
 {{- if .Values.deckhouse.nodeSelector }}
       nodeSelector:
         {{- .Values.deckhouse.nodeSelector | toYaml | nindent 8 }}

--- a/werf.yaml
+++ b/werf.yaml
@@ -453,7 +453,7 @@ ansible:
         chdir: /dhctl
 ---
 image: dhctl-tests
-fromCacheVersion: "20220125"
+fromCacheVersion: "20220131"
 fromImage: base-for-go
 git:
 - add: /


### PR DESCRIPTION
## Description
Add probes for check connection to control plane nodes and control-plane manager pod for node.
Add hook for terraform runner with 3 methods: before operation action, check ready and before action.
For control plane nodes we set special label on node and evict deckhouse pod (if need) wait deckhouse is ready, check connect to each node and check ready control-plane manager pod on each node is ready.

Another things:
- small refact converge 
- heal ssh-host param for control plane nodes
- add additional commands for check
- ssh-agent now started in one instance
- add node affinity for deckhouse for evicting

## Why we need it and what problem does it solve?
Close [issue](https://github.com/deckhouse/deckhouse/issues/113)

We need to make sure that the control plane components are ready and healthy in order to safely update the node.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: dhctl
type: feature
description: "Control plane readiness check before control plane node converging"
---
module: deckhouse
type: feature
description: "Add node affinity in deckhouse deployment for evicting pod from converging node"
note: "Node with label 'dhctl.deckhouse.io/node-for-converge' exclude from scheduling deckhouse pod"
```