### PR TITLE
[deckhouse] Add canary deployment for releases

### DIFF
--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -515,6 +515,17 @@ module.exports.runWorkflowForReleaseIssue = async ({ github, context, core }) =>
     }
   }
 
+  // suspend release in a channel
+  if (knownLabels.suspend.includes(label)) {
+    for (const channel of knownChannels) {
+      if (lowerLabel.includes(channel)) {
+        workflow_id = `suspend-${channel}.yml`;
+        isDeployChannel = true;
+        break;
+      }
+    }
+  }
+
   if (knownLabels['skip-validation'].includes(label)) {
     workflow_id = 'validation.yml';
   }

--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -25,6 +25,13 @@ const labels = {
     'deploy/deckhouse/stable',
     'deploy/deckhouse/rock-solid'
   ],
+  suspend: [
+    'suspend/deckhouse/alpha',
+    'suspend/deckhouse/beta',
+    'suspend/deckhouse/early-access',
+    'suspend/deckhouse/stable',
+    'suspend/deckhouse/rock-solid'
+  ],
   // prettier-ignore
   'deploy-web': [
     'deploy/web/test',

--- a/.github/workflow_templates/suspend-channel.multi.yml
+++ b/.github/workflow_templates/suspend-channel.multi.yml
@@ -1,0 +1,116 @@
+{!{- range $channel := slice "alpha" "beta" "early-access" "stable" "rock-solid" -}!}
+{!{- $ctx := dict "channel" $channel }!}
+{!{- $outFile := printf "suspend-%s.yml" $channel }!}
+{!{- $outPath := filepath.Join (getenv "OUTDIR") (toLower $outFile) }!}
+{!{- tmpl.Exec "suspend_channel_workflow_template" $ctx | file.Write $outPath }!}
+{!{- end -}!}
+
+{!{- define "suspend_channel_workflow_template" -}!}
+{!{- $channel := .channel -}!}
+{!{- $workflowName := printf "Suspend the %s" $channel -}!}
+name: '{!{ $workflowName }!}'
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_id:
+        description: 'Id of issue where label was set'
+        required: true
+      issue_number:
+        description: 'Number of issue where label was set'
+        required: true
+      comment_id:
+        description: 'Id of comment in issue where to put workflow run status'
+        required: true
+
+env:
+{!{ tmpl.Exec "werf_envs" | strings.Indent 2 }!}
+  DEPLOY_CHANNEL: {!{ .channel }!}
+
+# Analog of Gitlab's "interruptible: true" behaviour.
+# Note: Concurrency is currently in beta and subject to change.
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.ref }}-suspend-channel-{!{ .channel }!}
+  cancel-in-progress: true
+
+jobs:
+{!{ tmpl.Exec "git_info_job" . | strings.Indent 2 }!}
+
+{!{ tmpl.Exec "check_label_job" (slice "suspend" .channel) | strings.Indent 2 }!}
+
+  run_suspend:
+    name: Suspend deckhouse release on {!{ .channel }!} channel
+    environment:
+      name: {!{ .channel }!}
+    needs:
+      - check_label
+      - git_info
+    if: needs.check_label.outputs.should_run == 'true'
+    runs-on: self-hosted
+    steps:
+{!{ tmpl.Exec "checkout_from_event_ref_step" . | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_start" $workflowName | strings.Indent 6 }!}
+{!{ tmpl.Exec "restore_images_tags_json_from_cache_or_fail" . | strings.Indent 6 }!}
+{!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 6 }!}
+{!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 6 }!}
+{!{ tmpl.Exec "login_rw_registry_step" . | strings.Indent 6 }!}
+
+{!{/*
+Pull deckhouse images from cache, tag with channel name and push to dev and prod registries.
+Images:
+- deckhouse/release-channel image
+Destination registries:
+- DECKHOUSE_REGISTRY_HOST
+- DEV_REGISTRY_PATH
+*/}!}
+{!{ range $werfEnv := slice "CE" "EE" "FE" }!}
+      - name: Publish release images for {!{ $werfEnv }!}
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: {!{ $werfEnv }!}
+        run: |
+          # Some precautions.
+          if [[ -z $DEV_REGISTRY_PATH ]] ; then
+            echo "DEV_REGISTRY_PATH is not set!"
+            exit 1
+          fi
+          if [[ -z $WERF_ENV ]] ; then
+            echo "WERF_ENV is not set!"
+            exit 1
+          fi
+
+          # Variables
+          #   1. CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          echo "Registry suffix - ${REGISTRY_SUFFIX}"
+
+          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
+          RELEASE_CHANNEL={!{ $channel }!}
+          echo "Release channel - ${RELEASE_CHANNEL}"
+
+          #   3. Publish prod images to rw registry
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          else
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          fi
+
+          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          cat <<EOF >Dockerfile
+          FROM spotify/scratch
+          COPY version.json version.json
+          EOF
+          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+
+          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
+          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+
+          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+{!{- end }!}
+
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job" $workflowName) | strings.Indent 6 }!}
+
+{!{ end -}!}

