### PR TITLE
[github] CI workflows for external PR

### DIFF
--- a/.github/ci_includes/actions_versions.yml
+++ b/.github/ci_includes/actions_versions.yml
@@ -8,3 +8,4 @@
 "werf/actions/run": "werf/actions/run@v1.2"
 "werf/actions/build": "werf/actions/build@v1.2"
 "werf/actions/converge": "werf/actions/converge@v1.2"
+"dorny/paths-filter": "dorny/paths-filter@v2"

--- a/.github/ci_includes/werf_envs.yml
+++ b/.github/ci_includes/werf_envs.yml
@@ -1,4 +1,5 @@
 {!{ define "werf_envs" }!}
+# <template: werf_envs>
 # Don't forget to update .gitlab-ci-simple.yml if necessary
 WERF_CHANNEL: "ea"
 WERF_ENV: "FE"
@@ -13,4 +14,5 @@ DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss
 BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
 FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+# </template: werf_envs>
 {!{- end -}!}

--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -1,4 +1,5 @@
 {!{ define "go_generate_template" }!}
+# <template: go_generate_template>
 runs-on: ubuntu-latest
 steps:
   {!{ tmpl.Exec "checkout_step" . | strings.Indent 2 }!}
@@ -12,9 +13,11 @@ steps:
   - name: Check generated code
     run: |
       git diff --exit-code
+# </template: go_generate_template>
 {!{ end }!}
 
 {!{ define "build_modules_images_template" }!}
+# <template: build_modules_images_template>
 runs-on: [self-hosted, regular]
 steps:
   {!{ tmpl.Exec "checkout_full_step" . | strings.Indent 2 }!}
@@ -45,9 +48,11 @@ steps:
 
   {!{ tmpl.Exec "save_images_tags_json_step" . | strings.Indent 2 }!}
   {!{ tmpl.Exec "save_images_tags_json_to_cache_step" . | strings.Indent 2 }!}
+# </template: build_modules_images_template>
 {!{ end }!}
 
 {!{ define "build_template" }!}
+# <template: build_template>
 runs-on: [self-hosted, regular]
 steps:
   {!{ tmpl.Exec "checkout_full_step" . | strings.Indent 2 }!}
@@ -129,4 +134,5 @@ steps:
         docker image rmi ${DESTINATION_IMAGE} || true;
         docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
       fi
+# </template: build_template>
 {!{ end }!}

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -1,4 +1,5 @@
 {!{ define "e2e_run_template" }!}
+# <template: e2e_run_template>
 {!{- $provider := index . 0 -}!}
 {!{- $script_arg := index . 1 -}!}
 {!{- $script := "script.sh" -}!}
@@ -89,6 +90,7 @@ run: |
   )
   # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
   bash <<<"$werfRunProg"
+# </template: e2e_run_template>
 {!{- end -}!}
 
 
@@ -100,6 +102,7 @@ It sets run_{CRI}_{VERSION} outputs to use as conditionals for later jobs.
 */}!}
 {!{ define "check_e2e_labels_job" }!}
 {!{- $ctx := . -}!}
+# <template: check_e2e_labels_job>
 check_e2e_labels:
   name: Check e2e labels
   runs-on: ubuntu-latest
@@ -125,5 +128,5 @@ check_e2e_labels:
 
           const ci = require('./.github/scripts/js/ci');
           return await ci.checkE2ELabels({github, context, core, provider, defaults, criNames, kubernetesVersions});
-
+# </template: check_e2e_labels_job>
 {!{- end -}!}

--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -1,4 +1,20 @@
 {!{ define "git_info_job" }!}
+# <template: git_info_job>
+{!{/*
+Outputs:
+  ci_commit_tag - used as CI_COMMIT_TAG variable to publish release images.
+  ci_commit_branch - used as CI_COMMIT_BRANCH to publish images for main branch and dev images.
+  ci_commit_ref_name - used as image tag to run e2e and deploy-web, and for release-channel-version image.
+  github_sha - used as a key for caching images_tags_*.json file.
+  ci_pipeline_created_at - used for release-channel-version image (deprecated).
+
+TODO delete `ci_pipeline_created_at` everywhere in CI since it is useless.
+
+See:
+- https://docs.github.com/en/actions/learn-github-actions/environment-variables
+- https://github.com/actions/toolkit/blob/main/packages/github/src/context.ts
+
+*/}!}
 git_info:
   name: Get git info
   runs-on: ubuntu-latest
@@ -11,69 +27,164 @@ git_info:
   steps:
     - id: git_info
       name: Get tag name and SHA
