### PR TITLE
[deckhouse] Ignore flaky queues in D8DeckhouseQueueIsHung alert

### DIFF
--- a/modules/020-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/020-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -165,7 +165,7 @@
         Usually, this alert means that the Deckhouse Pod is having difficulties with connecting to the Internet.
 
   - alert: D8DeckhouseQueueIsHung
-    expr: max by (pod, instance, queue) (min_over_time(deckhouse_tasks_queue_length{queue!~"main-subqueue-kubernetes-.*|/modules/upmeter/update_selector"}[__SCRAPE_INTERVAL_X_3__])) != 0
+    expr: max by (pod, instance, queue) (min_over_time(deckhouse_tasks_queue_length{queue!~"main-subqueue-kubernetes-.*|/modules/upmeter/update_selector.*|/modules/secret-copier"}[__SCRAPE_INTERVAL_X_3__])) != 0
     for: 20m
     labels:
       severity_level: "7"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
We know about the problem and waiting for fix to be released. For now, we want to reduce flaky alerts.
