### PR TITLE
[deckhouse] fix update deckhouse hook

### DIFF
--- a/modules/020-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/020-deckhouse/hooks/update_deckhouse_image_test.go
@@ -241,6 +241,21 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 			})
 		})
 	})
+
+	Context("Single First Release", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(deckhousePodYaml + deckhousePatchRelease)
+			f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
+			f.RunHook()
+		})
+
+		It("Should update deckhouse deployment", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-1").Field("status.phase").String()).To(Equal("Deployed"))
+			dep := f.KubernetesResource("Deployment", "d8-system", "deckhouse")
+			Expect(dep.Field("spec.template.spec.containers").Array()[0].Get("image").String()).To(BeEquivalentTo("my.registry.com/deckhouse:v1.25.1"))
+		})
+	})
 })
 
 var (


### PR DESCRIPTION
## Description
First DeckhouseRelease in the cluster led to panic

## Why we need it and what problem does it solve?
Fix possible panic

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: deckhouse
type: fix 
description: Fix panic on a first DeckhouseRelease CR
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
