### PR TITLE
[ci][validators] Fix "No Cyrillic" validator formatting

### DIFF
--- a/tools/validation/no_cyrillic.go
+++ b/tools/validation/no_cyrillic.go
@@ -137,7 +137,9 @@ func checkCyrillicLettersInString(line string) (string, bool) {
 	cursor = cyrPointerRe.ReplaceAllString(cursor, "^")
 	cursor = strings.TrimRight(cursor, "-")
 
-	return line + "\n" + cursor, true
+	const formatPrefix = "  "
+
+	return formatPrefix + line + "\n" + formatPrefix + cursor, true
 }
 
 // checkCyrillicLettersInArray returns a fancy message for each string in array that contains Cyrillic letters.


### PR DESCRIPTION
## Description
Add necessary two spaces before line and cursor

## Why we need it and what problem does it solve?
Test cases for "No Cyrillic" validator did not pass

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
