### PR TITLE
[okmeter] Bump version to fix agents updating process

### DIFF
--- a/ee/fe/modules/500-okmeter/images/okagent/Dockerfile
+++ b/ee/fe/modules/500-okmeter/images/okagent/Dockerfile
@@ -1,6 +1,6 @@
 # Based on https://flant.slack.com/archives/C4U78TPC1/p1622732293021600
 ARG BASE_UBUNTU
-FROM okmeter/okagent:latest@sha256:52edf71d312b337a84c5a095105e1eb985d0341f04b5c6a306f60a92c88f4148 as artifact
+FROM registry.okmeter.io/agent/okagent@sha256:c7d38b51a673257a4fd06c1d61dfbe6921ac287837a6c0e747dfc8875ae9d985 as artifact
 
 FROM $BASE_UBUNTU
 RUN apt-get update && apt-get install -y ca-certificates curl iputils-ping gnupg gnupg2 gnupg1 && rm -rf /var/lib/apt/lists/*
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y smartmontools && rm -rf /var/lib/apt/li
 RUN echo "deb http://hwraid.le-vert.net/ubuntu bionic main" > /etc/apt/sources.list.d/hwraid.list && \
 	curl -sSL -o - https://hwraid.le-vert.net/debian/hwraid.le-vert.net.gpg.key | apt-key add - && \
 	apt-get update && apt-get install megacli arcconf && rm -rf /var/lib/apt/lists/*
-COPY --from=artifact /usr/local/bin/oksupervisor /usr/local/bin/oksupervisor
+COPY --from=artifact /bin/oksupervisor /usr/local/bin/oksupervisor
 VOLUME /usr/local/okagent
 ENV OKMETER_AGENT_INCONTAINER true
 #statsd


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Bump `oksupervisor`

## Why do we need it, and what problem does it solve?

The updating mechanism was fixed. The supervisor used to roll back okagent in case of any problem with its new version and never tried to update it again. 

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: okmener
type: fix
description: Bump oksupervisor version to fix updating problems
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
