### PR TITLE
[secret-copier] create or update target secrets

### DIFF
--- a/ee/fe/modules/600-secret-copier/docs/README.md
+++ b/ee/fe/modules/600-secret-copier/docs/README.md
@@ -20,3 +20,7 @@ Also, it synchronizes the secrets every night and makes sure they are identical 
 ### What do I need to configure?
 
 All you need to do is to create a secret with the `secret-copier.deckhouse.io/enabled: ""` label in the default namespace.
+
+### How to synchronize Secret to some selected namespaces instead of all namespaces?
+
+Specify namespace label-selector in the value of the `secret-copier.deckhouse.io/target-namespace-selector` annotation. For example: `secret-copier.deckhouse.io/target-namespace-selector: "app=custom"`. The module will create a copy of that Secret in all namespaces that matches the label-selector. 

--- a/ee/fe/modules/600-secret-copier/docs/README_RU.md
+++ b/ee/fe/modules/600-secret-copier/docs/README_RU.md
@@ -20,3 +20,7 @@ title: "Модуль secret-copier"
 ### Что нужно настроить?
 
 Для того, чтобы заработало, достаточно создать в "default" namespace секрет с лейблом `secret-copier.deckhouse.io/enabled: ""`.
+
+### Как ограничить список namespaces в которые будет производиться копирование?
+
+Задайте label–селектор в значении аннотации `secret-copier.deckhouse.io/target-namespace-selector`. Например: `secret-copier.deckhouse.io/target-namespace-selector: "app=custom"`. Модуль создаст копию этого секрета во всех пространствах имен, соответствующих заданному label–селектору. 


### PR DESCRIPTION
## Description
- Implement create–or–update logic for proper reconcile.
- Add support of namespace label-selector in `secret-copier.deckhouse.io/target-namespace-selector` annotation value.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why we need it and what problem does it solve?
Rarely deckhouse queue hangs on the following error:
```
module hook '600-secret-copier/hooks/handler.go' failed: can't create secret object `namespace/test`: secrets "test" already exists
```
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: secret-copier
type: feature
description: "Implement create–or–update logic for proper reconcile."
note: |
  Add support of namespace label-selector in `secret-copier.deckhouse.io/target-namespace-selector` annotation value.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
