### PR TITLE
[ci] feat(ci): use 'regular' label to schedule non e2e jobs

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -15,7 +15,7 @@ steps:
 {!{ end }!}
 
 {!{ define "build_modules_images_template" }!}
-runs-on: self-hosted
+runs-on: [self-hosted, regular]
 steps:
   {!{ tmpl.Exec "checkout_full_step" . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 2 }!}
@@ -48,7 +48,7 @@ steps:
 {!{ end }!}
 
 {!{ define "build_template" }!}
-runs-on: self-hosted
+runs-on: [self-hosted, regular]
 steps:
   {!{ tmpl.Exec "checkout_full_step" . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 2 }!}

--- a/.github/ci_templates/tests.yml
+++ b/.github/ci_templates/tests.yml
@@ -36,7 +36,7 @@ docker_options: '-w /deckhouse'
   {!{- $args_tmpl := printf "%s_run_args" $args_name }!}
   {!{- $default := dict "image" "tests" "args" "echo no args" "docker_options" "" }!}
   {!{- $ctx := coll.Merge (tmpl.Exec $args_tmpl | yaml) $default }!}
-runs-on: self-hosted
+runs-on: [self-hosted, regular]
 steps:
   {!{ tmpl.Exec "checkout_full_step" . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 2 }!}

--- a/.github/ci_templates/web.yml
+++ b/.github/ci_templates/web.yml
@@ -1,5 +1,5 @@
 {!{- define "doc_web_build_template" -}!}
