### PR TITLE
[extended-monitoring] Add cert-exporter alerts

### DIFF
--- a/ee/fe/modules/340-extended-monitoring/images/cert-exporter/Dockerfile
+++ b/ee/fe/modules/340-extended-monitoring/images/cert-exporter/Dockerfile
@@ -1,0 +1,19 @@
+ARG BASE_ALPINE
+FROM $BASE_ALPINE as artifact
+
+ARG VERSION=2.0.1
+ARG COMMIT_REF=d6f0dcb883004146ca3453a9e2d0c66514afe327
+
+RUN apk add --no-cache go git make
+RUN git clone https://github.com/giantswarm/cert-exporter.git
+WORKDIR /cert-exporter
+RUN git checkout "${COMMIT_REF}"
+RUN make
+
+FROM $BASE_ALPINE
+
+RUN apk add --no-cache ca-certificates
+USER 1000
+COPY --from=artifact /cert-exporter/cert-exporter /cert-exporter
+
+ENTRYPOINT ["/cert-exporter"]

--- a/ee/fe/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificate.yaml
+++ b/ee/fe/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificate.yaml
@@ -1,0 +1,29 @@
+- name: kubernetes.certmanager.certificate
+  rules:
+  - alert: CertificateSecretExpiredSoon
+    expr: |
+      max by (name, namespace) (
+        cert_exporter_secret_not_after{job="cert-exporter", secretkey!="ca.crt"} - time() < 1209600
+      )
+    for: 1h
+    labels:
+      severity: warning
+    annotations:
+      plk_protocol_version: "1"
+      plk_incident_initial_status: "todo"
+      description: The certificate in secret {{$labels.namespace}}/{{$labels.name}} will expire in less than 2 weeks
+      summary: Certificate will expire soon
+
+  - alert: CertificateSecretExpired
+    expr: |
+      max by (name, namespace) (
+        cert_exporter_secret_not_after{job="cert-exporter", secretkey!="ca.crt"} - time() < 0
+      )
+    for: 1h
+    labels:
+      severity: warning
+    annotations:
+      plk_protocol_version: "1"
+      plk_incident_initial_status: "todo"
+      description: Certificate in secret {{$labels.namespace}}/{{$labels.name}} expired
+      summary: Certificate expired

