### PR TITLE
[local-path-provisioner] Update and build from source

### DIFF
--- a/modules/031-local-path-provisioner/images/local-path-provisioner/Dockerfile
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/Dockerfile
@@ -1,5 +1,19 @@
 ARG BASE_ALPINE
-FROM rancher/local-path-provisioner:v0.0.20@sha256:d5999b20a1b180940061677db3bdb48dd7eb432cd48147c4ff15469fb74ade80 as artifact
+FROM $BASE_ALPINE as artifact
+
+ARG VERSION=0.0.21
+ARG COMMIT_REF=755e331a276d4dd26f84377db5504a38109df8fb
+
+RUN apk add --no-cache go git
+RUN git clone https://github.com/rancher/local-path-provisioner.git
+WORKDIR /local-path-provisioner
+RUN git checkout "${COMMIT_REF}"
+
+# Do not create directory if not found (GH: #224)
+COPY patches/fix-directory-or-create.patch /
+RUN git apply /fix-directory-or-create.patch
+
+RUN CGO_ENABLED=0 go build -ldflags "-X main.VERSION=${VERSION} -extldflags -static -s -w" -o /local-path-provisioner
 
 FROM $BASE_ALPINE
 
@@ -10,6 +24,6 @@ RUN apk add --no-cache ca-certificates \
                        blkid \
                        e2fsprogs-extra
 
-COPY --from=artifact /usr/bin/local-path-provisioner /usr/bin/local-path-provisioner
+COPY --from=artifact /local-path-provisioner /usr/bin/local-path-provisioner
 
 ENTRYPOINT ["/usr/bin/local-path-provisioner"]

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/patches/README.md
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/patches/README.md
@@ -1,0 +1,7 @@
+## Patches
+
+## Fix DirectoryOrCreate
+
+Use `type: Directory` instead of `type: DirectoryOrCreate` for created PVs
+to avoid the situations when initial storage is broken and unmounted.
+https://github.com/rancher/local-path-provisioner/pull/224

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/patches/fix-directory-or-create.patch
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/patches/fix-directory-or-create.patch
@@ -1,0 +1,13 @@
+diff --git a/provisioner.go b/provisioner.go
+index b6591d0..be1aa9b 100644
+--- a/provisioner.go
++++ b/provisioner.go
+@@ -215,7 +215,7 @@ func (p *LocalPathProvisioner) Provision(opts pvController.ProvisionOptions) (*v
+ 	}
+ 
+ 	fs := v1.PersistentVolumeFilesystem
+-	hostPathType := v1.HostPathDirectoryOrCreate
++	hostPathType := v1.HostPathDirectory
+ 
+ 	valueNode, ok := node.GetLabels()[KeyNode]
+ 	if !ok {


### PR DESCRIPTION
## Description
This PR:
- updating local-path-provisioner 0.0.20 --> 0.0.21
- enables building from source code
- and applies patch from https://github.com/rancher/local-path-provisioner/pull/224

## Why we need it and what problem does it solve?

There is known problem https://github.com/rancher/local-path-provisioner/issues/137 which was confirmed by maintainer. It was [fixed](https://github.com/rancher/local-path-provisioner/issues/138) by me about year ago but then reverted due to silly problem on maintainers side.

I do not give up hope that it will be united one time, as for now I suggest the permanent fix on our side.

## Changelog entries

```changes
module: local-path-provisioner
type: fix
description: "Update local-path-provisioner v0.0.21, include fix"
note: |
  Protect PVs to be reused in case of unmounted storage.
```
