### PR TITLE
[deckhouse] Add alert for invalid config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.9.0
-	github.com/flant/addon-operator v1.0.3
+	github.com/flant/addon-operator v1.0.4-0.20211223084356-d86a065d5763
 	github.com/flant/kube-client v0.0.6
 	github.com/flant/shell-operator v1.0.6
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwo
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/flant/addon-operator v1.0.3 h1:OGyiTNYY2BzUvaq+vKiGEmIR8tbc22SrA9vbGtcZntM=
-github.com/flant/addon-operator v1.0.3/go.mod h1:tnPlRx/3XjwLTm8Oi30IbpZuyp4l5XGiV6ipatms+Jw=
+github.com/flant/addon-operator v1.0.4-0.20211223084356-d86a065d5763 h1:FaxtUchM9imRO9R7UoO8Ac1TDmGwFH+6fEc0StIaOM0=
+github.com/flant/addon-operator v1.0.4-0.20211223084356-d86a065d5763/go.mod h1:tnPlRx/3XjwLTm8Oi30IbpZuyp4l5XGiV6ipatms+Jw=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v0.0.6 h1:cHFMf7xGtJOgg+KBuPcA+7q+M7IJRSgf2pHVStv2aj0=

--- a/modules/020-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/020-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -322,3 +322,23 @@
         Deckhouse does not work as expected.
 
         You can find out the exact problem in the relevant alerts.
+
+  - alert: D8DeckhouseConfigInvalid
+    expr: increase(deckhouse_config_values_errors_total[30s]) > 0
+    for: 1m
+    labels:
+      severity_level: "5"
+      d8_module: deckhouse
+      d8_component: deckhouse
+      tier: cluster
+    annotations:
+      plk_markup_format: "markdown"
+      plk_protocol_version: "1"
+      plk_grouped_by__main: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
+      description: |
+        Deckhouse config contains errors.
+
+        Please check Deckhouse logs by running `kubectl -n d8-system logs -f -l app=deckhouse`.
+        Edit Deckhouse config by running: `kubectl -n d8-system edit cm deckhouse`.
+      summary: |
+        Deckhouse config is invalid.


### PR DESCRIPTION
## Description
Add alert for broken deckhouse config

(Close #87)

## Why we need it and what problem does it solve?
We don't have in place validation for deckhouse config values cm. If someone put wrong values into it we can miss a problem and will be surprised by broken/abnormally working Deckhouse

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: deckhouse
type: feature
description: Add alert if deckhouse config is broken
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
