### PR TITLE
[prometheus] fixed node-exporter apparmor profile

### DIFF
--- a/candi/bashible/bundles/ubuntu-lts/all/002_install_apparmor_profiles.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/all/002_install_apparmor_profiles.sh.tpl
@@ -1,0 +1,56 @@
+# Copyright 2021 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bb-event-on 'bb-sync-file-changed' '_on_apparmor_profile_changed'
+_on_apparmor_profile_changed() {
+  systemctl reload apparmor.service
+}
+
+bb-sync-file /etc/apparmor.d/node-exporter - << "EOF"
+#include <tunables/global>
+
+profile node-exporter flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  capability,
+
+  network,
+
+  deny mount,
+
+  umount,
+
+  ptrace read peer=cri-containerd.apparmor.d,
+  ptrace read peer=unconfined,
+
+  deny /sys/[^f]*/** wlkx,
+  deny /sys/f[^s]*/** wlkx,
+  deny /sys/firmware/efi/efivars/** rwlkx,
+  deny /sys/fs/[^c]*/** wlkx,
+  deny /sys/fs/c[^g]*/** wlkx,
+  deny /sys/fs/cg[^r]*/** wlkx,
+  deny /sys/kernel/security/** rwlkx,
+  deny @{PROC}/* w, # deny write for all files directly in /proc (not in a subdir)
+  deny @{PROC}/kcore rwlkx,
+  deny @{PROC}/kmem rwlkx,
+  deny @{PROC}/mem rwlkx,
+  deny @{PROC}/sys/[^k]** w, # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
+  deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w, # deny everything except shm* in /proc/sys/kernel/
+  deny @{PROC}/sysrq-trigger rwlkx,
+  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
+
+  file,
+
+}
+EOF

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -43,6 +43,8 @@ spec:
       app: node-exporter
   template:
     metadata:
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/node-exporter: localhost/node-exporter
       labels:
         app: node-exporter
       name: node-exporter


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed node-exporter apparmor profile.
## Why we need it and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
With standard CRI AppArmor profile we got errors:
```
type=AVC msg=audit(1639955582.902:93693): apparmor="DENIED" operation="ptrace" profile="cri-containerd.apparmor.d" pid=315073 comm="node_exporter" requested_mask="read" denied_mask="read" peer="unconfined
```
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: monitoring-kubernetes
type: fix
description: "Fixed node-exporter apparmor profile."
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
