### PR TITLE
[extended-monitoring] Add cert-exporter

### DIFF
--- a/ee/fe/modules/340-extended-monitoring/docs/README.md
+++ b/ee/fe/modules/340-extended-monitoring/docs/README.md
@@ -7,3 +7,4 @@ This module consists of two Prometheus exporters:
 - `extended-monitoring-exporter` — generates free space / inode-related metrics and [alerts](configuration.html#non-namespaced-kubernetes-objects); also, it enables the "extended monitoring" of objects in the selected `namespaces`.
 - `image-availability-exporter` — generates metrics about issues with accessing Docker images in the registry.
 - `events-exporter` — collects Kubernetes cluster events end exposes them as metrics.
+- `cert-exporter`— scans Kubernetes secrets and generates metrics about certificates expiration in them.

--- a/ee/fe/modules/340-extended-monitoring/docs/README_RU.md
+++ b/ee/fe/modules/340-extended-monitoring/docs/README_RU.md
@@ -7,3 +7,4 @@ title: "Модуль extended-monitoring"
 - `extended-monitoring-exporter` — генерирует метрики и [алерты](configuration.html#non-namespaced-kubernetes-objects) по свободному месту и inode на нодах, плюс включает «расширенный мониторинг» объектов в указанных `namespace`.
 - `image-availability-exporter` — генерирует метрики о проблемах доступа к Docker-образу в registry.
 - `events-exporter` — собирает event'ы кластера Kubernetes и отдает их в виде метрик.
+- `cert-exporter`— сканирует секреты кластера Kubernetes и генерирует метрики об истечении срока действия сертификатов в них. 

--- a/ee/fe/modules/340-extended-monitoring/images/cert-exporter/Dockerfile
+++ b/ee/fe/modules/340-extended-monitoring/images/cert-exporter/Dockerfile
@@ -1,0 +1,19 @@
+ARG BASE_ALPINE
+FROM $BASE_ALPINE as artifact
+
+ARG VERSION=2.0.1
+ARG COMMIT_REF=d6f0dcb883004146ca3453a9e2d0c66514afe327
+
+RUN apk add --no-cache go git make
+RUN git clone https://github.com/giantswarm/cert-exporter.git
+WORKDIR /cert-exporter
+RUN git checkout "${COMMIT_REF}"
+RUN make
+
+FROM $BASE_ALPINE
+
+RUN apk add --no-cache ca-certificates
+USER 1000
+COPY --from=artifact /cert-exporter/cert-exporter /cert-exporter
+
+ENTRYPOINT ["/cert-exporter"]

--- a/ee/fe/modules/340-extended-monitoring/template_tests/cert_exporter_test.go
+++ b/ee/fe/modules/340-extended-monitoring/template_tests/cert_exporter_test.go
@@ -12,19 +12,19 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/helm"
 )
 
-func checkEventsObjects(hec *Config, exist bool) {
+func checkCertExporterObjects(hec *Config, exist bool) {
 	matcher := BeFalse()
 	if exist {
 		matcher = BeTrue()
 	}
 
-	Expect(hec.KubernetesResource("Deployment", "d8-monitoring", "events-exporter").Exists()).To(matcher)
-	Expect(hec.KubernetesResource("VerticalPodAutoscaler", "d8-monitoring", "events-exporter").Exists()).To(matcher)
-	Expect(hec.KubernetesResource("PodDisruptionBudget", "d8-monitoring", "events-exporter").Exists()).To(matcher)
-	Expect(hec.KubernetesResource("ServiceAccount", "d8-monitoring", "events-exporter").Exists()).To(matcher)
+	Expect(hec.KubernetesResource("Deployment", "d8-monitoring", "cert-exporter").Exists()).To(matcher)
+	Expect(hec.KubernetesResource("VerticalPodAutoscaler", "d8-monitoring", "cert-exporter").Exists()).To(matcher)
+	Expect(hec.KubernetesResource("PodDisruptionBudget", "d8-monitoring", "cert-exporter").Exists()).To(matcher)
+	Expect(hec.KubernetesResource("ServiceAccount", "d8-monitoring", "cert-exporter").Exists()).To(matcher)
 }
 
-var _ = Describe("Module :: extendedMonitoring :: helm template :: events ", func() {
+var _ = Describe("Module :: extendedMonitoring :: helm template :: cert-exporter ", func() {
 	hec := SetupHelmConfig("")
 	BeforeEach(func() {
 		hec.ValuesSet("global.discovery.kubernetesVersion", "1.15.6")
@@ -36,30 +36,28 @@ var _ = Describe("Module :: extendedMonitoring :: helm template :: events ", fun
 		hec.ValuesSet("global.discovery.d8SpecificNodeCountByRole.system", 2)
 	})
 
-	Context("With events.exporterEnabled", func() {
+	Context("With certificates.exporterEnabled", func() {
 		BeforeEach(func() {
-			hec.ValuesSet("extendedMonitoring.events.exporterEnabled", true)
-			hec.ValuesSet("extendedMonitoring.events.severityLevel", "OnlyWarnings")
+			hec.ValuesSet("extendedMonitoring.certificates.exporterEnabled", true)
 			hec.ValuesSetFromYaml("extendedMonitoring.imageAvailability", `{}`)
-			hec.ValuesSetFromYaml("extendedMonitoring.certificates", `{}`)
+			hec.ValuesSetFromYaml("extendedMonitoring.events", `{}`)
 			hec.HelmRender()
 		})
 		It("Should add desired objects", func() {
 			Expect(hec.RenderError).ShouldNot(HaveOccurred())
-			checkEventsObjects(hec, true)
+			checkCertExporterObjects(hec, true)
 		})
 	})
-	Context("Without events.exporterEnabled", func() {
+	Context("Without imageAvailability.exporterEnabled", func() {
 		BeforeEach(func() {
-			hec.ValuesSet("extendedMonitoring.events.exporterEnabled", false)
-			hec.ValuesSet("extendedMonitoring.events.severityLevel", "OnlyWarnings")
+			hec.ValuesSet("extendedMonitoring.certificates.exporterEnabled", false)
 			hec.ValuesSetFromYaml("extendedMonitoring.imageAvailability", `{}`)
-			hec.ValuesSetFromYaml("extendedMonitoring.certificates", `{}`)
+			hec.ValuesSetFromYaml("extendedMonitoring.events", `{}`)
 			hec.HelmRender()
 		})
 		It("Should not deploy desired objects", func() {
 			Expect(hec.RenderError).ShouldNot(HaveOccurred())
-			checkEventsObjects(hec, false)
+			checkCertExporterObjects(hec, false)
 		})
 	})
 })

--- a/ee/fe/modules/340-extended-monitoring/template_tests/image_availability_test.go
+++ b/ee/fe/modules/340-extended-monitoring/template_tests/image_availability_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Module :: extendedMonitoring :: helm template :: image availab
 	Context("With imageAvailability.exporterEnabled", func() {
 		BeforeEach(func() {
 			hec.ValuesSet("extendedMonitoring.imageAvailability.exporterEnabled", true)
+			hec.ValuesSetFromYaml("extendedMonitoring.certificates", `{}`)
 			hec.ValuesSetFromYaml("extendedMonitoring.events", `{}`)
 			hec.HelmRender()
 		})
@@ -52,6 +53,7 @@ var _ = Describe("Module :: extendedMonitoring :: helm template :: image availab
 	Context("Without imageAvailability.exporterEnabled", func() {
 		BeforeEach(func() {
 			hec.ValuesSet("extendedMonitoring.imageAvailability.exporterEnabled", false)
+			hec.ValuesSetFromYaml("extendedMonitoring.certificates", `{}`)
 			hec.ValuesSetFromYaml("extendedMonitoring.events", `{}`)
 			hec.HelmRender()
 		})
@@ -65,6 +67,8 @@ var _ = Describe("Module :: extendedMonitoring :: helm template :: image availab
 		Context("Empty", func() {
 			BeforeEach(func() {
 				hec.ValuesSet("extendedMonitoring.imageAvailability.exporterEnabled", true)
+				hec.ValuesSet("extendedMonitoring.certificates.exporterEnabled", false)
+				hec.ValuesSetFromYaml("extendedMonitoring.certificates", `{}`)
 				hec.ValuesSetFromYaml("extendedMonitoring.events", `{}`)
 				hec.HelmRender()
 			})
@@ -81,6 +85,7 @@ var _ = Describe("Module :: extendedMonitoring :: helm template :: image availab
 		Context("Filled", func() {
 			BeforeEach(func() {
 				hec.ValuesSet("extendedMonitoring.imageAvailability.exporterEnabled", true)
+				hec.ValuesSetFromYaml("extendedMonitoring.certificates", `{}`)
 				hec.ValuesSetFromYaml("extendedMonitoring.events", `{}`)
 				hec.ValuesSet("extendedMonitoring.imageAvailability.ignoredImages", []string{
 					"a.b.com/zzz:9.7.1",

--- a/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/deployment.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/deployment.yaml
@@ -1,0 +1,97 @@
+{{- if .Values.extendedMonitoring.certificates.exporterEnabled }}
+{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: cert-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "cert-exporter")) | nindent 2 }}
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: cert-exporter
+  updatePolicy:
+    updateMode: "Auto"
+{{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cert-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "cert-exporter")) | nindent 2 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      module: {{ $.Chart.Name }}
+      app: cert-exporter
+  template:
+    metadata:
+      labels:
+        module: {{ $.Chart.Name }}
+        app: cert-exporter
+    spec:
+      {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
+      imagePullSecrets:
+      - name: deckhouse-registry
+      serviceAccountName: cert-exporter
+      containers:
+      - name: cert-exporter
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+        image: {{ .Values.global.modulesImages.registry }}:{{ .Values.global.modulesImages.tags.extendedMonitoring.certExporter }}
+        args:
+        - --monitor-secrets=true
+        - --monitor-certificates=false
+        - --monitor-files=false
+        - --address=127.0.0.1:9000
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+            {{- if not (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+            cpu: "50m"
+            memory: "50Mi"
+            {{- end }}
+      - name: kube-rbac-proxy
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+        image: {{ .Values.global.modulesImages.registry }}:{{ .Values.global.modulesImages.tags.common.kubeRbacProxy }}
+        args:
+        - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):9001"
+        - "--client-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        - "--v=2"
+        - "--logtostderr=true"
+        - "--stale-cache-interval=1h30m"
+        ports:
+        - containerPort: 9001
+          name: https-metrics
+        env:
+        - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: KUBE_RBAC_PROXY_CONFIG
+          value: |
+            excludePaths:
+            - /healthz
+            upstreams:
+            - upstream: http://127.0.0.1:9000/
+              path: /
+              authorization:
+                resourceAttributes:
+                  namespace: d8-monitoring
+                  apiGroup: apps
+                  apiVersion: v1
+                  resource: deployments
+                  subresource: prometheus-metrics
+                  name: cert-exporter
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+{{- end }}

--- a/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/pdb.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.extendedMonitoring.certificates.exporterEnabled }}
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade, post-install
+    helm.sh/hook-delete-policy: before-hook-creation
+  name: cert-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "cert-exporter")) | nindent 2 }}
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app: cert-exporter
+{{- end }}

--- a/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/podmonitor.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/podmonitor.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.extendedMonitoring.certificates.exporterEnabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cert-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main")) | nindent 2 }}
+spec:
+  jobLabel: app
+  podMetricsEndpoints:
+  - port: https-metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+      cert:
+        secret:
+          name: prometheus-scraper-tls
+          key: tls.crt
+      keySecret:
+        name: prometheus-scraper-tls
+        key: tls.key
+    honorLabels: true
+    scrapeTimeout: 25s
+  selector:
+    matchLabels:
+      app: cert-exporter
+  namespaceSelector:
+    matchNames:
+    - d8-monitoring
+{{- end }}

--- a/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/rbac-for-us.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/rbac-for-us.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.extendedMonitoring.certificates.exporterEnabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: d8:extended-monitoring:cert-exporter
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups: [""]
+  resources: ["namespaces", "secrets"]
+  verbs: ["get", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: d8:extended-monitoring:cert-exporter
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+subjects:
+- kind: ServiceAccount
+  name: cert-exporter
+  namespace: d8-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: d8:extended-monitoring:cert-exporter
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: d8:extended-monitoring:cert-exporter:rbac-proxy
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: d8:rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: cert-exporter
+  namespace: d8-monitoring
+{{- end }}

--- a/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/rbac-to-us.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/rbac-to-us.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.extendedMonitoring.certificates.exporterEnabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: access-to-extended-monitoring-cert-exporter-metrics
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments/prometheus-metrics"]
+  resourceNames: ["cert-exporter"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: access-to-extended-monitoring-cert-exporter-metrics
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: access-to-extended-monitoring-cert-exporter-metrics
+subjects:
+- kind: User
+  name: d8-monitoring:scraper
+{{- end }}

--- a/ee/fe/modules/340-extended-monitoring/templates/events-exporter/deployment.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/events-exporter/deployment.yaml
@@ -1,12 +1,12 @@
 {{- if .Values.extendedMonitoring.events.exporterEnabled }}
-  {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: events-exporter
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list . (dict "app" "events-exporter")) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "events-exporter")) | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
@@ -14,14 +14,14 @@ spec:
     name: events-exporter
   updatePolicy:
     updateMode: "Auto"
-  {{- end }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: events-exporter
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list . (dict "app" "events-exporter")) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "events-exporter")) | nindent 2 }}
 spec:
   replicas: 1
   strategy:
@@ -36,29 +36,29 @@ spec:
         module: {{ $.Chart.Name }}
         app: events-exporter
     spec:
-{{- include "helm_lib_node_selector" (tuple . "monitoring") | indent 6 }}
-{{- include "helm_lib_tolerations" (tuple . "monitoring") | indent 6 }}
-{{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | indent 6 }}
-{{- include "helm_lib_priority_class" (tuple . "cluster-medium") | indent 6 }}
+      {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: events-exporter
       containers:
       - name: events-exporter
-{{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | indent 8 }}
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         image: {{ .Values.global.modulesImages.registry }}:{{ .Values.global.modulesImages.tags.extendedMonitoring.eventsExporter }}
         args:
         - "-server.exporter-address=127.0.0.1:9000"
-  {{- if eq .Values.extendedMonitoring.events.severityLevel "OnlyWarnings" }}
+        {{- if eq .Values.extendedMonitoring.events.severityLevel "OnlyWarnings" }}
         - "-kube.field-selector=type!=Normal"
-  {{- end }}
+        {{- end }}
         resources:
           requests:
-{{- include "helm_lib_module_ephemeral_storage_only_logs" . | indent 12 }}
-  {{- if not (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+            {{- if not (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
             cpu: "100m"
             memory: "64Mi"
-  {{- end }}
+            {{- end }}
         readinessProbe:
           httpGet:
             path: /healthz
@@ -70,7 +70,7 @@ spec:
             scheme: HTTPS
             port: 9001
       - name: kube-rbac-proxy
-{{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | indent 8 }}
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         image: {{ .Values.global.modulesImages.registry }}:{{ .Values.global.modulesImages.tags.common.kubeRbacProxy }}
         args:
         - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):9001"
@@ -103,5 +103,5 @@ spec:
                   name: events-exporter
         resources:
           requests:
-  {{- include "helm_lib_module_ephemeral_storage_only_logs" . | indent 12 }}
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
 {{- end }}

--- a/ee/fe/modules/340-extended-monitoring/templates/events-exporter/pdb.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/events-exporter/pdb.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation
   name: events-exporter
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list . (dict "app" "events-exporter")) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "events-exporter")) | nindent 2 }}
 spec:
   minAvailable: 0
   selector:

--- a/ee/fe/modules/340-extended-monitoring/templates/events-exporter/podmonitor.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/events-exporter/podmonitor.yaml
@@ -5,7 +5,7 @@ kind: PodMonitor
 metadata:
   name: events-exporter
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list . (dict "prometheus" "main")) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main")) | nindent 2 }}
 spec:
   jobLabel: app
   podMetricsEndpoints:

--- a/ee/fe/modules/340-extended-monitoring/templates/events-exporter/rbac-for-us.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/events-exporter/rbac-for-us.yaml
@@ -5,13 +5,13 @@ kind: ServiceAccount
 metadata:
   name: events-exporter
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: d8:extended-monitoring:events-exporter
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups: ["", "events.k8s.io"]
   resources: ["events"]
@@ -21,7 +21,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: d8:extended-monitoring:events-exporter
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 subjects:
 - kind: ServiceAccount
   name: events-exporter
@@ -35,7 +35,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: d8:extended-monitoring:events-exporter:rbac-proxy
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/ee/fe/modules/340-extended-monitoring/templates/events-exporter/rbac-to-us.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/events-exporter/rbac-to-us.yaml
@@ -5,7 +5,7 @@ kind: Role
 metadata:
   name: access-to-extended-monitoring-events-exporter-metrics
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups: ["apps"]
   resources: ["deployments/prometheus-metrics"]
@@ -17,7 +17,7 @@ kind: RoleBinding
 metadata:
   name: access-to-extended-monitoring-events-exporter-metrics
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/ee/fe/modules/340-extended-monitoring/templates/extended-monitoring-exporter/deployment.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/extended-monitoring-exporter/deployment.yaml
@@ -5,7 +5,7 @@ kind: VerticalPodAutoscaler
 metadata:
   name: extended-monitoring-exporter
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list . (dict "app" "extended-monitoring-exporter")) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "extended-monitoring-exporter")) | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
@@ -20,7 +20,7 @@ apiVersion: apps/v1
 metadata:
   name: extended-monitoring-exporter
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list . (dict "app" "extended-monitoring-exporter")) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "extended-monitoring-exporter")) | nindent 2 }}
 spec:
   replicas: 1
   strategy:
@@ -35,16 +35,16 @@ spec:
         module: {{ $.Chart.Name }}
         app: extended-monitoring-exporter
     spec:
-{{- include "helm_lib_node_selector" (tuple . "monitoring") | indent 6 }}
-{{- include "helm_lib_tolerations" (tuple . "monitoring") | indent 6 }}
-{{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | indent 6 }}
-{{- include "helm_lib_priority_class" (tuple . "cluster-medium") | indent 6 }}
+      {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: extended-monitoring-exporter
       containers:
       - name: extended-monitoring
-{{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | indent 8 }}
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         image: {{ .Values.global.modulesImages.registry }}:{{ .Values.global.modulesImages.tags.extendedMonitoring.extendedMonitoringExporter }}
         args:
         - "/app/extended-monitoring.py"
@@ -71,9 +71,9 @@ spec:
           periodSeconds: 10
         resources:
           requests:
-{{- include "helm_lib_module_ephemeral_storage_only_logs" . | indent 12 }}
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
       - name: kube-rbac-proxy
-{{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | indent 8 }}
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         image: {{ .Values.global.modulesImages.registry }}:{{ .Values.global.modulesImages.tags.common.kubeRbacProxy }}
         args:
         - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8081"
@@ -105,4 +105,4 @@ spec:
                   name: extended-monitoring-exporter
         resources:
           requests:
-{{- include "helm_lib_module_ephemeral_storage_only_logs" . | indent 12 }}
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}

--- a/ee/fe/modules/340-extended-monitoring/templates/extended-monitoring-exporter/pdb.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/extended-monitoring-exporter/pdb.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation
   name: extended-monitoring-exporter
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list . (dict "app" "extended-monitoring-exporter")) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "extended-monitoring-exporter")) | nindent 2 }}
 spec:
   minAvailable: 0
   selector:

--- a/ee/fe/modules/340-extended-monitoring/templates/extended-monitoring-exporter/podmonitor.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/extended-monitoring-exporter/podmonitor.yaml
@@ -5,7 +5,7 @@ kind: PodMonitor
 metadata:
   name: extended-monitoring-exporter
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list . (dict "prometheus" "main")) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main")) | nindent 2 }}
 spec:
   jobLabel: app
   podMetricsEndpoints:

