### PR TITLE
[prometheus][grafana][prometheus-crd][flant-integration] Add grafana alerts notification channels and migrate to proxy (server) data sources from direct (browser).

### DIFF
--- a/ee/modules/600-flant-integration/images/madison-proxy/rootfs/etc/nginx/madison.tmpl
+++ b/ee/modules/600-flant-integration/images/madison-proxy/rootfs/etc/nginx/madison.tmpl
@@ -25,6 +25,10 @@ server {
 
     rewrite /api/v2/alerts /api/events/prometheus/${MADISON_AUTH_KEY} break;
 
+    # grafana only support v1 endpoint.
+    # see https://github.com/grafana/grafana/discussions/42805 for additional information
+    rewrite /api/v1/alerts /api/events/prometheus/${MADISON_AUTH_KEY} break;
+
     proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504 http_403 http_404 http_429 non_idempotent;
     proxy_ssl_server_name on;
     proxy_ssl_name madison.flant.com;

--- a/ee/modules/600-flant-integration/templates/madison-proxy-grafana-alert-channel.yaml
+++ b/ee/modules/600-flant-integration/templates/madison-proxy-grafana-alert-channel.yaml
@@ -1,0 +1,14 @@
+{{- if and (.Values.flantIntegration.madisonAuthKey) (and ($.Values.global.enabledModules | has "prometheus-crd") ($.Values.global.enabledModules | has "prometheus")) }}
+apiVersion: deckhouse.io/v1alpha1
+kind: GrafanaAlertsChannel
+metadata:
+  name: madison-proxy
+{{ include "helm_lib_module_labels" (list . (dict "app" "madison-proxy")) | indent 2 }}
+spec:
+  description: "Channel to send alerts to Polk. Auto-created by flant-integration module."
+  type: PrometheusAlertManager
+  # TODO: think about disable default from config
+  isDefault: true
+  alertManager:
+    address: {{ printf "http://madison-proxy.d8-monitoring.svc.%s:8080" .Values.global.discovery.clusterDomain | quote }}
+{{- end }}

--- a/go_lib/module/module.go
+++ b/go_lib/module/module.go
@@ -65,6 +65,7 @@ func GetHTTPSMode(moduleName string, input *go_hook.HookInput) string {
 	panic("https mode is not defined")
 }
 
+// IsEnabled check module on enable. moduleName should be in `kebab-case` without order prefix
 func IsEnabled(moduleName string, input *go_hook.HookInput) bool {
 	return set.NewFromValues(input.Values, "global.enabledModules").Has(moduleName)
 }

--- a/modules/010-prometheus-crd/crds/doc-ru-grafanaalertschannel.yaml
+++ b/modules/010-prometheus-crd/crds/doc-ru-grafanaalertschannel.yaml
@@ -1,0 +1,87 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: grafanaalertschannels.deckhouse.io
+  labels:
+    heritage: deckhouse
+    module: prometheus
+    app: grafana
+spec:
+  group: deckhouse.io
+  scope: Cluster
+  names:
+    plural: grafanaalertschannels
+    singular: grafanaalertschannel
+    kind: GrafanaAlertsChannel
+  preserveUnknownFields: false
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: Ресурс для добавления каналов оповещения в Grafana.
+          required: ['spec']
+          properties:
+            spec:
+              type: object
+              required:
+              - type
+              - alertManager
+              properties:
+                description:
+                  type: string
+                  default: ""
+                  description: Небольшое необязательное описание для этого канала предупреждений.
+                type:
+                  type: string
+                  enum: ["PrometheusAlertManager"]
+                disableResolveMessage:
+                  type: boolean
+                  default: false
+                  description: Отключает отправку алерта о разрешении [OK] когда состояние алерт возвращается в неактивное состояние.
+                isDefault:
+                  type: boolean
+                  default: false
+                  description: Использовать этот канал для всех алертов.
+                alertManager:
+                  type: object
+                  description: Настройка канала внешнего Prometheus Alert Manager.
+                  required:
+                  - address
+                  properties:
+                    address:
+                      type: string
+                      x-examples: [ "http://alerts.mycompany.com", "https://alerts.company.com", "http://192.168.1.1" ]
+                      pattern: "^https?://[^\\s/$.?#].[^\\s]*$"
+                      description: URL внешнего Alertmanager.
+                    auth:
+                      type: object
+                      description: Параметры авторизации.
+                      required:
+                      - basic
+                      properties:
+                        basic:
+                          type: object
+                          description: Basic authorization параметры.
+                          required:
+                          - username
+                          - password
+                          properties:
+                            username:
+                              description: Пользователь.
+                              type: string
+                            password:
+                              description: Пароль.
+                              type: string
+                              format: password
+      additionalPrinterColumns:
+        - jsonPath: .spec.type
+          name: Type
+          description: Тип канала.
+          type: string
+        - jsonPath: .spec.description
+          name: Description
+          description: Описание канала.
+          type: string

--- a/modules/010-prometheus-crd/crds/grafanaalertschannel.yaml
+++ b/modules/010-prometheus-crd/crds/grafanaalertschannel.yaml
@@ -1,0 +1,87 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: grafanaalertschannels.deckhouse.io
+  labels:
+    heritage: deckhouse
+    module: prometheus
+    app: grafana
+spec:
+  group: deckhouse.io
+  scope: Cluster
+  names:
+    plural: grafanaalertschannels
+    singular: grafanaalertschannel
+    kind: GrafanaAlertsChannel
+  preserveUnknownFields: false
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: The resource for adding alert notification channels to Grafana.
+          required: ['spec']
+          properties:
+            spec:
+              type: object
+              required:
+              - type
+              - alertManager
+              properties:
+                description:
+                  type: string
+                  default: ""
+                  description: Small and optional description about this alerts channel.
+                type:
+                  type: string
+                  enum: ["PrometheusAlertManager"]
+                disableResolveMessage:
+                  type: boolean
+                  default: false
+                  description: When true, this option disables the resolve message [OK] that is sent when the alerting state returns to false.
+                isDefault:
+                  type: boolean
+                  default: false
+                  description: Use this notification channel for all alerts.
+                alertManager:
+                  type: object
+                  description: Alert manager settings.
+                  required:
+                  - address
+                  properties:
+                    address:
+                      type: string
+                      x-examples: [ "http://alerts.mycompany.com", "https://alerts.company.com", "http://192.168.1.1" ]
+                      pattern: "^https?://[^\\s/$.?#].[^\\s]*$"
+                      description: URL of an external Alertmanager.
+                    auth:
+                      type: object
+                      description: Authorization properties.
+                      required:
+                      - basic
+                      properties:
+                        basic:
+                          type: object
+                          description: Basic authorization properties.
+                          required:
+                          - username
+                          - password
+                          properties:
+                            username:
+                              description: User name.
+                              type: string
+                            password:
+                              description: Password.
+                              type: string
+                              format: password
+      additionalPrinterColumns:
+        - jsonPath: .spec.type
+          name: Type
+          description: Alerts channel type.
+          type: string
+        - jsonPath: .spec.description
+          name: Description
+          description: Alerts channel description.
+          type: string

--- a/modules/300-prometheus/hooks/grafana_alerts_channels.go
+++ b/modules/300-prometheus/hooks/grafana_alerts_channels.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/modules/300-prometheus/hooks/internal/v1alpha1"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/prometheus/grafana_alerts_channels",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "grafana_alerts_channels",
+			ApiVersion: "deckhouse.io/v1alpha1",
+			Kind:       "GrafanaAlertsChannel",
+			FilterFunc: filterGrafanaAlertsChannelCRD,
+		},
+	},
+}, grafanaAlertsChannelsHandler)
+
+type GrafanaAlertsChannel struct {
+	OrgID                 int                    `json:"org_id"`
+	Type                  string                 `json:"type"`
+	Name                  string                 `json:"name"`
+	UID                   string                 `json:"uid"`
+	IsDefault             bool                   `json:"is_default"`
+	DisableResolveMessage bool                   `json:"disable_resolve_message"`
+	SendReminder          bool                   `json:"send_reminder"`
+	Frequency             time.Duration          `json:"frequency,omitempty"`
+	Settings              map[string]interface{} `json:"settings"`
+	SecureSettings        map[string]interface{} `json:"secure_settings"`
+}
+
+type GrafanaAlertsChannelsConfig struct {
+	Notifiers []*GrafanaAlertsChannel `json:"notifiers"`
+}
+
+func getChannelSettings(notifyChannel *v1alpha1.GrafanaAlertsChannel) (settings map[string]interface{}, secureSettings map[string]interface{}, err error) {
+	settings = make(map[string]interface{})
+	secureSettings = make(map[string]interface{})
+
+	if notifyChannel.Spec.Type == "PrometheusAlertManager" {
+		alertManager := notifyChannel.Spec.AlertManager
+		settings["url"] = alertManager.Address
+
+		auth := alertManager.Auth
+		if auth != nil {
+			settings["basicAuthUser"] = auth.Basic.Username
+			secureSettings["basicAuthPassword"] = auth.Basic.Password
+		}
+	}
+
+	return settings, secureSettings, nil
+}
+
+func filterGrafanaAlertsChannelCRD(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var notifyChannel v1alpha1.GrafanaAlertsChannel
+
+	err := sdk.FromUnstructured(obj, &notifyChannel)
+	if err != nil {
+		return nil, fmt.Errorf("cannot unmarshal unstructure object %s/%s to v1alpha1.GrafanaAlertsChannel: %v", obj.GetNamespace(), obj.GetName(), err)
+	}
+
+	grafanaChannelType, ok := v1alpha1.GrafanaAlertChannelTypes[notifyChannel.Spec.Type]
+	if !ok {
+		return nil, fmt.Errorf("unsupported GrafanaAlertsChannel type %s", notifyChannel.Spec.Type)
+	}
+
+	settings, securitySettings, err := getChannelSettings(&notifyChannel)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GrafanaAlertsChannel{
+		OrgID:                 1,
+		Name:                  obj.GetName(),
+		UID:                   obj.GetName(),
+		IsDefault:             notifyChannel.Spec.IsDefault,
+		Type:                  grafanaChannelType,
+		DisableResolveMessage: notifyChannel.Spec.DisableResolveMessage,
+		Settings:              settings,
+		SecureSettings:        securitySettings,
+	}, nil
+}
+
+func grafanaAlertsChannelsHandler(input *go_hook.HookInput) error {
+	alertsChannelsRaw := input.Snapshots["grafana_alerts_channels"]
+
+	alertsChannels := make([]*GrafanaAlertsChannel, 0)
+
+	for _, nchRaw := range alertsChannelsRaw {
+		nch := nchRaw.(*GrafanaAlertsChannel)
+		alertsChannels = append(alertsChannels, nch)
+	}
+
+	cfg := GrafanaAlertsChannelsConfig{
+		Notifiers: alertsChannels,
+	}
+
+	input.Values.Set("prometheus.internal.grafana.alertsChannelsConfig", cfg)
+
+	return nil
+}