--- a/.github/workflows/suspend-alpha.yml
+++ b/.github/workflows/suspend-alpha.yml
@@ -1,0 +1,339 @@
+#
+# THIS FILE IS GENERATED, PLEASE DO NOT EDIT.
+#
+
+name: 'Suspend the alpha'
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_id:
+        description: 'Id of issue where label was set'
+        required: true
+      issue_number:
+        description: 'Number of issue where label was set'
+        required: true
+      comment_id:
+        description: 'Id of comment in issue where to put workflow run status'
+        required: true
+
+env:
+
+  # Don't forget to update .gitlab-ci-simple.yml if necessary
+  WERF_CHANNEL: "ea"
+  WERF_ENV: "FE"
+  # We use stapel image from own registry due to docker hub pull amount limitation.
+  # To re-push stapel image from docker hub use command:
+  # `skopeo copy docker://flant/werf-stapel:0.6.1 docker://registry-write.deckhouse.io/flant/werf-stapel:0.6.1`
+  WERF_STAPEL_IMAGE_NAME: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}/flant/werf-stapel"
+  WERF_STAPEL_IMAGE_VERSION: "0.6.1"
+  TEST_TIMEOUT: "15m"
+  # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
+  DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
+  BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
+
+  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  DEPLOY_CHANNEL: alpha
+
+# Analog of Gitlab's "interruptible: true" behaviour.
+# Note: Concurrency is currently in beta and subject to change.
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.ref }}-suspend-channel-alpha
+  cancel-in-progress: true
+
+jobs:
+
+  git_info:
+    name: Get git info
+    runs-on: ubuntu-latest
+    outputs:
+      ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
+      ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
+      ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
+      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      github_sha: ${{ steps.git_info.outputs.github_sha }}
+    steps:
+      - id: git_info
+        name: Get tag name and SHA
+        run: |
+          # Detect git tag for release.
+          gitTag=${GITHUB_REF#refs/tags/}
+          if [[ ${GITHUB_REF} == $gitTag ]] ; then
+            gitTag=
+          fi
+          echo "::set-output name=ci_commit_tag::${gitTag}"
+          echo "ci_commit_tag='${gitTag}'"
+
+          # Detect git branch.
+          gitBranch=${GITHUB_REF#refs/heads/}
+          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
+            gitBranch=
+          fi
+          echo "::set-output name=ci_commit_branch::${gitBranch}"
+          echo "ci_commit_branch='${gitBranch}'"
+
+          # CI_COMMIT_REF_NAME for main werf.yaml
+          commitRefName=
+          [[ -n $gitBranch ]] && commitRefName=$gitBranch
+          [[ -n $gitTag ]] && commitRefName=$gitTag
+          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
+          echo "ci_commit_ref_name='${commitRefName}'"
+
+          # CI_PIPELINE_CREATED_AT for main werf.yaml
+          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
+          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
+          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+
+          # Determine sha of commit.
+          # push event
+          githubSha=${GITHUB_SHA}
+          echo "github_sha for push '${githubSha}'"
+          # workflow_dispatch event
+          if [[ -z $githubSha ]] ; then
+            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
+            echo "github_sha for workflow_dispatch '${githubSha}'"
+          fi
+          echo "::set-output name=github_sha::$githubSha"
+          echo "github_sha='${githubSha}'"
+
+  check_label:
+    name: Check label
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check_label.outputs.should_run }}
+      labels: ${{ steps.check_label.outputs.labels }}
+    steps:
+
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+      - id: check_label
+        name: Check labels on push
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            const labelType = 'suspend';
+            const labelSubject = 'alpha';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.checkLabel({github, context, core, labelType, labelSubject});
+
+  run_suspend:
+    name: Suspend deckhouse release on alpha channel
+    environment:
+      name: alpha
+    needs:
+      - check_label
+      - git_info
+    if: needs.check_label.outputs.should_run == 'true'
+    runs-on: self-hosted
+    steps:
+
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.ref }}
+          fetch-depth: 0
+      - name: Update comment on start
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'Suspend the alpha';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      - name: Restore images_tags_json from cache
+        id: images-tags-json
+        uses: actions/cache@v2.1.7
+        with:
+          path: modules/images_tags_${{env.WERF_ENV}}.json
+          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
+      - name: Fail if not found
+        if: steps.images-tags-json.outputs.cache-hit != 'true'
+        run: |
+          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
+          exit 1
+
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+
+      - name: Login to readonly registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          logout: false
+
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+
+
+
+      - name: Publish release images for CE
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: CE
+        run: |
+          # Some precautions.
+          if [[ -z $DEV_REGISTRY_PATH ]] ; then
+            echo "DEV_REGISTRY_PATH is not set!"
+            exit 1
+          fi
+          if [[ -z $WERF_ENV ]] ; then
+            echo "WERF_ENV is not set!"
+            exit 1
+          fi
+
+          # Variables
+          #   1. CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          echo "Registry suffix - ${REGISTRY_SUFFIX}"
+
+          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
+          RELEASE_CHANNEL=alpha
+          echo "Release channel - ${RELEASE_CHANNEL}"
+
+          #   3. Publish prod images to rw registry
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          else
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          fi
+
+          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          cat <<EOF >Dockerfile
+          FROM spotify/scratch
+          COPY version.json version.json
+          EOF
+          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+
+          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
+          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+
+          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+      - name: Publish release images for EE
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: EE
+        run: |
+          # Some precautions.
+          if [[ -z $DEV_REGISTRY_PATH ]] ; then
+            echo "DEV_REGISTRY_PATH is not set!"
+            exit 1
+          fi
+          if [[ -z $WERF_ENV ]] ; then
+            echo "WERF_ENV is not set!"
+            exit 1
+          fi
+
+          # Variables
+          #   1. CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          echo "Registry suffix - ${REGISTRY_SUFFIX}"
+
+          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
+          RELEASE_CHANNEL=alpha
+          echo "Release channel - ${RELEASE_CHANNEL}"
+
+          #   3. Publish prod images to rw registry
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          else
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          fi
+
+          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          cat <<EOF >Dockerfile
+          FROM spotify/scratch
+          COPY version.json version.json
+          EOF
+          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+
+          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
+          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+
+          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+      - name: Publish release images for FE
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: FE
+        run: |
+          # Some precautions.
+          if [[ -z $DEV_REGISTRY_PATH ]] ; then
+            echo "DEV_REGISTRY_PATH is not set!"
+            exit 1
+          fi
+          if [[ -z $WERF_ENV ]] ; then
+            echo "WERF_ENV is not set!"
+            exit 1
+          fi
+
+          # Variables
+          #   1. CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          echo "Registry suffix - ${REGISTRY_SUFFIX}"
+
+          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
+          RELEASE_CHANNEL=alpha
+          echo "Release channel - ${RELEASE_CHANNEL}"
+
+          #   3. Publish prod images to rw registry
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          else
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          fi
+
+          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          cat <<EOF >Dockerfile
+          FROM spotify/scratch
+          COPY version.json version.json
+          EOF
+          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+
+          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
+          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+
+          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+
+      - name: Update comment on finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        continue-on-error: true
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusSource = 'job';
+            const name = 'Suspend the alpha';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+
+            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
+            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+