--- a/ee/fe/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/exporter-health.yaml
+++ b/ee/fe/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/exporter-health.yaml
@@ -1,0 +1,124 @@
+- name: d8.extended-monitoring.cert-exporter.availability
+  rules:
+
+  - alert: D8CertExporterTargetDown
+    expr: max by (job) (up{job="cert-exporter"} == 0)
+    labels:
+      severity_level: "8"
+      d8_module: extended-monitoring
+      d8_component: image-availability-exporter
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_pending_until_firing_for: "1m"
+      plk_grouped_by__main: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse"
+      plk_ignore_labels: "job"
+      description: |
+        Check the Pod status: `kubectl -n d8-monitoring get pod -l app=cert-exporter`
+
+        Or check the Pod logs: `kubectl -n d8-monitoring logs -l app=cert-exporter -c cert-exporter`
+      summary: Prometheus cannot scrape the cert-exporter metrics.
+
+  - alert: D8CertExporterTargetAbsent
+    expr: absent(up{job="cert-exporter"}) == 1
+    labels:
+      severity_level: "8"
+      d8_module: extended-monitoring
+      d8_component: cert-exporter
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_pending_until_firing_for: "15m"
+      plk_ignore_labels: "job"
+      plk_grouped_by__main: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse"
+      description: |
+        Check the Pod status: `kubectl -n d8-monitoring get pod -l app=cert-exporter`
+
+        Or check the Pod logs: `kubectl -n d8-monitoring logs -l app=cert-exporter -c cert-exporter`
+      summary: There is no `cert-exporter` target in Prometheus.
+
+  - alert: D8CertExporterPodIsNotReady
+    expr: min by (pod) (kube_pod_status_ready{condition="true", namespace="d8-monitoring", pod=~"cert-exporter-.*"}) != 1
+    labels:
+      severity_level: "8"
+      d8_module: extended-monitoring
+      d8_component: cert-exporter
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_pending_until_firing_for: "30m"
+      plk_labels_as_annotations: "pod"
+      plk_grouped_by__main: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse"
+      summary: The cert-exporter Pod is NOT Ready.
+      description: |
+        The recommended course of action:
+        1. Retrieve details of the Deployment: `kubectl -n d8-monitoring describe deploy cert-exporter`
+        2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-monitoring describe pod -l app=cert-exporter`
+
+  - alert: D8CertExporterPodIsNotRunning
+    expr: absent(kube_pod_status_phase{namespace="d8-monitoring",phase="Running",pod=~"cert-exporter-.*"})
+    labels:
+      severity_level: "8"
+      d8_module: extended-monitoring
+      d8_component: cert-exporter
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_pending_until_firing_for: "30m"
+      plk_grouped_by__main: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse"
+      summary: The cert-exporter Pod is NOT Running.
+      description: |
+        The recommended course of action:
+        1. Retrieve details of the Deployment: `kubectl -n d8-monitoring describe deploy cert-exporter`
+        2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-monitoring describe pod -l app=cert-exporter`
+
+  - alert: D8CertExporterUnavailable
+    expr: count(ALERTS{alertname=~"D8CertExporterTargetDown|D8CertExporterTargetAbsent", alertstate="firing"})
+    labels:
+      d8_module: extended-monitoring
+      d8_component: cert-exporter
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_alert_type: "group"
+      summary: cert-exporter does not work.
+      description: |
+        `cert-exporter` does not work.
+
+        The detailed information is available in one of the relevant alerts.
+
+- name: d8.extended-monitoring.cert-exporter.malfunctioning
+  rules:
+
+  - alert: D8CertExporterStuck
+    expr: |
+      increase(promhttp_metric_handler_requests_total{job="cert-exporter", code="200"}[10m])
+    labels:
+      severity_level: "8"
+      d8_module: extended-monitoring
+      d8_component: cert-exporter
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_pending_until_firing_for: "20m"
+      plk_grouped_by__main: "D8CertExporterMalfunctioning,tier=cluster,prometheus=deckhouse"
+      description: |
+        The `cert-exporter` failed to perform any checks for the certificates expiration for over 20 minutes.
+
+        You need to analyze its logs: `kubectl -n d8-monitoring logs -l app=cert-exporter -c cert-exporter`
+      summary: image-cert-exporter has crashed.
+
+  - alert: D8CertExporterMalfunctioning
+    expr: count(ALERTS{alertname=~"D8CertExporterStuck", alertstate="firing"})
+    labels:
+      d8_module: extended-monitoring
+      d8_component: cert-exporter
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_alert_type: "group"
+      description: |
+        `cert-exporter` does not work as expected.
+
+        The detailed information is available in one of the relevant alerts.
+      summary: cert-exporter does not work as expected.

--- a/ee/fe/modules/340-extended-monitoring/openapi/config-values.yaml
+++ b/ee/fe/modules/340-extended-monitoring/openapi/config-values.yaml
@@ -52,6 +52,12 @@ properties:
         default: false
         description: |
           Enables certExporter.
+      namespaces:
+        type: array
+        description: |
+          Whether to monitor only certain namespaces
+        items:
+          type: string
   nodeSelector:
     type: object
     additionalProperties:

--- a/ee/fe/modules/340-extended-monitoring/openapi/doc-ru-config-values.yaml
+++ b/ee/fe/modules/340-extended-monitoring/openapi/doc-ru-config-values.yaml
@@ -31,6 +31,9 @@ properties:
         default: false
         description: |
           Включен ли certExporter.
+      namespaces:
+        description: |
+          Отслеживать сертификаты только в определённых неймспейсах.
   nodeSelector:
     description: |
       Структура, аналогичная `spec.nodeSelector` Kubernetes pod.