--- a/modules/300-prometheus/hooks/grafana_alerts_channels_test.go
+++ b/modules/300-prometheus/hooks/grafana_alerts_channels_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"encoding/json"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Prometheus hooks :: grafana notification channels ::", func() {
+	const (
+		testAlertsChannelYAML = `
+apiVersion: deckhouse.io/v1alpha1
+kind: GrafanaAlertsChannel
+metadata:
+  name: test
+spec:
+  type: PrometheusAlertManager
+  description: Another text
+  isDefault: true
+  disableResolveMessage: false
+  alertManager:
+    address: "http://test-alert-manager-url"
+    auth:
+      basic:
+        username: user
+        password: password
+`
+		testAlertsChanelUpdatedYAML = `
+apiVersion: deckhouse.io/v1alpha1
+kind: GrafanaAlertsChannel
+metadata:
+  name: test
+spec:
+  type: PrometheusAlertManager
+  description: SomeText
+  isDefault: false
+  disableResolveMessage: true
+  alertManager:
+    address: "https://new-test-url"
+    auth:
+      basic:
+        username: user
+        password: new-password
+`
+		testAlertsChannelWithoutAuthYAML = `
+apiVersion: deckhouse.io/v1alpha1
+kind: GrafanaAlertsChannel
+metadata:
+  name: another
+spec:
+  type: PrometheusAlertManager
+  alertManager:
+    address: "https://another-url"
+`
+	)
+
+	var (
+		testAlertsChannel = GrafanaAlertsChannel{
+			OrgID:                 1,
+			Type:                  "prometheus-alertmanager",
+			Name:                  "test",
+			UID:                   "test",
+			IsDefault:             true,
+			DisableResolveMessage: false,
+			SendReminder:          false,
+			Frequency:             time.Duration(0),
+			Settings: map[string]interface{}{
+				"url":           "http://test-alert-manager-url",
+				"basicAuthUser": "user",
+			},
+			SecureSettings: map[string]interface{}{
+				"basicAuthPassword": "password",
+			},
+		}
+
+		testAlertsChanelUpdated = GrafanaAlertsChannel{
+			OrgID:                 1,
+			Type:                  "prometheus-alertmanager",
+			Name:                  "test",
+			UID:                   "test",
+			IsDefault:             false,
+			DisableResolveMessage: true,
+			SendReminder:          false,
+			Frequency:             time.Duration(0),
+			Settings: map[string]interface{}{
+				"url":           "https://new-test-url",
+				"basicAuthUser": "user",
+			},
+			SecureSettings: map[string]interface{}{
+				"basicAuthPassword": "new-password",
+			},
+		}
+
+		testAlertsChannelWithoutAuth = GrafanaAlertsChannel{
+			OrgID:                 1,
+			Type:                  "prometheus-alertmanager",
+			Name:                  "another",
+			UID:                   "another",
+			IsDefault:             false,
+			DisableResolveMessage: false,
+			SendReminder:          false,
+			Frequency:             time.Duration(0),
+			Settings: map[string]interface{}{
+				"url": "https://another-url",
+			},
+			SecureSettings: make(map[string]interface{}),
+		}
+	)
+
+	f := HookExecutionConfigInit(`
+{
+  "global": {
+    "enabledModules": [],
+    "discovery":{
+		"clusterDomain": "cluster.my"
+    }
+  },
+  "prometheus":{
+    "internal":{
+      "grafana":{}
+    }
+ }
+}`, ``)
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "GrafanaAlertsChannel", false)
+
+	assertChannelsInValues := func(f *HookExecutionConfig, expectChannels []GrafanaAlertsChannel) {
+		cfgJSON := f.ValuesGet("prometheus.internal.grafana.alertsChannelsConfig").Raw
+
+		var cfg GrafanaAlertsChannelsConfig
+		err := json.Unmarshal([]byte(cfgJSON), &cfg)
+		Expect(err).ToNot(HaveOccurred())
+
+		channels := cfg.Notifiers
+
+		Expect(channels).To(HaveLen(len(expectChannels)))
+
+		nameToChannel := make(map[string]GrafanaAlertsChannel)
+		for _, c := range expectChannels {
+			nameToChannel[c.UID] = c
+		}
+
+		for _, c := range channels {
+			expected, ok := nameToChannel[c.UID]
+
+			Expect(ok).To(BeTrue())
+			Expect(expected).To(Equal(*c))
+		}
+	}
+
+	Context("Empty cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Should store config in values", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			exists := f.ValuesGet("prometheus.internal.grafana.alertsChannelsConfig").Exists()
+			Expect(exists).To(BeTrue())
+
+			exists = f.ValuesGet("prometheus.internal.grafana.alertsChannelsConfig.notifiers").Exists()
+			Expect(exists).To(BeTrue())
+		})
+
+		It("Does not set any channels in values", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			assertChannelsInValues(f, make([]GrafanaAlertsChannel, 0))
+		})
+
+		Context("Add channel", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(testAlertsChannelYAML, 1))
+				f.RunHook()
+			})
+
+			It("Should store channel in values", func() {
+				Expect(f).To(ExecuteSuccessfully())
+
+				assertChannelsInValues(f, []GrafanaAlertsChannel{testAlertsChannel})
+			})
+
+			Context("Add another channel without auth", func() {
+				BeforeEach(func() {
+					JoinKubeResourcesAndSet(f, testAlertsChannelYAML, testAlertsChannelWithoutAuthYAML)
+					f.RunHook()
+				})
+
+				It("Should add new channel in values", func() {
+					Expect(f).To(ExecuteSuccessfully())
+
+					assertChannelsInValues(f, []GrafanaAlertsChannel{testAlertsChannel, testAlertsChannelWithoutAuth})
+				})
+
+				Context("Deleting channel without auth", func() {
+					BeforeEach(func() {
+						f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(testAlertsChannelYAML, 0))
+						f.RunHook()
+					})
+
+					It("Should only delete channel without auth", func() {
+						Expect(f).To(ExecuteSuccessfully())
+
+						assertChannelsInValues(f, []GrafanaAlertsChannel{testAlertsChannel})
+					})
+				})
+
+				Context("Updating test channel", func() {
+					BeforeEach(func() {
+						JoinKubeResourcesAndSet(f, testAlertsChanelUpdatedYAML, testAlertsChannelWithoutAuthYAML)
+						f.RunHook()
+					})
+
+					It("Should only update test channel in values", func() {
+						Expect(f).To(ExecuteSuccessfully())
+
+						assertChannelsInValues(f, []GrafanaAlertsChannel{testAlertsChanelUpdated, testAlertsChannelWithoutAuth})
+					})
+				})
+			})
+		})
+	})
+
+	Context("Alerts channels in cluster", func() {
+		BeforeEach(func() {
+			JoinKubeResourcesAndSet(f, testAlertsChannelYAML, testAlertsChannelWithoutAuthYAML)
+			f.RunHook()
+		})
+
+		It("Should store all alerts channel into values", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			assertChannelsInValues(f, []GrafanaAlertsChannel{testAlertsChannel, testAlertsChannelWithoutAuth})
+		})
+	})
+})

