### PR TITLE
[flant-integration] add a replica label to handle ha in the remote-write backend

### DIFF
--- a/ee/modules/600-flant-integration/templates/pricing/config.yaml
+++ b/ee/modules/600-flant-integration/templates/pricing/config.yaml
@@ -24,11 +24,16 @@ prometheus:
       - source_labels: [job]
         target_label: cluster_uuid
         replacement: {{ .Values.global.discovery.clusterUUID }}
+      - source_labels: [instance]
+        target_label: __replica__
+        replacement: ${NODE_NAME}
       - regex: hook|instance
         action: labeldrop
     remote_write:
     - url: {{ .Values.flantIntegration.metrics.url }}
       bearer_token: {{ .Values.flantIntegration.internal.licenseKey }}
+      metadata_config:
+        send: false
 {{- end }}
 
 {{- if .Values.flantIntegration.metrics }}

--- a/ee/modules/600-flant-integration/templates/pricing/daemonset.yaml
+++ b/ee/modules/600-flant-integration/templates/pricing/daemonset.yaml
@@ -125,6 +125,13 @@ spec:
       - name: grafana-agent
 {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | indent 8 }}
         image: {{ .Values.global.modulesImages.registry }}:{{ .Values.global.modulesImages.tags.flantIntegration.grafanaAgent }}
+        args:
+          - -config.expand-env
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         volumeMounts:
         - name: agent-data
           mountPath: /data/agent


### PR DESCRIPTION
## Description
Changes in `pricing` Grafana Agent:
- Add a replica label to handle HA in the remote-write backend.
- Turn off sending metadata.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why we need it and what problem does it solve?
We need properly de-duplicate metrics on the backend side.
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: flant-integration
type: fix
description: |
  Implement proper HA remote-write and reduce outgoing traffic amount.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