--- a/ee/fe/modules/340-extended-monitoring/template_tests/cert_exporter_test.go
+++ b/ee/fe/modules/340-extended-monitoring/template_tests/cert_exporter_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2021 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+func checkCertExporterObjects(hec *Config, exist bool) {
+	matcher := BeFalse()
+	if exist {
+		matcher = BeTrue()
+	}
+
+	Expect(hec.KubernetesResource("Deployment", "d8-monitoring", "cert-exporter").Exists()).To(matcher)
+	Expect(hec.KubernetesResource("VerticalPodAutoscaler", "d8-monitoring", "cert-exporter").Exists()).To(matcher)
+	Expect(hec.KubernetesResource("PodDisruptionBudget", "d8-monitoring", "cert-exporter").Exists()).To(matcher)
+	Expect(hec.KubernetesResource("ServiceAccount", "d8-monitoring", "cert-exporter").Exists()).To(matcher)
+}
+
+var _ = Describe("Module :: extendedMonitoring :: helm template :: cert-exporter ", func() {
+	hec := SetupHelmConfig("")
+	BeforeEach(func() {
+		hec.ValuesSet("global.discovery.kubernetesVersion", "1.15.6")
+		hec.ValuesSet("global.modules.publicDomainTemplate", "%s.example.com")
+		hec.ValuesSet("global.modules.https.mode", "CertManager")
+		hec.ValuesSet("global.modules.https.certManager.clusterIssuerName", "letsencrypt")
+		hec.ValuesSet("global.modulesImages.registry", "registry.example.com")
+		hec.ValuesSet("global.enabledModules", []string{"cert-manager", "vertical-pod-autoscaler-crd"})
+		hec.ValuesSet("global.discovery.d8SpecificNodeCountByRole.system", 2)
+	})
+
+	Context("With certificates.exporterEnabled", func() {
+		BeforeEach(func() {
+			hec.ValuesSet("extendedMonitoring.certificates.exporterEnabled", true)
+			hec.ValuesSetFromYaml("extendedMonitoring.imageAvailability", `{}`)
+			hec.ValuesSetFromYaml("extendedMonitoring.events", `{}`)
+			hec.HelmRender()
+		})
+		It("Should add desired objects", func() {
+			Expect(hec.RenderError).ShouldNot(HaveOccurred())
+			checkCertExporterObjects(hec, true)
+		})
+	})
+	Context("Without imageAvailability.exporterEnabled", func() {
+		BeforeEach(func() {
+			hec.ValuesSet("extendedMonitoring.certificates.exporterEnabled", false)
+			hec.ValuesSetFromYaml("extendedMonitoring.imageAvailability", `{}`)
+			hec.ValuesSetFromYaml("extendedMonitoring.events", `{}`)
+			hec.HelmRender()
+		})
+		It("Should not deploy desired objects", func() {
+			Expect(hec.RenderError).ShouldNot(HaveOccurred())
+			checkCertExporterObjects(hec, false)
+		})
+	})
+
+	Context("certificates.namespaces", func() {
+		Context("Empty", func() {
+			BeforeEach(func() {
+				hec.ValuesSet("extendedMonitoring.certificates.exporterEnabled", true)
+				hec.ValuesSetFromYaml("extendedMonitoring.imageAvailability", `{}`)
+				hec.ValuesSetFromYaml("extendedMonitoring.events", `{}`)
+				hec.HelmRender()
+			})
+			It("Should not contain --namespaces parameter", func() {
+				Expect(hec.RenderError).ShouldNot(HaveOccurred())
+
+				deploy := hec.KubernetesResource("Deployment", "d8-monitoring", "cert-exporter")
+				args := deploy.Field("spec.template.spec.containers.0.args").Array()
+				Expect(args).ShouldNot(ContainElements(MatchRegexp("^--namespaces")))
+			})
+		})
+
+		Context("Filled", func() {
+			BeforeEach(func() {
+				hec.ValuesSet("extendedMonitoring.certificates.exporterEnabled", true)
+				hec.ValuesSetFromYaml("extendedMonitoring.imageAvailability", `{}`)
+				hec.ValuesSetFromYaml("extendedMonitoring.events", `{}`)
+				hec.ValuesSet("extendedMonitoring.certificates.namespaces", []string{
+					"foo",
+					"bar",
+				})
+				hec.HelmRender()
+			})
+			It("Should contain --namespaces parameter", func() {
+				Expect(hec.RenderError).ShouldNot(HaveOccurred())
+
+				deploy := hec.KubernetesResource("Deployment", "d8-monitoring", "cert-exporter")
+				args := deploy.Field("spec.template.spec.containers.0.args").Array()
+
+				Expect(args).Should(ContainElements(MatchRegexp("^--namespaces=foo,bar$")))
+			})
+		})
+	})
+})

--- a/ee/fe/modules/340-extended-monitoring/template_tests/events_test.go
+++ b/ee/fe/modules/340-extended-monitoring/template_tests/events_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Module :: extendedMonitoring :: helm template :: events ", fun
 			hec.ValuesSet("extendedMonitoring.events.exporterEnabled", true)
 			hec.ValuesSet("extendedMonitoring.events.severityLevel", "OnlyWarnings")
 			hec.ValuesSetFromYaml("extendedMonitoring.imageAvailability", `{}`)