--- a/modules/300-prometheus/hooks/internal/v1alpha1/grafana_alerts_channel.go
+++ b/modules/300-prometheus/hooks/internal/v1alpha1/grafana_alerts_channel.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+var GrafanaAlertChannelTypes = map[string]string{
+	"PrometheusAlertManager": "prometheus-alertmanager",
+}
+
+type GrafanaAlertsChannelAlertManagerAuthBasic struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type GrafanaAlertsChannelAlertManagerAuth struct {
+	Basic GrafanaAlertsChannelAlertManagerAuthBasic `json:"basic"`
+}
+
+type GrafanaAlertsChannelAlertManager struct {
+	Address string                                `json:"address"`
+	Auth    *GrafanaAlertsChannelAlertManagerAuth `json:"auth,omitempty"`
+}
+
+type GrafanaAlertsChannelSpec struct {
+	Type                  string                           `json:"type"`
+	Description           string                           `json:"description,omitempty"`
+	IsDefault             bool                             `json:"isDefault,omitempty"`
+	DisableResolveMessage bool                             `json:"disableResolveMessage,omitempty"`
+	AlertManager          GrafanaAlertsChannelAlertManager `json:"alertManager"`
+}
+
+type GrafanaAlertsChannel struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec GrafanaAlertsChannelSpec `json:"spec"`
+}

