### PR TITLE
[ingress-nginx] add the ability to set a default certificate

### DIFF
--- a/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/doc-ru-ingress-nginx.yaml
@@ -287,6 +287,22 @@ spec:
                 maxReplicas:
                   description: |
                     Максимально количество реплик `LoadBalancer` и `LoadBalancerWithProxyProtocol` для HPA.
+                defaultSSLCertificate:
+                  description: |
+                    Этот сертификат используется, в случаях обращений на `catch-all` сервер (запросы, для которых на найден подходящщий Ingress) и для Ingress–ресурсов, в которых не задан `secretName` в секции `tls:`.
+
+                    По–умолчанию будет использоваться самоподписанный сертификат.
+                  properties:
+                    secretRef:
+                      description: |
+                        Ссылка на Secret для передачи Ingress Controller.
+                      properties:
+                        name:
+                          description: |
+                            Имя секрета, содержащего SSL–сертификат.
+                        namespace:
+                          description: |
+                            Имя namespace, в котором находится секрет с SSL—сертификатом.
     - name: v1
       served: true
       storage: false

--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -35,7 +35,7 @@ spec:
 
                     **Caution!** If you set it to "nginx", then Ingress resources lacking the `kubernetes.io/ingress.class` annotation will also be handled.
                   example: 'nginx'
-                  pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
+                  pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
                 inlet:
                   type: string
                   description: |
@@ -473,6 +473,29 @@ spec:
                     LoadBalancer and LoadBalancerWithProxyProtocol controller's Horizontal Pod Autoscaler maximum replicas count.
                   default: 1
                   minimum: 1
+                defaultSSLCertificate:
+                  description: |
+                    This certificate will be used when accessing the catch-all server and for Ingress resources without a `secretName` option in `tls:` section.
+
+                    By default a self-signed certificate will be used.
+                  type: object
+                  properties:
+                    secretRef:
+                      description: |
+                        The Secret reference to pass to the Ingress Controller.
+                      type: object
+                      properties:
+                        name:
+                          description: |
+                            Name of Secret containing SSL—certificate.
+                          type: string
+                          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+                        namespace:
+                          description: |
+                            Namespace, where the Secret is located.
+                          default: d8-ingress-nginx
+                          type: string
+                          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
               oneOf:
                 - properties:
                     inlet:

--- a/modules/402-ingress-nginx/openapi/values.yaml
+++ b/modules/402-ingress-nginx/openapi/values.yaml
@@ -255,3 +255,13 @@ properties:
                   type: integer
                 maxReplicas:
                   type: integer
+                defaultSSLCertificate:
+                  type: object
+                  properties:
+                    secretRef:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -16,6 +16,8 @@
 {{- else if eq $crd.spec.inlet "HostWithFailover" }}
   {{- $defaultGracePeriod = 0 }}
 {{- end }}
+{{- $defaultSSLCertificate := $crd.spec.defaultSSLCertificate | default dict }}
+{{- $defaultSSLCertificateSecretRef := $defaultSSLCertificate.secretRef | default dict }}
 
 ---
 apiVersion: policy/v1beta1
@@ -193,6 +195,9 @@ spec:
         - --validating-webhook=:8443
         - --validating-webhook-certificate=/etc/nginx/webhook-ssl/tls.crt
         - --validating-webhook-key=/etc/nginx/webhook-ssl/tls.key
+        {{- end }}
+        {{- if $defaultSSLCertificateSecretRef.name }}
+        - --default-ssl-certificate={{ printf "%s/%s" $defaultSSLCertificateSecretRef.namespace $defaultSSLCertificateSecretRef.name }}
         {{- end }}
   {{- if $crd.spec.customErrors }}
         - --default-backend-service={{ $crd.spec.customErrors.namespace }}/{{ $crd.spec.customErrors.serviceName }}

--- a/modules/402-ingress-nginx/webhooks/validating/ingressnginxcontroller
+++ b/modules/402-ingress-nginx/webhooks/validating/ingressnginxcontroller
@@ -31,33 +31,41 @@ kubernetesValidating:
 EOF
 }
 
+function forbid() {
+  jq -nc --arg message "$1" '
+    {
+      "allowed": false,
+      "message": $message
+    }
+    ' > $VALIDATING_RESPONSE_PATH
+}
+
 function __main__() {
   # Inlet on-flight change prohibited
   if context::jq -e -r '.review.request.operation == "UPDATE"' >/dev/null 2>&1; then
     oldInlet=$(context::jq -r '.review.request.oldObject.spec.inlet')
     if context::jq -e -r --arg oldInlet "$oldInlet" '.review.request.object.spec.inlet != $oldInlet' >/dev/null 2>&1; then
-      cat <<EOF > $VALIDATING_RESPONSE_PATH
-{"allowed":false, "message":".spec.inlet change prohibited"}
-EOF
-      exit 0;
+      forbid ".spec.inlet field is immutable"
+      exit 0
     fi
   fi
-
 
   if context::jq -e -r '.review.request.name | endswith("-failover")' >/dev/null 2>&1; then
     # -failover suffix is reserved for HostWithFailover inlet
     # To avoid collisions, we should forbid saving controllers with such name.
-    cat <<EOF > $VALIDATING_RESPONSE_PATH
-{"allowed":false, "message":"it is forbidden to create IngressNginxController with '-failover' suffix"}
-EOF
-    exit 0;
+    forbid ".metadata.name ends with reserved suffix \"-failover\""
+    exit 0
   fi
 
+  if defaultSSLSecret=( $(context::jq -re '.review.request.object.spec.defaultSSLCertificate.secretRef // empty | .namespace, .name') ); then
+    if ! kubectl get secret -n ${defaultSSLSecret[0]} ${defaultSSLSecret[1]} >/dev/null 2>&1; then
+      forbid ".spec.defaultSSLCertificate field contains reference to non existent Secret \"${defaultSSLSecret[0]}/${defaultSSLSecret[1]}\""
+      exit 0
+    fi
+  fi
 
-  # allowed response
-  cat <<EOF > $VALIDATING_RESPONSE_PATH
-{"allowed":true}
-EOF
+  # Allowed response.
+  jq -nc '{"allowed": true}' > $VALIDATING_RESPONSE_PATH
 }
 
 hook::run $@


### PR DESCRIPTION
## Description
- Add additional `.spec.defaultSSLCertificate.secretRef` field for IngressNginxController that controlls the value of `--default-ssl-certificate` argument of the particular nginx-ingress-controller.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why we need it and what problem does it solve?
Solves [#273](https://github.com/deckhouse/deckhouse/issues/273).
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: ‎ingress-nginx‎
type: feature
description: "Add the ability to set a default certificate."
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
