### PR TITLE
[ci] Reduce dependabot PRs quantity

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    open-pull-requests-limit: 1
 
   - package-ecosystem: "gomod"
     directory: "/dhctl"
@@ -18,6 +19,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    open-pull-requests-limit: 1
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Set limit to opened pull requests by dependabot

## Why do we need it, and what problem does it solve?
There are a lot of PRs from dependabot that we are not ready to review.