--- a/modules/300-prometheus/openapi/values.yaml
+++ b/modules/300-prometheus/openapi/values.yaml
@@ -82,6 +82,60 @@ properties:
         type: object
         default: {}
         properties:
+          alertsChannelsConfig:
+            type: object
+            default: {}
+            properties:
+              notifiers:
+                default: []
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  - type
+                  - uid
+                  - org_id
+                  - is_default
+                  - disable_resolve_message
+                  - settings
+                  properties:
+                    name:
+                      type: string
+                    type:
+                      type: string
+                      enum: ["prometheus-alertmanager"]
+                    uid:
+                      type: string
+                    org_id:
+                      type: number
+                      enum: [1]
+                    is_default:
+                      type: boolean
+                      default: false
+                    send_reminder:
+                      type: boolean
+                      default: false
+                    frequency:
+                      type: string
+                    disable_resolve_message:
+                      type: boolean
+                      default: false
+                    settings:
+                      type: object
+                      required:
+                      - url
+                      properties:
+                        url:
+                          type: string
+                        basicAuthUser:
+                          type: string
+                    secure_settings:
+                      type: object
+                      default: {}
+                      properties:
+                        basicAuthPassword:
+                          type: string
           additionalDatasources:
             type: array
             items:
@@ -135,6 +189,20 @@ properties:
                 jsonData:
                   anything: 1
                   nothing: special
