### PR TITLE
[flant-integration] Remove the plan parameter from the openAPI specification

### DIFF
--- a/ee/modules/600-flant-integration/openapi/config-values.yaml
+++ b/ee/modules/600-flant-integration/openapi/config-values.yaml
@@ -10,13 +10,6 @@ properties:
     default: false
     description: |
       Is the RockSolid release channel included in the price, or should we charge for it separately.
-  plan:
-    type: string
-    enum: ["Standard", "Silver", "Gold", "Platinum"]
-    default: Standard
-    x-examples: ["Standard"]
-    description: |
-      **Unused.** Tariff plan.
   planIsBoughtAsBundle:
     type: boolean
     default: false

--- a/ee/modules/600-flant-integration/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/600-flant-integration/openapi/doc-ru-config-values.yaml
@@ -5,9 +5,6 @@ properties:
   doNotChargeForRockSolid:
     description: |
       Входит ли канал обновлений RockSolid в стоимость, или надо за него чаржить отдельно.
-  plan:
-    description: |
-      **Не используется.** Тарифный план.
   planIsBoughtAsBundle:
     description: |
       Куплен ли "пакет".


### PR DESCRIPTION
## Description
The plan parameter was removed from the OpenAPI specification

## Why do we need it, and what problem does it solve?
The plan parameter was removed from the configuration in 1.29 and now we can remove it from the OpenAPI specification.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: flant-integration
type: fix
description: Remove the plan parameter from the OpenAPI specification
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
