### PR TITLE
[yandex-cloud-provider] Fix. Add additionalExternalNetworkIDs config in openapi spec

### DIFF
--- a/modules/030-cloud-provider-yandex/openapi/config-values.yaml
+++ b/modules/030-cloud-provider-yandex/openapi/config-values.yaml
@@ -1,5 +1,11 @@
 type: object
 properties:
+  additionalExternalNetworkIDs:
+    type: array
+    items:
+      type: string
+    default: []
+    description: A list of Network IDs that will be considered `ExternalIP` when listing Node addresses. An optional parameter.
   storageClass:
     type: object
     properties:

--- a/modules/030-cloud-provider-yandex/openapi/doc-ru-config-values.yaml
+++ b/modules/030-cloud-provider-yandex/openapi/doc-ru-config-values.yaml
@@ -1,5 +1,11 @@
 type: object
 properties:
+  additionalExternalNetworkIDs:
+    type: array
+    items:
+      type: string
+    default: []
+    description: Cписок Network ID, которые будут считаться `ExternalIP` при перечислении адресов у Node. Опциональный параметр.
   storageClass:
     type: object
     properties:


### PR DESCRIPTION
## Description
When we refact yandex-cloud-provider module we forget add additionalExternalNetworkIDs in openapi spec

## Why we need it and what problem does it solve?
Deckhouse does not converge

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: yandex-cloud-provider
type: fix
description: Add additionalExternalNetworkIDs config in openapi spec, because dechouse does not converge if this field exists in cluster
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
