### PR TITLE
[github] fix(ci): make curl error more verbose

### DIFF
--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -1,5 +1,6 @@
 //@ts-check
 const { knownLabels, labelsSrv, knownProviders, knownChannels } = require('./constants');
+const { dumpError } = require('./error');
 
 /**
  * Update a comment in "release" issue when workflow is started.
@@ -561,7 +562,7 @@ module.exports.runWorkflowForReleaseIssue = async ({ github, context, core }) =>
     }
     console.log(JSON.stringify(response));
   } catch (error) {
-    console.log(`get tag error: ${JSON.stringify(error)}`);
+    console.log(`get tag error: ${dumpError(error)}`);
   }
 
   console.log(`Use ref=${ref}`);
@@ -678,8 +679,8 @@ module.exports.runWorkflowForPullRequest = async ({ github, context, core }) => 
     } else {
       console.log(`Error calling RetryWorkflow. Response: ${JSON.stringify(response)}`);
     }
-  } catch (e) {
-    console.log(`Ignore error: ${JSON.stringify(e)}`);
+  } catch (error) {
+    console.log(`Ignore error: ${dumpError(error)}`);
   }
 };
 
@@ -757,7 +758,7 @@ module.exports.startBuildAndTestWorkflow = async ({ github, context, core }) => 
       return core.setFailed(error.message);
     } else {
       // handle non-GraphQL error
-      return core.setFailed(`List milestones failed: ${JSON.stringify(error)}`);
+      return core.setFailed(`List milestones failed: ${dumpError(error)}`);
     }
   }
 
@@ -788,7 +789,7 @@ module.exports.startBuildAndTestWorkflow = async ({ github, context, core }) => 
   }
   if (!milestone) {
     return core.setFailed(
-      'No appropriate milestone found. Create one and push or restart build with label. ${JSON.stringify(result)}'
+      `No appropriate milestone found. Create one and push or restart build with label. ${JSON.stringify(result)}`
     );
   }
   console.log(`The milestone is '${milestone.title}' with number ${milestone.number}`);

--- a/.github/scripts/js/error.js
+++ b/.github/scripts/js/error.js
@@ -1,0 +1,32 @@
+module.exports.dumpError = (error) => {
+  let result = '';
+  try {
+    // Max 10 recursive calls
+    result = JSON.stringify(simplifyObj({error, depth: 7}))
+  } catch (e) {
+    result = `${error.name||'UnknownError'}: ${error.message||'no message'}`
+  }
+  return result
+}
+
+// Use simplifyObj to break circular structures.
+// It copies objects recursively until depth is reached.
+const simplifyObj = ({obj, depth}) => {
+  if (depth <= 0 ) {
+    return '[Too deep]';
+  }
+  if (typeof(obj) == 'function'){
+    return '[Function]';
+  }
+  // Object or Array.
+  if (typeof(obj) == 'object') {
+    let simpleObj = {}
+    for (let prop in obj ){
+      if (obj.hasOwnProperty(prop)){
+        simpleObj[prop] = simplifyObj({obj: obj[prop], depth: depth - 1})
+      }
+    }
+    return simpleObj;
+  }
+  return obj;
+}


### PR DESCRIPTION

## Description

- handle circular structures when dump js errors

## Why do we need it, and what problem does it solve?

Github API has limits, but there is no message about problems.

<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
