### PR TITLE
[prometheus] Bump Grafana to 8.2.7

### DIFF
--- a/modules/300-prometheus/images/grafana/Dockerfile
+++ b/modules/300-prometheus/images/grafana/Dockerfile
@@ -18,7 +18,7 @@ ARG BUNDLED_PLUGINS="grafana-image-renderer,petrslavotinek-carpetplot-panel,vona
 FROM $BASE_ALPINE as src-files
 WORKDIR /usr/src/app
 RUN apk add --no-cache patch
-RUN wget https://github.com/grafana/grafana/archive/v8.2.4.tar.gz -O - | tar -xz  --strip-components=1
+RUN wget https://github.com/grafana/grafana/archive/v8.2.7.tar.gz -O - | tar -xz  --strip-components=1
 # Extra '__interval_*' vars for prometheus datasource.
 COPY ./patches/feat_prometheus_extra_vars.patch .
 RUN patch -p1 < ./feat_prometheus_extra_vars.patch


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Bump Grafana version to 8.2.7

## Why we need it and what problem does it solve?
https://grafana.com/blog/2021/12/07/grafana-8.3.1-8.2.7-8.1.8-and-8.0.7-released-with-high-severity-security-fix/

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: prometheus
type: fix
description: "Bump Grafana version to fix zero-day path traversal bug (CVE-2021-43798)"
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