--- a/.github/workflows/suspend-beta.yml
+++ b/.github/workflows/suspend-beta.yml
@@ -1,0 +1,339 @@
+#
+# THIS FILE IS GENERATED, PLEASE DO NOT EDIT.
+#
+
+name: 'Suspend the beta'
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_id:
+        description: 'Id of issue where label was set'
+        required: true
+      issue_number:
+        description: 'Number of issue where label was set'
+        required: true
+      comment_id:
+        description: 'Id of comment in issue where to put workflow run status'
+        required: true
+
+env:
+
+  # Don't forget to update .gitlab-ci-simple.yml if necessary
+  WERF_CHANNEL: "ea"
+  WERF_ENV: "FE"
+  # We use stapel image from own registry due to docker hub pull amount limitation.
+  # To re-push stapel image from docker hub use command:
+  # `skopeo copy docker://flant/werf-stapel:0.6.1 docker://registry-write.deckhouse.io/flant/werf-stapel:0.6.1`
+  WERF_STAPEL_IMAGE_NAME: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}/flant/werf-stapel"
+  WERF_STAPEL_IMAGE_VERSION: "0.6.1"
+  TEST_TIMEOUT: "15m"
+  # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
+  DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
+  BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
+
+  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  DEPLOY_CHANNEL: beta
+
+# Analog of Gitlab's "interruptible: true" behaviour.
+# Note: Concurrency is currently in beta and subject to change.
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.ref }}-suspend-channel-beta
+  cancel-in-progress: true
+
+jobs:
+
+  git_info:
+    name: Get git info
+    runs-on: ubuntu-latest
+    outputs:
+      ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
+      ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
+      ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
+      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      github_sha: ${{ steps.git_info.outputs.github_sha }}
+    steps:
+      - id: git_info
+        name: Get tag name and SHA
+        run: |
+          # Detect git tag for release.
+          gitTag=${GITHUB_REF#refs/tags/}
+          if [[ ${GITHUB_REF} == $gitTag ]] ; then
+            gitTag=
+          fi
+          echo "::set-output name=ci_commit_tag::${gitTag}"
+          echo "ci_commit_tag='${gitTag}'"
+
+          # Detect git branch.
+          gitBranch=${GITHUB_REF#refs/heads/}
+          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
+            gitBranch=
+          fi
+          echo "::set-output name=ci_commit_branch::${gitBranch}"
+          echo "ci_commit_branch='${gitBranch}'"
+
+          # CI_COMMIT_REF_NAME for main werf.yaml
+          commitRefName=
+          [[ -n $gitBranch ]] && commitRefName=$gitBranch
+          [[ -n $gitTag ]] && commitRefName=$gitTag
+          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
+          echo "ci_commit_ref_name='${commitRefName}'"
+
+          # CI_PIPELINE_CREATED_AT for main werf.yaml
+          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
+          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
+          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+
+          # Determine sha of commit.
+          # push event
+          githubSha=${GITHUB_SHA}
+          echo "github_sha for push '${githubSha}'"
+          # workflow_dispatch event
+          if [[ -z $githubSha ]] ; then
+            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
+            echo "github_sha for workflow_dispatch '${githubSha}'"
+          fi
+          echo "::set-output name=github_sha::$githubSha"
+          echo "github_sha='${githubSha}'"
+
+  check_label:
+    name: Check label
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check_label.outputs.should_run }}
+      labels: ${{ steps.check_label.outputs.labels }}
+    steps:
+
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+      - id: check_label
+        name: Check labels on push
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            const labelType = 'suspend';
+            const labelSubject = 'beta';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.checkLabel({github, context, core, labelType, labelSubject});
+
+  run_suspend:
+    name: Suspend deckhouse release on beta channel
+    environment:
+      name: beta
+    needs:
+      - check_label
+      - git_info
+    if: needs.check_label.outputs.should_run == 'true'
+    runs-on: self-hosted
+    steps:
+
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.ref }}
+          fetch-depth: 0
+      - name: Update comment on start
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'Suspend the beta';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      - name: Restore images_tags_json from cache
+        id: images-tags-json
+        uses: actions/cache@v2.1.7
+        with:
+          path: modules/images_tags_${{env.WERF_ENV}}.json
+          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
+      - name: Fail if not found
+        if: steps.images-tags-json.outputs.cache-hit != 'true'
+        run: |
+          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
+          exit 1
+
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+
+      - name: Login to readonly registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          logout: false
+
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+
+
+
+      - name: Publish release images for CE
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: CE
+        run: |
+          # Some precautions.
+          if [[ -z $DEV_REGISTRY_PATH ]] ; then
+            echo "DEV_REGISTRY_PATH is not set!"
+            exit 1
+          fi
+          if [[ -z $WERF_ENV ]] ; then
+            echo "WERF_ENV is not set!"
+            exit 1
+          fi
+
+          # Variables
+          #   1. CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          echo "Registry suffix - ${REGISTRY_SUFFIX}"
+
+          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
+          RELEASE_CHANNEL=beta
+          echo "Release channel - ${RELEASE_CHANNEL}"
+
+          #   3. Publish prod images to rw registry
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          else
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          fi
+
+          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          cat <<EOF >Dockerfile
+          FROM spotify/scratch
+          COPY version.json version.json
+          EOF
+          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+
+          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
+          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+
+          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+      - name: Publish release images for EE
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: EE
+        run: |
+          # Some precautions.
+          if [[ -z $DEV_REGISTRY_PATH ]] ; then
+            echo "DEV_REGISTRY_PATH is not set!"
+            exit 1
+          fi
+          if [[ -z $WERF_ENV ]] ; then
+            echo "WERF_ENV is not set!"
+            exit 1
+          fi
+
+          # Variables
+          #   1. CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          echo "Registry suffix - ${REGISTRY_SUFFIX}"
+
+          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
+          RELEASE_CHANNEL=beta
+          echo "Release channel - ${RELEASE_CHANNEL}"
+
+          #   3. Publish prod images to rw registry
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          else
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          fi
+
+          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          cat <<EOF >Dockerfile
+          FROM spotify/scratch
+          COPY version.json version.json
+          EOF
+          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+
+          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
+          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+
+          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+      - name: Publish release images for FE
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: FE
+        run: |
+          # Some precautions.
+          if [[ -z $DEV_REGISTRY_PATH ]] ; then
+            echo "DEV_REGISTRY_PATH is not set!"
+            exit 1
+          fi
+          if [[ -z $WERF_ENV ]] ; then
+            echo "WERF_ENV is not set!"
+            exit 1
+          fi
+
+          # Variables
+          #   1. CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          echo "Registry suffix - ${REGISTRY_SUFFIX}"
+
+          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
+          RELEASE_CHANNEL=beta
+          echo "Release channel - ${RELEASE_CHANNEL}"
+
+          #   3. Publish prod images to rw registry
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          else
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          fi
+
+          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          cat <<EOF >Dockerfile
+          FROM spotify/scratch
+          COPY version.json version.json
+          EOF
+          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+
+          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
+          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+
+          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+
+      - name: Update comment on finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        continue-on-error: true
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusSource = 'job';
+            const name = 'Suspend the beta';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+
+            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
+            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+

