### PR TITLE
[github] fix(ci): support for release branches and pre-release tags

### DIFF
--- a/.github/ci_templates/scripts.yml
+++ b/.github/ci_templates/scripts.yml
@@ -1,7 +1,7 @@
 {!{ define "update_comment_on_start" }!}
 {!{- $workflowName := . -}!}
 - name: Update comment on start
-  if: github.event_name == 'workflow_dispatch'
+  if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
   uses: {!{ index (ds "actions") "actions/github-script" }!}
   with:
     github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -17,7 +17,7 @@
 {!{- $name := index . 1 -}!}
 
 - name: Update comment on finish
-  if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+  if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
   continue-on-error: true
   env:
     NEEDS_CONTEXT: ${{ toJSON(needs) }}

--- a/.github/scripts/js/README.md
+++ b/.github/scripts/js/README.md
@@ -1,0 +1,11 @@
+Support scripts to use with github-script action in github workflows.
+
+1. Changelog.
+2. Run e2e tests.
+3. Deploy web and site to stage and test environments.
+4. Re-run validation workflows.
+
+Notes:
+- Standalone runner can run actions using nodejs v12 and v16.
+- github-script uses v12: https://github.com/actions/github-script/blob/v5.0.0/action.yml#L30
+- See [compatibility table](https://node.green/) when develop new methods. For example, `replaceAll` is [not available](https://node.green/#ES2021-features--String-prototype-replaceAll) in v12. 

--- a/.github/scripts/js/error.js
+++ b/.github/scripts/js/error.js
@@ -1,0 +1,32 @@
+module.exports.dumpError = (error) => {
+  let result = '';
+  try {
+    // Max 10 recursive calls
+    result = JSON.stringify(simplifyObj({error, depth: 7}))
+  } catch (e) {
+    result = `${error.name||'UnknownError'}: ${error.message||'no message'}`
+  }
+  return result
+}
+
+// Use simplifyObj to break circular structures.
+// It copies objects recursively until depth is reached.
+const simplifyObj = ({obj, depth}) => {
+  if (depth <= 0 ) {
+    return '[Too deep]';
+  }
+  if (typeof(obj) == 'function'){
+    return '[Function]';
+  }
+  // Object or Array.
+  if (typeof(obj) == 'object') {
+    let simpleObj = {}
+    for (let prop in obj ){
+      if (obj.hasOwnProperty(prop)){
+        simpleObj[prop] = simplifyObj({obj: obj[prop], depth: depth - 1})
+      }
+    }
+    return simpleObj;
+  }
+  return obj;
+}

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -7,13 +7,13 @@ on:
     inputs:
       issue_id:
         description: 'Id of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
-        required: true
+        required: false
 
 env:
 {!{ tmpl.Exec "werf_envs" | strings.Indent 2 }!}
@@ -50,7 +50,7 @@ jobs:
     needs:
       - git_info
       - comment_on_start
-    if: ${{ github.ref != 'refs/heads/main' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "EE"
 {!{ tmpl.Exec "build_modules_images_template" . | strings.Indent 4 }!}
@@ -61,7 +61,7 @@ jobs:
     needs:
       - git_info
       - comment_on_start
-    if: ${{ github.ref != 'refs/heads/main' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "CE"
 {!{ tmpl.Exec "build_modules_images_template" . | strings.Indent 4 }!}
@@ -91,7 +91,7 @@ jobs:
       - git_info
       - build_modules_images_ee
       - go_generate
-    if: ${{ github.ref != 'refs/heads/main' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "EE"
 {!{ tmpl.Exec "build_template" . | strings.Indent 4 }!}
@@ -103,7 +103,7 @@ jobs:
       - git_info
       - build_modules_images_ce
       - go_generate
-    if: ${{ github.ref != 'refs/heads/main' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "CE"
 {!{ tmpl.Exec "build_template" . | strings.Indent 4 }!}
@@ -250,7 +250,7 @@ jobs:
       - openapi_test_cases
       - web_links_test
       - validators
-    if: always()
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
 {!{ tmpl.Exec "checkout_step" . | strings.Indent 6 }!}

--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -15,13 +15,13 @@ on:
     inputs:
       issue_id:
         description: 'Id of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
-        required: true
+        required: false
 
 env:
 {!{ tmpl.Exec "werf_envs" | strings.Indent 2 }!}

--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -42,13 +42,17 @@ on:
     inputs:
       issue_id:
         description: 'ID of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'ID of comment in issue where to put workflow run status'
-        required: true
+        required: false
+      cri:
+        required: false
+      ver:
+        required: false
 env:
 {!{ tmpl.Exec "werf_envs" | strings.Indent 2 }!}
 {!{ tmpl.Exec "image_versions_envs" | strings.Indent 2 }!}

--- a/.github/workflow_templates/on-push-main-or-tag.yml
+++ b/.github/workflow_templates/on-push-main-or-tag.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'release-*'
     tags:
       - 'v*'
 
@@ -22,4 +23,4 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
             const ci = require('./.github/scripts/js/ci');
-            return await ci.startBuildAndTestWorkflow({github, context, core});
+            return await ci.runWorkflowForReleasePush({ github, context, core })

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -11,13 +11,13 @@ on:
     inputs:
       issue_id:
         description: 'Id of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
-        required: true
+        required: false
 
 env:
 
@@ -146,7 +146,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -233,7 +233,7 @@ jobs:
           key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -258,7 +258,7 @@ jobs:
     needs:
       - git_info
       - comment_on_start
-    if: ${{ github.ref != 'refs/heads/main' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "EE"
 
@@ -333,7 +333,7 @@ jobs:
           key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -358,7 +358,7 @@ jobs:
     needs:
       - git_info
       - comment_on_start
-    if: ${{ github.ref != 'refs/heads/main' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "CE"
 
@@ -433,7 +433,7 @@ jobs:
           key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -482,7 +482,7 @@ jobs:
           git diff --exit-code
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -635,7 +635,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -661,7 +661,7 @@ jobs:
       - git_info
       - build_modules_images_ee
       - go_generate
-    if: ${{ github.ref != 'refs/heads/main' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "EE"
 
@@ -789,7 +789,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -815,7 +815,7 @@ jobs:
       - git_info
       - build_modules_images_ce
       - go_generate
-    if: ${{ github.ref != 'refs/heads/main' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "CE"
 
@@ -943,7 +943,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1002,7 +1002,7 @@ jobs:
           WERF_LOG_VERBOSE: "on"
           WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1061,7 +1061,7 @@ jobs:
           WERF_LOG_VERBOSE: "on"
           WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1132,7 +1132,7 @@ jobs:
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1203,7 +1203,7 @@ jobs:
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1274,7 +1274,7 @@ jobs:
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1345,7 +1345,7 @@ jobs:
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1416,7 +1416,7 @@ jobs:
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1539,7 +1539,7 @@ jobs:
             rm -rf $_TMPDIR
           fi
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1610,7 +1610,7 @@ jobs:
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1677,7 +1677,7 @@ jobs:
           WERF_SET_URL: "global.url=deckhouse.io"
           WERF_SET_WEB_ENV: "web.env=web-production"
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1742,7 +1742,7 @@ jobs:
           WERF_SET_URL: "global.url=deckhouse.io"
           WERF_SET_WEB_ENV: "web.env=web-production"
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1784,14 +1784,14 @@ jobs:
       - openapi_test_cases
       - web_links_test
       - validators
-    if: always()
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
 
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -9,13 +9,13 @@ on:
     inputs:
       issue_id:
         description: 'Id of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
-        required: true
+        required: false
 
 env:
 
@@ -135,7 +135,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -520,7 +520,7 @@ jobs:
           git push --force origin "${RELEASE_BRANCH_NAME}"
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -9,13 +9,13 @@ on:
     inputs:
       issue_id:
         description: 'Id of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
-        required: true
+        required: false
 
 env:
 
@@ -135,7 +135,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -520,7 +520,7 @@ jobs:
           git push --force origin "${RELEASE_BRANCH_NAME}"
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -9,13 +9,13 @@ on:
     inputs:
       issue_id:
         description: 'Id of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
-        required: true
+        required: false
 
 env:
 
@@ -135,7 +135,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -520,7 +520,7 @@ jobs:
           git push --force origin "${RELEASE_BRANCH_NAME}"
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -9,13 +9,13 @@ on:
     inputs:
       issue_id:
         description: 'Id of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
-        required: true
+        required: false
 
 env:
 
@@ -135,7 +135,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -520,7 +520,7 @@ jobs:
           git push --force origin "${RELEASE_BRANCH_NAME}"
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -9,13 +9,13 @@ on:
     inputs:
       issue_id:
         description: 'Id of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
-        required: true
+        required: false
 
 env:
 
@@ -135,7 +135,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -520,7 +520,7 @@ jobs:
           git push --force origin "${RELEASE_BRANCH_NAME}"
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}

--- a/.github/workflows/deploy-web-stage.yml
+++ b/.github/workflows/deploy-web-stage.yml
@@ -172,7 +172,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -255,7 +255,7 @@ jobs:
           WERF_SET_WEB_ENV: "web.env=web-stage"
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}

--- a/.github/workflows/deploy-web-test.yml
+++ b/.github/workflows/deploy-web-test.yml
@@ -172,7 +172,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -255,7 +255,7 @@ jobs:
           WERF_SET_WEB_ENV: "web.env=web-test"
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -18,13 +18,17 @@ on:
     inputs:
       issue_id:
         description: 'ID of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'ID of comment in issue where to put workflow run status'
-        required: true
+        required: false
+      cri:
+        required: false
+      ver:
+        required: false
 env:
 
   # Don't forget to update .gitlab-ci-simple.yml if necessary
@@ -221,7 +225,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -427,7 +431,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -532,7 +536,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -738,7 +742,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -843,7 +847,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1049,7 +1053,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1154,7 +1158,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1360,7 +1364,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1465,7 +1469,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1671,7 +1675,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1776,7 +1780,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1982,7 +1986,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2087,7 +2091,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2293,7 +2297,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2398,7 +2402,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2604,7 +2608,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -18,13 +18,17 @@ on:
     inputs:
       issue_id:
         description: 'ID of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'ID of comment in issue where to put workflow run status'
-        required: true
+        required: false
+      cri:
+        required: false
+      ver:
+        required: false
 env:
 
   # Don't forget to update .gitlab-ci-simple.yml if necessary
@@ -221,7 +225,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -435,7 +439,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -540,7 +544,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -754,7 +758,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -859,7 +863,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1073,7 +1077,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1178,7 +1182,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1392,7 +1396,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1497,7 +1501,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1711,7 +1715,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1816,7 +1820,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2030,7 +2034,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2135,7 +2139,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2349,7 +2353,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2454,7 +2458,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2668,7 +2672,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -18,13 +18,17 @@ on:
     inputs:
       issue_id:
         description: 'ID of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'ID of comment in issue where to put workflow run status'
-        required: true
+        required: false
+      cri:
+        required: false
+      ver:
+        required: false
 env:
 
   # Don't forget to update .gitlab-ci-simple.yml if necessary
@@ -221,7 +225,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -423,7 +427,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -528,7 +532,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -730,7 +734,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -835,7 +839,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1037,7 +1041,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1142,7 +1146,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1344,7 +1348,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1449,7 +1453,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1651,7 +1655,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1756,7 +1760,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1958,7 +1962,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2063,7 +2067,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2265,7 +2269,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2370,7 +2374,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2572,7 +2576,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -18,13 +18,17 @@ on:
     inputs:
       issue_id:
         description: 'ID of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'ID of comment in issue where to put workflow run status'
-        required: true
+        required: false
+      cri:
+        required: false
+      ver:
+        required: false
 env:
 
   # Don't forget to update .gitlab-ci-simple.yml if necessary
@@ -221,7 +225,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -423,7 +427,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -528,7 +532,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -730,7 +734,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -835,7 +839,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1037,7 +1041,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1142,7 +1146,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1344,7 +1348,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1449,7 +1453,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1651,7 +1655,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1756,7 +1760,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1958,7 +1962,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2063,7 +2067,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2265,7 +2269,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2370,7 +2374,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2572,7 +2576,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -18,13 +18,17 @@ on:
     inputs:
       issue_id:
         description: 'ID of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'ID of comment in issue where to put workflow run status'
-        required: true
+        required: false
+      cri:
+        required: false
+      ver:
+        required: false
 env:
 
   # Don't forget to update .gitlab-ci-simple.yml if necessary
@@ -221,7 +225,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -423,7 +427,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -528,7 +532,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -730,7 +734,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -835,7 +839,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1037,7 +1041,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1142,7 +1146,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1344,7 +1348,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1449,7 +1453,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1651,7 +1655,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1756,7 +1760,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1958,7 +1962,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2063,7 +2067,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2265,7 +2269,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2370,7 +2374,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2572,7 +2576,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -18,13 +18,17 @@ on:
     inputs:
       issue_id:
         description: 'ID of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'ID of comment in issue where to put workflow run status'
-        required: true
+        required: false
+      cri:
+        required: false
+      ver:
+        required: false
 env:
 
   # Don't forget to update .gitlab-ci-simple.yml if necessary
@@ -221,7 +225,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -427,7 +431,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -532,7 +536,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -738,7 +742,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -843,7 +847,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1049,7 +1053,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1154,7 +1158,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1360,7 +1364,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1465,7 +1469,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1671,7 +1675,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1776,7 +1780,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1982,7 +1986,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2087,7 +2091,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2293,7 +2297,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2398,7 +2402,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2604,7 +2608,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -18,13 +18,17 @@ on:
     inputs:
       issue_id:
         description: 'ID of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'ID of comment in issue where to put workflow run status'
-        required: true
+        required: false
+      cri:
+        required: false
+      ver:
+        required: false
 env:
 
   # Don't forget to update .gitlab-ci-simple.yml if necessary
@@ -221,7 +225,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -431,7 +435,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -536,7 +540,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -746,7 +750,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -851,7 +855,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1061,7 +1065,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1166,7 +1170,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1376,7 +1380,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1481,7 +1485,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1691,7 +1695,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1796,7 +1800,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2006,7 +2010,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2111,7 +2115,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2321,7 +2325,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2426,7 +2430,7 @@ jobs:
           ref: ${{ github.event.ref }}
           fetch-depth: 0
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2636,7 +2640,7 @@ jobs:
           fi
 
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}

--- a/.github/workflows/on-push-main-or-tag.yml
+++ b/.github/workflows/on-push-main-or-tag.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'release-*'
     tags:
       - 'v*'
 
@@ -28,4 +29,4 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
             const ci = require('./.github/scripts/js/ci');
-            return await ci.startBuildAndTestWorkflow({github, context, core});
+            return await ci.runWorkflowForReleasePush({ github, context, core })


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- Run build and test on push to release-* branches and tags with suffixes.
- No commenting for now, use curl to start e2e and deploy workflows for tags.


## Why do we need it, and what problem does it solve?

There is no way to release v1.29.0 without support for pre-release tags.
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
