### PR TITLE
[cert-manager] vault integration docs

### DIFF
--- a/modules/101-cert-manager/docs/FAQ.md
+++ b/modules/101-cert-manager/docs/FAQ.md
@@ -114,54 +114,54 @@ In this case, you have to check the `CAA (Certificate Authority Authorization)` 
 
 ## Vault integration
 
-You can use [this manual](https://learn.hashicorp.com/tutorials/vault/kubernetes-cert-manager?in=vault/kubernetes) for configuring certificate issuance using Vault
+You can use [this manual](https://learn.hashicorp.com/tutorials/vault/kubernetes-cert-manager?in=vault/kubernetes) for configuring certificate issuance using Vault.
 
-After pki setup and kubernetes auth you have yo create service account and copy it's secret reference:
+After configuring PKI and enabling Kubernetes [authorization](../../modules/140-user-authz/), you have to:
+- Create a service account and copy its secret reference:
 
-```bash
-$ kubectl create serviceaccount issuer
-$ ISSUER_SECRET_REF=$(kubectl get serviceaccount issuer -o json | jq -r ".secrets[].name")
-```
+  ```shell
+  kubectl create serviceaccount issuer
+  ISSUER_SECRET_REF=$(kubectl get serviceaccount issuer -o json | jq -r ".secrets[].name")
+  ```
+- Create an Issuer:
 
-Create Issuer:
-```bash
-$ kubectl apply -f - <<EOF
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: vault-issuer
-  namespace: default
-spec:
-  vault:
-    server: http://vault.default.svc.cluster.local:8200 # hashicorp instruction has misstype here
-    path: pki/sign/example-dot-com # configure in pki setup step
-    auth:
-      kubernetes:
-        mountPath: /v1/auth/kubernetes
-        role: issuer
-        secretRef:
-          name: $ISSUER_SECRET_REF
-          key: token
-EOF
-```
-
-
-After this actions you can create a Certificate:
-```bash
-$ kubectl apply -f - <<EOF
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: example-com
-  namespace: default
-spec:
-  secretName: example-com-tls
-  issuerRef:
+  ```shell
+  kubectl apply -f - <<EOF
+  apiVersion: cert-manager.io/v1
+  kind: Issuer
+  metadata:
     name: vault-issuer
-  commonName: www.example.com # allowed domains are set on pki setup
-  dnsNames:
-  - www.example.com
-EOF
-```
+    namespace: default
+  spec:
+    vault:
+      # HashiCorp instruction has mistype here
+      server: http://vault.default.svc.cluster.local:8200 
+      path: pki/sign/example-dot-com # configure in pki setup step
+      auth:
+        kubernetes:
+          mountPath: /v1/auth/kubernetes
+          role: issuer
+          secretRef:
+            name: $ISSUER_SECRET_REF
+            key: token
+  EOF
+  ```
+- Create a Certificate resource, to get a TLS certificate, which is issued by Vault CA:
 
-and get TLS certificate, which is issued by Vault CA
+  ```shell
+  kubectl apply -f - <<EOF
+  apiVersion: cert-manager.io/v1
+  kind: Certificate
+  metadata:
+    name: example-com
+    namespace: default
+  spec:
+    secretName: example-com-tls
+    issuerRef:
+      name: vault-issuer
+    # domains are set on PKI setup
+    commonName: www.example.com 
+    dnsNames:
+    - www.example.com
+  EOF
+  ```

--- a/modules/101-cert-manager/docs/FAQ_RU.md
+++ b/modules/101-cert-manager/docs/FAQ_RU.md
@@ -113,3 +113,58 @@ CAA record does not match issuer
 То необходимо проверить `CAA (Certificate Authority Authorization)` DNS запись у домена, для которого заказывается сертификат.
 Если вы хотите использовать Let’s Encrypt сертификаты, то у домена должна быть CAA запись: `issue "letsencrypt.org"`.
 Подробнее про CAA можно почитать [тут](https://www.xolphin.com/support/Terminology/CAA_DNS_Records) и [тут](https://letsencrypt.org/docs/caa/).
+
+
+## Интеграция с Vault
+
+Вы можете использовать [данную инструкцию](https://learn.hashicorp.com/tutorials/vault/kubernetes-cert-manager?in=vault/kubernetes) для выпуска сертификатов с помощью Vault
+
+После конфигурации pki и включения kubernetes аутентификации вам нужно создать service account и скопировать ссылку на его секрет:
+
+```bash
+$ kubectl create serviceaccount issuer
+$ ISSUER_SECRET_REF=$(kubectl get serviceaccount issuer -o json | jq -r ".secrets[].name")
+```
+
+И создать Issuer
+```bash
+$ kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: vault-issuer
+  namespace: default
+spec:
+  vault:
+    server: http://vault.default.svc.cluster.local:8200 # если вы разворачивался vault по вышеуказанной инструкции, обратите внимание - здесь в инструкции опечатка
+    path: pki/sign/example-dot-com # указывается на этапе конфигурации pki
+    auth:
+      kubernetes:
+        mountPath: /v1/auth/kubernetes
+        role: issuer
+        secretRef:
+          name: $ISSUER_SECRET_REF
+          key: token
+EOF
+```
+
+
+После этих действий можно создать сертификат:
+```bash
+$ kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: example-com
+  namespace: default
+spec:
+  secretName: example-com-tls
+  issuerRef:
+    name: vault-issuer
+  commonName: www.example.com # доступные домены указываются на этапе конфигурации pki в vault
+  dnsNames:
+  - www.example.com
+EOF
+```
+
+и получить TLS сертификат, подписанный Vault CA


### PR DESCRIPTION
## Description
Instructions for connection Vault with cert-manager

## Why we need it and what problem does it solve?
Hashicorp instruction has a few mistakes. This guide fixes it and gives our users a way to integrate a Vault Issuer into their infrastructure

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: cert-manager
type: feature
description: Instructions for connection Vault with cert-manager
note: only docs change
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