--- a/.github/workflows/suspend-early-access.yml
+++ b/.github/workflows/suspend-early-access.yml
@@ -1,0 +1,339 @@
+#
+# THIS FILE IS GENERATED, PLEASE DO NOT EDIT.
+#
+
+name: 'Suspend the early-access'
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_id:
+        description: 'Id of issue where label was set'
+        required: true
+      issue_number:
+        description: 'Number of issue where label was set'
+        required: true
+      comment_id:
+        description: 'Id of comment in issue where to put workflow run status'
+        required: true
+
+env:
+
+  # Don't forget to update .gitlab-ci-simple.yml if necessary
+  WERF_CHANNEL: "ea"
+  WERF_ENV: "FE"
+  # We use stapel image from own registry due to docker hub pull amount limitation.
+  # To re-push stapel image from docker hub use command:
+  # `skopeo copy docker://flant/werf-stapel:0.6.1 docker://registry-write.deckhouse.io/flant/werf-stapel:0.6.1`
+  WERF_STAPEL_IMAGE_NAME: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}/flant/werf-stapel"
+  WERF_STAPEL_IMAGE_VERSION: "0.6.1"
+  TEST_TIMEOUT: "15m"
+  # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
+  DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
+  BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
+
+  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  DEPLOY_CHANNEL: early-access
+
+# Analog of Gitlab's "interruptible: true" behaviour.
+# Note: Concurrency is currently in beta and subject to change.
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.ref }}-suspend-channel-early-access
+  cancel-in-progress: true
+
+jobs:
+
+  git_info:
+    name: Get git info
+    runs-on: ubuntu-latest
+    outputs:
+      ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
+      ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
+      ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
+      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      github_sha: ${{ steps.git_info.outputs.github_sha }}
+    steps:
+      - id: git_info
+        name: Get tag name and SHA
+        run: |
+          # Detect git tag for release.
+          gitTag=${GITHUB_REF#refs/tags/}
+          if [[ ${GITHUB_REF} == $gitTag ]] ; then
+            gitTag=
+          fi
+          echo "::set-output name=ci_commit_tag::${gitTag}"
+          echo "ci_commit_tag='${gitTag}'"
+
+          # Detect git branch.
+          gitBranch=${GITHUB_REF#refs/heads/}
+          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
+            gitBranch=
+          fi
+          echo "::set-output name=ci_commit_branch::${gitBranch}"
+          echo "ci_commit_branch='${gitBranch}'"
+
+          # CI_COMMIT_REF_NAME for main werf.yaml
+          commitRefName=
+          [[ -n $gitBranch ]] && commitRefName=$gitBranch
+          [[ -n $gitTag ]] && commitRefName=$gitTag
+          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
+          echo "ci_commit_ref_name='${commitRefName}'"
+
+          # CI_PIPELINE_CREATED_AT for main werf.yaml
+          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
+          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
+          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+
+          # Determine sha of commit.
+          # push event
+          githubSha=${GITHUB_SHA}
+          echo "github_sha for push '${githubSha}'"
+          # workflow_dispatch event
+          if [[ -z $githubSha ]] ; then
+            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
+            echo "github_sha for workflow_dispatch '${githubSha}'"
+          fi
+          echo "::set-output name=github_sha::$githubSha"
+          echo "github_sha='${githubSha}'"
+
+  check_label:
+    name: Check label
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check_label.outputs.should_run }}
+      labels: ${{ steps.check_label.outputs.labels }}
+    steps:
+
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+      - id: check_label
+        name: Check labels on push
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            const labelType = 'suspend';
+            const labelSubject = 'early-access';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.checkLabel({github, context, core, labelType, labelSubject});
+
+  run_suspend:
+    name: Suspend deckhouse release on early-access channel
+    environment:
+      name: early-access
+    needs:
+      - check_label
+      - git_info
+    if: needs.check_label.outputs.should_run == 'true'
+    runs-on: self-hosted
+    steps:
+
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.ref }}
+          fetch-depth: 0
+      - name: Update comment on start
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'Suspend the early-access';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      - name: Restore images_tags_json from cache
+        id: images-tags-json
+        uses: actions/cache@v2.1.7
+        with:
+          path: modules/images_tags_${{env.WERF_ENV}}.json
+          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
+      - name: Fail if not found
+        if: steps.images-tags-json.outputs.cache-hit != 'true'
+        run: |
+          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
+          exit 1
+
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+
+      - name: Login to readonly registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          logout: false
+
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+
+
+
+      - name: Publish release images for CE
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: CE
+        run: |
+          # Some precautions.
+          if [[ -z $DEV_REGISTRY_PATH ]] ; then
+            echo "DEV_REGISTRY_PATH is not set!"
+            exit 1
+          fi
+          if [[ -z $WERF_ENV ]] ; then
+            echo "WERF_ENV is not set!"
+            exit 1
+          fi
+
+          # Variables
+          #   1. CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          echo "Registry suffix - ${REGISTRY_SUFFIX}"
+
+          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
+          RELEASE_CHANNEL=early-access
+          echo "Release channel - ${RELEASE_CHANNEL}"
+
+          #   3. Publish prod images to rw registry
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          else
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          fi
+
+          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          cat <<EOF >Dockerfile
+          FROM spotify/scratch
+          COPY version.json version.json
+          EOF
+          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+
+          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
+          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+
+          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+      - name: Publish release images for EE
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: EE
+        run: |
+          # Some precautions.
+          if [[ -z $DEV_REGISTRY_PATH ]] ; then
+            echo "DEV_REGISTRY_PATH is not set!"
+            exit 1
+          fi
+          if [[ -z $WERF_ENV ]] ; then
+            echo "WERF_ENV is not set!"
+            exit 1
+          fi
+
+          # Variables
+          #   1. CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          echo "Registry suffix - ${REGISTRY_SUFFIX}"
+
+          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
+          RELEASE_CHANNEL=early-access
+          echo "Release channel - ${RELEASE_CHANNEL}"
+
+          #   3. Publish prod images to rw registry
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          else
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          fi
+
+          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          cat <<EOF >Dockerfile
+          FROM spotify/scratch
+          COPY version.json version.json
+          EOF
+          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+
+          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
+          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+
+          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+      - name: Publish release images for FE
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: FE
+        run: |
+          # Some precautions.
+          if [[ -z $DEV_REGISTRY_PATH ]] ; then
+            echo "DEV_REGISTRY_PATH is not set!"
+            exit 1
+          fi
+          if [[ -z $WERF_ENV ]] ; then
+            echo "WERF_ENV is not set!"
+            exit 1
+          fi
+
+          # Variables
+          #   1. CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          echo "Registry suffix - ${REGISTRY_SUFFIX}"
+
+          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
+          RELEASE_CHANNEL=early-access
+          echo "Release channel - ${RELEASE_CHANNEL}"
+
+          #   3. Publish prod images to rw registry
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          else
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          fi
+
+          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          cat <<EOF >Dockerfile
+          FROM spotify/scratch
+          COPY version.json version.json
+          EOF
+          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+
+          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
+          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+
+          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+
+      - name: Update comment on finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        continue-on-error: true
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusSource = 'job';
+            const name = 'Suspend the early-access';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+
+            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
+            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+

