### PR TITLE
[cert-manager] Fix. Service account for acme solver pod cannot create

### DIFF
--- a/modules/101-cert-manager/hooks/create_registry_secret_for_solver.go
+++ b/modules/101-cert-manager/hooks/create_registry_secret_for_solver.go
@@ -36,6 +36,7 @@ const (
 
 	challengesSnapshot = "challenges"
 	secretsSnapshot    = "registry_secrets_namespaces"
+	saSnapshot         = "sa_namespaces"
 	d8RegistrySnapshot = "d8_registry_secret"
 
 	solverSecretName         = "acme-solver-deckhouse-regestry"
@@ -70,6 +71,15 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			FilterFunc: applyRegistrySecretFilter,
 			NameSelector: &types.NameSelector{
 				MatchNames: []string{solverSecretName},
+			},
+		},
+		{
+			Name:       saSnapshot,
+			Kind:       "ServiceAccount",
+			ApiVersion: "v1",
+			FilterFunc: applyServiceAccountFilter,
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{solverServiceAccountName},
 			},
 		},
 		{
@@ -111,6 +121,16 @@ func applyRegistrySecretFilter(obj *unstructured.Unstructured) (go_hook.FilterRe
 		Namespace: ns,
 		Config:    string(conf),
 	}, nil
+}
+
+func applyServiceAccountFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var s corev1.ServiceAccount
+	err := sdk.FromUnstructured(obj, &s)
+	if err != nil {
+		return "", err
+	}
+
+	return s.GetNamespace(), nil
 }
 
 func prepareSolverRegistrySecret(namespace, dockerCfg string) *corev1.Secret {
@@ -181,8 +201,10 @@ func handleChallenge(input *go_hook.HookInput) error {
 	registryCfg := d8RegistrySnap[0].(registrySecret).Config
 
 	challengesNss := set.NewFromSnapshot(input.Snapshots[challengesSnapshot])
-	legacyChallengesNss := set.NewFromSnapshot(input.Snapshots[challengesLegacySnapshot]).Slice()
-	challengesNss.Add(legacyChallengesNss...)
+	legacyChallengesNss := set.NewFromSnapshot(input.Snapshots[challengesLegacySnapshot])
+	challengesNss.AddSet(legacyChallengesNss)
+
+	serviceAccountsNss := set.NewFromSnapshot(input.Snapshots[saSnapshot])
 
 	// namespace -> .dockerconfigjson content
 	secretsByNs := map[string]string{}
@@ -194,17 +216,17 @@ func handleChallenge(input *go_hook.HookInput) error {
 
 	// create secrets
 	for ns := range challengesNss {
-		secretContent, ok := secretsByNs[ns]
+		secretContent, secretExists := secretsByNs[ns]
 		// secret already exists in namespace. do not create or patch
-		if ok && secretContent == registryCfg {
-			continue
+		if !secretExists || secretContent != registryCfg {
+			secret := prepareSolverRegistrySecret(ns, registryCfg)
+			input.PatchCollector.Create(secret, object_patch.UpdateIfExists())
 		}
 
-		secret := prepareSolverRegistrySecret(ns, registryCfg)
-		sa := prepareSolverRegistryServiceAccount(ns)
-
-		input.PatchCollector.Create(secret, object_patch.UpdateIfExists())
-		input.PatchCollector.Create(sa, object_patch.UpdateIfExists())
+		if _, saExists := serviceAccountsNss[ns]; !saExists {
+			sa := prepareSolverRegistryServiceAccount(ns)
+			input.PatchCollector.Create(sa, object_patch.UpdateIfExists())
+		}
 	}
 
 	// gc secrets
@@ -215,6 +237,15 @@ func handleChallenge(input *go_hook.HookInput) error {
 		}
 
 		input.PatchCollector.Delete("v1", "Secret", ns, solverSecretName)
+	}
+
+	// gc SA's
+	for ns := range serviceAccountsNss {
+		if challengesNss.Has(ns) {
+			// a service account exists in namespace, and exists one more challenges. do not delete secret
+			continue
+		}
+
 		input.PatchCollector.Delete("v1", "ServiceAccount", ns, solverServiceAccountName)
 	}
 


### PR DESCRIPTION
## Description
If acmesolver registry secret already exists in namespace when challenge was created, then service account for acme solver will not create

## Why we need it and what problem does it solve?
Certificates cannot created because acmesolver pod cannot be pulled.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: cert-manager
type: fix
description: Service account will be created if registry secret already located in namespace
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
