### PR TITLE
[extended-monitoring] Add cert-exporter alerts

### DIFF
--- a/ee/fe/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificate.yaml
+++ b/ee/fe/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificate.yaml
@@ -1,0 +1,62 @@
+- name: kubernetes.certmanager.certificate
+  rules:
+  - alert: CertificateSecretExpiredSoon
+    expr: |
+      max by (name, namespace) (
+        cert_exporter_secret_not_after{job="cert-exporter", secretkey!="ca.crt"} - time() < 1209600
+      ) * on (namespace) group_left() max by (namespace) (extended_monitoring_enabled)
+    for: 1h
+    labels:
+      severity_level: "8"
+    annotations:
+      plk_protocol_version: "1"
+      plk_incident_initial_status: "todo"
+      plk_markup_format: "markdown"
+      plk_pending_until_firing_for: "30m"
+      plk_grouped_by__main: "CertificateSecretExpiration,tier=~tier,prometheus=deckhouse"
+      summary: Certificate will expire soon.
+      description: |
+        Certificate in secret {{$labels.namespace}}/{{$labels.name}} will expire in less than 2 weeks
+
+        - If the certificate is manually managed, upload a newer one.
+        - If certificate is managed by cert-manager, try inspecting certificate resource, the recommended course of action:
+          1. Retrieve certificate name from the secret: `cert=$(kubectl get secret -n {{$labels.namespace}} {{$labels.name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')`
+          2. View the status of the Certificate and try to figure out why it is not updated: `kubectl describe cert -m {{$labels.namespace}} "$cert"`
+
+  - alert: CertificateSecretExpired
+    expr: |
+      max by (name, namespace) (
+        cert_exporter_secret_not_after{job="cert-exporter", secretkey!="ca.crt"} - time() < 0
+      ) * on (namespace) group_left() max by (namespace) (extended_monitoring_enabled)
+    for: 1h
+    labels:
+      severity_level: "8"
+    annotations:
+      plk_protocol_version: "1"
+      plk_incident_initial_status: "todo"
+      plk_markup_format: "markdown"
+      plk_pending_until_firing_for: "30m"
+      plk_grouped_by__main: "CertificateSecretExpiration,tier=~tier,prometheus=deckhouse"
+      summary: Certificate expired
+      description: |
+        Certificate in secret {{$labels.namespace}}/{{$labels.name}} expired.
+
+        - If the certificate is manually managed, upload a newer one.
+        - If the certificate is managed by cert-manager, try inspecting certificate resource, the recommended course of action:
+          1. Retrieve certificate name from the secret: `cert=$(kubectl get secret -n {{$labels.namespace}} {{$labels.name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')`
+          2. View the status of the Certificate and try to figure out why it is not updated: `kubectl describe cert -m {{$labels.namespace}} "$cert"`
+
+  - alert: CertificateSecretExpiration
+    expr: count(ALERTS{alertname=~"CertificateSecretExpiredSoon|CertificateSecretExpired", alertstate="firing"})
+    labels:
+      d8_module: extended-monitoring
+      d8_component: cert-exporter
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_alert_type: "group"
+      description: |
+        Certificate in secret has problems with the validity period.
+
+        The detailed information is available in one of the relevant alerts.
+      summary: cert-exporter does not work as expected.

