### PR TITLE
[deckhouse] severity level based on releases count

### DIFF
--- a/modules/020-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/020-deckhouse/hooks/check_deckhouse_release.go
@@ -115,9 +115,9 @@ func checkReleases(input *go_hook.HookInput, dc dependency.Container) error {
 	input.Values.Set("deckhouse.internal.releaseVersionImageHash", newImageHash)
 
 	snap := input.Snapshots["releases"]
-	releases := make([]deckhouseReleaseUpdate, 0, len(snap))
+	releases := make([]deckhouseRelease, 0, len(snap))
 	for _, rl := range snap {
-		releases = append(releases, rl.(deckhouseReleaseUpdate))
+		releases = append(releases, rl.(deckhouseRelease))
 	}
 
 	sort.Sort(sort.Reverse(byVersion(releases)))

--- a/modules/020-deckhouse/hooks/check_deckhouse_release_test.go
+++ b/modules/020-deckhouse/hooks/check_deckhouse_release_test.go
@@ -221,23 +221,23 @@ func (fl fakeLayer) Size() (int64, error) {
 }
 
 func TestSort(t *testing.T) {
-	s1 := deckhouseReleaseUpdate{
+	s1 := deckhouseRelease{
 		Version: semver.MustParse("v1.24.0"),
 	}
-	s2 := deckhouseReleaseUpdate{
+	s2 := deckhouseRelease{
 		Version: semver.MustParse("v1.24.1"),
 	}
-	s3 := deckhouseReleaseUpdate{
+	s3 := deckhouseRelease{
 		Version: semver.MustParse("v1.24.2"),
 	}
-	s4 := deckhouseReleaseUpdate{
+	s4 := deckhouseRelease{
 		Version: semver.MustParse("v1.24.3"),
 	}
-	s5 := deckhouseReleaseUpdate{
+	s5 := deckhouseRelease{
 		Version: semver.MustParse("v1.24.4"),
 	}
 
-	releases := []deckhouseReleaseUpdate{s3, s4, s1, s5, s2}
+	releases := []deckhouseRelease{s3, s4, s1, s5, s2}
 	sort.Sort(sort.Reverse(byVersion(releases)))
 
 	for i, rl := range releases {

--- a/modules/020-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/020-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -21,9 +21,43 @@
       summary: |
         Deckhouse in the cluster is not subscribed to one of the regular release channels.
   - alert: DeckhouseReleaseIsWaitingManualApproval
-    expr: max by (name) (d8_release_waiting_manual) > 0
+    expr: max by (name) (d8_release_waiting_manual) == 1
     labels:
       severity_level: "9"
+      d8_module: deckhouse
+      d8_component: deckhouse
+      tier: cluster
+    annotations:
+      plk_markup_format: "markdown"
+      plk_protocol_version: "1"
+      plk_incident_initial_status: "todo"
+      description: |
+        Deckhouse release is waiting for manual approval.
+
+        Please run `kubectl patch DeckhouseRelease {{ $labels.name }} --type=merge -p='{"approved": true}'` for confirmation.
+      summary: |
+        Deckhouse release is waiting for manual approval.
+  - alert: DeckhouseReleaseIsWaitingManualApproval
+    expr: max by (name) (d8_release_waiting_manual) == 2
+    labels:
+      severity_level: "6"
+      d8_module: deckhouse
+      d8_component: deckhouse
+      tier: cluster
+    annotations:
+      plk_markup_format: "markdown"
+      plk_protocol_version: "1"
+      plk_incident_initial_status: "todo"
+      description: |
+        Deckhouse release is waiting for manual approval.
+
+        Please run `kubectl patch DeckhouseRelease {{ $labels.name }} --type=merge -p='{"approved": true}'` for confirmation.
+      summary: |
+        Deckhouse release is waiting for manual approval.
+  - alert: DeckhouseReleaseIsWaitingManualApproval
+    expr: max by (name) (d8_release_waiting_manual) >= 3
+    labels:
+      severity_level: "3"
       d8_module: deckhouse
       d8_component: deckhouse
       tier: cluster


### PR DESCRIPTION
## Description
Change alert severity level based on pending manual releases

(Close https://github.com/deckhouse/deckhouse/issues/340)

## Why we need it and what problem does it solve?
We can miss the low severity alert but if we have a few pending releases - something is going wrong.
We want to increase the level and pay more attention for the alert

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: deckhouse
type: feature
description: Different severity level based on pending DeckhouseReleases count
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
