### PR TITLE
[ci][validators] Golang copyright one line comments without previous new line

### DIFF
--- a/tools/validation/copyright.go
+++ b/tools/validation/copyright.go
@@ -25,8 +25,7 @@ import (
 
 var EELicenseRe = regexp.MustCompile(`(?s)Copyright 2021 Flant JSC.*Licensed under the Deckhouse Platform Enterprise Edition \(EE\) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE`)
 
-var CELicenseRe = regexp.MustCompile(`(?s)
-[/#{!-]*(\s)*Copyright 2021 Flant JSC[-!}\n#/]*
+var CELicenseRe = regexp.MustCompile(`(?s)[/#{!-]*(\s)*Copyright 2021 Flant JSC[-!}\n#/]*
 [/#{!-]*(\s)*Licensed under the Apache License, Version 2.0 \(the \"License\"\);[-!}\n]*
 [/#{!-]*(\s)*you may not use this file except in compliance with the License.[-!}\n]*
 [/#{!-]*(\s)*You may obtain a copy of the License at[-!}\n#/]*

--- a/tools/validation/copyright_test.go
+++ b/tools/validation/copyright_test.go
@@ -30,7 +30,13 @@ no license
 		t.Errorf("should not detect license")
 	}
 
-	in = `
+	validCases := []struct {
+		title   string
+		content string
+	}{
+		{
+			title: "Bash comment with previous spaces",
+			content: `
 #!/bin/bash
 
 # Copyright 2021 Flant JSC
@@ -49,11 +55,188 @@ no license
 
 
 set -Eeo pipefail
-`
+`,
+		},
 
-	res = CELicenseRe.Match([]byte(in))
+		{
+			title: "Bash comment without previous spaces",
+			content: `#!/bin/bash
+# Copyright 2021 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-	if !res {
-		t.Errorf("should detect license")
+
+set -Eeo pipefail
+`,
+		},
+
+		{
+			title: "Golang multiline comment without previous spaces",
+			content: `/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+  "fmt"
+  "os"
+)
+
+func main() {
+	fmt.Printf("Hello, world!")
+    os.Exit(0)
+}
+`,
+		},
+
+		{
+			title: "Golang multiline comment with previous spaces",
+			content: `
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+  "fmt"
+  "os"
+)
+
+func main() {
+	fmt.Printf("Hello, world!")
+    os.Exit(0)
+}
+`,
+		},
+
+		{
+			title: "Golang multiple one line comments without previous spaces",
+			content: `// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+  "fmt"
+  "os"
+)
+
+func main() {
+	fmt.Printf("Hello, world!")
+    os.Exit(0)
+}
+`,
+		},
+
+		{
+			title: "Golang multiple one line comments with previous spaces",
+			content: `
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+  "fmt"
+  "os"
+)
+
+func main() {
+	fmt.Printf("Hello, world!")
+    os.Exit(0)
+}
+`,
+		},
+
+		{
+			title: "Lua multiple one line comments without previous spaces",
+			content: `--[[
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+--]]
+
+local a = require "table.nkeys"
+
+print("Hello")
+`,
+		},
 	}
+
+	for _, c := range validCases {
+		t.Run(c.title, func(t *testing.T) {
+			res = CELicenseRe.Match([]byte(c.content))
+
+			if !res {
+				t.Errorf("should detect license")
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
## Description
Copyright validation was failed for golang files with multiple one line comments on top file. If add new line before comments validation passed.

Passed:

```

// ...
// ...
```

Not passed:

```
// ...
// ...
```

## Why we need it and what problem does it solve?
PR's with correct copyright comments failed on copyright validation

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: ci
type: fix
description: Copyright validation was failed for golang files with multiple one line comments on top file. If add new line before comments validation passed.
note: none
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