--- a/ee/fe/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/exporter-health.yaml
+++ b/ee/fe/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/exporter-health.yaml
@@ -1,0 +1,124 @@
+- name: d8.extended-monitoring.cert-exporter.availability
+  rules:
+
+  - alert: D8CertExporterTargetDown
+    expr: max by (job) (up{job="cert-exporter"} == 0)
+    labels:
+      severity_level: "8"
+      d8_module: extended-monitoring
+      d8_component: cert-exporter
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_pending_until_firing_for: "1m"
+      plk_grouped_by__main: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse"
+      plk_ignore_labels: "job"
+      description: |
+        Check the Pod status: `kubectl -n d8-monitoring get pod -l app=cert-exporter`
+
+        Or check the Pod logs: `kubectl -n d8-monitoring logs -l app=cert-exporter -c cert-exporter`
+      summary: Prometheus cannot scrape the cert-exporter metrics.
+
+  - alert: D8CertExporterTargetAbsent
+    expr: absent(up{job="cert-exporter"}) == 1
+    labels:
+      severity_level: "8"
+      d8_module: extended-monitoring
+      d8_component: cert-exporter
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_pending_until_firing_for: "15m"
+      plk_ignore_labels: "job"
+      plk_grouped_by__main: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse"
+      description: |
+        Check the Pod status: `kubectl -n d8-monitoring get pod -l app=cert-exporter`
+
+        Or check the Pod logs: `kubectl -n d8-monitoring logs -l app=cert-exporter -c cert-exporter`
+      summary: There is no `cert-exporter` target in Prometheus.
+
+  - alert: D8CertExporterPodIsNotReady
+    expr: min by (pod) (kube_pod_status_ready{condition="true", namespace="d8-monitoring", pod=~"cert-exporter-.*"}) != 1
+    labels:
+      severity_level: "8"
+      d8_module: extended-monitoring
+      d8_component: cert-exporter
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_pending_until_firing_for: "30m"
+      plk_labels_as_annotations: "pod"
+      plk_grouped_by__main: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse"
+      summary: The cert-exporter Pod is NOT Ready.
+      description: |
+        The recommended course of action:
+        1. Retrieve details of the Deployment: `kubectl -n d8-monitoring describe deploy cert-exporter`
+        2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-monitoring describe pod -l app=cert-exporter`
+
+  - alert: D8CertExporterPodIsNotRunning
+    expr: absent(kube_pod_status_phase{namespace="d8-monitoring",phase="Running",pod=~"cert-exporter-.*"})
+    labels:
+      severity_level: "8"
+      d8_module: extended-monitoring
+      d8_component: cert-exporter
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_pending_until_firing_for: "30m"
+      plk_grouped_by__main: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse"
+      summary: The cert-exporter Pod is NOT Running.
+      description: |
+        The recommended course of action:
+        1. Retrieve details of the Deployment: `kubectl -n d8-monitoring describe deploy cert-exporter`
+        2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-monitoring describe pod -l app=cert-exporter`
+
+  - alert: D8CertExporterUnavailable
+    expr: count(ALERTS{alertname=~"D8CertExporterTargetDown|D8CertExporterTargetAbsent", alertstate="firing"})
+    labels:
+      d8_module: extended-monitoring
+      d8_component: cert-exporter
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_alert_type: "group"
+      summary: cert-exporter does not work.
+      description: |
+        `cert-exporter` does not work.
+
+        The detailed information is available in one of the relevant alerts.
+
+- name: d8.extended-monitoring.cert-exporter.malfunctioning
+  rules:
+
+  - alert: D8CertExporterStuck
+    expr: |
+      increase(promhttp_metric_handler_requests_total{job="cert-exporter", code="200"}[10m])
+    labels:
+      severity_level: "8"
+      d8_module: extended-monitoring
+      d8_component: cert-exporter
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_pending_until_firing_for: "20m"
+      plk_grouped_by__main: "D8CertExporterMalfunctioning,tier=cluster,prometheus=deckhouse"
+      description: |
+        The `cert-exporter` failed to perform any checks for the certificates expiration for over 20 minutes.
+
+        You need to analyze its logs: `kubectl -n d8-monitoring logs -l app=cert-exporter -c cert-exporter`
+      summary: image-cert-exporter has crashed.
+
+  - alert: D8CertExporterMalfunctioning
+    expr: count(ALERTS{alertname=~"D8CertExporterStuck", alertstate="firing"})
+    labels:
+      d8_module: extended-monitoring
+      d8_component: cert-exporter
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_alert_type: "group"
+      description: |
+        `cert-exporter` does not work as expected.
+
+        The detailed information is available in one of the relevant alerts.
+      summary: cert-exporter does not work as expected.

--- a/ee/fe/modules/340-extended-monitoring/templates/monitoring.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/monitoring.yaml
@@ -4,3 +4,6 @@
 {{- if .Values.extendedMonitoring.imageAvailability.exporterEnabled }}
   {{- include "helm_lib_prometheus_rules_recursion" (list . $namespace "monitoring/prometheus-rules/image-availability") }}
 {{- end }}
+{{- if .Values.extendedMonitoring.certificates.exporterEnabled }}
+  {{- include "helm_lib_prometheus_rules_recursion" (list . $namespace "monitoring/prometheus-rules/certificates") }}
+{{- end }}


### PR DESCRIPTION
## Description

This PR adds cert-exporter alerts to the extended-monitoring module

## Why do we need it, and what problem does it solve?

follows-up #479
fixes #365

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: extended-monitoring
type: feature
description: Add cert-exporter alerts
note: |
  Added alerts to track certificates expiration and cert-exporter health
```

