### PR TITLE
[bashible] kubernetes-data volume mount fix

### DIFF
--- a/candi/bashible/common-steps/node-group/002_integrate_kubernetes_data_device.sh.tpl
+++ b/candi/bashible/common-steps/node-group/002_integrate_kubernetes_data_device.sh.tpl
@@ -58,7 +58,7 @@ fi
 
 if grep -qv kubernetes-data /etc/fstab; then
   cat >> /etc/fstab << EOF
-LABEL=kubernetes-data           /mnt/kubernetes-data     ext4   defaults,discard        0 0
+LABEL=kubernetes-data           /mnt/kubernetes-data     ext4   defaults,discard,x-systemd.automount        0 0
 EOF
 fi
 


### PR DESCRIPTION
## Description
Fix for automatic volume mount after reboot in ubuntu 20.04. Solves https://github.com/deckhouse/deckhouse/issues/341.

## Why we need it and what problem does it solve?
There is a problem in azure with the ubuntu 20.04 image — the kubernetes-data volume isn't mounted after a reboot.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: bashible
type: fix
description: Cluster bootstrab on Azure works for Ubuntu 20.04
```