### PR TITLE
[extended-monitoring] CronJobFailed alert expr fix

### DIFF
--- a/ee/fe/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
+++ b/ee/fe/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
@@ -9,7 +9,7 @@
           # compare start time of a Job with the last schedule time of a CronJob
           (
             kube_job_status_start_time
-            > on (namespace, job_name) group_left(owner_name)
+            >= on (namespace, job_name) group_left(owner_name)
             (
               max by (owner_name, namespace) (label_replace(kube_cronjob_status_last_schedule_time, "owner_name", "$1", "cronjob", "(.*)"))
               * on (namespace, owner_name) group_right()


### PR DESCRIPTION
## Description
CronJobFailed alert bugfix.

## Why do we need it, and what problem does it solve?
The alert didn't work.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: extended-monitoring
type: fix
description: CronJobFailed alert bugfix.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
