### PR TITLE
[log-shipper] [chrony] add workload-resource-policy label to VPA

### DIFF
--- a/modules/460-log-shipper/templates/daemonset.yaml
+++ b/modules/460-log-shipper/templates/daemonset.yaml
@@ -7,7 +7,7 @@ kind: VerticalPodAutoscaler
 metadata:
   name: vector-agent
   namespace: d8-{{ $.Chart.Name }}
-{{ include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | indent 2 }}
+{{ include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name "workload-resource-policy.deckhouse.io" "every-node")) | indent 2 }}
 spec:
   targetRef:
     apiVersion: apps/v1

--- a/modules/470-chrony/openapi/config-values.yaml
+++ b/modules/470-chrony/openapi/config-values.yaml
@@ -5,7 +5,7 @@ properties:
     x-examples:
       - {updateMode: "Initial", maxCPU: "30m", maxMemory: "30Mi"}
       - {updateMode: "Off", maxCPU: "10m", maxMemory: "10Mi"}
-    default: {updateMode: "Initial",maxCPU: "10m", maxMemory: "10Mi"}
+    default: {updateMode: "Auto",maxCPU: "10m", maxMemory: "10Mi"}
     properties:
       maxCPU:
         oneOf:

--- a/modules/470-chrony/templates/daemonset.yaml
+++ b/modules/470-chrony/templates/daemonset.yaml
@@ -5,7 +5,7 @@ kind: VerticalPodAutoscaler
 metadata:
   name: chrony
   namespace: d8-{{ .Chart.Name }}
-{{ include "helm_lib_module_labels" (list . (dict "app" "chrony" "tier" "node")) | indent 2 }}
+{{ include "helm_lib_module_labels" (list . (dict "app" "chrony" "tier" "node" "workload-resource-policy.deckhouse.io" "every-node")) | indent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"


### PR DESCRIPTION
## Description
Add Label `workload-resource-policy.deckhouse.io=every-node` to `vector-agent` and `chrony` VPAs, to make them take part in resources requests calculations.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why we need it and what problem does it solve?
Sometimes `vector-agent` and `chrony` requests resources that are not considered by our automated logic that tends to Pod become un-schedulable.
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: log-shipper
type: fix
description: |
  Add VPA label `workload-resource-policy` to make it take part in resources requests calculations.
---
module: chrony
type: fix
description: |
  Add VPA label `workload-resource-policy` to make it take part in resources requests calculations.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