-runs-on: self-hosted
+runs-on: [self-hosted, regular]
 steps:
   {!{ tmpl.Exec "checkout_full_step" . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}
@@ -16,7 +16,7 @@ steps:
 {!{- end -}!}
 
 {!{- define "main_web_build_template" -}!}
-runs-on: self-hosted
+runs-on: [self-hosted, regular]
 steps:
   {!{ tmpl.Exec "checkout_full_step" . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}
@@ -33,7 +33,7 @@ steps:
 {!{- end -}!}
 
 {!{- define "web_links_test_template" -}!}
-runs-on: self-hosted
+runs-on: [self-hosted, regular]
 steps:
   {!{ tmpl.Exec "checkout_full_step" . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -206,7 +206,7 @@ jobs:
       - main_web_build
     continue-on-error: true
     if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 {!{ tmpl.Exec "doc_version_template" | strings.Indent 6 }!}
 {!{ tmpl.Exec "deploy_doc_template" "production" | strings.Indent 6 }!}
@@ -221,7 +221,7 @@ jobs:
       - doc_web_build
     continue-on-error: true
     if: ${{ needs.git_info.outputs.ci_commit_tag != '' }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 {!{ tmpl.Exec "doc_version_template" | strings.Indent 6 }!}
 {!{ tmpl.Exec "deploy_doc_template" "stage" | strings.Indent 6 }!}

--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -47,7 +47,7 @@ jobs:
       - check_label
       - git_info
     if: needs.check_label.outputs.should_run == 'true'
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 {!{ tmpl.Exec "checkout_from_event_ref_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "update_comment_on_start" $workflowName | strings.Indent 6 }!}

--- a/.github/workflow_templates/deploy-web.multi.yml
+++ b/.github/workflow_templates/deploy-web.multi.yml
@@ -45,7 +45,7 @@ jobs:
     - git_info
     if: needs.check_label.outputs.should_run == 'true'
     name: Deploy site
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 {!{ tmpl.Exec "checkout_from_event_ref_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "update_comment_on_start" $workflowName | strings.Indent 6 }!}

--- a/.github/workflow_templates/schedule-cleanup.yml
+++ b/.github/workflow_templates/schedule-cleanup.yml
@@ -24,7 +24,7 @@ jobs:
     name: Cleanup registry
     needs:
       - git_info
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 {!{ tmpl.Exec "checkout_full_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 6 }!}
@@ -46,7 +46,7 @@ jobs:
     name: Cleanup modules registry
     needs:
       - git_info
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 {!{ tmpl.Exec "checkout_full_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 6 }!}
@@ -68,7 +68,7 @@ jobs:
 
   cleanup_modules_images:
     name: Cleanup modules images
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 {!{ tmpl.Exec "checkout_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 6 }!}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -140,7 +140,7 @@ jobs:
     needs:
       - git_info
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -247,7 +247,7 @@ jobs:
       - build_modules_images_fe
       - go_generate
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -377,7 +377,7 @@ jobs:
     needs:
       - git_info
       - build_modules_images_fe
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -416,7 +416,7 @@ jobs:
     needs:
       - git_info
       - build_modules_images_fe
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -456,7 +456,7 @@ jobs:
       - build_modules_images_fe
       - build_fe
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -506,7 +506,7 @@ jobs:
       - build_modules_images_fe
       - build_fe
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -556,7 +556,7 @@ jobs:
       - build_modules_images_fe
       - build_fe
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -606,7 +606,7 @@ jobs:
       - build_modules_images_fe
       - build_fe
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -656,7 +656,7 @@ jobs:
       - build_modules_images_fe
       - build_fe
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -706,7 +706,7 @@ jobs:
       - doc_web_build
       - main_web_build
     continue-on-error: true
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -809,7 +809,7 @@ jobs:
       - build_modules_images_fe
       - build_fe
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -162,7 +162,7 @@ jobs:
       - git_info
       - comment_on_start
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -262,7 +262,7 @@ jobs:
     env:
       WERF_ENV: "EE"
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -362,7 +362,7 @@ jobs:
     env:
       WERF_ENV: "CE"
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -511,7 +511,7 @@ jobs:
     env:
       WERF_ENV: "FE"
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -665,7 +665,7 @@ jobs:
     env:
       WERF_ENV: "EE"
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -819,7 +819,7 @@ jobs:
     env:
       WERF_ENV: "CE"
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -969,7 +969,7 @@ jobs:
     needs:
       - git_info
       - build_modules_images_fe
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -1028,7 +1028,7 @@ jobs:
     needs:
       - git_info
       - build_modules_images_fe
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -1089,7 +1089,7 @@ jobs:
       - build_fe
     continue-on-error: true
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -1160,7 +1160,7 @@ jobs:
       - build_fe
     continue-on-error: true
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -1231,7 +1231,7 @@ jobs:
       - build_fe
     continue-on-error: true
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -1302,7 +1302,7 @@ jobs:
       - build_fe
     continue-on-error: true
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -1373,7 +1373,7 @@ jobs:
       - build_fe
     continue-on-error: true
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -1443,7 +1443,7 @@ jobs:
       - doc_web_build
       - main_web_build
     continue-on-error: true
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -1567,7 +1567,7 @@ jobs:
       - build_fe
     continue-on-error: true
 
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -1639,7 +1639,7 @@ jobs:
       - main_web_build
     continue-on-error: true
     if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Set documentation version
@@ -1705,7 +1705,7 @@ jobs:
       - doc_web_build
     continue-on-error: true
     if: ${{ needs.git_info.outputs.ci_commit_tag != '' }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Set documentation version

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -126,7 +126,7 @@ jobs:
       - check_label
       - git_info
     if: needs.check_label.outputs.should_run == 'true'
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -126,7 +126,7 @@ jobs:
       - check_label
       - git_info
     if: needs.check_label.outputs.should_run == 'true'
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -126,7 +126,7 @@ jobs:
       - check_label
       - git_info
     if: needs.check_label.outputs.should_run == 'true'
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -126,7 +126,7 @@ jobs:
       - check_label
       - git_info
     if: needs.check_label.outputs.should_run == 'true'
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -126,7 +126,7 @@ jobs:
       - check_label
       - git_info
     if: needs.check_label.outputs.should_run == 'true'
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources

--- a/.github/workflows/deploy-web-stage.yml
+++ b/.github/workflows/deploy-web-stage.yml
@@ -163,7 +163,7 @@ jobs:
     - git_info
     if: needs.check_label.outputs.should_run == 'true'
     name: Deploy site
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources

--- a/.github/workflows/deploy-web-test.yml
+++ b/.github/workflows/deploy-web-test.yml
@@ -163,7 +163,7 @@ jobs:
     - git_info
     if: needs.check_label.outputs.should_run == 'true'
     name: Deploy site
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources

--- a/.github/workflows/schedule-cleanup.yml
+++ b/.github/workflows/schedule-cleanup.yml
@@ -132,7 +132,7 @@ jobs:
     name: Cleanup registry
     needs:
       - git_info
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -190,7 +190,7 @@ jobs:
     name: Cleanup modules registry
     needs:
       - git_info
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources
@@ -248,7 +248,7 @@ jobs:
 
   cleanup_modules_images:
     name: Cleanup modules images
-    runs-on: self-hosted
+    runs-on: [self-hosted, regular]
     steps:
 
       - name: Checkout sources


### PR DESCRIPTION
## Description

Add 'regular' label to schedule non-e2e jobs.

## Why we need it and what problem does it solve?

Sometimes non-e2e jobs are accidentally scheduled to the wrong runner. Additional label for runners prevents this situation.
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->


<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