--- a/.github/workflows/suspend-rock-solid.yml
+++ b/.github/workflows/suspend-rock-solid.yml
@@ -1,0 +1,339 @@
+#
+# THIS FILE IS GENERATED, PLEASE DO NOT EDIT.
+#
+
+name: 'Suspend the rock-solid'
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_id:
+        description: 'Id of issue where label was set'
+        required: true
+      issue_number:
+        description: 'Number of issue where label was set'
+        required: true
+      comment_id:
+        description: 'Id of comment in issue where to put workflow run status'
+        required: true
+
+env:
+
+  # Don't forget to update .gitlab-ci-simple.yml if necessary
+  WERF_CHANNEL: "ea"
+  WERF_ENV: "FE"
+  # We use stapel image from own registry due to docker hub pull amount limitation.
+  # To re-push stapel image from docker hub use command:
+  # `skopeo copy docker://flant/werf-stapel:0.6.1 docker://registry-write.deckhouse.io/flant/werf-stapel:0.6.1`
+  WERF_STAPEL_IMAGE_NAME: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}/flant/werf-stapel"
+  WERF_STAPEL_IMAGE_VERSION: "0.6.1"
+  TEST_TIMEOUT: "15m"
+  # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
+  DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
+  BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
+
+  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  DEPLOY_CHANNEL: rock-solid
+
+# Analog of Gitlab's "interruptible: true" behaviour.
+# Note: Concurrency is currently in beta and subject to change.
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.ref }}-suspend-channel-rock-solid
+  cancel-in-progress: true
+
+jobs:
+
+  git_info:
+    name: Get git info
+    runs-on: ubuntu-latest
+    outputs:
+      ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
+      ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
+      ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
+      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      github_sha: ${{ steps.git_info.outputs.github_sha }}
+    steps:
+      - id: git_info
+        name: Get tag name and SHA
+        run: |
+          # Detect git tag for release.
+          gitTag=${GITHUB_REF#refs/tags/}
+          if [[ ${GITHUB_REF} == $gitTag ]] ; then
+            gitTag=
+          fi
+          echo "::set-output name=ci_commit_tag::${gitTag}"
+          echo "ci_commit_tag='${gitTag}'"
+
+          # Detect git branch.
+          gitBranch=${GITHUB_REF#refs/heads/}
+          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
+            gitBranch=
+          fi
+          echo "::set-output name=ci_commit_branch::${gitBranch}"
+          echo "ci_commit_branch='${gitBranch}'"
+
+          # CI_COMMIT_REF_NAME for main werf.yaml
+          commitRefName=
+          [[ -n $gitBranch ]] && commitRefName=$gitBranch
+          [[ -n $gitTag ]] && commitRefName=$gitTag
+          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
+          echo "ci_commit_ref_name='${commitRefName}'"
+
+          # CI_PIPELINE_CREATED_AT for main werf.yaml
+          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
+          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
+          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+
+          # Determine sha of commit.
+          # push event
+          githubSha=${GITHUB_SHA}
+          echo "github_sha for push '${githubSha}'"
+          # workflow_dispatch event
+          if [[ -z $githubSha ]] ; then
+            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
+            echo "github_sha for workflow_dispatch '${githubSha}'"
+          fi
+          echo "::set-output name=github_sha::$githubSha"
+          echo "github_sha='${githubSha}'"
+
+  check_label:
+    name: Check label
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check_label.outputs.should_run }}
+      labels: ${{ steps.check_label.outputs.labels }}
+    steps:
+
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+      - id: check_label
+        name: Check labels on push
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            const labelType = 'suspend';
+            const labelSubject = 'rock-solid';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.checkLabel({github, context, core, labelType, labelSubject});
+
+  run_suspend:
+    name: Suspend deckhouse release on rock-solid channel
+    environment:
+      name: rock-solid
+    needs:
+      - check_label
+      - git_info
+    if: needs.check_label.outputs.should_run == 'true'
+    runs-on: self-hosted
+    steps:
+
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.ref }}
+          fetch-depth: 0
+      - name: Update comment on start
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'Suspend the rock-solid';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      - name: Restore images_tags_json from cache
+        id: images-tags-json
+        uses: actions/cache@v2.1.7
+        with:
+          path: modules/images_tags_${{env.WERF_ENV}}.json
+          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
+      - name: Fail if not found
+        if: steps.images-tags-json.outputs.cache-hit != 'true'
+        run: |
+          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
+          exit 1
+
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+
+      - name: Login to readonly registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          logout: false
+
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+
+
+
+      - name: Publish release images for CE
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: CE
+        run: |
+          # Some precautions.
+          if [[ -z $DEV_REGISTRY_PATH ]] ; then
+            echo "DEV_REGISTRY_PATH is not set!"
+            exit 1
+          fi
+          if [[ -z $WERF_ENV ]] ; then
+            echo "WERF_ENV is not set!"
+            exit 1
+          fi
+
+          # Variables
+          #   1. CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          echo "Registry suffix - ${REGISTRY_SUFFIX}"
+
+          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
+          RELEASE_CHANNEL=rock-solid
+          echo "Release channel - ${RELEASE_CHANNEL}"
+
+          #   3. Publish prod images to rw registry
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          else
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          fi
+
+          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          cat <<EOF >Dockerfile
+          FROM spotify/scratch
+          COPY version.json version.json
+          EOF
+          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+
+          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
+          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+
+          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+      - name: Publish release images for EE
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: EE
+        run: |
+          # Some precautions.
+          if [[ -z $DEV_REGISTRY_PATH ]] ; then
+            echo "DEV_REGISTRY_PATH is not set!"
+            exit 1
+          fi
+          if [[ -z $WERF_ENV ]] ; then
+            echo "WERF_ENV is not set!"
+            exit 1
+          fi
+
+          # Variables
+          #   1. CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          echo "Registry suffix - ${REGISTRY_SUFFIX}"
+
+          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
+          RELEASE_CHANNEL=rock-solid
+          echo "Release channel - ${RELEASE_CHANNEL}"
+
+          #   3. Publish prod images to rw registry
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          else
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          fi
+
+          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          cat <<EOF >Dockerfile
+          FROM spotify/scratch
+          COPY version.json version.json
+          EOF
+          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+
+          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
+          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+
+          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+      - name: Publish release images for FE
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: FE
+        run: |
+          # Some precautions.
+          if [[ -z $DEV_REGISTRY_PATH ]] ; then
+            echo "DEV_REGISTRY_PATH is not set!"
+            exit 1
+          fi
+          if [[ -z $WERF_ENV ]] ; then
+            echo "WERF_ENV is not set!"
+            exit 1
+          fi
+
+          # Variables
+          #   1. CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          echo "Registry suffix - ${REGISTRY_SUFFIX}"
+
+          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
+          RELEASE_CHANNEL=rock-solid
+          echo "Release channel - ${RELEASE_CHANNEL}"
+
+          #   3. Publish prod images to rw registry
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          else
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          fi
+
+          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          cat <<EOF >Dockerfile
+          FROM spotify/scratch
+          COPY version.json version.json
+          EOF
+          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+
+          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
+          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+
+          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+
+      - name: Update comment on finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        continue-on-error: true
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusSource = 'job';
+            const name = 'Suspend the rock-solid';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+
+            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
+            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+