--- a/ee/fe/modules/340-extended-monitoring/templates/extended-monitoring-exporter/rbac-for-us.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/extended-monitoring-exporter/rbac-for-us.yaml
@@ -4,13 +4,13 @@ kind: ServiceAccount
 metadata:
   name: extended-monitoring-exporter
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: d8:extended-monitoring:extended-monitoring-exporter
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups: [""]
   resources:
@@ -54,7 +54,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: d8:extended-monitoring:extended-monitoring-exporter
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 subjects:
 - kind: ServiceAccount
   name: extended-monitoring-exporter
@@ -68,7 +68,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: d8:extended-monitoring:extended-monitoring-exporter:rbac-proxy
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/ee/fe/modules/340-extended-monitoring/templates/extended-monitoring-exporter/rbac-to-us.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/extended-monitoring-exporter/rbac-to-us.yaml
@@ -4,7 +4,7 @@ kind: Role
 metadata:
   name: access-to-extended-monitoring-extended-monitoring-exporter-metrics
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups: ["apps"]
   resources: ["deployments/prometheus-metrics"]
@@ -16,7 +16,7 @@ kind: RoleBinding
 metadata:
   name: access-to-extended-monitoring-extended-monitoring-exporter-metrics
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/ee/fe/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
@@ -1,12 +1,12 @@
 {{- if .Values.extendedMonitoring.imageAvailability.exporterEnabled }}