+			hec.ValuesSetFromYaml("extendedMonitoring.certificates", `{}`)
 			hec.HelmRender()
 		})
 		It("Should add desired objects", func() {
@@ -53,6 +54,7 @@ var _ = Describe("Module :: extendedMonitoring :: helm template :: events ", fun
 			hec.ValuesSet("extendedMonitoring.events.exporterEnabled", false)
 			hec.ValuesSet("extendedMonitoring.events.severityLevel", "OnlyWarnings")
 			hec.ValuesSetFromYaml("extendedMonitoring.imageAvailability", `{}`)
+			hec.ValuesSetFromYaml("extendedMonitoring.certificates", `{}`)
 			hec.HelmRender()
 		})
 		It("Should not deploy desired objects", func() {

--- a/ee/fe/modules/340-extended-monitoring/template_tests/image_availability_test.go
+++ b/ee/fe/modules/340-extended-monitoring/template_tests/image_availability_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Module :: extendedMonitoring :: helm template :: image availab
 	Context("With imageAvailability.exporterEnabled", func() {
 		BeforeEach(func() {
 			hec.ValuesSet("extendedMonitoring.imageAvailability.exporterEnabled", true)
+			hec.ValuesSetFromYaml("extendedMonitoring.certificates", `{}`)
 			hec.ValuesSetFromYaml("extendedMonitoring.events", `{}`)
 			hec.HelmRender()
 		})
@@ -52,6 +53,7 @@ var _ = Describe("Module :: extendedMonitoring :: helm template :: image availab
 	Context("Without imageAvailability.exporterEnabled", func() {
 		BeforeEach(func() {
 			hec.ValuesSet("extendedMonitoring.imageAvailability.exporterEnabled", false)
+			hec.ValuesSetFromYaml("extendedMonitoring.certificates", `{}`)
 			hec.ValuesSetFromYaml("extendedMonitoring.events", `{}`)
 			hec.HelmRender()
 		})
@@ -65,6 +67,8 @@ var _ = Describe("Module :: extendedMonitoring :: helm template :: image availab
 		Context("Empty", func() {
 			BeforeEach(func() {
 				hec.ValuesSet("extendedMonitoring.imageAvailability.exporterEnabled", true)
+				hec.ValuesSet("extendedMonitoring.certificates.exporterEnabled", false)
+				hec.ValuesSetFromYaml("extendedMonitoring.certificates", `{}`)
 				hec.ValuesSetFromYaml("extendedMonitoring.events", `{}`)
 				hec.HelmRender()
 			})
@@ -81,6 +85,7 @@ var _ = Describe("Module :: extendedMonitoring :: helm template :: image availab
 		Context("Filled", func() {
 			BeforeEach(func() {
 				hec.ValuesSet("extendedMonitoring.imageAvailability.exporterEnabled", true)
+				hec.ValuesSetFromYaml("extendedMonitoring.certificates", `{}`)
 				hec.ValuesSetFromYaml("extendedMonitoring.events", `{}`)
 				hec.ValuesSet("extendedMonitoring.imageAvailability.ignoredImages", []string{
 					"a.b.com/zzz:9.7.1",

--- a/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/deployment.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/deployment.yaml
@@ -1,0 +1,100 @@
+{{- if .Values.extendedMonitoring.certificates.exporterEnabled }}
+{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: cert-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "cert-exporter")) | nindent 2 }}
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: cert-exporter
+  updatePolicy:
+    updateMode: "Auto"
+{{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cert-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "cert-exporter")) | nindent 2 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      module: {{ $.Chart.Name }}
+      app: cert-exporter
+  template:
+    metadata:
+      labels:
+        module: {{ $.Chart.Name }}
+        app: cert-exporter
+    spec:
+      {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
+      imagePullSecrets:
+      - name: deckhouse-registry
+      serviceAccountName: cert-exporter
+      containers:
+      - name: cert-exporter
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+        image: {{ .Values.global.modulesImages.registry }}:{{ .Values.global.modulesImages.tags.extendedMonitoring.certExporter }}
+        args:
+        - --monitor-secrets=true
+        - --monitor-certificates=true
+        - --monitor-files=false
+        - --address=127.0.0.1:9000
+        {{- with .Values.extendedMonitoring.certificates.namespaces }}
+        - --namespaces={{ join "," . }}
+        {{- end }}
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+            {{- if not (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
+            cpu: "50m"
+            memory: "50Mi"
+            {{- end }}
+      - name: kube-rbac-proxy
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+        image: {{ .Values.global.modulesImages.registry }}:{{ .Values.global.modulesImages.tags.common.kubeRbacProxy }}
+        args:
+        - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):9001"
+        - "--client-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        - "--v=2"
+        - "--logtostderr=true"
+        - "--stale-cache-interval=1h30m"
+        ports:
+        - containerPort: 9001
+          name: https-metrics
+        env:
+        - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: KUBE_RBAC_PROXY_CONFIG
+          value: |
+            excludePaths:
+            - /healthz
+            upstreams:
+            - upstream: http://127.0.0.1:9000/
+              path: /
+              authorization:
+                resourceAttributes:
+                  namespace: d8-monitoring
+                  apiGroup: apps
+                  apiVersion: v1
+                  resource: deployments
+                  subresource: prometheus-metrics
+                  name: cert-exporter
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+{{- end }}

--- a/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/deployment.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/deployment.yaml
@@ -49,7 +49,7 @@ spec:
         image: {{ .Values.global.modulesImages.registry }}:{{ .Values.global.modulesImages.tags.extendedMonitoring.certExporter }}
         args:
         - --monitor-secrets=true
-        - --monitor-certificates=true
+        - --monitor-certificates=false
         - --monitor-files=false
         - --address=127.0.0.1:9000
         {{- with .Values.extendedMonitoring.certificates.namespaces }}

--- a/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/pdb.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.extendedMonitoring.certificates.exporterEnabled }}
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade, post-install
+    helm.sh/hook-delete-policy: before-hook-creation
+  name: cert-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "cert-exporter")) | nindent 2 }}
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels:
+      app: cert-exporter
+{{- end }}

--- a/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/podmonitor.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/podmonitor.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.extendedMonitoring.certificates.exporterEnabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: cert-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main")) | nindent 2 }}
+spec:
+  jobLabel: app
+  podMetricsEndpoints:
+  - port: https-metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+      cert:
+        secret:
+          name: prometheus-scraper-tls
+          key: tls.crt
+      keySecret:
+        name: prometheus-scraper-tls
+        key: tls.key
+    honorLabels: true
+    scrapeTimeout: 25s
+  selector:
+    matchLabels:
+      app: cert-exporter
+  namespaceSelector:
+    matchNames:
+    - d8-monitoring
+{{- end }}

--- a/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/rbac-for-us.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/rbac-for-us.yaml
@@ -16,9 +16,6 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces", "secrets"]
   verbs: ["get", "list"]
-- apiGroups: ["cert-manager.io"]
-  resources: ["certificates", "clusterissuers", "issuers"]
-  verbs: ["list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/rbac-for-us.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/rbac-for-us.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.extendedMonitoring.certificates.exporterEnabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: d8:extended-monitoring:cert-exporter
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups: [""]
+  resources: ["namespaces", "secrets"]
+  verbs: ["get", "list"]
+- apiGroups: ["cert-manager.io"]
+  resources: ["certificates", "clusterissuers", "issuers"]
+  verbs: ["list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: d8:extended-monitoring:cert-exporter
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+subjects:
+- kind: ServiceAccount
+  name: cert-exporter
+  namespace: d8-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: d8:extended-monitoring:cert-exporter
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: d8:extended-monitoring:cert-exporter:rbac-proxy
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: d8:rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: cert-exporter
+  namespace: d8-monitoring
+{{- end }}

--- a/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/rbac-to-us.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/rbac-to-us.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.extendedMonitoring.certificates.exporterEnabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: access-to-extended-monitoring-cert-exporter-metrics
+  namespace: d8-monitoring
+{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments/prometheus-metrics"]
+  resourceNames: ["cert-exporter"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: access-to-extended-monitoring-cert-exporter-metrics
+  namespace: d8-monitoring
+{{ include "helm_lib_module_labels" (list .) | indent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: access-to-extended-monitoring-cert-exporter-metrics
+subjects:
+- kind: User
+  name: d8-monitoring:scraper
+{{- end }}

--- a/ee/fe/modules/340-extended-monitoring/templates/monitoring.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/monitoring.yaml
@@ -4,3 +4,6 @@
 {{- if .Values.extendedMonitoring.imageAvailability.exporterEnabled }}
   {{- include "helm_lib_prometheus_rules_recursion" (list . $namespace "monitoring/prometheus-rules/image-availability") }}
 {{- end }}
+{{- if .Values.extendedMonitoring.certificates.exporterEnabled }}
+  {{- include "helm_lib_prometheus_rules_recursion" (list . $namespace "monitoring/prometheus-rules/certificates") }}
+{{- end }}


### PR DESCRIPTION
## Description

This PR adds cert-exporter alerts to the extended-monitoring module

## Why do we need it, and what problem does it solve?

follows-up #479
fixes #365

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: extended-monitoring
type: feature
description: Add cert-exporter alerts
note: |
  Added alerts to track certificates expiration and cert-exporter health
```