--- a/.github/workflows/suspend-stable.yml
+++ b/.github/workflows/suspend-stable.yml
@@ -1,0 +1,339 @@
+#
+# THIS FILE IS GENERATED, PLEASE DO NOT EDIT.
+#
+
+name: 'Suspend the stable'
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_id:
+        description: 'Id of issue where label was set'
+        required: true
+      issue_number:
+        description: 'Number of issue where label was set'
+        required: true
+      comment_id:
+        description: 'Id of comment in issue where to put workflow run status'
+        required: true
+
+env:
+
+  # Don't forget to update .gitlab-ci-simple.yml if necessary
+  WERF_CHANNEL: "ea"
+  WERF_ENV: "FE"
+  # We use stapel image from own registry due to docker hub pull amount limitation.
+  # To re-push stapel image from docker hub use command:
+  # `skopeo copy docker://flant/werf-stapel:0.6.1 docker://registry-write.deckhouse.io/flant/werf-stapel:0.6.1`
+  WERF_STAPEL_IMAGE_NAME: "${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}/flant/werf-stapel"
+  WERF_STAPEL_IMAGE_VERSION: "0.6.1"
+  TEST_TIMEOUT: "15m"
+  # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
+  DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
+  BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
+
+  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  DEPLOY_CHANNEL: stable
+
+# Analog of Gitlab's "interruptible: true" behaviour.
+# Note: Concurrency is currently in beta and subject to change.
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.ref }}-suspend-channel-stable
+  cancel-in-progress: true
+
+jobs:
+
+  git_info:
+    name: Get git info
+    runs-on: ubuntu-latest
+    outputs:
+      ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
+      ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
+      ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
+      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      github_sha: ${{ steps.git_info.outputs.github_sha }}
+    steps:
+      - id: git_info
+        name: Get tag name and SHA
+        run: |
+          # Detect git tag for release.
+          gitTag=${GITHUB_REF#refs/tags/}
+          if [[ ${GITHUB_REF} == $gitTag ]] ; then
+            gitTag=
+          fi
+          echo "::set-output name=ci_commit_tag::${gitTag}"
+          echo "ci_commit_tag='${gitTag}'"
+
+          # Detect git branch.
+          gitBranch=${GITHUB_REF#refs/heads/}
+          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
+            gitBranch=
+          fi
+          echo "::set-output name=ci_commit_branch::${gitBranch}"
+          echo "ci_commit_branch='${gitBranch}'"
+
+          # CI_COMMIT_REF_NAME for main werf.yaml
+          commitRefName=
+          [[ -n $gitBranch ]] && commitRefName=$gitBranch
+          [[ -n $gitTag ]] && commitRefName=$gitTag
+          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
+          echo "ci_commit_ref_name='${commitRefName}'"
+
+          # CI_PIPELINE_CREATED_AT for main werf.yaml
+          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
+          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
+          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+
+          # Determine sha of commit.
+          # push event
+          githubSha=${GITHUB_SHA}
+          echo "github_sha for push '${githubSha}'"
+          # workflow_dispatch event
+          if [[ -z $githubSha ]] ; then
+            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
+            echo "github_sha for workflow_dispatch '${githubSha}'"
+          fi
+          echo "::set-output name=github_sha::$githubSha"
+          echo "github_sha='${githubSha}'"
+
+  check_label:
+    name: Check label
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check_label.outputs.should_run }}
+      labels: ${{ steps.check_label.outputs.labels }}
+    steps:
+
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+      - id: check_label
+        name: Check labels on push
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            const labelType = 'suspend';
+            const labelSubject = 'stable';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.checkLabel({github, context, core, labelType, labelSubject});
+
+  run_suspend:
+    name: Suspend deckhouse release on stable channel
+    environment:
+      name: stable
+    needs:
+      - check_label
+      - git_info
+    if: needs.check_label.outputs.should_run == 'true'
+    runs-on: self-hosted
+    steps:
+
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.ref }}
+          fetch-depth: 0
+      - name: Update comment on start
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'Suspend the stable';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      - name: Restore images_tags_json from cache
+        id: images-tags-json
+        uses: actions/cache@v2.1.7
+        with:
+          path: modules/images_tags_${{env.WERF_ENV}}.json
+          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
+      - name: Fail if not found
+        if: steps.images-tags-json.outputs.cache-hit != 'true'
+        run: |
+          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
+          exit 1
+
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+
+      - name: Login to readonly registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          logout: false
+
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+
+
+
+      - name: Publish release images for CE
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: CE
+        run: |
+          # Some precautions.
+          if [[ -z $DEV_REGISTRY_PATH ]] ; then
+            echo "DEV_REGISTRY_PATH is not set!"
+            exit 1
+          fi
+          if [[ -z $WERF_ENV ]] ; then
+            echo "WERF_ENV is not set!"
+            exit 1
+          fi
+
+          # Variables
+          #   1. CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          echo "Registry suffix - ${REGISTRY_SUFFIX}"
+
+          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
+          RELEASE_CHANNEL=stable
+          echo "Release channel - ${RELEASE_CHANNEL}"
+
+          #   3. Publish prod images to rw registry
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          else
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          fi
+
+          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          cat <<EOF >Dockerfile
+          FROM spotify/scratch
+          COPY version.json version.json
+          EOF
+          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+
+          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
+          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+
+          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+      - name: Publish release images for EE
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: EE
+        run: |
+          # Some precautions.
+          if [[ -z $DEV_REGISTRY_PATH ]] ; then
+            echo "DEV_REGISTRY_PATH is not set!"
+            exit 1
+          fi
+          if [[ -z $WERF_ENV ]] ; then
+            echo "WERF_ENV is not set!"
+            exit 1
+          fi
+
+          # Variables
+          #   1. CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          echo "Registry suffix - ${REGISTRY_SUFFIX}"
+
+          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
+          RELEASE_CHANNEL=stable
+          echo "Release channel - ${RELEASE_CHANNEL}"
+
+          #   3. Publish prod images to rw registry
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          else
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          fi
+
+          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          cat <<EOF >Dockerfile
+          FROM spotify/scratch
+          COPY version.json version.json
+          EOF
+          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+
+          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
+          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+
+          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+      - name: Publish release images for FE
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          WERF_ENV: FE
+        run: |
+          # Some precautions.
+          if [[ -z $DEV_REGISTRY_PATH ]] ; then
+            echo "DEV_REGISTRY_PATH is not set!"
+            exit 1
+          fi
+          if [[ -z $WERF_ENV ]] ; then
+            echo "WERF_ENV is not set!"
+            exit 1
+          fi
+
+          # Variables
+          #   1. CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          echo "Registry suffix - ${REGISTRY_SUFFIX}"
+
+          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
+          RELEASE_CHANNEL=stable
+          echo "Release channel - ${RELEASE_CHANNEL}"
+
+          #   3. Publish prod images to rw registry
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          else
+            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          fi
+
+          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          cat <<EOF >Dockerfile
+          FROM spotify/scratch
+          COPY version.json version.json
+          EOF
+          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+
+          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
+          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+
+          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+
+      - name: Update comment on finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        continue-on-error: true
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusSource = 'job';
+            const name = 'Suspend the stable';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+
+            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
+            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+

