### PR TITLE
[deckhouse] fix update hook Manual mode

### DIFF
--- a/modules/020-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/020-deckhouse/hooks/update_deckhouse_image_test.go
@@ -25,26 +25,6 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = FDescribe("tmppp", func() {
-	f := HookExecutionConfigInit(`{
-        "global": {
-          "modulesImages": {
-			"registry": "my.registry.com/deckhouse"
-		  }
-        },
-		"deckhouse": {
-			"bundle": "Default",
-    		"logLevel": "Info",
-    		"releaseChannel": "Stable",
-    		"update": {
-      			"mode": "Manual"
-			}
-		}
-}`, `{}`)
-	f.RegisterCRD("deckhouse.io", "v1alpha1", "DeckhouseRelease", false)
-
-})
-
 var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", func() {
 	f := HookExecutionConfigInit(`{
         "global": {

--- a/modules/020-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/020-deckhouse/hooks/update_deckhouse_image_test.go
@@ -25,6 +25,26 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
+var _ = FDescribe("tmppp", func() {
+	f := HookExecutionConfigInit(`{
+        "global": {
+          "modulesImages": {
+			"registry": "my.registry.com/deckhouse"
+		  }
+        },
+		"deckhouse": {
+			"bundle": "Default",
+    		"logLevel": "Info",
+    		"releaseChannel": "Stable",
+    		"update": {
+      			"mode": "Manual"
+			}
+		}
+}`, `{}`)
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "DeckhouseRelease", false)
+
+})
+
 var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", func() {
 	f := HookExecutionConfigInit(`{
         "global": {


### PR DESCRIPTION
## Description
Fix update deckhouse hook behavior

## Why we need it and what problem does it solve?
Second run of the hook with Manual update mode enabled leaded to the wrong behavior and always applied release

## Changelog entries

```changes
module: deckhouse
type: fix
description:  "Fix Deckhouse Manual update mode."
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
