### PR TITLE
Count only VPA targeting existing controllers with existing pods

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/namespace/namespaces.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/namespace/namespaces.json
@@ -890,7 +890,7 @@
           "refId": "A"
         },
         {
-          "expr": "100 * count by (namespace) (\n  sum by (namespace, verticalpodautoscaler) (avg_over_time(vpa_target_recommendation{namespace=~\"$namespace\", container!=\"POD\"}[$__range]))\n) \n/ count by (namespace) (sum by (namespace, controller) (avg_over_time(kube_controller_pod{namespace=~\"$namespace\"}[$__range])))\nor\ncount (avg_over_time(kube_controller_pod{node=~\"$node\", namespace=~\"$namespace\"}[$__range])) by (namespace) * 0",
+          "expr": "100 * count by (namespace) (\n  sum by (namespace, verticalpodautoscaler) (  \n    count by (namespace, controller_name, verticalpodautoscaler) (avg_over_time(vpa_target_recommendation{namespace=~\"$namespace\", container!=\"POD\"}[$__range]))\n    / on (controller_name, namespace) group_left\n    count by (namespace, controller_name) (avg_over_time(kube_controller_pod{namespace=~\"$namespace\"}[$__range]))\n  )\n) \n/ count by (namespace) (sum by (namespace, controller) (avg_over_time(kube_controller_pod{namespace=~\"$namespace\"}[$__range])))\nor\ncount (avg_over_time(kube_controller_pod{node=~\"$node\", namespace=~\"$namespace\"}[$__range])) by (namespace) * 0",
           "format": "table",
           "hide": false,
           "instant": true,


### PR DESCRIPTION
## Description

In 'Namespaces' dashboard, VPA '%' is calculated as the count of _VPA providing requests_ divided by the _count of active controllers_. Sometimes existing VPA do not target any controller or the controllers are not active. hence, the dashboard tale shows VPA covering more than 100% of controllers.

This PR fixes the expression. It calculates the VPA coverage as the division of _VPA providing requests and targeting active controllers_ divided by the _count of active controllers_.

## Why we need it and what problem does it solve?

Fixes #334

## Changelog entries

```changes
module: "monitoring-kubernetes"
type: "fix"
description: "Filter VPA by actual controllers to calculate VPA coverage"
```