--- a/canary.json
+++ b/canary.json
@@ -1,0 +1,7 @@
+{
+  "alpha": {"enabled": true, "waves": 2, "interval": "5m"},
+  "beta": {"enabled": false, "waves": 1, "interval": "1m"},
+  "early-access": {"enabled": true, "waves": 6, "interval": "30m"},
+  "stable": {"enabled": true, "waves": 6, "interval": "20m"},
+  "rock-solid": {"enabled": false, "waves": 5, "interval": "5m"}
+}

--- a/modules/020-deckhouse/crds/deckhouse-release.yaml
+++ b/modules/020-deckhouse/crds/deckhouse-release.yaml
@@ -41,6 +41,9 @@ spec:
                   type: string
                   description: Deckhouse version.
                   example: 'v1.24.20'
+                applyAfter:
+                  type: string
+                  description: Marks release as a part of canary release. This release will be delayed until this time.
             status:
               type: object
               properties:
@@ -50,6 +53,7 @@ spec:
                     - Pending
                     - Deployed
                     - Outdated
+                    - Suspended
                   description: Current status of the release.
                 transitionTime:
                   type: string
@@ -69,6 +73,10 @@ spec:
           jsonPath: .status.phase
           type: string
           description: 'Current release status.'
+        - name: applyAfter
+          jsonPath: .spec.applyAfter
+          type: string
+          description: 'This release will be applied after this time.'
         - name: transitionTime
           jsonPath: .status.transitionTime
           type: date

