### PR TITLE
[ingress-nginx][monitoring-k8s] Fix. Revert refresh on grafana dashboard

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/nodes.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/nodes.json
@@ -1829,7 +1829,7 @@
       }
     }
   ],
-  "refresh": "",
+  "refresh": "30s",
   "schemaVersion": 32,
   "style": "dark",
   "tags": [

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/controller.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/controller.json
@@ -3961,7 +3961,7 @@
       "type": "row"
     }
   ],
-  "refresh": "",
+  "refresh": "30s",
   "schemaVersion": 32,
   "style": "dark",
   "tags": [

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/namespace/namespace.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/namespace/namespace.json
@@ -4059,7 +4059,7 @@
       "type": "row"
     }
   ],
-  "refresh": "",
+  "refresh": "30s",
   "schemaVersion": 32,
   "style": "dark",
   "tags": [

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/namespace/namespaces.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/namespace/namespaces.json
@@ -3678,7 +3678,7 @@
       }
     }
   ],
-  "refresh": "",
+  "refresh": "30s",
   "schemaVersion": 32,
   "style": "dark",
   "tags": [

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/pod.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/pod.json
@@ -3965,7 +3965,7 @@
       "type": "row"
     }
   ],
-  "refresh": "",
+  "refresh": "30s",
   "schemaVersion": 32,
   "style": "dark",
   "tags": [

--- a/modules/402-ingress-nginx/monitoring/grafana-dashboards/ingress-nginx/vhost/vhost_detail.json
+++ b/modules/402-ingress-nginx/monitoring/grafana-dashboards/ingress-nginx/vhost/vhost_detail.json
@@ -9274,7 +9274,7 @@
       "type": "row"
     }
   ],
-  "refresh": "",
+  "refresh": "30s",
   "schemaVersion": 32,
   "style": "dark",
   "tags": [

--- a/modules/402-ingress-nginx/monitoring/grafana-dashboards/ingress-nginx/vhost/vhosts.json
+++ b/modules/402-ingress-nginx/monitoring/grafana-dashboards/ingress-nginx/vhost/vhosts.json
@@ -7605,7 +7605,7 @@
       "type": "row"
     }
   ],
-  "refresh": "",
+  "refresh": "30s",
   "schemaVersion": 32,
   "style": "dark",
   "tags": [


### PR DESCRIPTION
## Description
We add regression in [commit](https://github.com/deckhouse/deckhouse/commit/41b17676c122daf9dcfb0f5dff0d9ee867115506) 
Dashboard does not have refresh

## Why we need it and what problem does it solve?
Refresh does not work in part of dashboards 

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: monitoring
type: fix
description: Refresh does not work on some dashboards
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
