### PR TITLE
[user-authn] Delete not matching secrets on publish api mode change

### DIFF
--- a/modules/150-user-authn/hooks/discover_publish_api_cert_test.go
+++ b/modules/150-user-authn/hooks/discover_publish_api_cert_test.go
@@ -158,4 +158,19 @@ data:
 			"",
 		),
 	)
+
+	Context("With all secrets in cluster", func() {
+		BeforeEach(func() {
+			f.ValuesSet("userAuthn.publishAPI.https.mode", "SelfSigned")
+			f.ValuesSet("userAuthn.https.mode", "CertManager")
+			f.BindingContexts.Set(f.KubeStateSet(selfSignedCertSecret + certManagerCertSecret + customCertSecret))
+			f.RunHook()
+		})
+
+		It("Should delete not matching secrets", func() {
+			Expect(f.KubernetesResource("Secret", "d8-user-authn", "kubernetes-tls-selfsigned").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Secret", "d8-user-authn", "kubernetes-tls").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Secret", "d8-user-authn", "kubernetes-tls-customcertificate").Exists()).To(BeFalse())
+		})
+	})
 })


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
* Delete secret if it is unused by the publish API ingress

## Why we need it and what problem does it solve?
1. It looks confusing when you see all the secrets in the namespace.
2. Without this change, Prometheus sends alerts that there are orphaned secrets (which is excessive, we do not have a real problem in the cluster).

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: user-authn
type: fix
description: Delete publish API secrets with not matching names to avoid the orphaned secrets alerts
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
