### PR TITLE
[ingress-nginx] clarify inlet LoadBalancer usage with MetalLB

### DIFF
--- a/modules/402-ingress-nginx/docs/USAGE.md
+++ b/modules/402-ingress-nginx/docs/USAGE.md
@@ -74,7 +74,7 @@ spec:
       loadbalancer.openstack.org/timeout-member-connect: "2000"
 ```
 
-## An example for bare metal
+## An example for bare metal (Host Ports)
 
 ```yaml
 apiVersion: deckhouse.io/v1
@@ -91,4 +91,38 @@ spec:
     key: dedicated.deckhouse.io
     value: frontend
 ```
+
+## An example for bare metal (MetalLB Load Balancer)
+
+```yaml
+apiVersion: deckhouse.io/v1
+kind: IngressNginxController
+metadata:
+  name: main
+spec:
+  ingressClass: nginx
+  inlet: LoadBalancer
+  nodeSelector:
+    node-role.deckhouse.io/frontend: ""
+  tolerations:
+  - effect: NoExecute
+    key: dedicated.deckhouse.io
+    value: frontend
+```
+In the case of using MetalLB, its speaker Pods must be run on the same Nodes as the ingress–controller Pods.
+
+The controller must receive real IP addresses of clients — therefore its Service is created with the parameter `externalTrafficPolicy: Local` (disabling cross–node SNAT), and to satisfy this parameter the MetalLB speaker announce this Service only from those Nodes where the target Pods are running.
+
+So for the current example [metallb module configuration](../380-metallb/configuration.html) should be like this:
+```yaml
+metallb:
+ speaker: 
+   nodeSelector: 
+     node-role.deckhouse.io/frontend: ""
+   tolerations: 
+    - effect: NoExecute
+      key: dedicated.deckhouse.io
+      value: frontend
+```
+
 {% endraw %}


### PR DESCRIPTION
## Description
Clarify inlet LoadBalancer usage with MetalLB.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why we need it and what problem does it solve?
There was a request for our support about such a case.
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: ingress-nginx
type: feature
description: |
  Add an example of usage LoadBalancer inlet with MetalLB.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
