### PR TITLE
[github] fix(ci): rename ok-to-test to status/ok-to-test

### DIFF
--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -127,7 +127,7 @@ pull_request_info:
           const isInternal = prRepo === targetRepo;
           const isDependabot = (context.actor === 'dependabot[bot]');
           const isChangelog = context.payload.pull_request.head.ref.startsWith('changelog/v');
-          const okToTest = response.data[0].labels.some((l) => l.name === 'ok-to-test');
+          const okToTest = response.data[0].labels.some((l) => l.name === 'status/ok-to-test');
           core.info(`PR internal?          ${isInternal}`)
           core.info(`PR from dependabot?   ${isDependabot}`)
           core.info(`PR changelog?         ${isChangelog}`)
@@ -139,9 +139,9 @@ pull_request_info:
               return core.setFailed(`PR#${context.payload.pull_request.number} for changelog is ignored.`);
             }
           } else {
-            // External and dependabot pull requests should be labeled with 'ok-to-test'.
+            // External and dependabot pull requests should be labeled with 'status/ok-to-test'.
             if (!okToTest) {
-              return core.setFailed(`PR#${context.payload.pull_request.number} without label 'ok-to-test' is ignored.`);
+              return core.setFailed(`PR#${context.payload.pull_request.number} without label 'status/ok-to-test' is ignored.`);
             }
           }
 

--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -18,7 +18,7 @@ const labels = {
     'e2e/run/static'
   ],
   'issue-release': 'issue/release',
-  'ok-to-test': 'ok-to-test',
+  'ok-to-test': 'status/ok-to-test',
   deploy: [
     'deploy/deckhouse/alpha',
     'deploy/deckhouse/beta',

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -123,7 +123,7 @@ jobs:
             const isInternal = prRepo === targetRepo;
             const isDependabot = (context.actor === 'dependabot[bot]');
             const isChangelog = context.payload.pull_request.head.ref.startsWith('changelog/v');
-            const okToTest = response.data[0].labels.some((l) => l.name === 'ok-to-test');
+            const okToTest = response.data[0].labels.some((l) => l.name === 'status/ok-to-test');
             core.info(`PR internal?          ${isInternal}`)
             core.info(`PR from dependabot?   ${isDependabot}`)
             core.info(`PR changelog?         ${isChangelog}`)
@@ -135,9 +135,9 @@ jobs:
                 return core.setFailed(`PR#${context.payload.pull_request.number} for changelog is ignored.`);
               }
             } else {
-              // External and dependabot pull requests should be labeled with 'ok-to-test'.
+              // External and dependabot pull requests should be labeled with 'status/ok-to-test'.
               if (!okToTest) {
-                return core.setFailed(`PR#${context.payload.pull_request.number} without label 'ok-to-test' is ignored.`);
+                return core.setFailed(`PR#${context.payload.pull_request.number} without label 'status/ok-to-test' is ignored.`);
               }
             }
 

--- a/.github/workflows/on-pull-request-labeled.yml
+++ b/.github/workflows/on-pull-request-labeled.yml
@@ -56,7 +56,7 @@ jobs:
             const isInternal = prRepo === targetRepo;
             const isDependabot = (context.actor === 'dependabot[bot]');
             const isChangelog = context.payload.pull_request.head.ref.startsWith('changelog/v');
-            const okToTest = response.data[0].labels.some((l) => l.name === 'ok-to-test');
+            const okToTest = response.data[0].labels.some((l) => l.name === 'status/ok-to-test');
             core.info(`PR internal?          ${isInternal}`)
             core.info(`PR from dependabot?   ${isDependabot}`)
             core.info(`PR changelog?         ${isChangelog}`)
@@ -68,9 +68,9 @@ jobs:
                 return core.setFailed(`PR#${context.payload.pull_request.number} for changelog is ignored.`);
               }
             } else {
-              // External and dependabot pull requests should be labeled with 'ok-to-test'.
+              // External and dependabot pull requests should be labeled with 'status/ok-to-test'.
               if (!okToTest) {
-                return core.setFailed(`PR#${context.payload.pull_request.number} without label 'ok-to-test' is ignored.`);
+                return core.setFailed(`PR#${context.payload.pull_request.number} without label 'status/ok-to-test' is ignored.`);
               }
             }
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -72,7 +72,7 @@ jobs:
             const isInternal = prRepo === targetRepo;
             const isDependabot = (context.actor === 'dependabot[bot]');
             const isChangelog = context.payload.pull_request.head.ref.startsWith('changelog/v');
-            const okToTest = response.data[0].labels.some((l) => l.name === 'ok-to-test');
+            const okToTest = response.data[0].labels.some((l) => l.name === 'status/ok-to-test');
             core.info(`PR internal?          ${isInternal}`)
             core.info(`PR from dependabot?   ${isDependabot}`)
             core.info(`PR changelog?         ${isChangelog}`)
@@ -84,9 +84,9 @@ jobs:
                 return core.setFailed(`PR#${context.payload.pull_request.number} for changelog is ignored.`);
               }
             } else {
-              // External and dependabot pull requests should be labeled with 'ok-to-test'.
+              // External and dependabot pull requests should be labeled with 'status/ok-to-test'.
               if (!okToTest) {
-                return core.setFailed(`PR#${context.payload.pull_request.number} without label 'ok-to-test' is ignored.`);
+                return core.setFailed(`PR#${context.payload.pull_request.number} without label 'status/ok-to-test' is ignored.`);
               }
             }
 


### PR DESCRIPTION
## Description

Rename label.

## Why do we need it, and what problem does it solve?

A forgotten change from #483.