-      run: |
-        # Detect git tag for release.
-        gitTag=${GITHUB_REF#refs/tags/}
-        if [[ ${GITHUB_REF} == $gitTag ]] ; then
-          gitTag=
-        fi
-        echo "::set-output name=ci_commit_tag::${gitTag}"
-        echo "ci_commit_tag='${gitTag}'"
-
-        # Detect git branch.
-        gitBranch=${GITHUB_REF#refs/heads/}
-        if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-          gitBranch=
-        fi
-        echo "::set-output name=ci_commit_branch::${gitBranch}"
-        echo "ci_commit_branch='${gitBranch}'"
-
-        # CI_COMMIT_REF_NAME for main werf.yaml
-        commitRefName=
-        [[ -n $gitBranch ]] && commitRefName=$gitBranch
-        [[ -n $gitTag ]] && commitRefName=$gitTag
-        echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-        echo "ci_commit_ref_name='${commitRefName}'"
-
-        # CI_PIPELINE_CREATED_AT for main werf.yaml
-        pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-        echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-        echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
-
-        # Determine sha of commit.
-        # push event
-        githubSha=${GITHUB_SHA}
-        echo "github_sha for push '${githubSha}'"
-        # workflow_dispatch event
-        if [[ -z $githubSha ]] ; then
-          githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-          echo "github_sha for workflow_dispatch '${githubSha}'"
-        fi
-        echo "::set-output name=github_sha::$githubSha"
-        echo "github_sha='${githubSha}'"
-
-{!{- end -}!}
-
-
-{!{ define "restore_images_tags_json_template" }!}
-images_tags_json:
-  name: Put images_tags_json into artifact
-  runs-on: ubuntu-latest
-
-  steps:
-    - name: Restore from cache
-      id: images-tags-json
-      uses: actions/cache@v2
+      uses: {!{ index (ds "actions") "actions/github-script" }!}
       with:
-        path: modules/images_tags_${{env.WERF_ENV}}.json
-        key: ${{ github.sha }}-images-tags
+        script: |
+          core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-    - name: Fail if not found
-      if: steps.cache-primes.outputs.cache-hit != 'true'
-      run: |
-        echo images_tags json file not found in cache: restart build modules job.
-        exit 1
+          const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-{!{ tmpl.Exec "save_images_tags_json_step" . | strings.Indent 4 }!}
+          let githubBranch = '';
+          let githubTag = '';
+          let githubSHA = '';
+          let refName = '';
+          if (context.eventName === "workflow_dispatch") {
+            // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+            // Note: value in inputs.pull_request_ref is for pull_request_info job.
+            if (context.payload.inputs.pull_request_ref) {
+              refName       = context.payload.inputs.ci_commit_ref_name
+              githubBranch  = refName
+              githubSHA     = context.payload.inputs.pull_request_sha
+              core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+            } else {
+              refName       = GITHUB_REF_NAME
+              githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+              githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+              githubSHA     = context.sha
+              core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+            }
+          } else {
+            // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+            const targetRepo = context.payload.repository.full_name;
+            const prRepo = context.payload.pull_request.head.repo.full_name
+            const prRef = context.payload.pull_request.head.ref
+
+            refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+            githubBranch = refName
+            githubSHA = context.payload.pull_request.head.sha
+            core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+          }
+
+          core.info(`output.ci_commit_ref_name: '${refName}'`)
+          core.info(`output.ci_commit_tag:      '${githubTag}'`)
+          core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+          core.info(`output.github_sha:         '${githubSHA}'`)
+
+          core.setOutput('ci_commit_ref_name', refName)
+          core.setOutput(`ci_commit_tag`, githubTag)
+          core.setOutput(`ci_commit_branch`, githubBranch)
+          core.setOutput('github_sha', githubSHA)
+
+# </template: git_info_job>
 {!{- end -}!}
 
+
+# Only useful with pull_request_target.
+#
+# Checks out merge commit, checks for dangerous changes, and if none found, returns the ref.
+{!{ define "pull_request_info_job" }!}
+# <template: pull_request_info>
+pull_request_info:
+  name: Get pull request reference
+  runs-on: ubuntu-latest
+  outputs:
+    ref: ${{ steps.ref.outputs.ref }}
+  steps:
+    - name: Check if allow to run tests
+      id: check
+      uses: {!{ index (ds "actions") "actions/github-script" }!}
+      with:
+        script: |
+          // Assume workflow_dispatch is safe to run.
+          // TODO add owner, repo, sha to inputs to check them here.
+          if (context.eventName === 'workflow_dispatch') {
+            core.info(`workflow_dispatch detected, set should_run to 'true'`);
+            return core.setOutput('should_run', 'true');
+          }
+
+          if (!context.payload.pull_request) {
+            return core.setFailed(`Unknown event, no pull request context. event_name=${context.eventName} action=${context.action} ref=${context.ref}`);
+          }
+
+          // Fetch fresh pull request state using sha.
+          // Why? Workflow rerun of 'opened' pull request contains outdated labels.
+          const owner = context.payload.pull_request.head.repo.owner.login
+          const repo = context.payload.pull_request.head.repo.name
+          const commit_sha = context.payload.pull_request.head.sha
+          core.info(`List pull request inputs: ${JSON.stringify({ owner, repo, commit_sha })}`);
+          const response = await github.rest.repos.listPullRequestsAssociatedWithCommit({ owner, repo, commit_sha });
+          if (response.status != 200) {
+            return core.setFailed(`Cannot list PRs for commit ${commit_sha}: ${JSON.stringify(response)}`);
+          }
+
+          // No PR found, do not run next jobs.
+          if (!response.data || response.data.length === 0) {
+            return core.setFailed(`No pull_request found. event_name=${context.eventName} action=${context.action} ref=${context.ref}`);
+          }
+
+          const prRepo = context.payload.pull_request.head.repo.full_name;
+          const targetRepo = context.payload.repository.full_name;
+          const isInternal = prRepo === targetRepo;
+          const isDependabot = (context.actor === 'dependabot[bot]');
+          const isChangelog = context.payload.pull_request.head.ref.startsWith('changelog/v');
+          const okToTest = response.data[0].labels.some((l) => l.name === 'ok-to-test');
+          core.info(`PR internal?          ${isInternal}`)
+          core.info(`PR from dependabot?   ${isDependabot}`)
+          core.info(`PR changelog?         ${isChangelog}`)
+          core.info(`PR has 'ok-to-test'?  ${okToTest}`)
+
+          if (isInternal && !isDependabot) {
+            // Ignore changelog pull requests.
+            if (isChangelog) {
+              return core.setFailed(`PR#${context.payload.pull_request.number} for changelog is ignored.`);
+            }
+          } else {
+            // External and dependabot pull requests should be labeled with 'ok-to-test'.
+            if (!okToTest) {
+              return core.setFailed(`PR#${context.payload.pull_request.number} without label 'ok-to-test' is ignored.`);
+            }
+          }
+
+    # Checkhout the merge commit
+    - name: Checkout PR merge commit
+      uses: {!{ index (ds "actions") "actions/checkout" }!}
+      with:
+        ref: "refs/pull/${{ github.event.number }}/merge"
+
+    # Detect dangerous changes in external PR.
+    - name: Check for dangerous changes
+      uses: {!{ index (ds "actions") "dorny/paths-filter" }!}
+      if: github.event.pull_request.head.repo.full_name != github.repository
+      id: changes
+      with:
+        token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+        filters: |
+          dangerous:
+            - './.github/**'
+            - './.gitlab/**'
+            - './tools/**'
+            - './testing/**'
+            - './docs/**/js/**'
+            - './docs/**/css/**'
+            - './docs/**/images/**'
+            - './docs/**/assets/**'
+
+    # Stop workflow if external PR contains dangerous changes.
+    - name: Fail workflow on dangerous changes
+      if: steps.changes.outputs.dangerous == 'true'
+      uses: {!{ index (ds "actions") "actions/github-script" }!}
+      with:
+        script: |
+          core.setFailed('External PR contains dangerous changes.')
+
+    # Set output.
+    - name: Return PR merge commit ref
+      id: ref
+      uses: {!{ index (ds "actions") "actions/github-script" }!}
+      with:
+        script: |
+          const ref = `refs/pull/${ context.issue.number }/merge`
+          core.info(`ref: '${ref}'`)
+          core.setOutput('ref', ref)
+# </template: pull_request_info>
+{!{- end -}!}

--- a/.github/ci_templates/scripts.yml
+++ b/.github/ci_templates/scripts.yml
@@ -1,7 +1,8 @@
 {!{ define "update_comment_on_start" }!}
 {!{- $workflowName := . -}!}
+# <template: update_comment_on_start>
 - name: Update comment on start
-  if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+  if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
   uses: {!{ index (ds "actions") "actions/github-script" }!}
   with:
     github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -10,14 +11,17 @@
 
       const ci = require('./.github/scripts/js/ci');
       return await ci.updateCommentOnStart({github, context, core, name})
+
+# </template: update_comment_on_start>
 {!{- end -}!}
 
 {!{ define "update_comment_on_finish" }!}
 {!{- $statusSource := index . 0 -}!}
 {!{- $name := index . 1 -}!}
 
+# <template: update_comment_on_finish>
 - name: Update comment on finish
-  if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+  if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
   continue-on-error: true
   env:
     NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -36,6 +40,7 @@
 
       const ci = require('./.github/scripts/js/ci');
       return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+# </template: update_comment_on_finish>
 {!{- end -}!}
 
 {!{/* This job checks if label is set on pr or issue and return should_run output. Also, all labels are returned as JSON. */}!}
@@ -43,6 +48,7 @@
 {!{- $labelType := index . 0 -}!}
 {!{- $labelSubject := index . 1 -}!}
 
+# <template: check_label_job>
 check_label:
   name: Check label
   runs-on: ubuntu-latest
@@ -61,4 +67,5 @@ check_label:
 
           const ci = require('./.github/scripts/js/ci');
           return await ci.checkLabel({github, context, core, labelType, labelSubject});
+# </template: check_label_job>
 {!{- end -}!}

--- a/.github/ci_templates/steps.yml
+++ b/.github/ci_templates/steps.yml
@@ -1,24 +1,38 @@
 {!{ define "checkout_step" }!}
+# <template: checkout_step>
 - name: Checkout sources
   uses: {!{ index (ds "actions") "actions/checkout" }!}
+  {!{ if coll.Has . "pullRequestRefField" -}!}
+  with:
+    ref: ${{ {!{ .pullRequestRefField }!} }}
+  {!{- end }!}
+# </template: checkout_step>
 {!{- end -}!}
 
 {!{ define "checkout_full_step" }!}
+# <template: checkout_full_step>
 - name: Checkout sources
   uses: {!{ index (ds "actions") "actions/checkout" }!}
   with:
     fetch-depth: 0
+  {!{- if coll.Has . "pullRequestRefField" }!}
+    ref: ${{ {!{ .pullRequestRefField }!} }}
+  {!{- end }!}
+# </template: checkout_full_step>
 {!{- end -}!}
 
 {!{ define "checkout_from_event_ref_step" }!}
+# <template: checkout_from_event_ref_step>
 - name: Checkout sources
   uses: {!{ index (ds "actions") "actions/checkout" }!}
   with:
-    ref: ${{ github.event.ref }}
+    ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
     fetch-depth: 0
-{!{- end -}!}
+# </template: checkout_from_event_ref_step>
+{!{- end }!}
 
 {!{ define "login_dev_registry_step" }!}
+# <template: login_dev_registry_step>
 - name: Login to dev registry
   uses: {!{ index (ds "actions") "docker/login-action" }!}
   with:
@@ -26,9 +40,11 @@
     username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
     password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
     logout: false
+# </template: login_dev_registry_step>
 {!{- end -}!}
 
 {!{ define "login_readonly_registry_step" }!}
+# <template: login_readonly_registry_step>
 - name: Login to readonly registry
   uses: {!{ index (ds "actions") "docker/login-action" }!}
   with:
@@ -36,9 +52,11 @@
     username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
     password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
     logout: false
+# </template: login_readonly_registry_step>
 {!{- end -}!}
 
 {!{ define "login_rw_registry_step" }!}
+# <template: login_rw_registry_step>
 - name: Login to rw registry
   uses: {!{ index (ds "actions") "docker/login-action" }!}
   with:
@@ -46,9 +64,11 @@
     username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
     password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
     logout: false
+# </template: login_rw_registry_step>
 {!{- end -}!}
 
 {!{ define "login_flant_registry_step" }!}
+# <template: login_flant_registry_step>
 - name: Login to flant registry
   uses: {!{ index (ds "actions") "docker/login-action" }!}
   with:
@@ -56,40 +76,50 @@
     username: ${{ secrets.FLANT_REGISTRY_USER }}
     password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
     logout: false
+# </template: login_flant_registry_step>
 {!{- end -}!}
 
 {!{ define "werf_install_step" }!}
+# <template: werf_install_step>
 - name: Install werf CLI
   uses: {!{ index (ds "actions") "werf/actions/install" }!}
   with:
     channel: ${{env.WERF_CHANNEL}}
+# </template: werf_install_step>
 {!{- end -}!}
 
 {!{ define "save_images_tags_json_step" }!}
+# <template: save_images_tags_json_step>
 - name: Save images_tags file
   uses: {!{ index (ds "actions") "actions/upload-artifact" }!}
   with:
     name: images_tags_json_${{env.WERF_ENV}}
     path: modules/images_tags_${{env.WERF_ENV}}.json
+# </template: save_images_tags_json_step>
 {!{- end -}!}
 
 {!{ define "restore_images_tags_json_step" }!}
+# <template: restore_images_tags_json_step>
 - name: Restore images_tags file
   uses: {!{ index (ds "actions") "actions/download-artifact" }!}
   with:
     name: images_tags_json_${{env.WERF_ENV}}
     path: modules
+# </template: restore_images_tags_json_step>
 {!{- end -}!}
 
 {!{ define "save_images_tags_json_to_cache_step" }!}
+# <template: save_images_tags_json_to_cache_step>
 - name: Save images_tags file
   uses: {!{ index (ds "actions") "actions/cache" }!}
   with:
     path: modules/images_tags_${{env.WERF_ENV}}.json
     key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
+# </template: save_images_tags_json_to_cache_step>
 {!{- end -}!}
 
 {!{ define "restore_images_tags_json_from_cache_or_fail" }!}
+# <template: restore_images_tags_json_from_cache_or_fail>
 - name: Restore images_tags_json from cache
   id: images-tags-json
   uses: {!{ index (ds "actions") "actions/cache" }!}
@@ -101,4 +131,5 @@
   run: |
     echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
     exit 1
+# </template: restore_images_tags_json_from_cache_or_fail>
 {!{- end -}!}

--- a/.github/ci_templates/tests.yml
+++ b/.github/ci_templates/tests.yml
@@ -1,59 +1,73 @@
 {!{/* Source: .gitlab/ci_templates/tests.yml */}!}
 
 {!{ define "unit_run_args" }!}
+# <template: unit_run_args>
 args: 'go test -timeout=${{env.TEST_TIMEOUT}} -vet=off ./modules/... ./global-hooks/...'
 docker_options: '-w /deckhouse'
+# <template: unit_run_args>
 {!{- end -}!}
 
 {!{ define "matrix_run_args" }!}
+# <template: matrix_run_args>
 args: 'ginkgo -timeout=${{env.TEST_TIMEOUT}} -vet=off --slowSpecThreshold=30 ./testing/matrix/'
 docker_options: '-w /deckhouse'
+# </template: matrix_run_args>
 {!{- end -}!}
 
 {!{ define "dhctl_run_args" }!}
+# <template: dhctl_run_args>
 image: dhctl-tests
 args: 'make ci'
 docker_options: '-v ${{github.workspace}}:/deckhouse -w /deckhouse/dhctl'
+# </template: dhctl_run_args>
 {!{- end -}!}
 
 {!{ define "golangci_lint_run_args" }!}
+# <template: golangci_lint_run_args>
 args: 'sh -c "go generate tools/register.go && golangci-lint run"'
 docker_options: '-w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color"'
+# </template: golangci_lint_run_args>
 {!{- end -}!}
 
 {!{ define "openapi_test_cases_run_args" }!}
+# <template: openapi_test_cases_run_args>
 args: 'ginkgo -vet=off ./testing/openapi_cases/'
 docker_options: '-v ${{github.workspace}}:/deckhouse -w /deckhouse'
+# </template: openapi_test_cases_run_args>
 {!{- end -}!}
 
 {!{ define "validators_run_args" }!}
+# <template: validators_run_args>
 args: 'go test -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...'
 docker_options: '-w /deckhouse'
+# </template: validators_run_args>
 {!{- end -}!}
 
 {!{ define "tests_template" }!}
-  {!{- $args_name := . }!}
-  {!{- $args_tmpl := printf "%s_run_args" $args_name }!}
-  {!{- $default := dict "image" "tests" "args" "echo no args" "docker_options" "" }!}
-  {!{- $ctx := coll.Merge (tmpl.Exec $args_tmpl | yaml) $default }!}
+# <template: tests_template>
+{!{- $ctx       := index . 0 }!}
+{!{- $args_name := index . 1 }!}
+{!{- $args_tmpl := printf "%s_run_args" $args_name }!}
+{!{- $default   := dict "image" "tests" "args" "echo no args" "docker_options" "" }!}
+{!{- $run       := coll.Merge (tmpl.Exec $args_tmpl | yaml) $default }!}
 runs-on: [self-hosted, regular]
 steps:
-  {!{ tmpl.Exec "checkout_full_step" . | strings.Indent 2 }!}
-  {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 2 }!}
-  {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}
-  {!{ tmpl.Exec "restore_images_tags_json_step" . | strings.Indent 2 }!}
+{!{ tmpl.Exec "checkout_full_step"            $ctx | strings.Indent 2 }!}
+{!{ tmpl.Exec "login_dev_registry_step"       $ctx | strings.Indent 2 }!}
+{!{ tmpl.Exec "login_readonly_registry_step"  $ctx | strings.Indent 2 }!}
+{!{ tmpl.Exec "restore_images_tags_json_step" $ctx | strings.Indent 2 }!}
   - name: Run tests
     uses: {!{ index (ds "actions") "werf/actions/run" }!}
     with:
       channel: ${{env.WERF_CHANNEL}}
-      image: {!{ $ctx.image }!}
-      args: {!{ $ctx.args | squote }!}
+      image: {!{ $run.image }!}
+      args: {!{ $run.args | squote }!}
     env:
       WERF_SKIP_BUILD: "true"
-      WERF_DOCKER_OPTIONS: {!{ $ctx.docker_options | squote }!}
+      WERF_DOCKER_OPTIONS: {!{ $run.docker_options | squote }!}
       WERF_REPO: ${{ env.DEV_REGISTRY_PATH }}
       CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
       CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
       CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+# </template: tests_template>
 {!{- end -}!}
-

--- a/.github/ci_templates/web.yml
+++ b/.github/ci_templates/web.yml
@@ -1,9 +1,10 @@
 {!{- define "doc_web_build_template" -}!}
+# <template: doc_web_build_template>
 runs-on: [self-hosted, regular]
 steps:
-  {!{ tmpl.Exec "checkout_full_step" . | strings.Indent 2 }!}
+  {!{ tmpl.Exec "checkout_full_step"           . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}
-  {!{ tmpl.Exec "login_flant_registry_step" . | strings.Indent 2 }!}
+  {!{ tmpl.Exec "login_flant_registry_step"    . | strings.Indent 2 }!}
 
   - name: Run doc web build
     uses: {!{ index (ds "actions") "werf/actions/build" }!}
@@ -13,14 +14,16 @@ steps:
       WERF_DIR: "docs/documentation"
       WERF_LOG_VERBOSE: "on"
       WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+# </template: doc_web_build_template>
 {!{- end -}!}
 
 {!{- define "main_web_build_template" -}!}
+# <template: main_web_build_template>
 runs-on: [self-hosted, regular]
 steps:
-  {!{ tmpl.Exec "checkout_full_step" . | strings.Indent 2 }!}
+  {!{ tmpl.Exec "checkout_full_step"           . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}
-  {!{ tmpl.Exec "login_flant_registry_step" . | strings.Indent 2 }!}
+  {!{ tmpl.Exec "login_flant_registry_step"    . | strings.Indent 2 }!}
 
   - name: Run main web build
     uses: {!{ index (ds "actions") "werf/actions/build" }!}
@@ -30,15 +33,17 @@ steps:
       WERF_DIR: "docs/site"
       WERF_LOG_VERBOSE: "on"
       WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+# </template: main_web_build_template>
 {!{- end -}!}
 
 {!{- define "web_links_test_template" -}!}
+# <template: web_links_test_template>
 runs-on: [self-hosted, regular]
 steps:
-  {!{ tmpl.Exec "checkout_full_step" . | strings.Indent 2 }!}
+  {!{ tmpl.Exec "checkout_full_step"           . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}
-  {!{ tmpl.Exec "login_flant_registry_step" . | strings.Indent 2 }!}
-  {!{ tmpl.Exec "werf_install_step" . | strings.Indent 2 }!}
+  {!{ tmpl.Exec "login_flant_registry_step"    . | strings.Indent 2 }!}
+  {!{ tmpl.Exec "werf_install_step"            . | strings.Indent 2 }!}
 
   - name: Prepare site structure
     run: |
@@ -106,16 +111,19 @@ steps:
       if [[ -n $_TMPDIR ]] ; then
         rm -rf $_TMPDIR
       fi
+# </template: web_links_test_template>
 {!{- end -}!}
 
 {!{/* doc version is a tag name or 'latest' for main branch or a branch name for dev branches */}!}
 {!{/* ci_commit_ref_name is a tagname or branch name */}!}
 {!{ define "doc_version_template" }!}
+# <template: doc_version_template>
 - name: Set documentation version
   env:
     CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
   run: |
     echo "DOC_VERSION=${CI_COMMIT_TAG:-latest}" >> $GITHUB_ENV
+# </template: doc_version_template>
 {!{- end -}!}
 
 {!{ define "deploy_doc_template" }!}
@@ -128,6 +136,8 @@ steps:
   {!{- $url = "deckhouse.io" -}!}
   {!{- $kubeConfig = "${{ secrets.KUBECONFIG_BASE64_PROD }}" -}!}
 {!{- end -}!}
+
+# <template: deploy_doc_template>
 - name: Deploy documentation to {!{ $env }!}
   uses: {!{ index (ds "actions") "werf/actions/converge" }!}
   with:
@@ -142,6 +152,7 @@ steps:
     WERF_SET_DOC_VERSION: "global.doc_version=${{ env.DOC_VERSION }}"
     WERF_SET_URL: "global.url={!{ $url }!}"
     WERF_SET_WEB_ENV: "web.env={!{ $webEnv }!}"
+# </template: deploy_doc_template>
 {!{- end -}!}
 
 {!{ define "deploy_site_template" }!}
@@ -154,6 +165,8 @@ steps:
   {!{- $url = "deckhouse.io" -}!}
   {!{- $kubeConfig = "${{ secrets.KUBECONFIG_BASE64_PROD }}" -}!}
 {!{- end -}!}
+
+# <template: deploy_site_template>
 - name: Deploy site to {!{ $env }!}
   uses: {!{ index (ds "actions") "werf/actions/converge" }!}
   with:
@@ -169,5 +182,5 @@ steps:
     WERF_SET_ACTIVE_RELEASE: "global.active_release=v1"
     WERF_SET_URL: "global.url={!{ $url }!}"
     WERF_SET_WEB_ENV: "web.env={!{ $webEnv }!}"
+# </template: deploy_site_template>
 {!{- end -}!}
-

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -419,35 +419,27 @@ module.exports.checkE2ELabels = async ({ github, context, core, provider, defaul
  * @returns {Promise<void|*>}
  */
 module.exports.checkValidationLabels = async ({ github, context, core }) => {
-  // Get first associated PR.
-  const response = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    commit_sha: context.sha
-  });
-  if (response.status != 200) {
-    return core.setFailed(`Cannot list PRs for commit ${context.sha}: ${JSON.stringify(response)}`);
-  }
-
   // Run all validations by default.
   core.setOutput('run_no_cyrillic', 'true');
   core.setOutput('run_doc_changes', 'true');
   core.setOutput('run_copyright', 'true');
 
-  // No PR found. It can be first push before creating PR.
-  // Assume there are no labels and all validations should run
-  // using commit diff as input for validation scripts.
-  //
-  // context.payload.compare contains a proper url
-  // for one commit and for multiple commits in branch.
-  if (!response.data || response.data.length === 0) {
-    const diff_url = context.payload.compare + '.diff';
-    core.setOutput('diff_url', diff_url);
-    console.log(`diff_url="${diff_url}"`);
+  // This method runs on pull_request_target, so pull_request context is available.
 
-    return console.log(
-      `No pull_request found. Run all validations. event_name=${context.eventName} action=${context.action} ref=${context.ref}`
-    );
+  // Fetch fresh pull request state using sha.
+  // Why? Workflow rerun of 'opened' pull request contains outdated labels.
+  const owner = context.payload.pull_request.head.repo.owner.login
+  const repo = context.payload.pull_request.head.repo.name
+  const commit_sha = context.payload.pull_request.head.sha
+  core.info(`List pull request inputs: ${JSON.stringify({ owner, repo, commit_sha })}`);
+  const response = await github.rest.repos.listPullRequestsAssociatedWithCommit({ owner, repo, commit_sha });
+  if (response.status != 200) {
+    return core.setFailed(`Cannot list PRs for commit ${commit_sha}: ${JSON.stringify(response)}`);
+  }
+
+  // No PR found, do not run validations.
+  if (!response.data || response.data.length === 0) {
+    return core.setFailed(`No pull_request found. event_name=${context.eventName} action=${context.action}`);
   }
 
   const pr = response.data[0];
@@ -459,15 +451,15 @@ module.exports.checkValidationLabels = async ({ github, context, core }) => {
     let validationName = '';
     if (/no-cyrillic/.test(skipLabel)) {
       validationName = 'no_cyrillic';
-      console.log(`Skip 'no-cyrillic'`);
+      core.info(`Skip 'no-cyrillic'`);
     }
     if (/documentation/.test(skipLabel)) {
       validationName = 'doc_changes';
-      console.log(`Skip 'doc-changes'`);
+      core.info(`Skip 'doc-changes'`);
     }
     if (/copyright/.test(skipLabel)) {
       validationName = 'copyright';
-      console.log(`Skip 'copyright'`);
+      core.info(`Skip 'copyright'`);
     }
 
     if (prHasSkipLabel) {
@@ -477,13 +469,13 @@ module.exports.checkValidationLabels = async ({ github, context, core }) => {
   }
 
   core.setOutput('pr_title', pr.title);
-  console.log(`pr_title='${pr.title}'`);
+  core.info(`pr_title='${pr.title}'`);
 
   core.setOutput('pr_description', pr.body);
-  console.log(`pr_description='${pr.body}'`);
+  core.info(`pr_description='${pr.body}'`);
 
   core.setOutput('diff_url', pr.diff_url);
-  console.log(`diff_url='${pr.diff_url}'`);
+  core.info(`diff_url='${pr.diff_url}'`);
 };
 
 /**
@@ -629,20 +621,22 @@ module.exports.runWorkflowForReleaseIssue = async ({ github, context, core }) =>
  * @param {object} inputs.github - A pre-authenticated octokit/rest.js client with pagination plugins.
  * @param {object} inputs.context - An object containing the context of the workflow run.
  * @param {object} inputs.core - A reference to the '@actions/core' package.
+ * @param {string} inputs.ref - A git ref to checkout merge commit for PR (e.g. refs/pull/133/merge).
  * @returns {Promise<void>}
  */
-module.exports.runWorkflowForPullRequest = async ({ github, context, core }) => {
+module.exports.runWorkflowForPullRequest = async ({ github, context, core, ref }) => {
   const event = context.payload;
   const label = event.label.name;
+  let command = {action: 'workflow_dispatch', workflows:[]};
+
   console.log(`Event label name: '${label}'`);
   console.log(`Known labels: ${JSON.stringify(knownLabels, null, '  ')}`);
-
-  let workflow_id = '';
+  console.log(`Git ref: '${ref}'`);
 
   if (knownLabels.e2e.includes(label) && event.action === 'labeled') {
     for (const provider of knownProviders) {
       if (label.includes(provider)) {
-        workflow_id = `e2e-${provider}.yml`;
+        command.workflows = [`e2e-${provider}.yml`];
         break;
       }
     }
@@ -652,29 +646,90 @@ module.exports.runWorkflowForPullRequest = async ({ github, context, core }) => 
     // prod env is not available for pull request.
     for (const webEnv of ['test', 'stage']) {
       if (label.includes(webEnv)) {
-        workflow_id = `deploy-web-${webEnv}.yml`;
+        command.workflows = [`deploy-web-${webEnv}.yml`];
         break;
       }
     }
   }
 
   if (knownLabels['skip-validation'].includes(label)) {
-    workflow_id = 'validation.yml';
+    command.workflows = ['validation.yml'];
+    command.action = 'rerun';
   }
 
-  if (workflow_id === '') {
+  if (knownLabels['ok-to-test'] === label) {
+    command.workflows = ['build-and-test_dev.yml', 'validation.yml'];
+    command.action = 'rerun';
+  }
+
+  if (command.workflows.length === 0) {
     return console.log(`Workflow for label '${event.label.name}' and action '${event.action}' not found. Ignore it.`);
   }
 
-  console.log(`Label '${label}' is set. Should retry workflow '${workflow_id}'.`);
+  if (command.action === 'rerun') {
+    console.log(`Label '${label}' was set on PR#${context.payload.pull_request.number}. Will retry workflows: '${JSON.stringify(command.workflows)}'.`);
+    for (const workflow_id of command.workflows) {
+      await findAndRerunWorkflow({github, context, core, workflow_id});
+    }
+  }
 
+  if (command.action === 'workflow_dispatch') {
+    const workflow_id = command.workflows[0];
+    console.log(`Label '${label}' was set on PR#${context.payload.pull_request.number}. Will start workflow '${workflow_id}'.`);
+
+    // workflow_dispatch requires a ref. In PRs from forks, we assign images with `prXXX` tags to
+    // avoid clashes with inner branches.
+    const prNumber = context.payload.pull_request.number
+
+    // Add comment to pull request.
+    console.log(`Add comment to pull request ${prNumber}.`);
+    let response = await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: prNumber,
+      body: `Run workflow "${label}"...`
+    });
+
+    if (response.status < 200 || response.status >= 300) {
+      return core.setFailed(`Cannot start workflow: ${JSON.stringify(response)}`);
+    }
+
+    const targetRepo = context.payload.repository.full_name;
+    const prRepo = context.payload.pull_request.head.repo.full_name;
+    const prRef = context.payload.pull_request.head.ref
+    const inputs = {
+      issue_id: '' + context.payload.pull_request.id,
+      issue_number: '' + prNumber,
+      comment_id: '' + response.data.id,
+      ci_commit_ref_name: (prRepo === targetRepo) ? prRef : `pr${prNumber}`,
+      pull_request_ref: ref,
+      pull_request_sha: context.payload.pull_request.head.sha,
+    }
+    console.log(`Start workflow '${workflow_id}'. Inputs: ${JSON.stringify(inputs)}.`);
+    response = await github.rest.actions.createWorkflowDispatch({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      workflow_id: workflow_id,
+      ref: 'refs/heads/main',
+      inputs: inputs
+    });
+
+    if (response.status > 200 && response.status < 300) {
+      console.log('Workflow started successfully');
+    } else {
+      return core.setFailed(`Error calling dispatch. Response: ${JSON.stringify(response)}`);
+    }
+  }
+
+};
+
+const findAndRerunWorkflow = async ({ github, context, core, workflow_id }) => {
   // Retrieve latest workflow run and rerun it.
   let response = await github.rest.actions.listWorkflowRuns({
     owner: context.repo.owner,
     repo: context.repo.repo,
     workflow_id: workflow_id,
-    branch: context.payload.pull_request.head.ref,
-    event: 'push'
+    branch: context.payload.pull_request.head.ref
   });
 
   if (!response.data.workflow_runs || response.data.workflow_runs.length === 0) {
@@ -682,14 +737,25 @@ module.exports.runWorkflowForPullRequest = async ({ github, context, core }) => 
     return core.setFailed(`No runs found for workflow '${workflow_id}'. Just return.`);
   }
 
-  const latestWorkflowRunId = response.data.workflow_runs[0].id;
-  console.log(`Last workflow run id: ${latestWorkflowRunId}`);
+  let lastRun = null;
+  for (const wr of response.data.workflow_runs) {
+    if (wr.head_sha === context.payload.pull_request.head.sha) {
+      lastRun = wr;
+      break;
+    }
+  }
+
+  if (!lastRun) {
+    return core.setFailed(`Workflow run of '${workflow_id}' not found for PR#${context.payload.pull_request.number} and SHA=${context.payload.pull_request.head.sha}.`);
+  }
+
+  console.log(`Found last workflow run of '${workflow_id}'. ID ${lastRun.id}, run number ${lastRun.run_number}, started at ${lastRun.run_started_at}`);
 
   try {
     const response = await github.rest.actions.retryWorkflow({
       owner: context.repo.owner,
       repo: context.repo.repo,
-      run_id: latestWorkflowRunId
+      run_id: lastRun.id
     });
 
     if (response.status > 200 && response.status < 300) {
@@ -700,7 +766,7 @@ module.exports.runWorkflowForPullRequest = async ({ github, context, core }) => 
   } catch (error) {
     console.log(`Ignore error: ${dumpError(error)}`);
   }
-};
+}
 
 /**
  * Create new "release" issue when new milestone is created.

--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -18,6 +18,7 @@ const labels = {
     'e2e/run/static'
   ],
   'issue-release': 'issue/release',
+  'ok-to-test': 'ok-to-test',
   deploy: [
     'deploy/deckhouse/alpha',
     'deploy/deckhouse/beta',

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -1,16 +1,14 @@
+{!{- $pullRequestContext := coll.Dict "pullRequestRefField" "needs.pull_request_info.outputs.ref" -}!}
+{!{- $ctx := coll.Merge $pullRequestContext . -}!}
+
 # on every push to dev branches
 name: Build and test for dev branches
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'release-*'
-      - 'alpha'
-      - 'beta'
-      - 'early-access'
-      - 'stable'
-      - 'rock-solid'
-      - 'changelog/*'
+  pull_request_target:
+     types:
+      - opened
+      - synchronize
+      - reopened
 
 env:
 {!{ tmpl.Exec "werf_envs" | strings.Indent 2 }!}
@@ -21,101 +19,114 @@ env:
 # Note: Concurrency is currently in beta and subject to change.
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ${{ github.ref }}-dev
+  group: ${{ github.event.number }}-dev
   cancel-in-progress: true
 
 jobs:
-{!{ tmpl.Exec "git_info_job" . | strings.Indent 2 }!}
+{!{ tmpl.Exec "pull_request_info_job" $ctx | strings.Indent 2 }!}
+{!{ tmpl.Exec "git_info_job" $ctx | strings.Indent 2 }!}
 
   build_modules_images_fe:
     name: Build Modules Images FE
     needs:
       - git_info
-{!{ tmpl.Exec "build_modules_images_template" . | strings.Indent 4 }!}
+      - pull_request_info
+{!{ tmpl.Exec "build_modules_images_template" $ctx | strings.Indent 4 }!}
 
   go_generate:
     name: Go Generate
     needs:
       - git_info
-{!{ tmpl.Exec "go_generate_template" . | strings.Indent 4 }!}
+      - pull_request_info
+{!{ tmpl.Exec "go_generate_template" $ctx | strings.Indent 4 }!}
 
   build_fe:
     name: Build FE
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
       - go_generate
-{!{ tmpl.Exec "build_template" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "build_template" $ctx | strings.Indent 4 }!}
 
   doc_web_build:
     name: Doc web build
     # Wait for success build of modules.
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
-{!{ tmpl.Exec "doc_web_build_template" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "doc_web_build_template" $ctx | strings.Indent 4 }!}
 
   main_web_build:
     name: Main web build
     # Wait for success build of modules.
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
-{!{ tmpl.Exec "main_web_build_template" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "main_web_build_template" $ctx | strings.Indent 4 }!}
 
   tests:
     name: Tests
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
       - build_fe
-{!{ tmpl.Exec "tests_template" "unit" | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "unit") | strings.Indent 4 }!}
 
   matrix_tests:
     name: Matrix tests
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
       - build_fe
-{!{ tmpl.Exec "tests_template" "matrix" | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "matrix") | strings.Indent 4 }!}
 
   dhctl_tests:
     name: Dhctl Tests
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
       - build_fe
-{!{ tmpl.Exec "tests_template" "dhctl" | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "dhctl") | strings.Indent 4 }!}
 
   golangci_lint:
     name: GolangCI Lint
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
       - build_fe
-{!{ tmpl.Exec "tests_template" "golangci_lint" | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "golangci_lint") | strings.Indent 4 }!}
 
   openapi_test_cases:
     name: OpenAPI Test Cases
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
       - build_fe
-{!{ tmpl.Exec "tests_template" "openapi_test_cases" | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "openapi_test_cases") | strings.Indent 4 }!}
 
   web_links_test:
     name: Web links test
     needs:
       - git_info
+      - pull_request_info
       - doc_web_build
       - main_web_build
     continue-on-error: true
-{!{ tmpl.Exec "web_links_test_template" | strings.Indent 4 }!}
+{!{ tmpl.Exec "web_links_test_template" $ctx | strings.Indent 4 }!}
 
   validators:
     name: Validators
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
       - build_fe
-{!{ tmpl.Exec "tests_template" "validators" | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "validators") | strings.Indent 4 }!}

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -1,4 +1,6 @@
 # on push to default branch or on tags
+{!{- $ctx := dict -}!}
+{!{- $ctx = coll.Merge $ctx . -}!}
 {!{ $workflowName := "Build and test for release" }!}
 name: {!{ $workflowName }!}
 
@@ -16,8 +18,8 @@ on:
         required: false
 
 env:
-{!{ tmpl.Exec "werf_envs" | strings.Indent 2 }!}
-{!{ tmpl.Exec "image_versions_envs" | strings.Indent 2 }!}
+{!{ tmpl.Exec "werf_envs"               | strings.Indent 2 }!}
+{!{ tmpl.Exec "image_versions_envs"     | strings.Indent 2 }!}
 {!{ tmpl.Exec "terraform_versions_envs" | strings.Indent 2 }!}
 
 # Analog of Gitlab's "interruptible: true" behaviour.
@@ -28,13 +30,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-{!{ tmpl.Exec "git_info_job" . | strings.Indent 2 }!}
+{!{ tmpl.Exec "git_info_job" $ctx | strings.Indent 2 }!}
 
   comment_on_start:
     name: Add comment on start
     runs-on: ubuntu-latest
     steps:
-{!{ tmpl.Exec "checkout_step" . | strings.Indent 6 }!}
+{!{ tmpl.Exec "checkout_step" $ctx | strings.Indent 6 }!}
 {!{ tmpl.Exec "update_comment_on_start" "Build and test for release" | strings.Indent 6 }!}
 
   build_modules_images_fe:
@@ -42,7 +44,7 @@ jobs:
     needs:
       - git_info
       - comment_on_start
-{!{ tmpl.Exec "build_modules_images_template" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "build_modules_images_template" $ctx | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Build Modules Images FE") | strings.Indent 6 }!}
 
   build_modules_images_ee:
@@ -53,7 +55,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "EE"
-{!{ tmpl.Exec "build_modules_images_template" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "build_modules_images_template" $ctx | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Build Modules Images EE") | strings.Indent 6 }!}
 
   build_modules_images_ce:
@@ -64,14 +66,14 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "CE"
-{!{ tmpl.Exec "build_modules_images_template" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "build_modules_images_template" $ctx | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Build Modules Images CE") | strings.Indent 6 }!}
 
   go_generate:
     name: Go Generate
     needs:
       - git_info
-{!{ tmpl.Exec "go_generate_template" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "go_generate_template" $ctx | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Go Generate") | strings.Indent 6 }!}
 
   build_fe:
@@ -82,7 +84,7 @@ jobs:
       - go_generate
     env:
       WERF_ENV: "FE"
-{!{ tmpl.Exec "build_template" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "build_template" $ctx | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Build FE") | strings.Indent 6 }!}
 
   build_ee:
@@ -94,7 +96,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "EE"
-{!{ tmpl.Exec "build_template" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "build_template" $ctx | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Build EE") | strings.Indent 6 }!}
 
   build_ce:
@@ -106,7 +108,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "CE"
-{!{ tmpl.Exec "build_template" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "build_template" $ctx | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Build CE") | strings.Indent 6 }!}
 
   doc_web_build:
@@ -115,7 +117,7 @@ jobs:
     needs:
       - git_info
       - build_modules_images_fe
-{!{ tmpl.Exec "doc_web_build_template" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "doc_web_build_template" $ctx | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Doc web build") | strings.Indent 6 }!}
 
   main_web_build:
@@ -124,7 +126,7 @@ jobs:
     needs:
       - git_info
       - build_modules_images_fe
-{!{ tmpl.Exec "main_web_build_template" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "main_web_build_template" $ctx | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Main web build") | strings.Indent 6 }!}
 
   tests:
@@ -134,7 +136,7 @@ jobs:
       - build_modules_images_fe
       - build_fe
     continue-on-error: true
-{!{ tmpl.Exec "tests_template" "unit" | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "unit") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Tests") | strings.Indent 6 }!}
 
   matrix_tests:
@@ -144,7 +146,7 @@ jobs:
       - build_modules_images_fe
       - build_fe
     continue-on-error: true
-{!{ tmpl.Exec "tests_template" "matrix" | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "matrix") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Matrix tests") | strings.Indent 6 }!}
 
   dhctl_tests:
@@ -154,7 +156,7 @@ jobs:
       - build_modules_images_fe
       - build_fe
     continue-on-error: true
-{!{ tmpl.Exec "tests_template" "dhctl" | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "dhctl") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Dhctl Tests") | strings.Indent 6 }!}
 
   golangci_lint:
@@ -164,7 +166,7 @@ jobs:
       - build_modules_images_fe
       - build_fe
     continue-on-error: true
-{!{ tmpl.Exec "tests_template" "golangci_lint" | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "golangci_lint") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "GolangCI Lint") | strings.Indent 6 }!}
 
   openapi_test_cases:
@@ -174,7 +176,7 @@ jobs:
       - build_modules_images_fe
       - build_fe
     continue-on-error: true
-{!{ tmpl.Exec "tests_template" "openapi_test_cases" | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "openapi_test_cases") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "OpenAPI Test Cases") | strings.Indent 6 }!}
 
   web_links_test:
@@ -184,7 +186,7 @@ jobs:
       - doc_web_build
       - main_web_build
     continue-on-error: true
-{!{ tmpl.Exec "web_links_test_template" | strings.Indent 4 }!}
+{!{ tmpl.Exec "web_links_test_template" $ctx | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Web links test") | strings.Indent 6 }!}
 
   validators:
@@ -194,7 +196,7 @@ jobs:
       - build_modules_images_fe
       - build_fe
     continue-on-error: true
-{!{ tmpl.Exec "tests_template" "validators" | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "validators") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Validators") | strings.Indent 6 }!}
 
   {!{/* Autodeploy site and docs to production env on push to main branch. */}!}
@@ -253,5 +255,5 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-{!{ tmpl.Exec "checkout_step" . | strings.Indent 6 }!}
+{!{ tmpl.Exec "checkout_step" $ctx | strings.Indent 6 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "workflow" $workflowName) | strings.Indent 6 }!}

--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -1,8 +1,8 @@
 {!{- range $channel := slice "alpha" "beta" "early-access" "stable" "rock-solid" -}!}
-{!{- $ctx := dict "channel" $channel }!}
-{!{- $outFile := printf "deploy-%s.yml" $channel }!}
-{!{- $outPath := filepath.Join (getenv "OUTDIR") (toLower $outFile) }!}
-{!{- tmpl.Exec "deploy_channel_workflow_template" $ctx | file.Write $outPath }!}
+{!{-   $ctx := dict "channel" $channel }!}
+{!{-   $outFile := printf "deploy-%s.yml" $channel }!}
+{!{-   $outPath := filepath.Join (getenv "OUTDIR") (toLower $outFile) }!}
+{!{-   tmpl.Exec "deploy_channel_workflow_template" $ctx | file.Write $outPath }!}
 {!{- end -}!}
 
 {!{- define "deploy_channel_workflow_template" -}!}

--- a/.github/workflow_templates/deploy-web.multi.yml
+++ b/.github/workflow_templates/deploy-web.multi.yml
@@ -10,17 +10,26 @@
 name: '{!{ $workflowName }!}'
 
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'release-*'
-      - 'alpha'
-      - 'beta'
-      - 'early-access'
-      - 'stable'
-      - 'rock-solid'
-      - 'changelog/*'
-
+  workflow_dispatch:
+    inputs:
+      issue_id:
+        description: 'ID of issue where label was set'
+        required: true
+      issue_number:
+        description: 'Number of issue where label was set'
+        required: true
+      comment_id:
+        description: 'ID of comment in issue where to put workflow run status'
+        required: true
+      ci_commit_ref_name:
+        description: 'Git ref name for image tags'
+        required: false
+      pull_request_ref:
+        description: 'Git ref for checkout PR sources'
+        required: false
+      pull_request_sha:
+        description: 'Git SHA for restoring artifacts from cache'
+        required: false
 
 env:
 {!{ tmpl.Exec "werf_envs" | strings.Indent 2 }!}

--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -28,16 +28,6 @@ Jobs are enabled according to outputs from check labels job.
 {!{- $workflowName := printf "e2e: %s" $ctx.providerName -}!}
 name: '{!{ $workflowName }!}'
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'release-*'
-      - 'alpha'
-      - 'beta'
-      - 'early-access'
-      - 'stable'
-      - 'rock-solid'
-      - 'changelog/*'
   workflow_dispatch:
     inputs:
       issue_id:
@@ -48,6 +38,15 @@ on:
         required: false
       comment_id:
         description: 'ID of comment in issue where to put workflow run status'
+        required: false
+      ci_commit_ref_name:
+        description: 'Git ref name for image tags'
+        required: false
+      pull_request_ref:
+        description: 'Git ref for checkout PR sources'
+        required: false
+      pull_request_sha:
+        description: 'Git SHA for restoring artifacts from cache'
         required: false
       cri:
         required: false
@@ -62,7 +61,7 @@ env:
 # Note: Concurrency is currently in beta and subject to change.
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ${{ github.ref }}-e2e-{!{ $ctx.provider }!}
+  group: ${{ github.ref }}-${{ github.event.inputs.pull_request_ref }}-e2e-{!{ $ctx.provider }!}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflow_templates/on-pull-request-labeled.yml
+++ b/.github/workflow_templates/on-pull-request-labeled.yml
@@ -4,19 +4,22 @@
 name: Rerun workflows for pull request
 
 on:
-  pull_request:
-    types: [labeled,unlabeled]
-
+  pull_request_target:
+    types: [labeled, unlabeled]
 jobs:
+{!{ tmpl.Exec "pull_request_info_job" . | strings.Indent 2 }!}
   rerun_workflow_for_pull_request:
     name: Rerun workflow for pull request
     runs-on: ubuntu-latest
+    needs:
+      - pull_request_info
     steps:
 {!{ tmpl.Exec "checkout_step" . | strings.Indent 6 }!}
       - name: Rerun workflow
         uses: {!{ index (ds "actions") "actions/github-script" }!}
         with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          github-token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
           script: |
             const ci = require('./.github/scripts/js/ci');
-            return await ci.runWorkflowForPullRequest({github, context, core});
+            const ref = "${{ needs.pull_request_info.outputs.ref }}"
+            return await ci.runWorkflowForPullRequest({ github, context, core, ref });

--- a/.github/workflow_templates/validation.yml
+++ b/.github/workflow_templates/validation.yml
@@ -1,3 +1,6 @@
+{!{- $pullRequestContext := coll.Dict "pullRequestRefField" "needs.pull_request_info.outputs.ref" -}!}
+{!{- $ctx := coll.Merge $pullRequestContext . -}!}
+
 # Run validation script on every push to dev branches.
 #
 # Validation scripts require  PR title, PR description and diff.
@@ -10,30 +13,27 @@
 
 name: Validations
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'release-*'
-      - 'alpha'
-      - 'beta'
-      - 'early-access'
-      - 'stable'
-      - 'rock-solid'
-      - 'changelog/*'
+  pull_request_target:
+     types:
+      - opened
+      - synchronize
 
 # Analog of Gitlab's "interruptible: true" behaviour.
 # Note: Concurrency is currently in beta and subject to change.
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ${{ github.ref }}-validation
+  group: ${{ github.event.number }}-validation
   cancel-in-progress: true
 
 jobs:
+{!{ tmpl.Exec "pull_request_info_job" $ctx | strings.Indent 2 }!}
 
   # Get pull request info for validation scripts.
   # Push event has no pull request information, so retrieve it with Rest API.
   discover:
     name: Prepare input for validation scripts
+    needs:
+      - pull_request_info
     runs-on: ubuntu-latest
     outputs:
       run_no_cyrillic: ${{ steps.on_push.outputs.run_no_cyrillic }}
@@ -47,40 +47,42 @@ jobs:
       diff_url: ${{ steps.on_push.outputs.diff_url }}
 
     steps:
-{!{ tmpl.Exec "checkout_step" . | strings.Indent 6 }!}
+{!{ tmpl.Exec "checkout_step" $ctx | strings.Indent 6 }!}
       - id: on_push
         name: Check labels on push
         uses: {!{ index (ds "actions") "actions/github-script" }!}
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const ci = require('./.github/scripts/js/ci');
-            return await ci.checkValidationLabels({github, context, core});
+            return await ci.checkValidationLabels({ github, context, core });
 
   no_cyrillic_validation:
     name: No Cyrillic Validation
     env:
       VALIDATE_TITLE: ${{ needs.discover.outputs.pr_title }}
       VALIDATE_DESCRIPTION: ${{ needs.discover.outputs.pr_description }}
-{!{ tmpl.Exec "validation_template" "no_cyrillic" | strings.Indent 4 }!}
+{!{ tmpl.Exec "validation_template" (slice $ctx "no_cyrillic") | strings.Indent 4 }!}
 
   doc_validation:
     name: Documentation Validation
-{!{ tmpl.Exec "validation_template" "doc_changes" | strings.Indent 4 }!}
+{!{ tmpl.Exec "validation_template" (slice $ctx "doc_changes") | strings.Indent 4 }!}
 
   copyright_validation:
     name: Copyright Validation
-{!{ tmpl.Exec "validation_template" "copyright" | strings.Indent 4 -}!}
+{!{ tmpl.Exec "validation_template" (slice $ctx "copyright") | strings.Indent 4 -}!}
 
 {!{/* Template for validation jobs. CI_COMMIT_REF_NAME and CI_PIPELINE_CREATED_AT are required for werf.yaml */}!}
 {!{ define "validation_template" }!}
-{!{- $type := . }!}
+{!{- $ctx := index . 0 -}!}
+{!{- $type := index . 1 }!}
 needs:
   - discover
+  - pull_request_info
 if: needs.discover.outputs.run_{!{ $type }!} == 'true'
 runs-on: ubuntu-latest
 steps:
-  {!{ tmpl.Exec "checkout_step" . | strings.Indent 2 }!}
+  {!{ tmpl.Exec "checkout_step" $ctx | strings.Indent 2 }!}
 
   - name: Run check
     env:

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -5,19 +5,15 @@
 # on every push to dev branches
 name: Build and test for dev branches
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'release-*'
-      - 'alpha'
-      - 'beta'
-      - 'early-access'
-      - 'stable'
-      - 'rock-solid'
-      - 'changelog/*'
+  pull_request_target:
+     types:
+      - opened
+      - synchronize
+      - reopened
 
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -32,6 +28,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
 
 
   # command to copy image to our registry - crane copy alpine:3.12.1@sha256:HASHVALUE ${OUR_PRIVATE_REGISTRY}/base_images/alpine:3.12.1@sha256:HASHVALUE
@@ -77,10 +74,117 @@ env:
 # Note: Concurrency is currently in beta and subject to change.
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ${{ github.ref }}-dev
+  group: ${{ github.event.number }}-dev
   cancel-in-progress: true
 
 jobs:
+
+  # <template: pull_request_info>
+  pull_request_info:
+    name: Get pull request reference
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.ref.outputs.ref }}
+    steps:
+      - name: Check if allow to run tests
+        id: check
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            // Assume workflow_dispatch is safe to run.
+            // TODO add owner, repo, sha to inputs to check them here.
+            if (context.eventName === 'workflow_dispatch') {
+              core.info(`workflow_dispatch detected, set should_run to 'true'`);
+              return core.setOutput('should_run', 'true');
+            }
+
+            if (!context.payload.pull_request) {
+              return core.setFailed(`Unknown event, no pull request context. event_name=${context.eventName} action=${context.action} ref=${context.ref}`);
+            }
+
+            // Fetch fresh pull request state using sha.
+            // Why? Workflow rerun of 'opened' pull request contains outdated labels.
+            const owner = context.payload.pull_request.head.repo.owner.login
+            const repo = context.payload.pull_request.head.repo.name
+            const commit_sha = context.payload.pull_request.head.sha
+            core.info(`List pull request inputs: ${JSON.stringify({ owner, repo, commit_sha })}`);
+            const response = await github.rest.repos.listPullRequestsAssociatedWithCommit({ owner, repo, commit_sha });
+            if (response.status != 200) {
+              return core.setFailed(`Cannot list PRs for commit ${commit_sha}: ${JSON.stringify(response)}`);
+            }
+
+            // No PR found, do not run next jobs.
+            if (!response.data || response.data.length === 0) {
+              return core.setFailed(`No pull_request found. event_name=${context.eventName} action=${context.action} ref=${context.ref}`);
+            }
+
+            const prRepo = context.payload.pull_request.head.repo.full_name;
+            const targetRepo = context.payload.repository.full_name;
+            const isInternal = prRepo === targetRepo;
+            const isDependabot = (context.actor === 'dependabot[bot]');
+            const isChangelog = context.payload.pull_request.head.ref.startsWith('changelog/v');
+            const okToTest = response.data[0].labels.some((l) => l.name === 'ok-to-test');
+            core.info(`PR internal?          ${isInternal}`)
+            core.info(`PR from dependabot?   ${isDependabot}`)
+            core.info(`PR changelog?         ${isChangelog}`)
+            core.info(`PR has 'ok-to-test'?  ${okToTest}`)
+
+            if (isInternal && !isDependabot) {
+              // Ignore changelog pull requests.
+              if (isChangelog) {
+                return core.setFailed(`PR#${context.payload.pull_request.number} for changelog is ignored.`);
+              }
+            } else {
+              // External and dependabot pull requests should be labeled with 'ok-to-test'.
+              if (!okToTest) {
+                return core.setFailed(`PR#${context.payload.pull_request.number} without label 'ok-to-test' is ignored.`);
+              }
+            }
+
+      # Checkhout the merge commit
+      - name: Checkout PR merge commit
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
+
+      # Detect dangerous changes in external PR.
+      - name: Check for dangerous changes
+        uses: dorny/paths-filter@v2
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        id: changes
+        with:
+          token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          filters: |
+            dangerous:
+              - './.github/**'
+              - './.gitlab/**'
+              - './tools/**'
+              - './testing/**'
+              - './docs/**/js/**'
+              - './docs/**/css/**'
+              - './docs/**/images/**'
+              - './docs/**/assets/**'
+
+      # Stop workflow if external PR contains dangerous changes.
+      - name: Fail workflow on dangerous changes
+        if: steps.changes.outputs.dangerous == 'true'
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setFailed('External PR contains dangerous changes.')
+
+      # Set output.
+      - name: Return PR merge commit ref
+        id: ref
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            const ref = `refs/pull/${ context.issue.number }/merge`
+            core.info(`ref: '${ref}'`)
+            core.setOutput('ref', ref)
+  # </template: pull_request_info>
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -94,60 +198,75 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
+
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
 
   build_modules_images_fe:
     name: Build Modules Images FE
     needs:
       - git_info
+      - pull_request_info
 
+    # <template: build_modules_images_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -155,7 +274,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -163,7 +284,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -171,11 +294,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: Build and push modules images
         env:
@@ -198,30 +324,42 @@ jobs:
       #    fi
 
 
+      # <template: save_images_tags_json_step>
       - name: Save images_tags file
         uses: actions/upload-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules/images_tags_${{env.WERF_ENV}}.json
+      # </template: save_images_tags_json_step>
 
+      # <template: save_images_tags_json_to_cache_step>
       - name: Save images_tags file
         uses: actions/cache@v2.1.7
         with:
           path: modules/images_tags_${{env.WERF_ENV}}.json
           key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
+      # </template: save_images_tags_json_to_cache_step>
+    # </template: build_modules_images_template>
 
 
   go_generate:
     name: Go Generate
     needs:
       - git_info
+      - pull_request_info
 
+    # <template: go_generate_template>
     runs-on: ubuntu-latest
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -229,6 +367,7 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
       - name: Run go generate
         run: |
@@ -238,23 +377,30 @@ jobs:
       - name: Check generated code
         run: |
           git diff --exit-code
+    # </template: go_generate_template>
 
 
   build_fe:
     name: Build FE
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
       - go_generate
 
+    # <template: build_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -262,7 +408,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -270,7 +418,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -278,7 +428,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: login_flant_registry_step>
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
         with:
@@ -286,17 +438,22 @@ jobs:
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_flant_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
+      # <template: restore_images_tags_json_step>
       - name: Restore images_tags file
         uses: actions/download-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules
+      # </template: restore_images_tags_json_step>
 
       - name: Build and push deckhouse images
         env:
@@ -369,6 +526,7 @@ jobs:
             docker image rmi ${DESTINATION_IMAGE} || true;
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
+    # </template: build_template>
 
 
   doc_web_build:
@@ -376,15 +534,21 @@ jobs:
     # Wait for success build of modules.
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
+    # <template: doc_web_build_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_full_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -392,7 +556,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_flant_registry_step>
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
         with:
@@ -400,6 +566,7 @@ jobs:
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_flant_registry_step>
 
       - name: Run doc web build
         uses: werf/actions/build@v1.2
@@ -409,21 +576,28 @@ jobs:
           WERF_DIR: "docs/documentation"
           WERF_LOG_VERBOSE: "on"
           WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+    # </template: doc_web_build_template>
 
   main_web_build:
     name: Main web build
     # Wait for success build of modules.
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
+    # <template: main_web_build_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_full_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -431,7 +605,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_flant_registry_step>
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
         with:
@@ -439,6 +615,7 @@ jobs:
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_flant_registry_step>
 
       - name: Run main web build
         uses: werf/actions/build@v1.2
@@ -448,22 +625,29 @@ jobs:
           WERF_DIR: "docs/site"
           WERF_LOG_VERBOSE: "on"
           WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+    # </template: main_web_build_template>
 
   tests:
     name: Tests
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
       - build_fe
 
+    # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -471,7 +655,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -479,12 +665,15 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: restore_images_tags_json_step>
       - name: Restore images_tags file
         uses: actions/download-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules
+      # </template: restore_images_tags_json_step>
       - name: Run tests
         uses: werf/actions/run@v1.2
         with:
@@ -498,22 +687,29 @@ jobs:
           CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+    # </template: tests_template>
 
   matrix_tests:
     name: Matrix tests
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
       - build_fe
 
+    # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -521,7 +717,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -529,12 +727,15 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: restore_images_tags_json_step>
       - name: Restore images_tags file
         uses: actions/download-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules
+      # </template: restore_images_tags_json_step>
       - name: Run tests
         uses: werf/actions/run@v1.2
         with:
@@ -548,22 +749,29 @@ jobs:
           CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+    # </template: tests_template>
 
   dhctl_tests:
     name: Dhctl Tests
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
       - build_fe
 
+    # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -571,7 +779,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -579,12 +789,15 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: restore_images_tags_json_step>
       - name: Restore images_tags file
         uses: actions/download-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules
+      # </template: restore_images_tags_json_step>
       - name: Run tests
         uses: werf/actions/run@v1.2
         with:
@@ -598,22 +811,29 @@ jobs:
           CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+    # </template: tests_template>
 
   golangci_lint:
     name: GolangCI Lint
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
       - build_fe
 
+    # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -621,7 +841,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -629,12 +851,15 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: restore_images_tags_json_step>
       - name: Restore images_tags file
         uses: actions/download-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules
+      # </template: restore_images_tags_json_step>
       - name: Run tests
         uses: werf/actions/run@v1.2
         with:
@@ -648,22 +873,29 @@ jobs:
           CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+    # </template: tests_template>
 
   openapi_test_cases:
     name: OpenAPI Test Cases
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
       - build_fe
 
+    # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -671,7 +903,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -679,12 +913,15 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: restore_images_tags_json_step>
       - name: Restore images_tags file
         uses: actions/download-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules
+      # </template: restore_images_tags_json_step>
       - name: Run tests
         uses: werf/actions/run@v1.2
         with:
@@ -698,22 +935,29 @@ jobs:
           CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+    # </template: tests_template>
 
   web_links_test:
     name: Web links test
     needs:
       - git_info
+      - pull_request_info
       - doc_web_build
       - main_web_build
     continue-on-error: true
+    # <template: web_links_test_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_full_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -721,7 +965,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_flant_registry_step>
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
         with:
@@ -729,11 +975,14 @@ jobs:
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_flant_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: Prepare site structure
         run: |
@@ -801,22 +1050,29 @@ jobs:
           if [[ -n $_TMPDIR ]] ; then
             rm -rf $_TMPDIR
           fi
+    # </template: web_links_test_template>
 
   validators:
     name: Validators
     needs:
       - git_info
+      - pull_request_info
       - build_modules_images_fe
       - build_fe
 
+    # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -824,7 +1080,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -832,12 +1090,15 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: restore_images_tags_json_step>
       - name: Restore images_tags file
         uses: actions/download-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules
+      # </template: restore_images_tags_json_step>
       - name: Run tests
         uses: werf/actions/run@v1.2
         with:
@@ -851,3 +1112,4 @@ jobs:
           CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+    # </template: tests_template>

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -3,7 +3,6 @@
 #
 
 # on push to default branch or on tags
-
 name: Build and test for release
 
 on:
@@ -21,6 +20,7 @@ on:
 
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -35,6 +35,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
 
 
   # command to copy image to our registry - crane copy alpine:3.12.1@sha256:HASHVALUE ${OUR_PRIVATE_REGISTRY}/base_images/alpine:3.12.1@sha256:HASHVALUE
@@ -85,6 +86,8 @@ concurrency:
 
 jobs:
 
+  # <template: git_info_job>
+
   git_info:
     name: Get git info
     runs-on: ubuntu-latest
@@ -97,56 +100,69 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
+
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
 
   comment_on_start:
     name: Add comment on start
     runs-on: ubuntu-latest
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -156,20 +172,26 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
   build_modules_images_fe:
     name: Build Modules Images FE
     needs:
       - git_info
       - comment_on_start
 
+    # <template: build_modules_images_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -177,7 +199,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -185,7 +209,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -193,11 +219,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: Build and push modules images
         env:
@@ -220,20 +249,26 @@ jobs:
       #    fi
 
 
+      # <template: save_images_tags_json_step>
       - name: Save images_tags file
         uses: actions/upload-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules/images_tags_${{env.WERF_ENV}}.json
+      # </template: save_images_tags_json_step>
 
+      # <template: save_images_tags_json_to_cache_step>
       - name: Save images_tags file
         uses: actions/cache@v2.1.7
         with:
           path: modules/images_tags_${{env.WERF_ENV}}.json
           key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
+      # </template: save_images_tags_json_to_cache_step>
+    # </template: build_modules_images_template>
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -252,6 +287,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
   build_modules_images_ee:
     name: Build Modules Images EE
@@ -262,14 +298,18 @@ jobs:
     env:
       WERF_ENV: "EE"
 
+    # <template: build_modules_images_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -277,7 +317,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -285,7 +327,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -293,11 +337,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: Build and push modules images
         env:
@@ -320,20 +367,26 @@ jobs:
       #    fi
 
 
+      # <template: save_images_tags_json_step>
       - name: Save images_tags file
         uses: actions/upload-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules/images_tags_${{env.WERF_ENV}}.json
+      # </template: save_images_tags_json_step>
 
+      # <template: save_images_tags_json_to_cache_step>
       - name: Save images_tags file
         uses: actions/cache@v2.1.7
         with:
           path: modules/images_tags_${{env.WERF_ENV}}.json
           key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
+      # </template: save_images_tags_json_to_cache_step>
+    # </template: build_modules_images_template>
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -352,6 +405,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
   build_modules_images_ce:
     name: Build Modules Images CE
@@ -362,14 +416,18 @@ jobs:
     env:
       WERF_ENV: "CE"
 
+    # <template: build_modules_images_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -377,7 +435,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -385,7 +445,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -393,11 +455,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: Build and push modules images
         env:
@@ -420,20 +485,26 @@ jobs:
       #    fi
 
 
+      # <template: save_images_tags_json_step>
       - name: Save images_tags file
         uses: actions/upload-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules/images_tags_${{env.WERF_ENV}}.json
+      # </template: save_images_tags_json_step>
 
+      # <template: save_images_tags_json_to_cache_step>
       - name: Save images_tags file
         uses: actions/cache@v2.1.7
         with:
           path: modules/images_tags_${{env.WERF_ENV}}.json
           key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
+      # </template: save_images_tags_json_to_cache_step>
+    # </template: build_modules_images_template>
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -452,18 +523,24 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
   go_generate:
     name: Go Generate
     needs:
       - git_info
 
+    # <template: go_generate_template>
     runs-on: ubuntu-latest
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
 
+      # </template: checkout_step>
+
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -471,6 +548,7 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
       - name: Run go generate
         run: |
@@ -480,9 +558,11 @@ jobs:
       - name: Check generated code
         run: |
           git diff --exit-code
+    # </template: go_generate_template>
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -501,6 +581,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
   build_fe:
     name: Build FE
@@ -511,14 +592,18 @@ jobs:
     env:
       WERF_ENV: "FE"
 
+    # <template: build_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -526,7 +611,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -534,7 +621,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -542,7 +631,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: login_flant_registry_step>
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
         with:
@@ -550,17 +641,22 @@ jobs:
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_flant_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
+      # <template: restore_images_tags_json_step>
       - name: Restore images_tags file
         uses: actions/download-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules
+      # </template: restore_images_tags_json_step>
 
       - name: Build and push deckhouse images
         env:
@@ -633,9 +729,11 @@ jobs:
             docker image rmi ${DESTINATION_IMAGE} || true;
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
+    # </template: build_template>
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -654,6 +752,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
   build_ee:
     name: Build EE
@@ -665,14 +764,18 @@ jobs:
     env:
       WERF_ENV: "EE"
 
+    # <template: build_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -680,7 +783,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -688,7 +793,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -696,7 +803,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: login_flant_registry_step>
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
         with:
@@ -704,17 +813,22 @@ jobs:
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_flant_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
+      # <template: restore_images_tags_json_step>
       - name: Restore images_tags file
         uses: actions/download-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules
+      # </template: restore_images_tags_json_step>
 
       - name: Build and push deckhouse images
         env:
@@ -787,9 +901,11 @@ jobs:
             docker image rmi ${DESTINATION_IMAGE} || true;
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
+    # </template: build_template>
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -808,6 +924,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
   build_ce:
     name: Build CE
@@ -819,14 +936,18 @@ jobs:
     env:
       WERF_ENV: "CE"
 
+    # <template: build_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -834,7 +955,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -842,7 +965,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -850,7 +975,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: login_flant_registry_step>
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
         with:
@@ -858,17 +985,22 @@ jobs:
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_flant_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
+      # <template: restore_images_tags_json_step>
       - name: Restore images_tags file
         uses: actions/download-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules
+      # </template: restore_images_tags_json_step>
 
       - name: Build and push deckhouse images
         env:
@@ -941,9 +1073,11 @@ jobs:
             docker image rmi ${DESTINATION_IMAGE} || true;
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
+    # </template: build_template>
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -962,6 +1096,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
   doc_web_build:
     name: Doc web build
@@ -969,14 +1104,18 @@ jobs:
     needs:
       - git_info
       - build_modules_images_fe
+    # <template: doc_web_build_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -984,7 +1123,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_flant_registry_step>
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
         with:
@@ -992,6 +1133,7 @@ jobs:
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_flant_registry_step>
 
       - name: Run doc web build
         uses: werf/actions/build@v1.2
@@ -1001,8 +1143,10 @@ jobs:
           WERF_DIR: "docs/documentation"
           WERF_LOG_VERBOSE: "on"
           WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+    # </template: doc_web_build_template>
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1021,6 +1165,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
   main_web_build:
     name: Main web build
@@ -1028,14 +1173,18 @@ jobs:
     needs:
       - git_info
       - build_modules_images_fe
+    # <template: main_web_build_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1043,7 +1192,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_flant_registry_step>
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1051,6 +1202,7 @@ jobs:
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_flant_registry_step>
 
       - name: Run main web build
         uses: werf/actions/build@v1.2
@@ -1060,8 +1212,10 @@ jobs:
           WERF_DIR: "docs/site"
           WERF_LOG_VERBOSE: "on"
           WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+    # </template: main_web_build_template>
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1080,6 +1234,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
   tests:
     name: Tests
@@ -1089,14 +1244,18 @@ jobs:
       - build_fe
     continue-on-error: true
 
+    # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1104,7 +1263,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1112,12 +1273,15 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: restore_images_tags_json_step>
       - name: Restore images_tags file
         uses: actions/download-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules
+      # </template: restore_images_tags_json_step>
       - name: Run tests
         uses: werf/actions/run@v1.2
         with:
@@ -1131,8 +1295,10 @@ jobs:
           CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+    # </template: tests_template>
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1151,6 +1317,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
   matrix_tests:
     name: Matrix tests
@@ -1160,14 +1327,18 @@ jobs:
       - build_fe
     continue-on-error: true
 
+    # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1175,7 +1346,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1183,12 +1356,15 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: restore_images_tags_json_step>
       - name: Restore images_tags file
         uses: actions/download-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules
+      # </template: restore_images_tags_json_step>
       - name: Run tests
         uses: werf/actions/run@v1.2
         with:
@@ -1202,8 +1378,10 @@ jobs:
           CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+    # </template: tests_template>
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1222,6 +1400,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
   dhctl_tests:
     name: Dhctl Tests
@@ -1231,14 +1410,18 @@ jobs:
       - build_fe
     continue-on-error: true
 
+    # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1246,7 +1429,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1254,12 +1439,15 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: restore_images_tags_json_step>
       - name: Restore images_tags file
         uses: actions/download-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules
+      # </template: restore_images_tags_json_step>
       - name: Run tests
         uses: werf/actions/run@v1.2
         with:
@@ -1273,8 +1461,10 @@ jobs:
           CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+    # </template: tests_template>
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1293,6 +1483,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
   golangci_lint:
     name: GolangCI Lint
@@ -1302,14 +1493,18 @@ jobs:
       - build_fe
     continue-on-error: true
 
+    # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1317,7 +1512,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1325,12 +1522,15 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: restore_images_tags_json_step>
       - name: Restore images_tags file
         uses: actions/download-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules
+      # </template: restore_images_tags_json_step>
       - name: Run tests
         uses: werf/actions/run@v1.2
         with:
@@ -1344,8 +1544,10 @@ jobs:
           CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+    # </template: tests_template>
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1364,6 +1566,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
   openapi_test_cases:
     name: OpenAPI Test Cases
@@ -1373,14 +1576,18 @@ jobs:
       - build_fe
     continue-on-error: true
 
+    # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1388,7 +1595,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1396,12 +1605,15 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: restore_images_tags_json_step>
       - name: Restore images_tags file
         uses: actions/download-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules
+      # </template: restore_images_tags_json_step>
       - name: Run tests
         uses: werf/actions/run@v1.2
         with:
@@ -1415,8 +1627,10 @@ jobs:
           CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+    # </template: tests_template>
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1435,6 +1649,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
   web_links_test:
     name: Web links test
@@ -1443,14 +1658,18 @@ jobs:
       - doc_web_build
       - main_web_build
     continue-on-error: true
+    # <template: web_links_test_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1458,7 +1677,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_flant_registry_step>
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1466,11 +1687,14 @@ jobs:
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_flant_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: Prepare site structure
         run: |
@@ -1538,8 +1762,10 @@ jobs:
           if [[ -n $_TMPDIR ]] ; then
             rm -rf $_TMPDIR
           fi
+    # </template: web_links_test_template>
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1558,6 +1784,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
   validators:
     name: Validators
@@ -1567,14 +1794,18 @@ jobs:
       - build_fe
     continue-on-error: true
 
+    # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1582,7 +1813,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1590,12 +1823,15 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: restore_images_tags_json_step>
       - name: Restore images_tags file
         uses: actions/download-artifact@v2
         with:
           name: images_tags_json_${{env.WERF_ENV}}
           path: modules
+      # </template: restore_images_tags_json_step>
       - name: Run tests
         uses: werf/actions/run@v1.2
         with:
@@ -1609,8 +1845,10 @@ jobs:
           CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
           CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
           CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+    # </template: tests_template>
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1629,6 +1867,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
 
   deploy_latest_web:
@@ -1642,11 +1881,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: doc_version_template>
       - name: Set documentation version
         env:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
         run: |
           echo "DOC_VERSION=${CI_COMMIT_TAG:-latest}" >> $GITHUB_ENV
+      # </template: doc_version_template>
+      # <template: deploy_doc_template>
       - name: Deploy documentation to production
         uses: werf/actions/converge@v1.2
         with:
@@ -1661,6 +1903,8 @@ jobs:
           WERF_SET_DOC_VERSION: "global.doc_version=${{ env.DOC_VERSION }}"
           WERF_SET_URL: "global.url=deckhouse.io"
           WERF_SET_WEB_ENV: "web.env=web-production"
+      # </template: deploy_doc_template>
+      # <template: deploy_site_template>
       - name: Deploy site to production
         uses: werf/actions/converge@v1.2
         with:
@@ -1676,8 +1920,10 @@ jobs:
           WERF_SET_ACTIVE_RELEASE: "global.active_release=v1"
           WERF_SET_URL: "global.url=deckhouse.io"
           WERF_SET_WEB_ENV: "web.env=web-production"
+      # </template: deploy_site_template>
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1696,6 +1942,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
 
   deploy_tagged_doc:
@@ -1708,11 +1955,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: doc_version_template>
       - name: Set documentation version
         env:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
         run: |
           echo "DOC_VERSION=${CI_COMMIT_TAG:-latest}" >> $GITHUB_ENV
+      # </template: doc_version_template>
+      # <template: deploy_doc_template>
       - name: Deploy documentation to stage
         uses: werf/actions/converge@v1.2
         with:
@@ -1727,6 +1977,8 @@ jobs:
           WERF_SET_DOC_VERSION: "global.doc_version=${{ env.DOC_VERSION }}"
           WERF_SET_URL: "global.url=deckhouse.stage.flant.com"
           WERF_SET_WEB_ENV: "web.env=web-stage"
+      # </template: deploy_doc_template>
+      # <template: deploy_doc_template>
       - name: Deploy documentation to production
         uses: werf/actions/converge@v1.2
         with:
@@ -1741,8 +1993,10 @@ jobs:
           WERF_SET_DOC_VERSION: "global.doc_version=${{ env.DOC_VERSION }}"
           WERF_SET_URL: "global.url=deckhouse.io"
           WERF_SET_WEB_ENV: "web.env=web-production"
+      # </template: deploy_doc_template>
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1761,6 +2015,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
   last_comment:
     name: Update comment on finish
@@ -1788,10 +2043,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1810,3 +2069,4 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -19,6 +19,7 @@ on:
 
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -33,6 +34,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
   DEPLOY_CHANNEL: alpha
 
 # Analog of Gitlab's "interruptible: true" behaviour.
@@ -43,6 +45,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -56,47 +60,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_label_job>
   check_label:
     name: Check label
     runs-on: ubuntu-latest
@@ -105,8 +119,11 @@ jobs:
       labels: ${{ steps.check_label.outputs.labels }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - id: check_label
         name: Check labels on push
         uses: actions/github-script@v5.0.0
@@ -117,6 +134,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkLabel({github, context, core, labelType, labelSubject});
+  # </template: check_label_job>
 
   run_deploy:
     name: Deploy deckhouse to alpha channel
@@ -129,13 +147,16 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -145,6 +166,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -156,7 +180,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -164,7 +190,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -172,7 +200,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -180,6 +210,7 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
 
 
@@ -519,8 +550,9 @@ jobs:
           git checkout -b "${RELEASE_BRANCH_NAME}"
           git push --force origin "${RELEASE_BRANCH_NAME}"
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -539,4 +571,5 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -19,6 +19,7 @@ on:
 
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -33,6 +34,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
   DEPLOY_CHANNEL: beta
 
 # Analog of Gitlab's "interruptible: true" behaviour.
@@ -43,6 +45,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -56,47 +60,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_label_job>
   check_label:
     name: Check label
     runs-on: ubuntu-latest
@@ -105,8 +119,11 @@ jobs:
       labels: ${{ steps.check_label.outputs.labels }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - id: check_label
         name: Check labels on push
         uses: actions/github-script@v5.0.0
@@ -117,6 +134,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkLabel({github, context, core, labelType, labelSubject});
+  # </template: check_label_job>
 
   run_deploy:
     name: Deploy deckhouse to beta channel
@@ -129,13 +147,16 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -145,6 +166,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -156,7 +180,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -164,7 +190,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -172,7 +200,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -180,6 +210,7 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
 
 
@@ -519,8 +550,9 @@ jobs:
           git checkout -b "${RELEASE_BRANCH_NAME}"
           git push --force origin "${RELEASE_BRANCH_NAME}"
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -539,4 +571,5 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -19,6 +19,7 @@ on:
 
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -33,6 +34,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
   DEPLOY_CHANNEL: early-access
 
 # Analog of Gitlab's "interruptible: true" behaviour.
@@ -43,6 +45,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -56,47 +60,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_label_job>
   check_label:
     name: Check label
     runs-on: ubuntu-latest
@@ -105,8 +119,11 @@ jobs:
       labels: ${{ steps.check_label.outputs.labels }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - id: check_label
         name: Check labels on push
         uses: actions/github-script@v5.0.0
@@ -117,6 +134,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkLabel({github, context, core, labelType, labelSubject});
+  # </template: check_label_job>
 
   run_deploy:
     name: Deploy deckhouse to early-access channel
@@ -129,13 +147,16 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -145,6 +166,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -156,7 +180,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -164,7 +190,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -172,7 +200,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -180,6 +210,7 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
 
 
@@ -519,8 +550,9 @@ jobs:
           git checkout -b "${RELEASE_BRANCH_NAME}"
           git push --force origin "${RELEASE_BRANCH_NAME}"
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -539,4 +571,5 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -19,6 +19,7 @@ on:
 
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -33,6 +34,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
   DEPLOY_CHANNEL: rock-solid
 
 # Analog of Gitlab's "interruptible: true" behaviour.
@@ -43,6 +45,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -56,47 +60,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_label_job>
   check_label:
     name: Check label
     runs-on: ubuntu-latest
@@ -105,8 +119,11 @@ jobs:
       labels: ${{ steps.check_label.outputs.labels }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - id: check_label
         name: Check labels on push
         uses: actions/github-script@v5.0.0
@@ -117,6 +134,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkLabel({github, context, core, labelType, labelSubject});
+  # </template: check_label_job>
 
   run_deploy:
     name: Deploy deckhouse to rock-solid channel
@@ -129,13 +147,16 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -145,6 +166,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -156,7 +180,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -164,7 +190,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -172,7 +200,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -180,6 +210,7 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
 
 
@@ -519,8 +550,9 @@ jobs:
           git checkout -b "${RELEASE_BRANCH_NAME}"
           git push --force origin "${RELEASE_BRANCH_NAME}"
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -539,4 +571,5 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -19,6 +19,7 @@ on:
 
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -33,6 +34,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
   DEPLOY_CHANNEL: stable
 
 # Analog of Gitlab's "interruptible: true" behaviour.
@@ -43,6 +45,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -56,47 +60,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_label_job>
   check_label:
     name: Check label
     runs-on: ubuntu-latest
@@ -105,8 +119,11 @@ jobs:
       labels: ${{ steps.check_label.outputs.labels }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - id: check_label
         name: Check labels on push
         uses: actions/github-script@v5.0.0
@@ -117,6 +134,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkLabel({github, context, core, labelType, labelSubject});
+  # </template: check_label_job>
 
   run_deploy:
     name: Deploy deckhouse to stable channel
@@ -129,13 +147,16 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -145,6 +166,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -156,7 +180,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -164,7 +190,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -172,7 +200,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -180,6 +210,7 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
 
 
@@ -519,8 +550,9 @@ jobs:
           git checkout -b "${RELEASE_BRANCH_NAME}"
           git push --force origin "${RELEASE_BRANCH_NAME}"
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -539,4 +571,5 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 

--- a/.github/workflows/deploy-web-stage.yml
+++ b/.github/workflows/deploy-web-stage.yml
@@ -5,20 +5,30 @@
 name: 'Deploy web to stage'
 
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'release-*'
-      - 'alpha'
-      - 'beta'
-      - 'early-access'
-      - 'stable'
-      - 'rock-solid'
-      - 'changelog/*'
-
+  workflow_dispatch:
+    inputs:
+      issue_id:
+        description: 'ID of issue where label was set'
+        required: true
+      issue_number:
+        description: 'Number of issue where label was set'
+        required: true
+      comment_id:
+        description: 'ID of comment in issue where to put workflow run status'
+        required: true
+      ci_commit_ref_name:
+        description: 'Git ref name for image tags'
+        required: false
+      pull_request_ref:
+        description: 'Git ref for checkout PR sources'
+        required: false
+      pull_request_sha:
+        description: 'Git SHA for restoring artifacts from cache'
+        required: false
 
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -33,6 +43,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
 
 
   # command to copy image to our registry - crane copy alpine:3.12.1@sha256:HASHVALUE ${OUR_PRIVATE_REGISTRY}/base_images/alpine:3.12.1@sha256:HASHVALUE
@@ -83,6 +94,8 @@ concurrency:
 
 jobs:
 
+  # <template: git_info_job>
+
   git_info:
     name: Get git info
     runs-on: ubuntu-latest
@@ -95,47 +108,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_label_job>
   check_label:
     name: Check label
     runs-on: ubuntu-latest
@@ -144,8 +167,11 @@ jobs:
       labels: ${{ steps.check_label.outputs.labels }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - id: check_label
         name: Check labels on push
         uses: actions/github-script@v5.0.0
@@ -156,6 +182,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkLabel({github, context, core, labelType, labelSubject});
+  # </template: check_label_job>
 
   run_web_deploy:
     needs:
@@ -166,13 +193,16 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -182,6 +212,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -193,7 +226,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -201,7 +236,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -209,7 +246,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_flant_registry_step>
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
         with:
@@ -217,7 +256,9 @@ jobs:
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_flant_registry_step>
 
+      # <template: deploy_site_template>
       - name: Deploy site to stage
         uses: werf/actions/converge@v1.2
         with:
@@ -233,12 +274,16 @@ jobs:
           WERF_SET_ACTIVE_RELEASE: "global.active_release=v1"
           WERF_SET_URL: "global.url=deckhouse.stage.flant.com"
           WERF_SET_WEB_ENV: "web.env=web-stage"
+      # </template: deploy_site_template>
 
+      # <template: doc_version_template>
       - name: Set documentation version
         env:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
         run: |
           echo "DOC_VERSION=${CI_COMMIT_TAG:-latest}" >> $GITHUB_ENV
+      # </template: doc_version_template>
+      # <template: deploy_doc_template>
       - name: Deploy documentation to stage
         uses: werf/actions/converge@v1.2
         with:
@@ -253,9 +298,11 @@ jobs:
           WERF_SET_DOC_VERSION: "global.doc_version=${{ env.DOC_VERSION }}"
           WERF_SET_URL: "global.url=deckhouse.stage.flant.com"
           WERF_SET_WEB_ENV: "web.env=web-stage"
+      # </template: deploy_doc_template>
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -274,4 +321,5 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 

--- a/.github/workflows/deploy-web-test.yml
+++ b/.github/workflows/deploy-web-test.yml
@@ -5,20 +5,30 @@
 name: 'Deploy web to test'
 
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'release-*'
-      - 'alpha'
-      - 'beta'
-      - 'early-access'
-      - 'stable'
-      - 'rock-solid'
-      - 'changelog/*'
-
+  workflow_dispatch:
+    inputs:
+      issue_id:
+        description: 'ID of issue where label was set'
+        required: true
+      issue_number:
+        description: 'Number of issue where label was set'
+        required: true
+      comment_id:
+        description: 'ID of comment in issue where to put workflow run status'
+        required: true
+      ci_commit_ref_name:
+        description: 'Git ref name for image tags'
+        required: false
+      pull_request_ref:
+        description: 'Git ref for checkout PR sources'
+        required: false
+      pull_request_sha:
+        description: 'Git SHA for restoring artifacts from cache'
+        required: false
 
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -33,6 +43,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
 
 
   # command to copy image to our registry - crane copy alpine:3.12.1@sha256:HASHVALUE ${OUR_PRIVATE_REGISTRY}/base_images/alpine:3.12.1@sha256:HASHVALUE
@@ -83,6 +94,8 @@ concurrency:
 
 jobs:
 
+  # <template: git_info_job>
+
   git_info:
     name: Get git info
     runs-on: ubuntu-latest
@@ -95,47 +108,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_label_job>
   check_label:
     name: Check label
     runs-on: ubuntu-latest
@@ -144,8 +167,11 @@ jobs:
       labels: ${{ steps.check_label.outputs.labels }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - id: check_label
         name: Check labels on push
         uses: actions/github-script@v5.0.0
@@ -156,6 +182,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkLabel({github, context, core, labelType, labelSubject});
+  # </template: check_label_job>
 
   run_web_deploy:
     needs:
@@ -166,13 +193,16 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -182,6 +212,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -193,7 +226,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -201,7 +236,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -209,7 +246,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_flant_registry_step>
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
         with:
@@ -217,7 +256,9 @@ jobs:
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_flant_registry_step>
 
+      # <template: deploy_site_template>
       - name: Deploy site to test
         uses: werf/actions/converge@v1.2
         with:
@@ -233,12 +274,16 @@ jobs:
           WERF_SET_ACTIVE_RELEASE: "global.active_release=v1"
           WERF_SET_URL: "global.url=deckhouse.test.flant.com"
           WERF_SET_WEB_ENV: "web.env=web-test"
+      # </template: deploy_site_template>
 
+      # <template: doc_version_template>
       - name: Set documentation version
         env:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
         run: |
           echo "DOC_VERSION=${CI_COMMIT_TAG:-latest}" >> $GITHUB_ENV
+      # </template: doc_version_template>
+      # <template: deploy_doc_template>
       - name: Deploy documentation to test
         uses: werf/actions/converge@v1.2
         with:
@@ -253,9 +298,11 @@ jobs:
           WERF_SET_DOC_VERSION: "global.doc_version=${{ env.DOC_VERSION }}"
           WERF_SET_URL: "global.url=deckhouse.test.flant.com"
           WERF_SET_WEB_ENV: "web.env=web-test"
+      # </template: deploy_doc_template>
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -274,4 +321,5 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -4,16 +4,6 @@
 
 name: 'e2e: AWS'
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'release-*'
-      - 'alpha'
-      - 'beta'
-      - 'early-access'
-      - 'stable'
-      - 'rock-solid'
-      - 'changelog/*'
   workflow_dispatch:
     inputs:
       issue_id:
@@ -25,12 +15,22 @@ on:
       comment_id:
         description: 'ID of comment in issue where to put workflow run status'
         required: false
+      ci_commit_ref_name:
+        description: 'Git ref name for image tags'
+        required: false
+      pull_request_ref:
+        description: 'Git ref for checkout PR sources'
+        required: false
+      pull_request_sha:
+        description: 'Git SHA for restoring artifacts from cache'
+        required: false
       cri:
         required: false
       ver:
         required: false
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -45,6 +45,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
 
 
   # command to copy image to our registry - crane copy alpine:3.12.1@sha256:HASHVALUE ${OUR_PRIVATE_REGISTRY}/base_images/alpine:3.12.1@sha256:HASHVALUE
@@ -90,10 +91,12 @@ env:
 # Note: Concurrency is currently in beta and subject to change.
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ${{ github.ref }}-e2e-aws
+  group: ${{ github.ref }}-${{ github.event.inputs.pull_request_ref }}-e2e-aws
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -107,47 +110,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
     runs-on: ubuntu-latest
@@ -163,8 +176,11 @@ jobs:
       run_containerd_1_22: ${{ steps.check.outputs.run_containerd_1_22 }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - name: Check e2e labels
         id: check
         uses: actions/github-script@v5.0.0
@@ -177,6 +193,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkE2ELabels({github, context, core, provider, defaults, criNames, kubernetesVersions});
+  # </template: check_e2e_labels_job>
 
 
   run_docker_1_19:
@@ -219,13 +236,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -235,6 +255,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -246,7 +269,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -254,7 +279,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -262,7 +289,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -270,11 +299,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: AWS/Docker/1.19"
         env:
@@ -290,6 +322,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -341,6 +374,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -358,6 +392,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -409,6 +444,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -430,8 +466,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -450,6 +487,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -530,13 +568,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -546,6 +587,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -557,7 +601,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -565,7 +611,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -573,7 +621,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -581,11 +631,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: AWS/Docker/1.20"
         env:
@@ -601,6 +654,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -652,6 +706,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -669,6 +724,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -720,6 +776,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -741,8 +798,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -761,6 +819,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -841,13 +900,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -857,6 +919,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -868,7 +933,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -876,7 +943,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -884,7 +953,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -892,11 +963,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: AWS/Docker/1.21"
         env:
@@ -912,6 +986,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -963,6 +1038,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -980,6 +1056,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -1031,6 +1108,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1052,8 +1130,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1072,6 +1151,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1152,13 +1232,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1168,6 +1251,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1179,7 +1265,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1187,7 +1275,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1195,7 +1285,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1203,11 +1295,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: AWS/Docker/1.22"
         env:
@@ -1223,6 +1318,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -1274,6 +1370,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1291,6 +1388,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -1342,6 +1440,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1363,8 +1462,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1383,6 +1483,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1463,13 +1564,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1479,6 +1583,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1490,7 +1597,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1498,7 +1607,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1506,7 +1617,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1514,11 +1627,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: AWS/Containerd/1.19"
         env:
@@ -1534,6 +1650,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -1585,6 +1702,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1602,6 +1720,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -1653,6 +1772,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1674,8 +1794,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1694,6 +1815,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1774,13 +1896,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1790,6 +1915,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1801,7 +1929,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1809,7 +1939,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1817,7 +1949,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1825,11 +1959,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: AWS/Containerd/1.20"
         env:
@@ -1845,6 +1982,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -1896,6 +2034,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1913,6 +2052,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -1964,6 +2104,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1985,8 +2126,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2005,6 +2147,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -2085,13 +2228,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2101,6 +2247,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -2112,7 +2261,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2120,7 +2271,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2128,7 +2281,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2136,11 +2291,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: AWS/Containerd/1.21"
         env:
@@ -2156,6 +2314,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -2207,6 +2366,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -2224,6 +2384,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -2275,6 +2436,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -2296,8 +2458,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2316,6 +2479,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -2396,13 +2560,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2412,6 +2579,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -2423,7 +2593,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2431,7 +2603,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2439,7 +2613,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2447,11 +2623,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: AWS/Containerd/1.22"
         env:
@@ -2467,6 +2646,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -2518,6 +2698,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -2535,6 +2716,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
@@ -2586,6 +2768,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -2607,8 +2790,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2627,6 +2811,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -4,16 +4,6 @@
 
 name: 'e2e: Azure'
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'release-*'
-      - 'alpha'
-      - 'beta'
-      - 'early-access'
-      - 'stable'
-      - 'rock-solid'
-      - 'changelog/*'
   workflow_dispatch:
     inputs:
       issue_id:
@@ -25,12 +15,22 @@ on:
       comment_id:
         description: 'ID of comment in issue where to put workflow run status'
         required: false
+      ci_commit_ref_name:
+        description: 'Git ref name for image tags'
+        required: false
+      pull_request_ref:
+        description: 'Git ref for checkout PR sources'
+        required: false
+      pull_request_sha:
+        description: 'Git SHA for restoring artifacts from cache'
+        required: false
       cri:
         required: false
       ver:
         required: false
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -45,6 +45,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
 
 
   # command to copy image to our registry - crane copy alpine:3.12.1@sha256:HASHVALUE ${OUR_PRIVATE_REGISTRY}/base_images/alpine:3.12.1@sha256:HASHVALUE
@@ -90,10 +91,12 @@ env:
 # Note: Concurrency is currently in beta and subject to change.
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ${{ github.ref }}-e2e-azure
+  group: ${{ github.ref }}-${{ github.event.inputs.pull_request_ref }}-e2e-azure
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -107,47 +110,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
     runs-on: ubuntu-latest
@@ -163,8 +176,11 @@ jobs:
       run_containerd_1_22: ${{ steps.check.outputs.run_containerd_1_22 }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - name: Check e2e labels
         id: check
         uses: actions/github-script@v5.0.0
@@ -177,6 +193,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkE2ELabels({github, context, core, provider, defaults, criNames, kubernetesVersions});
+  # </template: check_e2e_labels_job>
 
 
   run_docker_1_19:
@@ -219,13 +236,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -235,6 +255,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -246,7 +269,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -254,7 +279,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -262,7 +289,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -270,11 +299,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Azure/Docker/1.19"
         env:
@@ -290,6 +322,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
@@ -345,6 +378,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -362,6 +396,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
@@ -417,6 +452,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -438,8 +474,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -458,6 +495,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -538,13 +576,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -554,6 +595,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -565,7 +609,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -573,7 +619,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -581,7 +629,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -589,11 +639,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Azure/Docker/1.20"
         env:
@@ -609,6 +662,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
@@ -664,6 +718,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -681,6 +736,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
@@ -736,6 +792,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -757,8 +814,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -777,6 +835,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -857,13 +916,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -873,6 +935,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -884,7 +949,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -892,7 +959,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -900,7 +969,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -908,11 +979,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Azure/Docker/1.21"
         env:
@@ -928,6 +1002,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
@@ -983,6 +1058,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1000,6 +1076,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
@@ -1055,6 +1132,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1076,8 +1154,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1096,6 +1175,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1176,13 +1256,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1192,6 +1275,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1203,7 +1289,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1211,7 +1299,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1219,7 +1309,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1227,11 +1319,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Azure/Docker/1.22"
         env:
@@ -1247,6 +1342,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
@@ -1302,6 +1398,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1319,6 +1416,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
@@ -1374,6 +1472,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1395,8 +1494,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1415,6 +1515,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1495,13 +1596,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1511,6 +1615,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1522,7 +1629,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1530,7 +1639,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1538,7 +1649,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1546,11 +1659,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Azure/Containerd/1.19"
         env:
@@ -1566,6 +1682,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
@@ -1621,6 +1738,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1638,6 +1756,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
@@ -1693,6 +1812,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1714,8 +1834,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1734,6 +1855,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1814,13 +1936,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1830,6 +1955,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1841,7 +1969,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1849,7 +1979,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1857,7 +1989,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1865,11 +1999,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Azure/Containerd/1.20"
         env:
@@ -1885,6 +2022,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
@@ -1940,6 +2078,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1957,6 +2096,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
@@ -2012,6 +2152,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -2033,8 +2174,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2053,6 +2195,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -2133,13 +2276,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2149,6 +2295,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -2160,7 +2309,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2168,7 +2319,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2176,7 +2329,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2184,11 +2339,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Azure/Containerd/1.21"
         env:
@@ -2204,6 +2362,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
@@ -2259,6 +2418,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -2276,6 +2436,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
@@ -2331,6 +2492,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -2352,8 +2514,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2372,6 +2535,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -2452,13 +2616,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2468,6 +2635,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -2479,7 +2649,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2487,7 +2659,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2495,7 +2669,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2503,11 +2679,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Azure/Containerd/1.22"
         env:
@@ -2523,6 +2702,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
@@ -2578,6 +2758,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -2595,6 +2776,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
@@ -2650,6 +2832,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -2671,8 +2854,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2691,6 +2875,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -4,16 +4,6 @@
 
 name: 'e2e: GCP'
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'release-*'
-      - 'alpha'
-      - 'beta'
-      - 'early-access'
-      - 'stable'
-      - 'rock-solid'
-      - 'changelog/*'
   workflow_dispatch:
     inputs:
       issue_id:
@@ -25,12 +15,22 @@ on:
       comment_id:
         description: 'ID of comment in issue where to put workflow run status'
         required: false
+      ci_commit_ref_name:
+        description: 'Git ref name for image tags'
+        required: false
+      pull_request_ref:
+        description: 'Git ref for checkout PR sources'
+        required: false
+      pull_request_sha:
+        description: 'Git SHA for restoring artifacts from cache'
+        required: false
       cri:
         required: false
       ver:
         required: false
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -45,6 +45,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
 
 
   # command to copy image to our registry - crane copy alpine:3.12.1@sha256:HASHVALUE ${OUR_PRIVATE_REGISTRY}/base_images/alpine:3.12.1@sha256:HASHVALUE
@@ -90,10 +91,12 @@ env:
 # Note: Concurrency is currently in beta and subject to change.
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ${{ github.ref }}-e2e-gcp
+  group: ${{ github.ref }}-${{ github.event.inputs.pull_request_ref }}-e2e-gcp
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -107,47 +110,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
     runs-on: ubuntu-latest
@@ -163,8 +176,11 @@ jobs:
       run_containerd_1_22: ${{ steps.check.outputs.run_containerd_1_22 }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - name: Check e2e labels
         id: check
         uses: actions/github-script@v5.0.0
@@ -177,6 +193,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkE2ELabels({github, context, core, provider, defaults, criNames, kubernetesVersions});
+  # </template: check_e2e_labels_job>
 
 
   run_docker_1_19:
@@ -219,13 +236,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -235,6 +255,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -246,7 +269,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -254,7 +279,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -262,7 +289,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -270,11 +299,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: GCP/Docker/1.19"
         env:
@@ -290,6 +322,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -339,6 +372,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -356,6 +390,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -405,6 +440,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -426,8 +462,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -446,6 +483,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -526,13 +564,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -542,6 +583,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -553,7 +597,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -561,7 +607,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -569,7 +617,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -577,11 +627,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: GCP/Docker/1.20"
         env:
@@ -597,6 +650,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -646,6 +700,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -663,6 +718,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -712,6 +768,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -733,8 +790,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -753,6 +811,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -833,13 +892,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -849,6 +911,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -860,7 +925,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -868,7 +935,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -876,7 +945,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -884,11 +955,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: GCP/Docker/1.21"
         env:
@@ -904,6 +978,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -953,6 +1028,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -970,6 +1046,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1019,6 +1096,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1040,8 +1118,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1060,6 +1139,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1140,13 +1220,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1156,6 +1239,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1167,7 +1253,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1175,7 +1263,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1183,7 +1273,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1191,11 +1283,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: GCP/Docker/1.22"
         env:
@@ -1211,6 +1306,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1260,6 +1356,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1277,6 +1374,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1326,6 +1424,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1347,8 +1446,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1367,6 +1467,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1447,13 +1548,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1463,6 +1567,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1474,7 +1581,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1482,7 +1591,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1490,7 +1601,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1498,11 +1611,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: GCP/Containerd/1.19"
         env:
@@ -1518,6 +1634,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1567,6 +1684,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1584,6 +1702,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1633,6 +1752,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1654,8 +1774,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1674,6 +1795,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1754,13 +1876,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1770,6 +1895,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1781,7 +1909,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1789,7 +1919,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1797,7 +1929,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1805,11 +1939,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: GCP/Containerd/1.20"
         env:
@@ -1825,6 +1962,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1874,6 +2012,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1891,6 +2030,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1940,6 +2080,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1961,8 +2102,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1981,6 +2123,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -2061,13 +2204,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2077,6 +2223,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -2088,7 +2237,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2096,7 +2247,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2104,7 +2257,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2112,11 +2267,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: GCP/Containerd/1.21"
         env:
@@ -2132,6 +2290,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -2181,6 +2340,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -2198,6 +2358,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -2247,6 +2408,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -2268,8 +2430,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2288,6 +2451,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -2368,13 +2532,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2384,6 +2551,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -2395,7 +2565,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2403,7 +2575,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2411,7 +2585,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2419,11 +2595,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: GCP/Containerd/1.22"
         env:
@@ -2439,6 +2618,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -2488,6 +2668,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -2505,6 +2686,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -2554,6 +2736,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -2575,8 +2758,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2595,6 +2779,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -4,16 +4,6 @@
 
 name: 'e2e: Openstack'
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'release-*'
-      - 'alpha'
-      - 'beta'
-      - 'early-access'
-      - 'stable'
-      - 'rock-solid'
-      - 'changelog/*'
   workflow_dispatch:
     inputs:
       issue_id:
@@ -25,12 +15,22 @@ on:
       comment_id:
         description: 'ID of comment in issue where to put workflow run status'
         required: false
+      ci_commit_ref_name:
+        description: 'Git ref name for image tags'
+        required: false
+      pull_request_ref:
+        description: 'Git ref for checkout PR sources'
+        required: false
+      pull_request_sha:
+        description: 'Git SHA for restoring artifacts from cache'
+        required: false
       cri:
         required: false
       ver:
         required: false
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -45,6 +45,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
 
 
   # command to copy image to our registry - crane copy alpine:3.12.1@sha256:HASHVALUE ${OUR_PRIVATE_REGISTRY}/base_images/alpine:3.12.1@sha256:HASHVALUE
@@ -90,10 +91,12 @@ env:
 # Note: Concurrency is currently in beta and subject to change.
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ${{ github.ref }}-e2e-openstack
+  group: ${{ github.ref }}-${{ github.event.inputs.pull_request_ref }}-e2e-openstack
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -107,47 +110,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
     runs-on: ubuntu-latest
@@ -163,8 +176,11 @@ jobs:
       run_containerd_1_22: ${{ steps.check.outputs.run_containerd_1_22 }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - name: Check e2e labels
         id: check
         uses: actions/github-script@v5.0.0
@@ -177,6 +193,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkE2ELabels({github, context, core, provider, defaults, criNames, kubernetesVersions});
+  # </template: check_e2e_labels_job>
 
 
   run_docker_1_19:
@@ -219,13 +236,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -235,6 +255,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -246,7 +269,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -254,7 +279,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -262,7 +289,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -270,11 +299,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Openstack/Docker/1.19"
         env:
@@ -290,6 +322,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -339,6 +372,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -356,6 +390,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -405,6 +440,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -426,8 +462,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -446,6 +483,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -526,13 +564,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -542,6 +583,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -553,7 +597,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -561,7 +607,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -569,7 +617,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -577,11 +627,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Openstack/Docker/1.20"
         env:
@@ -597,6 +650,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -646,6 +700,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -663,6 +718,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -712,6 +768,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -733,8 +790,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -753,6 +811,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -833,13 +892,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -849,6 +911,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -860,7 +925,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -868,7 +935,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -876,7 +945,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -884,11 +955,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Openstack/Docker/1.21"
         env:
@@ -904,6 +978,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -953,6 +1028,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -970,6 +1046,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1019,6 +1096,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1040,8 +1118,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1060,6 +1139,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1140,13 +1220,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1156,6 +1239,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1167,7 +1253,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1175,7 +1263,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1183,7 +1273,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1191,11 +1283,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Openstack/Docker/1.22"
         env:
@@ -1211,6 +1306,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1260,6 +1356,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1277,6 +1374,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1326,6 +1424,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1347,8 +1446,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1367,6 +1467,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1447,13 +1548,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1463,6 +1567,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1474,7 +1581,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1482,7 +1591,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1490,7 +1601,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1498,11 +1611,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Openstack/Containerd/1.19"
         env:
@@ -1518,6 +1634,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1567,6 +1684,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1584,6 +1702,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1633,6 +1752,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1654,8 +1774,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1674,6 +1795,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1754,13 +1876,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1770,6 +1895,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1781,7 +1909,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1789,7 +1919,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1797,7 +1929,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1805,11 +1939,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Openstack/Containerd/1.20"
         env:
@@ -1825,6 +1962,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1874,6 +2012,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1891,6 +2030,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1940,6 +2080,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1961,8 +2102,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1981,6 +2123,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -2061,13 +2204,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2077,6 +2223,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -2088,7 +2237,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2096,7 +2247,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2104,7 +2257,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2112,11 +2267,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Openstack/Containerd/1.21"
         env:
@@ -2132,6 +2290,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -2181,6 +2340,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -2198,6 +2358,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -2247,6 +2408,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -2268,8 +2430,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2288,6 +2451,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -2368,13 +2532,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2384,6 +2551,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -2395,7 +2565,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2403,7 +2575,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2411,7 +2585,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2419,11 +2595,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Openstack/Containerd/1.22"
         env:
@@ -2439,6 +2618,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -2488,6 +2668,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -2505,6 +2686,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -2554,6 +2736,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -2575,8 +2758,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2595,6 +2779,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -4,16 +4,6 @@
 
 name: 'e2e: Static'
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'release-*'
-      - 'alpha'
-      - 'beta'
-      - 'early-access'
-      - 'stable'
-      - 'rock-solid'
-      - 'changelog/*'
   workflow_dispatch:
     inputs:
       issue_id:
@@ -25,12 +15,22 @@ on:
       comment_id:
         description: 'ID of comment in issue where to put workflow run status'
         required: false
+      ci_commit_ref_name:
+        description: 'Git ref name for image tags'
+        required: false
+      pull_request_ref:
+        description: 'Git ref for checkout PR sources'
+        required: false
+      pull_request_sha:
+        description: 'Git SHA for restoring artifacts from cache'
+        required: false
       cri:
         required: false
       ver:
         required: false
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -45,6 +45,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
 
 
   # command to copy image to our registry - crane copy alpine:3.12.1@sha256:HASHVALUE ${OUR_PRIVATE_REGISTRY}/base_images/alpine:3.12.1@sha256:HASHVALUE
@@ -90,10 +91,12 @@ env:
 # Note: Concurrency is currently in beta and subject to change.
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ${{ github.ref }}-e2e-static
+  group: ${{ github.ref }}-${{ github.event.inputs.pull_request_ref }}-e2e-static
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -107,47 +110,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
     runs-on: ubuntu-latest
@@ -163,8 +176,11 @@ jobs:
       run_containerd_1_22: ${{ steps.check.outputs.run_containerd_1_22 }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - name: Check e2e labels
         id: check
         uses: actions/github-script@v5.0.0
@@ -177,6 +193,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkE2ELabels({github, context, core, provider, defaults, criNames, kubernetesVersions});
+  # </template: check_e2e_labels_job>
 
 
   run_docker_1_19:
@@ -219,13 +236,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -235,6 +255,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -246,7 +269,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -254,7 +279,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -262,7 +289,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -270,11 +299,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Static/Docker/1.19"
         env:
@@ -290,6 +322,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -339,6 +372,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -356,6 +390,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -405,6 +440,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -426,8 +462,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -446,6 +483,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -526,13 +564,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -542,6 +583,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -553,7 +597,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -561,7 +607,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -569,7 +617,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -577,11 +627,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Static/Docker/1.20"
         env:
@@ -597,6 +650,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -646,6 +700,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -663,6 +718,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -712,6 +768,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -733,8 +790,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -753,6 +811,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -833,13 +892,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -849,6 +911,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -860,7 +925,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -868,7 +935,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -876,7 +945,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -884,11 +955,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Static/Docker/1.21"
         env:
@@ -904,6 +978,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -953,6 +1028,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -970,6 +1046,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1019,6 +1096,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1040,8 +1118,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1060,6 +1139,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1140,13 +1220,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1156,6 +1239,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1167,7 +1253,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1175,7 +1263,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1183,7 +1273,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1191,11 +1283,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Static/Docker/1.22"
         env:
@@ -1211,6 +1306,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1260,6 +1356,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1277,6 +1374,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1326,6 +1424,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1347,8 +1446,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1367,6 +1467,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1447,13 +1548,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1463,6 +1567,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1474,7 +1581,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1482,7 +1591,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1490,7 +1601,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1498,11 +1611,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Static/Containerd/1.19"
         env:
@@ -1518,6 +1634,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1567,6 +1684,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1584,6 +1702,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1633,6 +1752,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1654,8 +1774,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1674,6 +1795,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1754,13 +1876,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1770,6 +1895,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1781,7 +1909,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1789,7 +1919,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1797,7 +1929,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1805,11 +1939,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Static/Containerd/1.20"
         env:
@@ -1825,6 +1962,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1874,6 +2012,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1891,6 +2030,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1940,6 +2080,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1961,8 +2102,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1981,6 +2123,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -2061,13 +2204,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2077,6 +2223,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -2088,7 +2237,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2096,7 +2247,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2104,7 +2257,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2112,11 +2267,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Static/Containerd/1.21"
         env:
@@ -2132,6 +2290,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -2181,6 +2340,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -2198,6 +2358,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -2247,6 +2408,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -2268,8 +2430,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2288,6 +2451,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -2368,13 +2532,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2384,6 +2551,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -2395,7 +2565,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2403,7 +2575,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2411,7 +2585,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2419,11 +2595,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Static/Containerd/1.22"
         env:
@@ -2439,6 +2618,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -2488,6 +2668,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -2505,6 +2686,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -2554,6 +2736,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -2575,8 +2758,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2595,6 +2779,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -4,16 +4,6 @@
 
 name: 'e2e: vSphere'
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'release-*'
-      - 'alpha'
-      - 'beta'
-      - 'early-access'
-      - 'stable'
-      - 'rock-solid'
-      - 'changelog/*'
   workflow_dispatch:
     inputs:
       issue_id:
@@ -25,12 +15,22 @@ on:
       comment_id:
         description: 'ID of comment in issue where to put workflow run status'
         required: false
+      ci_commit_ref_name:
+        description: 'Git ref name for image tags'
+        required: false
+      pull_request_ref:
+        description: 'Git ref for checkout PR sources'
+        required: false
+      pull_request_sha:
+        description: 'Git SHA for restoring artifacts from cache'
+        required: false
       cri:
         required: false
       ver:
         required: false
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -45,6 +45,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
 
 
   # command to copy image to our registry - crane copy alpine:3.12.1@sha256:HASHVALUE ${OUR_PRIVATE_REGISTRY}/base_images/alpine:3.12.1@sha256:HASHVALUE
@@ -90,10 +91,12 @@ env:
 # Note: Concurrency is currently in beta and subject to change.
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ${{ github.ref }}-e2e-vsphere
+  group: ${{ github.ref }}-${{ github.event.inputs.pull_request_ref }}-e2e-vsphere
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -107,47 +110,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
     runs-on: ubuntu-latest
@@ -163,8 +176,11 @@ jobs:
       run_containerd_1_22: ${{ steps.check.outputs.run_containerd_1_22 }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - name: Check e2e labels
         id: check
         uses: actions/github-script@v5.0.0
@@ -177,6 +193,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkE2ELabels({github, context, core, provider, defaults, criNames, kubernetesVersions});
+  # </template: check_e2e_labels_job>
 
 
   run_docker_1_19:
@@ -219,13 +236,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -235,6 +255,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -246,7 +269,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -254,7 +279,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -262,7 +289,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -270,11 +299,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: vSphere/Docker/1.19"
         env:
@@ -290,6 +322,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
@@ -341,6 +374,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -358,6 +392,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
@@ -409,6 +444,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -430,8 +466,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -450,6 +487,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -530,13 +568,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -546,6 +587,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -557,7 +601,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -565,7 +611,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -573,7 +621,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -581,11 +631,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: vSphere/Docker/1.20"
         env:
@@ -601,6 +654,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
@@ -652,6 +706,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -669,6 +724,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
@@ -720,6 +776,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -741,8 +798,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -761,6 +819,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -841,13 +900,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -857,6 +919,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -868,7 +933,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -876,7 +943,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -884,7 +953,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -892,11 +963,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: vSphere/Docker/1.21"
         env:
@@ -912,6 +986,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
@@ -963,6 +1038,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -980,6 +1056,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
@@ -1031,6 +1108,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1052,8 +1130,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1072,6 +1151,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1152,13 +1232,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1168,6 +1251,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1179,7 +1265,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1187,7 +1275,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1195,7 +1285,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1203,11 +1295,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: vSphere/Docker/1.22"
         env:
@@ -1223,6 +1318,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
@@ -1274,6 +1370,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1291,6 +1388,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
@@ -1342,6 +1440,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1363,8 +1462,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1383,6 +1483,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1463,13 +1564,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1479,6 +1583,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1490,7 +1597,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1498,7 +1607,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1506,7 +1617,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1514,11 +1627,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: vSphere/Containerd/1.19"
         env:
@@ -1534,6 +1650,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
@@ -1585,6 +1702,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1602,6 +1720,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
@@ -1653,6 +1772,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1674,8 +1794,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1694,6 +1815,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1774,13 +1896,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1790,6 +1915,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1801,7 +1929,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1809,7 +1939,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1817,7 +1949,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1825,11 +1959,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: vSphere/Containerd/1.20"
         env:
@@ -1845,6 +1982,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
@@ -1896,6 +2034,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1913,6 +2052,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
@@ -1964,6 +2104,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1985,8 +2126,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2005,6 +2147,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -2085,13 +2228,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2101,6 +2247,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -2112,7 +2261,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2120,7 +2271,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2128,7 +2281,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2136,11 +2291,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: vSphere/Containerd/1.21"
         env:
@@ -2156,6 +2314,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
@@ -2207,6 +2366,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -2224,6 +2384,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
@@ -2275,6 +2436,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -2296,8 +2458,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2316,6 +2479,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -2396,13 +2560,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2412,6 +2579,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -2423,7 +2593,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2431,7 +2603,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2439,7 +2613,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2447,11 +2623,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: vSphere/Containerd/1.22"
         env:
@@ -2467,6 +2646,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
@@ -2518,6 +2698,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -2535,6 +2716,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
@@ -2586,6 +2768,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -2607,8 +2790,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2627,6 +2811,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -4,16 +4,6 @@
 
 name: 'e2e: Yandex.Cloud'
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'release-*'
-      - 'alpha'
-      - 'beta'
-      - 'early-access'
-      - 'stable'
-      - 'rock-solid'
-      - 'changelog/*'
   workflow_dispatch:
     inputs:
       issue_id:
@@ -25,12 +15,22 @@ on:
       comment_id:
         description: 'ID of comment in issue where to put workflow run status'
         required: false
+      ci_commit_ref_name:
+        description: 'Git ref name for image tags'
+        required: false
+      pull_request_ref:
+        description: 'Git ref for checkout PR sources'
+        required: false
+      pull_request_sha:
+        description: 'Git SHA for restoring artifacts from cache'
+        required: false
       cri:
         required: false
       ver:
         required: false
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -45,6 +45,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
 
 
   # command to copy image to our registry - crane copy alpine:3.12.1@sha256:HASHVALUE ${OUR_PRIVATE_REGISTRY}/base_images/alpine:3.12.1@sha256:HASHVALUE
@@ -90,10 +91,12 @@ env:
 # Note: Concurrency is currently in beta and subject to change.
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ${{ github.ref }}-e2e-yandex-cloud
+  group: ${{ github.ref }}-${{ github.event.inputs.pull_request_ref }}-e2e-yandex-cloud
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -107,47 +110,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
     runs-on: ubuntu-latest
@@ -163,8 +176,11 @@ jobs:
       run_containerd_1_22: ${{ steps.check.outputs.run_containerd_1_22 }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - name: Check e2e labels
         id: check
         uses: actions/github-script@v5.0.0
@@ -177,6 +193,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkE2ELabels({github, context, core, provider, defaults, criNames, kubernetesVersions});
+  # </template: check_e2e_labels_job>
 
 
   run_docker_1_19:
@@ -219,13 +236,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -235,6 +255,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -246,7 +269,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -254,7 +279,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -262,7 +289,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -270,11 +299,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.19"
         env:
@@ -290,6 +322,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
@@ -343,6 +376,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -360,6 +394,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
@@ -413,6 +448,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -434,8 +470,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -454,6 +491,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -534,13 +572,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -550,6 +591,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -561,7 +605,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -569,7 +615,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -577,7 +625,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -585,11 +635,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.20"
         env:
@@ -605,6 +658,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
@@ -658,6 +712,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -675,6 +730,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
@@ -728,6 +784,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -749,8 +806,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -769,6 +827,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -849,13 +908,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -865,6 +927,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -876,7 +941,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -884,7 +951,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -892,7 +961,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -900,11 +971,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.21"
         env:
@@ -920,6 +994,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
@@ -973,6 +1048,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -990,6 +1066,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
@@ -1043,6 +1120,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1064,8 +1142,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1084,6 +1163,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1164,13 +1244,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1180,6 +1263,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1191,7 +1277,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1199,7 +1287,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1207,7 +1297,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1215,11 +1307,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.22"
         env:
@@ -1235,6 +1330,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
@@ -1288,6 +1384,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1305,6 +1402,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
@@ -1358,6 +1456,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1379,8 +1478,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1399,6 +1499,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1479,13 +1580,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1495,6 +1599,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1506,7 +1613,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1514,7 +1623,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1522,7 +1633,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1530,11 +1643,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.19"
         env:
@@ -1550,6 +1666,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
@@ -1603,6 +1720,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1620,6 +1738,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
@@ -1673,6 +1792,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -1694,8 +1814,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -1714,6 +1835,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -1794,13 +1916,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -1810,6 +1935,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -1821,7 +1949,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1829,7 +1959,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1837,7 +1969,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -1845,11 +1979,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.20"
         env:
@@ -1865,6 +2002,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
@@ -1918,6 +2056,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -1935,6 +2074,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
@@ -1988,6 +2128,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -2009,8 +2150,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2029,6 +2171,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -2109,13 +2252,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2125,6 +2271,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -2136,7 +2285,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2144,7 +2295,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2152,7 +2305,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2160,11 +2315,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.21"
         env:
@@ -2180,6 +2338,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
@@ -2233,6 +2392,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -2250,6 +2410,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
@@ -2303,6 +2464,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -2324,8 +2486,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2344,6 +2507,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
@@ -2424,13 +2588,16 @@ jobs:
           echo "::set-output name=tmppath::${tmppath}"
 
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: ${{ github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -2440,6 +2607,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -2451,7 +2621,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2459,7 +2631,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2467,7 +2641,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -2475,11 +2651,14 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.22"
         env:
@@ -2495,6 +2674,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
@@ -2548,6 +2728,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
         if: ${{ always() }}
@@ -2565,6 +2746,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+        # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
@@ -2618,6 +2800,7 @@ jobs:
           )
           # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
           bash <<<"$werfRunProg"
+        # </template: e2e_run_template>
 
       - name: Save test results
         uses: actions/upload-artifact@v2
@@ -2639,8 +2822,9 @@ jobs:
             echo Not a directory.
           fi
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!inputs.issue_number }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -2659,6 +2843,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}

--- a/.github/workflows/on-issue-labeled.yml
+++ b/.github/workflows/on-issue-labeled.yml
@@ -13,8 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - name: Run workflow
         uses: actions/github-script@v5.0.0
         with:

--- a/.github/workflows/on-milestone-created.yml
+++ b/.github/workflows/on-milestone-created.yml
@@ -13,8 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - name: Create issue
         uses: actions/github-script@v5.0.0
         with:

--- a/.github/workflows/on-pull-request-labeled.yml
+++ b/.github/workflows/on-pull-request-labeled.yml
@@ -8,21 +8,131 @@
 name: Rerun workflows for pull request
 
 on:
-  pull_request:
-    types: [labeled,unlabeled]
-
+  pull_request_target:
+    types: [labeled, unlabeled]
 jobs:
+
+  # <template: pull_request_info>
+  pull_request_info:
+    name: Get pull request reference
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.ref.outputs.ref }}
+    steps:
+      - name: Check if allow to run tests
+        id: check
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            // Assume workflow_dispatch is safe to run.
+            // TODO add owner, repo, sha to inputs to check them here.
+            if (context.eventName === 'workflow_dispatch') {
+              core.info(`workflow_dispatch detected, set should_run to 'true'`);
+              return core.setOutput('should_run', 'true');
+            }
+
+            if (!context.payload.pull_request) {
+              return core.setFailed(`Unknown event, no pull request context. event_name=${context.eventName} action=${context.action} ref=${context.ref}`);
+            }
+
+            // Fetch fresh pull request state using sha.
+            // Why? Workflow rerun of 'opened' pull request contains outdated labels.
+            const owner = context.payload.pull_request.head.repo.owner.login
+            const repo = context.payload.pull_request.head.repo.name
+            const commit_sha = context.payload.pull_request.head.sha
+            core.info(`List pull request inputs: ${JSON.stringify({ owner, repo, commit_sha })}`);
+            const response = await github.rest.repos.listPullRequestsAssociatedWithCommit({ owner, repo, commit_sha });
+            if (response.status != 200) {
+              return core.setFailed(`Cannot list PRs for commit ${commit_sha}: ${JSON.stringify(response)}`);
+            }
+
+            // No PR found, do not run next jobs.
+            if (!response.data || response.data.length === 0) {
+              return core.setFailed(`No pull_request found. event_name=${context.eventName} action=${context.action} ref=${context.ref}`);
+            }
+
+            const prRepo = context.payload.pull_request.head.repo.full_name;
+            const targetRepo = context.payload.repository.full_name;
+            const isInternal = prRepo === targetRepo;
+            const isDependabot = (context.actor === 'dependabot[bot]');
+            const isChangelog = context.payload.pull_request.head.ref.startsWith('changelog/v');
+            const okToTest = response.data[0].labels.some((l) => l.name === 'ok-to-test');
+            core.info(`PR internal?          ${isInternal}`)
+            core.info(`PR from dependabot?   ${isDependabot}`)
+            core.info(`PR changelog?         ${isChangelog}`)
+            core.info(`PR has 'ok-to-test'?  ${okToTest}`)
+
+            if (isInternal && !isDependabot) {
+              // Ignore changelog pull requests.
+              if (isChangelog) {
+                return core.setFailed(`PR#${context.payload.pull_request.number} for changelog is ignored.`);
+              }
+            } else {
+              // External and dependabot pull requests should be labeled with 'ok-to-test'.
+              if (!okToTest) {
+                return core.setFailed(`PR#${context.payload.pull_request.number} without label 'ok-to-test' is ignored.`);
+              }
+            }
+
+      # Checkhout the merge commit
+      - name: Checkout PR merge commit
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
+
+      # Detect dangerous changes in external PR.
+      - name: Check for dangerous changes
+        uses: dorny/paths-filter@v2
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        id: changes
+        with:
+          token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          filters: |
+            dangerous:
+              - './.github/**'
+              - './.gitlab/**'
+              - './tools/**'
+              - './testing/**'
+              - './docs/**/js/**'
+              - './docs/**/css/**'
+              - './docs/**/images/**'
+              - './docs/**/assets/**'
+
+      # Stop workflow if external PR contains dangerous changes.
+      - name: Fail workflow on dangerous changes
+        if: steps.changes.outputs.dangerous == 'true'
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setFailed('External PR contains dangerous changes.')
+
+      # Set output.
+      - name: Return PR merge commit ref
+        id: ref
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            const ref = `refs/pull/${ context.issue.number }/merge`
+            core.info(`ref: '${ref}'`)
+            core.setOutput('ref', ref)
+  # </template: pull_request_info>
   rerun_workflow_for_pull_request:
     name: Rerun workflow for pull request
     runs-on: ubuntu-latest
+    needs:
+      - pull_request_info
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - name: Rerun workflow
         uses: actions/github-script@v5.0.0
         with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          github-token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
           script: |
             const ci = require('./.github/scripts/js/ci');
-            return await ci.runWorkflowForPullRequest({github, context, core});
+            const ref = "${{ needs.pull_request_info.outputs.ref }}"
+            return await ci.runWorkflowForPullRequest({ github, context, core, ref });

--- a/.github/workflows/on-push-main-or-tag.yml
+++ b/.github/workflows/on-push-main-or-tag.yml
@@ -21,8 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - name: Find latest milestone and issue
         uses: actions/github-script@v5.0.0
         with:

--- a/.github/workflows/pipeline-dev.md
+++ b/.github/workflows/pipeline-dev.md
@@ -1,6 +1,16 @@
 # Workflows for development branches
 
-Development branches are all branches not matched to patterns: 'main', 'master' or 'release-*'.
+Development branches are all branches not matched to patterns:
+
+- 'main'
+- 'master'
+- 'release-*'
+- 'alpha'
+- 'beta'
+- 'early-access'
+- 'stable'
+- 'rock-solid'
+- 'changelog/*'
 
 Each pushed commit to development branch starts several workflows:
 
@@ -12,9 +22,9 @@ This workflow checks generated sources, builds images, runs different tests
 
 Validates changes in source files:
 
-- check presence of license headers.
-- check simultaneous changes for English and Russian documentation.
-- check for accidental cyrillic letters in non documention files.
+- the presence of license headers
+- simultaneous changes in English and Russian documentation
+- accidental cyrillic letters in non-documention files
 
 ## e2e
 

--- a/.github/workflows/schedule-cleanup.yml
+++ b/.github/workflows/schedule-cleanup.yml
@@ -10,6 +10,7 @@ on:
 
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -24,6 +25,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
 
 
   # command to copy image to our registry - crane copy alpine:3.12.1@sha256:HASHVALUE ${OUR_PRIVATE_REGISTRY}/base_images/alpine:3.12.1@sha256:HASHVALUE
@@ -75,6 +77,8 @@ concurrency:
 jobs:
 # Note: git_info is needed for werf.yaml
 
+  # <template: git_info_job>
+
   git_info:
     name: Get git info
     runs-on: ubuntu-latest
@@ -87,46 +91,55 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
+
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
 
   cleanup_registry:
     name: Cleanup registry
@@ -135,11 +148,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -147,7 +163,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -155,7 +173,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -163,7 +183,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: login_flant_registry_step>
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
         with:
@@ -171,11 +193,14 @@ jobs:
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_flant_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
       - name: Cleanup
         env:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
@@ -193,11 +218,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0
+      # </template: checkout_full_step>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -205,7 +233,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -213,7 +243,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -221,7 +253,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: login_flant_registry_step>
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
         with:
@@ -229,11 +263,14 @@ jobs:
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_flant_registry_step>
 
+      # <template: werf_install_step>
       - name: Install werf CLI
         uses: werf/actions/install@v1.2
         with:
           channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
       - name: Cleanup
         env:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
@@ -251,9 +288,13 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
 
+      # </template: checkout_step>
+
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -261,7 +302,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -269,7 +312,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -277,7 +322,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
+      # <template: login_flant_registry_step>
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
         with:
@@ -285,6 +332,7 @@ jobs:
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_flant_registry_step>
       - name: Cleanup
         run: |
           docker ps --filter status=exited -q | xargs --no-run-if-empty docker rm -v

--- a/.github/workflows/suspend-alpha.yml
+++ b/.github/workflows/suspend-alpha.yml
@@ -19,6 +19,7 @@ on:
 
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -33,6 +34,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
   DEPLOY_CHANNEL: alpha
 
 # Analog of Gitlab's "interruptible: true" behaviour.
@@ -43,6 +45,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -56,47 +60,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_label_job>
   check_label:
     name: Check label
     runs-on: ubuntu-latest
@@ -105,8 +119,11 @@ jobs:
       labels: ${{ steps.check_label.outputs.labels }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - id: check_label
         name: Check labels on push
         uses: actions/github-script@v5.0.0
@@ -117,6 +134,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkLabel({github, context, core, labelType, labelSubject});
+  # </template: check_label_job>
 
   run_suspend:
     name: Suspend deckhouse release on alpha channel
@@ -129,13 +147,16 @@ jobs:
     runs-on: self-hosted
     steps:
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -145,6 +166,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -156,7 +180,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -164,7 +190,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -172,7 +200,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -180,6 +210,7 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
 
 
@@ -316,8 +347,9 @@ jobs:
 
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -336,4 +368,5 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 

--- a/.github/workflows/suspend-beta.yml
+++ b/.github/workflows/suspend-beta.yml
@@ -19,6 +19,7 @@ on:
 
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -33,6 +34,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
   DEPLOY_CHANNEL: beta
 
 # Analog of Gitlab's "interruptible: true" behaviour.
@@ -43,6 +45,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -56,47 +60,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_label_job>
   check_label:
     name: Check label
     runs-on: ubuntu-latest
@@ -105,8 +119,11 @@ jobs:
       labels: ${{ steps.check_label.outputs.labels }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - id: check_label
         name: Check labels on push
         uses: actions/github-script@v5.0.0
@@ -117,6 +134,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkLabel({github, context, core, labelType, labelSubject});
+  # </template: check_label_job>
 
   run_suspend:
     name: Suspend deckhouse release on beta channel
@@ -129,13 +147,16 @@ jobs:
     runs-on: self-hosted
     steps:
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -145,6 +166,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -156,7 +180,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -164,7 +190,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -172,7 +200,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -180,6 +210,7 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
 
 
@@ -316,8 +347,9 @@ jobs:
 
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -336,4 +368,5 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 

--- a/.github/workflows/suspend-early-access.yml
+++ b/.github/workflows/suspend-early-access.yml
@@ -19,6 +19,7 @@ on:
 
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -33,6 +34,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
   DEPLOY_CHANNEL: early-access
 
 # Analog of Gitlab's "interruptible: true" behaviour.
@@ -43,6 +45,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -56,47 +60,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_label_job>
   check_label:
     name: Check label
     runs-on: ubuntu-latest
@@ -105,8 +119,11 @@ jobs:
       labels: ${{ steps.check_label.outputs.labels }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - id: check_label
         name: Check labels on push
         uses: actions/github-script@v5.0.0
@@ -117,6 +134,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkLabel({github, context, core, labelType, labelSubject});
+  # </template: check_label_job>
 
   run_suspend:
     name: Suspend deckhouse release on early-access channel
@@ -129,13 +147,16 @@ jobs:
     runs-on: self-hosted
     steps:
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -145,6 +166,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -156,7 +180,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -164,7 +190,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -172,7 +200,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -180,6 +210,7 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
 
 
@@ -316,8 +347,9 @@ jobs:
 
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -336,4 +368,5 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 

--- a/.github/workflows/suspend-rock-solid.yml
+++ b/.github/workflows/suspend-rock-solid.yml
@@ -19,6 +19,7 @@ on:
 
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -33,6 +34,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
   DEPLOY_CHANNEL: rock-solid
 
 # Analog of Gitlab's "interruptible: true" behaviour.
@@ -43,6 +45,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -56,47 +60,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_label_job>
   check_label:
     name: Check label
     runs-on: ubuntu-latest
@@ -105,8 +119,11 @@ jobs:
       labels: ${{ steps.check_label.outputs.labels }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - id: check_label
         name: Check labels on push
         uses: actions/github-script@v5.0.0
@@ -117,6 +134,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkLabel({github, context, core, labelType, labelSubject});
+  # </template: check_label_job>
 
   run_suspend:
     name: Suspend deckhouse release on rock-solid channel
@@ -129,13 +147,16 @@ jobs:
     runs-on: self-hosted
     steps:
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -145,6 +166,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -156,7 +180,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -164,7 +190,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -172,7 +200,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -180,6 +210,7 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
 
 
@@ -316,8 +347,9 @@ jobs:
 
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -336,4 +368,5 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 

--- a/.github/workflows/suspend-stable.yml
+++ b/.github/workflows/suspend-stable.yml
@@ -19,6 +19,7 @@ on:
 
 env:
 
+  # <template: werf_envs>
   # Don't forget to update .gitlab-ci-simple.yml if necessary
   WERF_CHANNEL: "ea"
   WERF_ENV: "FE"
@@ -33,6 +34,7 @@ env:
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
 
   FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # </template: werf_envs>
   DEPLOY_CHANNEL: stable
 
 # Analog of Gitlab's "interruptible: true" behaviour.
@@ -43,6 +45,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # <template: git_info_job>
 
   git_info:
     name: Get git info
@@ -56,47 +60,57 @@ jobs:
     steps:
       - id: git_info
         name: Get tag name and SHA
-        run: |
-          # Detect git tag for release.
-          gitTag=${GITHUB_REF#refs/tags/}
-          if [[ ${GITHUB_REF} == $gitTag ]] ; then
-            gitTag=
-          fi
-          echo "::set-output name=ci_commit_tag::${gitTag}"
-          echo "ci_commit_tag='${gitTag}'"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setOutput('ci_pipeline_created_at', new Date().toISOString())
 
-          # Detect git branch.
-          gitBranch=${GITHUB_REF#refs/heads/}
-          if [[ ${GITHUB_REF} == $gitBranch ]] ; then
-            gitBranch=
-          fi
-          echo "::set-output name=ci_commit_branch::${gitBranch}"
-          echo "ci_commit_branch='${gitBranch}'"
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
 
-          # CI_COMMIT_REF_NAME for main werf.yaml
-          commitRefName=
-          [[ -n $gitBranch ]] && commitRefName=$gitBranch
-          [[ -n $gitTag ]] && commitRefName=$gitTag
-          echo "::set-output name=ci_commit_ref_name::${commitRefName}"
-          echo "ci_commit_ref_name='${commitRefName}'"
+            let githubBranch = '';
+            let githubTag = '';
+            let githubSHA = '';
+            let refName = '';
+            if (context.eventName === "workflow_dispatch") {
+              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
+              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              if (context.payload.inputs.pull_request_ref) {
+                refName       = context.payload.inputs.ci_commit_ref_name
+                githubBranch  = refName
+                githubSHA     = context.payload.inputs.pull_request_sha
+                core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
+              } else {
+                refName       = GITHUB_REF_NAME
+                githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
+                githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
+                githubSHA     = context.sha
+                core.info(`workflow_dispatch event: set git info from context. inputs: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
+              }
+            } else {
+              // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
+              const targetRepo = context.payload.repository.full_name;
+              const prRepo = context.payload.pull_request.head.repo.full_name
+              const prRef = context.payload.pull_request.head.ref
 
-          # CI_PIPELINE_CREATED_AT for main werf.yaml
-          pipelineCreatedAt=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
-          echo "::set-output name=ci_pipeline_created_at::${pipelineCreatedAt}"
-          echo "ci_pipeline_created_at='${pipelineCreatedAt}'"
+              refName = (prRepo === targetRepo) ? prRef : `pr${context.issue.number}`
+              githubBranch = refName
+              githubSHA = context.payload.pull_request.head.sha
+              core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
+            }
 
-          # Determine sha of commit.
-          # push event
-          githubSha=${GITHUB_SHA}
-          echo "github_sha for push '${githubSha}'"
-          # workflow_dispatch event
-          if [[ -z $githubSha ]] ; then
-            githubSha = $(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-            echo "github_sha for workflow_dispatch '${githubSha}'"
-          fi
-          echo "::set-output name=github_sha::$githubSha"
-          echo "github_sha='${githubSha}'"
+            core.info(`output.ci_commit_ref_name: '${refName}'`)
+            core.info(`output.ci_commit_tag:      '${githubTag}'`)
+            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
+            core.info(`output.github_sha:         '${githubSHA}'`)
 
+            core.setOutput('ci_commit_ref_name', refName)
+            core.setOutput(`ci_commit_tag`, githubTag)
+            core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput('github_sha', githubSHA)
+
+  # </template: git_info_job>
+
+  # <template: check_label_job>
   check_label:
     name: Check label
     runs-on: ubuntu-latest
@@ -105,8 +119,11 @@ jobs:
       labels: ${{ steps.check_label.outputs.labels }}
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
       - id: check_label
         name: Check labels on push
         uses: actions/github-script@v5.0.0
@@ -117,6 +134,7 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.checkLabel({github, context, core, labelType, labelSubject});
+  # </template: check_label_job>
 
   run_suspend:
     name: Suspend deckhouse release on stable channel
@@ -129,13 +147,16 @@ jobs:
     runs-on: self-hosted
     steps:
 
+      # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
         with:
-          ref: ${{ github.event.ref }}
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
           fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
       - name: Update comment on start
-        if: github.event_name == 'workflow_dispatch'
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
@@ -145,6 +166,9 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
 
+      # </template: update_comment_on_start>
+
+      # <template: restore_images_tags_json_from_cache_or_fail>
       - name: Restore images_tags_json from cache
         id: images-tags-json
         uses: actions/cache@v2.1.7
@@ -156,7 +180,9 @@ jobs:
         run: |
           echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
           exit 1
+      # </template: restore_images_tags_json_from_cache_or_fail>
 
+      # <template: login_dev_registry_step>
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
         with:
@@ -164,7 +190,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_dev_registry_step>
 
+      # <template: login_readonly_registry_step>
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
         with:
@@ -172,7 +200,9 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
+      # </template: login_readonly_registry_step>
 
+      # <template: login_rw_registry_step>
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
         with:
@@ -180,6 +210,7 @@ jobs:
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      # </template: login_rw_registry_step>
 
 
 
@@ -316,8 +347,9 @@ jobs:
 
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
 
+      # <template: update_comment_on_finish>
       - name: Update comment on finish
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
         continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
@@ -336,4 +368,5 @@ jobs:
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      # </template: update_comment_on_finish>
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -14,30 +14,131 @@
 
 name: Validations
 on:
-  push:
-    branches-ignore:
-      - 'main'
-      - 'release-*'
-      - 'alpha'
-      - 'beta'
-      - 'early-access'
-      - 'stable'
-      - 'rock-solid'
-      - 'changelog/*'
+  pull_request_target:
+     types:
+      - opened
+      - synchronize
 
 # Analog of Gitlab's "interruptible: true" behaviour.
 # Note: Concurrency is currently in beta and subject to change.
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ${{ github.ref }}-validation
+  group: ${{ github.event.number }}-validation
   cancel-in-progress: true
 
 jobs:
+
+  # <template: pull_request_info>
+  pull_request_info:
+    name: Get pull request reference
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.ref.outputs.ref }}
+    steps:
+      - name: Check if allow to run tests
+        id: check
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            // Assume workflow_dispatch is safe to run.
+            // TODO add owner, repo, sha to inputs to check them here.
+            if (context.eventName === 'workflow_dispatch') {
+              core.info(`workflow_dispatch detected, set should_run to 'true'`);
+              return core.setOutput('should_run', 'true');
+            }
+
+            if (!context.payload.pull_request) {
+              return core.setFailed(`Unknown event, no pull request context. event_name=${context.eventName} action=${context.action} ref=${context.ref}`);
+            }
+
+            // Fetch fresh pull request state using sha.
+            // Why? Workflow rerun of 'opened' pull request contains outdated labels.
+            const owner = context.payload.pull_request.head.repo.owner.login
+            const repo = context.payload.pull_request.head.repo.name
+            const commit_sha = context.payload.pull_request.head.sha
+            core.info(`List pull request inputs: ${JSON.stringify({ owner, repo, commit_sha })}`);
+            const response = await github.rest.repos.listPullRequestsAssociatedWithCommit({ owner, repo, commit_sha });
+            if (response.status != 200) {
+              return core.setFailed(`Cannot list PRs for commit ${commit_sha}: ${JSON.stringify(response)}`);
+            }
+
+            // No PR found, do not run next jobs.
+            if (!response.data || response.data.length === 0) {
+              return core.setFailed(`No pull_request found. event_name=${context.eventName} action=${context.action} ref=${context.ref}`);
+            }
+
+            const prRepo = context.payload.pull_request.head.repo.full_name;
+            const targetRepo = context.payload.repository.full_name;
+            const isInternal = prRepo === targetRepo;
+            const isDependabot = (context.actor === 'dependabot[bot]');
+            const isChangelog = context.payload.pull_request.head.ref.startsWith('changelog/v');
+            const okToTest = response.data[0].labels.some((l) => l.name === 'ok-to-test');
+            core.info(`PR internal?          ${isInternal}`)
+            core.info(`PR from dependabot?   ${isDependabot}`)
+            core.info(`PR changelog?         ${isChangelog}`)
+            core.info(`PR has 'ok-to-test'?  ${okToTest}`)
+
+            if (isInternal && !isDependabot) {
+              // Ignore changelog pull requests.
+              if (isChangelog) {
+                return core.setFailed(`PR#${context.payload.pull_request.number} for changelog is ignored.`);
+              }
+            } else {
+              // External and dependabot pull requests should be labeled with 'ok-to-test'.
+              if (!okToTest) {
+                return core.setFailed(`PR#${context.payload.pull_request.number} without label 'ok-to-test' is ignored.`);
+              }
+            }
+
+      # Checkhout the merge commit
+      - name: Checkout PR merge commit
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
+
+      # Detect dangerous changes in external PR.
+      - name: Check for dangerous changes
+        uses: dorny/paths-filter@v2
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        id: changes
+        with:
+          token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          filters: |
+            dangerous:
+              - './.github/**'
+              - './.gitlab/**'
+              - './tools/**'
+              - './testing/**'
+              - './docs/**/js/**'
+              - './docs/**/css/**'
+              - './docs/**/images/**'
+              - './docs/**/assets/**'
+
+      # Stop workflow if external PR contains dangerous changes.
+      - name: Fail workflow on dangerous changes
+        if: steps.changes.outputs.dangerous == 'true'
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            core.setFailed('External PR contains dangerous changes.')
+
+      # Set output.
+      - name: Return PR merge commit ref
+        id: ref
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            const ref = `refs/pull/${ context.issue.number }/merge`
+            core.info(`ref: '${ref}'`)
+            core.setOutput('ref', ref)
+  # </template: pull_request_info>
 
   # Get pull request info for validation scripts.
   # Push event has no pull request information, so retrieve it with Rest API.
   discover:
     name: Prepare input for validation scripts
+    needs:
+      - pull_request_info
     runs-on: ubuntu-latest
     outputs:
       run_no_cyrillic: ${{ steps.on_push.outputs.run_no_cyrillic }}
@@ -52,16 +153,20 @@ jobs:
 
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_step>
       - id: on_push
         name: Check labels on push
         uses: actions/github-script@v5.0.0
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const ci = require('./.github/scripts/js/ci');
-            return await ci.checkValidationLabels({github, context, core});
+            return await ci.checkValidationLabels({ github, context, core });
 
   no_cyrillic_validation:
     name: No Cyrillic Validation
@@ -71,12 +176,17 @@ jobs:
 
     needs:
       - discover
+      - pull_request_info
     if: needs.discover.outputs.run_no_cyrillic == 'true'
     runs-on: ubuntu-latest
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_step>
 
       - name: Run check
         env:
@@ -90,12 +200,17 @@ jobs:
 
     needs:
       - discover
+      - pull_request_info
     if: needs.discover.outputs.run_doc_changes == 'true'
     runs-on: ubuntu-latest
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_step>
 
       - name: Run check
         env:
@@ -109,12 +224,17 @@ jobs:
 
     needs:
       - discover
+      - pull_request_info
     if: needs.discover.outputs.run_copyright == 'true'
     runs-on: ubuntu-latest
     steps:
 
+      # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_step>
 
       - name: Run check
         env:


### PR DESCRIPTION
## Description

Two PRs here:
#395 - support for external PRs
#403 - run e2e and deploy-web jobs on workflows_dispatch

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

1. `push` event is not triggered for external PRs. `pull_request_target` is now used along with checking PR for dangerous changes.
2. Set `ok-to-test` label to run workflows for external PRs (and PRs from dependabot).
3. e2e and deploy-web workflows now triggered via workflows_dispatch and write comments to PR. This reduces checks for commit by 80% and makes workflow runs more visible.

<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
