### PR TITLE
[prometheus] fixed FAQ about Lens

### DIFF
--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -257,15 +257,22 @@ metadata:
   name: prometheus-lens-proxy-conf
   namespace: lens-proxy
 data:
-  prometheus.conf.template: |
+  "40-prometheus-proxy-conf.sh": |
+    #!/bin/sh
+    prometheus_service="$(getent hosts prometheus.d8-monitoring | awk '{print $2}')"
+    nameserver="$(awk '/nameserver/{print $2}' < /etc/resolv.conf)"
+    cat > /etc/nginx/conf.d/prometheus.conf <<EOF
     server {
       listen 80 default_server;
+      resolver ${nameserver} valid=30s;
+      set \$upstream ${prometheus_service};
       location / {
         proxy_http_version 1.1;
         proxy_set_header Authorization "Bearer ${BEARER_TOKEN}";
-        proxy_pass https://prometheus.d8-monitoring:9090/;
+        proxy_pass https://\$upstream:9090$request_uri;
       }
     }
+    EOF
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -294,17 +301,15 @@ spec:
         ports:
         - containerPort: 80
         volumeMounts:
-        - mountPath: /etc/nginx/templates
-          readOnly: true
+        - mountPath: /docker-entrypoint.d/40-prometheus-proxy-conf.sh
+          subPath: "40-prometheus-proxy-conf.sh"
           name: prometheus-lens-proxy-conf
       serviceAccountName: prometheus-lens-proxy
       volumes:
       - name: prometheus-lens-proxy-conf
         configMap:
           name: prometheus-lens-proxy-conf
-          items:
-            - key: prometheus.conf.template
-              path: prometheus.conf.template
+          defaultMode: 0755
 ---
 apiVersion: v1
 kind: Service
@@ -315,10 +320,11 @@ spec:
   selector:
     app: prometheus-lens-proxy
   ports:
-    - protocol: TCP
-      port: 8080
-      targetPort: 80
+  - protocol: TCP
+    port: 8080
+    targetPort: 80
 ```
 {% endofftopic %}
 
 After the resources deployment, Prometheus metrics will be available at address `lens-proxy/prometheus-lens-proxy:8080`.
+Lens Prometheus type - `Prometheus Operator`.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Improved Prometheus FAQ about Lens access.
## Why we need it and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: prometheus
type: feature
description: "Improved Prometheus FAQ about Lens access."
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
