### PR TITLE
[deckhouse] Add alert for invalid config

### DIFF
--- a/modules/020-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/020-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -324,7 +324,7 @@
         You can find out the exact problem in the relevant alerts.
 
   - alert: D8DeckhouseConfigInvalid
-    expr: increase(deckhouse_config_values_errors_total[30s]) > 0
+    expr: increase(deckhouse_config_values_errors_total[__SCRAPE_INTERVAL_X_2__]) > 0
     for: 1m
     labels:
       severity_level: "5"


### PR DESCRIPTION
(Close #87)

## Description
Fix time interval

## Why do we need it, and what problem does it solve?
Hardcoded time interval was too short. Use ScrapeInterval x2 instead

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: deckhouse
type: fix 
description: Use scrape interval x2 instead of hardcoded value for invalid config values alerting
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