+            alertsChannelsConfig:
+              notifiers:
+                - org_id: 1
+                  type: prometheus-alertmanager
+                  name: "test"
+                  uid: "test"
+                  is_default: false
+                  disable_resolve_message: false
+                  send_reminder: false
+                  settings:
+                    basicAuthUser: user
+                    url: "http://test-alert-manager-url"
+                  secure_settings:
+                    basicAuthPassword: "password"
       remoteWrite:
         type: array
         items:

--- a/modules/300-prometheus/template_tests/common_test.go
+++ b/modules/300-prometheus/template_tests/common_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}

--- a/modules/300-prometheus/template_tests/copy_custom_certificate_test.go
+++ b/modules/300-prometheus/template_tests/copy_custom_certificate_test.go
@@ -17,18 +17,11 @@ limitations under the License.
 package template_tests
 
 import (
-	"testing"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	. "github.com/deckhouse/deckhouse/testing/helm"
 )
-
-func Test(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "")
-}
 
 const globalValues = `
 enabledModules: ["vertical-pod-autoscaler-crd", "prometheus"]

--- a/modules/300-prometheus/template_tests/secret_datasources_list_test.go
+++ b/modules/300-prometheus/template_tests/secret_datasources_list_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/yaml"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+	"github.com/deckhouse/deckhouse/testing/library/object_store"
+)
+
+var _ = Describe("Module :: prometheus :: helm template :: render data sources", func() {
+	getGlobalValues := func(haEnabled bool) string {
+		haStr := ""
+		if haEnabled {
+			haStr = "highAvailability: true"
+		}
+
+		return fmt.Sprintf(`
+%s
+enabledModules: ["vertical-pod-autoscaler-crd", "prometheus"]
+modulesImages:
+  registry: registry.deckhouse.io
+  registryDockercfg: cfg
+  tags:
+    common:
+      kubeCaAuthProxy: tagstring
+      kubeRbacProxy: tagstring
+    prometheus:
+      grafana: tagstring
+      grafanaDashboardProvisioner: tagstring
+      prometheus: tagstring
+      trickster: tagstring
+modules:
+  https:
+    mode: CustomCertificate
+  publicDomainTemplate: "%%s.example.com"
+  placement: {}
+discovery:
+  d8SpecificNodeCountByRole:
+    system: 1
+    master: 1
+`, haStr)
+	}
+
+	getPrometheusValues := func(longtermRetentionDays int) string {
+		return fmt.Sprintf(`
+longtermRetentionDays: %d
+scrapeInterval: 10s
+auth: {}
+vpa: {}
+grafana: {}
+https:
+  mode: CustomCertificate
+internal:
+  vpa: {}
+  prometheusMain: {}
+  grafana: {}
+  prometheusLongterm:
+    retentionGigabytes: 1
+  customCertificateData:
+    tls.crt: CRTCRTCRT
+    tls.key: KEYKEYKEY
+  alertmanagers: {}
+  prometheusAPIClientTLS:
+    certificate: CRTCRTCRT
+    key: KEYKEYKEY
+  prometheusScraperTLS:
+    certificate: CRTCRTCRT
+    key: KEYKEYKEY
+`, longtermRetentionDays)
+
+	}
+	extractYamlDataFromData := func(createdSecret object_store.KubeObject, key string) map[string]interface{} {
+		var dataSources map[string]interface{}
+
+		prometheusYamlEncoded := createdSecret.Field(fmt.Sprintf("data.%s", key)).String()
+		prometheusYaml, err := base64.StdEncoding.DecodeString(prometheusYamlEncoded)
+		Expect(err).ShouldNot(HaveOccurred())
+		err = yaml.Unmarshal(prometheusYaml, &dataSources)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		return dataSources
+	}
+
+	assertDataSources := func(createdSecret object_store.KubeObject, countSources, countDeleted int) {
+		dataSources := extractYamlDataFromData(createdSecret, "prometheus\\.yaml")
+
+		Expect(dataSources).To(HaveKey("deleteDatasources"))
+		Expect(dataSources["deleteDatasources"]).To(HaveLen(countDeleted))
+
+		Expect(dataSources).To(HaveKey("datasources"))
+		Expect(dataSources["datasources"]).To(HaveLen(countSources))
+	}
+
+	f := SetupHelmConfig(``)
+
+	DescribeTable(
+		"Grafana datasources secret was rendered correctly",
+		func(haEnabled bool, longtermRetentionDays, countSources, countDeleted int) {
+			f.ValuesSetFromYaml("global", getGlobalValues(haEnabled))
+			f.ValuesSetFromYaml("prometheus", getPrometheusValues(longtermRetentionDays))
+			f.HelmRender()
+
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			createdSecret := f.KubernetesResource("Secret", "d8-monitoring", "grafana-datasources")
+			Expect(createdSecret.Exists()).To(BeTrue())
+
+			assertDataSources(createdSecret, countSources, countDeleted)
+
+			additionalDataSourcesExists := createdSecret.Field("data.additional_datasources\\.yaml").Exists()
+			Expect(additionalDataSourcesExists).To(BeFalse())
+		},
+
+		Entry("Height availability and longterm enabled", true, 1, 4, 4),
+		Entry("Height availability enabled, longterm disabled", true, 0, 3, 5),
+		Entry("Height availability disabled, longterm enabled", false, 1, 2, 2),
+		Entry("Height availability and longterm disabled", false, 0, 1, 3),
+	)
+})

--- a/modules/300-prometheus/templates/grafana/cm-datasources-list.yaml
+++ b/modules/300-prometheus/templates/grafana/cm-datasources-list.yaml
@@ -1,4 +1,6 @@
 ---
+# TODO remove after 1.32 release from 1.30 we use grafana-datasources secret
+# Leave this cm for prevent mount volume error while terminating pod
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/modules/300-prometheus/templates/grafana/deployment.yaml
+++ b/modules/300-prometheus/templates/grafana/deployment.yaml
@@ -31,8 +31,9 @@ spec:
       labels:
         app: grafana
       annotations:
-        checksum/datasources: {{ include (print $.Template.BasePath "/grafana/cm-datasources-list.yaml") . | sha256sum }}
+        checksum/datasources: {{ include (print $.Template.BasePath "/grafana/secret-datasources-list.yaml") . | sha256sum }}
         checksum/dashboards-list-custom: {{ include (print $.Template.BasePath "/grafana/cm-dashboards-list-custom.yaml") . | sha256sum }}
+        checksum/alerts-channels: {{ include (print $.Template.BasePath "/grafana/grafana-alerts-channels.yaml") . | sha256sum }}
         threshold.extended-monitoring.flant.com/container-throttling-warning: "40"
     spec:
 {{- include "helm_lib_node_selector" (tuple . "monitoring") | indent 6 }}
@@ -109,6 +110,8 @@ spec:
           mountPath: /var/lib/grafana/data
         - name: grafana-datasources
           mountPath: /etc/grafana/provisioning/datasources
+        - name: grafana-alerts-channels
+          mountPath: /etc/grafana/provisioning/notifiers
         - name: grafana-dashboard-definitions
           mountPath: /etc/grafana/provisioning/dashboards/d8-custom.yaml
           subPath: grafana-dashboard-definitions.yaml
@@ -193,8 +196,11 @@ spec:
       - name: shared-dashboards-folder
         emptyDir: {}
       - name: grafana-datasources
-        configMap:
-          name: grafana-datasources
+        secret:
+          secretName: grafana-datasources
+      - name: grafana-alerts-channels
+        secret:
+          secretName: grafana-alerts-channels
       - name: grafana-dashboard-definitions
         configMap:
           name: grafana-dashboard-definitions

--- a/modules/300-prometheus/templates/grafana/grafana-alerts-channels.yaml
+++ b/modules/300-prometheus/templates/grafana/grafana-alerts-channels.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-alerts-channels
+  namespace: d8-monitoring
+{{ include "helm_lib_module_labels" (list . (dict "app" "grafana")) | indent 2 }}
+data:
+  notifiers.yaml: {{ .Values.prometheus.internal.grafana.alertsChannelsConfig | toYaml | b64enc }}

--- a/modules/300-prometheus/templates/grafana/secret-datasources-list.yaml
+++ b/modules/300-prometheus/templates/grafana/secret-datasources-list.yaml
@@ -1,0 +1,110 @@
+{{- define "trickster_client_tls_cert_params" }}
+secureJsonData:
+  tlsClientCert: |
+{{ .Values.prometheus.internal.prometheusAPIClientTLS.certificate | indent 4 }}
+  tlsClientKey: |
+{{ .Values.prometheus.internal.prometheusAPIClientTLS.key | indent 4 }}
+{{- end }}
+
+{{- define "trickster_tls_params" }}
+tlsAuth: true
+tlsAuthWithCACert: false
+tlsSkipVerify: true
+{{- end }}
+
+{{- define "render_grafana_datasources_config" }}
+apiVersion: 1
+deleteDatasources:
+ - name: trickster
+   orgId: 1
+ - name: trickster-longterm
+   orgId: 1
+
+{{- if eq (int .Values.prometheus.longtermRetentionDays) 0 }}
+ - name: longterm
+   orgId: 1
+{{- end }}
+
+{{- if (include "helm_lib_ha_enabled" .) }}
+ - name: main-0
+   orgId: 1
+ - name: main-1
+   orgId: 1
+{{- end }}
+
+datasources:
+ - name: main
+   type: prometheus
+   access: proxy
+   orgId: 1
+   url: https://trickster.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}/trickster/main
+   version: 1
+   isDefault: true
+   jsonData:
+     httpMethod: POST
+     timeInterval: {{ .Values.prometheus.scrapeInterval | default "30s" }}
+{{- include "trickster_tls_params" . | indent 5 }}
+{{- include "trickster_client_tls_cert_params" . | indent 3 }}
+
+
+{{- if ne (int .Values.prometheus.longtermRetentionDays) 0 }}
+ - name: longterm
+   type: prometheus
+   access: proxy
+   orgId: 1
+   url: https://trickster.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}/trickster/longterm
+   version: 1
+   jsonData:
+     httpMethod: POST
+     timeInterval: {{ .Values.prometheus.longtermScrapeInterval | default "5m" }}
+{{- include "trickster_tls_params" . | indent 5 }}
+{{- include "trickster_client_tls_cert_params" . | indent 3 }}
+{{- end }}
+
+{{- if (include "helm_lib_ha_enabled" .) }}
+ - name: main-uncached-0
+   type: prometheus
+   access: proxy
+   orgId: 1
+   url: https://prometheus-main-0.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}:9090
+   version: 1
+   jsonData:
+     httpMethod: POST
+     timeInterval: {{ .Values.prometheus.scrapeInterval | default "30s" }}
+{{- include "trickster_tls_params" . | indent 5 }}
+{{- include "trickster_client_tls_cert_params" . | indent 3 }}
+ - name: main-uncached-1
+   type: prometheus
+   access: proxy
+   orgId: 1
+   url: https://prometheus-main-1.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}:9090
+   version: 1
+   jsonData:
+     httpMethod: POST
+     timeInterval: {{ .Values.prometheus.scrapeInterval | default "30s" }}
+{{- include "trickster_tls_params" . | indent 5 }}
+{{- include "trickster_client_tls_cert_params" . | indent 3 }}
+{{- end }}
+
+{{- end }}
+
+{{- define "render_grafana_additional_datasources_config" }}
+
+apiVersion: 1
+datasources:
+{{ .Values.prometheus.internal.grafana.additionalDatasources | toYaml | indent 2 }}
+
+{{- end }}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-datasources
+  namespace: d8-monitoring
+{{ include "helm_lib_module_labels" (list . (dict "app" "grafana")) | indent 2 }}
+data:
+  prometheus.yaml: {{ include "render_grafana_datasources_config" . | b64enc | quote }}
+{{ if .Values.prometheus.internal.grafana.additionalDatasources }}
+  additional_datasources.yaml: {{ include "render_grafana_additional_datasources_config" . | b64enc | quote }}
+{{- end }}

--- a/testing/openapi_validation/validators/enum.go
+++ b/testing/openapi_validation/validators/enum.go
@@ -94,6 +94,10 @@ var (
 			// ignore internal values
 			"properties.internal.properties.specificNodeType",
 		},
+		"modules/300-prometheus/openapi/values.yaml": {
+			// grafana constant in internal values
+			"properties.internal.properties.grafana.properties.alertsChannelsConfig.properties.notifiers.items.properties.type",
+		},
 		"modules/402-ingress-nginx/crds/ingress-nginx.yaml": {
 			// GeoIP base constants: GeoIP2-ISP, GeoIP2-ASN, ...
 			"spec.versions[*].schema.openAPIV3Schema.properties.spec.properties.geoIP2.properties.maxmindEditionIDs.items",


### PR DESCRIPTION
## Description
Add grafana notification channel support.

## Why we need it and what problem does it solve?
Users need to add alerts in Grafana for non-Prometheus data sources like Clickhouse. They can save dashboards with notifications to the cluster as GrafanaDashboardDefinitions, but without notification channels, it will not work.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: prometheus-crd
type: feature
description: Add GrafanaAlertsChannel CRD.
note: Support only prometheus alert manager notification channel
---
module: prometheus
type: feature
description: Provisioning alerts channels from CRD's to grafana via new secret. Migrate to direct datasources.
note: |
  Grafana will be restarted.
  Now grafana using direct (proxy) type for deckhouse datasources (main, longterm, uncached), because direct(browse) datasources type is depreated now. And alerts don't work with direct data sources.
  Provisioning datasources from secret instead configmap. Deckhouse datasources need client certificates to connect to  prometheus or trickter. Old cm leave to prevent mount error while terminating.
---
module: flant-integration
type: feature
description: Add madison-proxy notification channel to send alert from grafana to madison via proxy and show them in Polk 
note: |
  Add rewrite rule to madison-proxy from /api/v1/alerts url to madison url, because grafana always send notification to this url.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