-  {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: image-availability-exporter
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list . (dict "app" "image-availability")) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "image-availability")) | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
@@ -14,14 +14,14 @@ spec:
     name: image-availability-exporter
   updatePolicy:
     updateMode: "Auto"
-  {{- end }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: image-availability-exporter
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list . (dict "app" "image-availability")) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "image-availability")) | nindent 2 }}
 spec:
   replicas: 1
   strategy:
@@ -36,44 +36,44 @@ spec:
         module: {{ $.Chart.Name }}
         app: image-availability-exporter
     spec:
-{{- include "helm_lib_node_selector" (tuple . "monitoring") | indent 6 }}
-{{- include "helm_lib_tolerations" (tuple . "monitoring") | indent 6 }}
-{{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | indent 6 }}
-{{- include "helm_lib_priority_class" (tuple . "cluster-medium") | indent 6 }}
+      {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: image-availability-exporter
       containers:
       - name: image-availability-exporter
-{{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | indent 8 }}
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         image: {{ .Values.global.modulesImages.registry }}:{{ .Values.global.modulesImages.tags.extendedMonitoring.imageAvailabilityExporter }}
         args:
         - --bind-address=127.0.0.1:8080
         # The exporter checks for string equality.
         # https://github.com/deckhouse/k8s-image-availability-exporter/blob/b1589b40c18290b9d105f0ac39ddc3fc554884d9/pkg/registry_checker/checker.go#L212
         # Among known inexisting images, there is the one from Upmeter probe where we don't want a container to start.
-  {{- $ignoredImages := list "k8s.gcr.io/upmeter-nonexistent:3.1415" }}
-  {{- if .Values.extendedMonitoring.imageAvailability.ignoredImages }}
-    {{- $ignoredImages = concat $ignoredImages .Values.extendedMonitoring.imageAvailability.ignoredImages }}
-  {{- end }}
+        {{- $ignoredImages := list "k8s.gcr.io/upmeter-nonexistent:3.1415" }}
+        {{- if .Values.extendedMonitoring.imageAvailability.ignoredImages }}
+          {{- $ignoredImages = concat $ignoredImages .Values.extendedMonitoring.imageAvailability.ignoredImages }}
+        {{- end }}
         - '--ignored-images={{ $ignoredImages | join "," }}'
-  {{- if .Values.extendedMonitoring.imageAvailability.skipRegistryCertVerification }}
+        {{- if .Values.extendedMonitoring.imageAvailability.skipRegistryCertVerification }}
         - --skip-registry-cert-verification={{ .Values.extendedMonitoring.imageAvailability.skipRegistryCertVerification }}
-  {{- end }}
+        {{- end }}
         resources:
           requests:
-{{- include "helm_lib_module_ephemeral_storage_only_logs" . | indent 12 }}
-  {{- if not (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+            {{- if not (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
             cpu: "100m"
             memory: "64Mi"
-  {{- end }}
+            {{- end }}
         readinessProbe:
           httpGet:
             path: /healthz
             scheme: HTTPS
             port: 8081
       - name: kube-rbac-proxy
-{{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | indent 8 }}
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         image: {{ .Values.global.modulesImages.registry }}:{{ .Values.global.modulesImages.tags.common.kubeRbacProxy }}
         args:
         - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8081"
@@ -107,5 +107,5 @@ spec:
                   name: image-availability-exporter
         resources:
           requests:
-  {{- include "helm_lib_module_ephemeral_storage_only_logs" . | indent 12 }}
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
 {{- end }}

--- a/ee/fe/modules/340-extended-monitoring/templates/image-availability-exporter/pdb.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/image-availability-exporter/pdb.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation
   name: image-availability-exporter
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list . (dict "app" "image-availability")) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "image-availability")) | nindent 2 }}
 spec:
   minAvailable: 0
   selector:

--- a/ee/fe/modules/340-extended-monitoring/templates/image-availability-exporter/podmonitor.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/image-availability-exporter/podmonitor.yaml
@@ -5,7 +5,7 @@ kind: PodMonitor
 metadata:
   name: image-availability-exporter
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list . (dict "prometheus" "main")) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main")) | nindent 2 }}
 spec:
   jobLabel: app
   podMetricsEndpoints:

--- a/ee/fe/modules/340-extended-monitoring/templates/image-availability-exporter/rbac-for-us.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/image-availability-exporter/rbac-for-us.yaml
@@ -5,13 +5,13 @@ kind: ServiceAccount
 metadata:
   name: image-availability-exporter
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: d8:extended-monitoring:image-availability-exporter
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups: [""]
   resources:
@@ -49,7 +49,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: d8:extended-monitoring:image-availability-exporter
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 subjects:
 - kind: ServiceAccount
   name: image-availability-exporter
@@ -63,7 +63,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: d8:extended-monitoring:image-availability-exporter:rbac-proxy
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/ee/fe/modules/340-extended-monitoring/templates/image-availability-exporter/rbac-to-us.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/image-availability-exporter/rbac-to-us.yaml
@@ -5,7 +5,7 @@ kind: Role
 metadata:
   name: access-to-extended-monitoring-image-availability-exporter-metrics
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups: ["apps"]
   resources: ["deployments/prometheus-metrics"]
@@ -17,7 +17,7 @@ kind: RoleBinding
 metadata:
   name: access-to-extended-monitoring-image-availability-exporter-metrics
   namespace: d8-monitoring
-{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
## Description
This PR adds cert-exporter to the extended-monitoring module

## Why we need it and what problem does it solve?

cert-exporter allows to track certificates expiration.

fixes https://github.com/deckhouse/deckhouse/issues/365

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: extended-monitoring
type: feature
description: Add cert-exporter
note: |
  Added cert-exporter to track certificates expiration
```