--- a/modules/020-deckhouse/crds/doc-ru-deckhouse-release.yaml
+++ b/modules/020-deckhouse/crds/doc-ru-deckhouse-release.yaml
@@ -15,6 +15,8 @@ spec:
               properties:
                 version:
                   description: Версия Deckhouse.
+                applyAfter:
+                  description: Релиз является частью canary-release. Он отложен до указанного времени.
             status:
               properties:
                 phase:
@@ -35,6 +37,10 @@ spec:
           jsonPath: .status.phase
           type: string
           description: 'Показывает текущий статус релиза.'
+        - name: applyAfter
+          jsonPath: .spec.applyAfter
+          type: string
+          description: 'Релиз отложен до указанного времени.'
         - name: transitionTime
           jsonPath: .status.transitionTime
           type: date

--- a/modules/020-deckhouse/hooks/internal/v1alpha1/deckhouse_release.go
+++ b/modules/020-deckhouse/hooks/internal/v1alpha1/deckhouse_release.go
@@ -28,9 +28,10 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 const (
-	PhasePending  = "Pending"
-	PhaseDeployed = "Deployed"
-	PhaseOutdated = "Outdated"
+	PhasePending   = "Pending"
+	PhaseDeployed  = "Deployed"
+	PhaseOutdated  = "Outdated"
+	PhaseSuspended = "Suspended"
 )
 
 // DeckhouseRelease is a deckhouse release object.
@@ -49,7 +50,8 @@ type DeckhouseRelease struct {
 }
 
 type DeckhouseReleaseSpec struct {
-	Version string `json:"version,omitempty"`
+	Version    string     `json:"version,omitempty"`
+	ApplyAfter *time.Time `json:"applyAfter,omitempty"`
 }
 
 type DeckhouseReleaseStatus struct {

--- a/werf.yaml
+++ b/werf.yaml
@@ -741,5 +741,6 @@ shell:
   install:
   - |
     version="{{ env "CI_COMMIT_REF_NAME" }}"
-    createdDate="{{ env "CI_PIPELINE_CREATED_AT" }}"
-    echo '{"version": "'${version}'", "release_date": "'${createdDate}'"}' > /version.json
+    canary='{{ .Files.Get "canary.json" | fromJson | toJson }}'
+    json="{\"version\": \"${version}\", \"canary\": ${canary}}"
+    echo "$json" > /version.json


### PR DESCRIPTION
## Description
For a large number of clusters on a release channel, we want to have the ability to spread release in time

## Why we need it and what problem does it solve?
Spreaded release will generate less load and become more stable

Closes https://github.com/deckhouse/deckhouse/issues/332

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: deckhouse
type: feature
description: Add canary deckhouse release update
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
