### PR TITLE
[prometheus] Grafana home dashboard queries improvements

### DIFF
--- a/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
+++ b/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
@@ -431,7 +431,7 @@
           "refId": "A"
         }
       ],
-      "title": "Kubernetes Server Version",
+      "title": "Kubernetes Version",
       "transformations": [],
       "transparent": true,
       "type": "stat"
@@ -496,13 +496,12 @@
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
-        "orientation": "auto",
+        "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "max"
-          ],
+          "calcs": [],
           "fields": "",
-          "values": false
+          "limit": 1,
+          "values": true
         },
         "text": {},
         "textMode": "name"
@@ -555,13 +554,12 @@
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
-        "orientation": "auto",
+        "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": [
-            "max"
-          ],
+          "calcs": [],
           "fields": "",
-          "values": false
+          "limit": 1,
+          "values": true
         },
         "text": {},
         "textMode": "name"
@@ -571,6 +569,8 @@
         {
           "exemplar": true,
           "expr": "sum by (os_image) (kube_node_info)",
+          "format": "time_series",
+          "instant": true,
           "interval": "",
           "legendFormat": "{{ git_version }}",
           "refId": "A"
@@ -629,9 +629,10 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "prometheus_build_info{service=\"prometheus\"}",
+          "expr": "max by (version, namespace) (prometheus_build_info{service=\"prometheus\", namespace=\"d8-monitoring\"})",
+          "instant": true,
           "interval": "",
-          "legendFormat": "{{ version }} {{ edition }}",
+          "legendFormat": "{{ version }}",
           "refId": "A"
         }
       ],
@@ -688,7 +689,8 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (version) (grafana_build_info{job=\"grafana\"})",
+          "expr": "max by (version, namespace) (grafana_build_info{service=\"grafana\", namespace=\"d8-monitoring\"})",
+          "instant": true,
           "interval": "",
           "legendFormat": "{{ version }} {{ edition }}",
           "refId": "A"


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
* Fix panel titles
* Fix queries

## Why do we need it and what problem does it solve?
There may be a variety of CRI/OS in the cluster, which makes the home dashboard output ugly and unreadable information on version panels. The second issue is that there may be Prometheus/Grafana instances in user namespaces, which will affect the shown versions of Deckhouse modules.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: prometheus
type: fix
description: Make Grafana home dashboard queries to only show the top-used versions  
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
