### PR TITLE
[cloud-provider-aws] add peering for without-nat and standard layouts

### DIFF
--- a/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/main.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/main.tf
@@ -256,61 +256,14 @@ locals {
   peer_vpc_ids = lookup(var.providerClusterConfiguration, "peeredVPCs", [])
 }
 
-data "aws_caller_identity" "kube" {}
-
-resource "aws_vpc_peering_connection" "kube" {
-  count         = length(local.peer_vpc_ids)
-  vpc_id        = module.vpc.id
-  peer_vpc_id   = local.peer_vpc_ids[count.index]
-  peer_owner_id = data.aws_caller_identity.kube.account_id
-  peer_region   = var.providerClusterConfiguration.provider.region
-  auto_accept   = false
-
-  tags = merge(local.tags, {
-    Name = local.prefix
-  })
-}
-
-resource "aws_vpc_peering_connection_accepter" "kube" {
-  count                     = length(local.peer_vpc_ids)
-  vpc_peering_connection_id = aws_vpc_peering_connection.kube[count.index].id
-  auto_accept               = true
-
-  tags = merge(local.tags, {
-    Name = local.prefix
-  })
-}
-
-resource "aws_route" "kube" {
-  count                     = length(local.peer_vpc_ids)
-  route_table_id            = aws_route_table.kube_internal.id
-  destination_cidr_block    = data.aws_vpc.target[count.index].cidr_block
-  vpc_peering_connection_id = aws_vpc_peering_connection.kube[count.index].id
-  depends_on                = [aws_route_table.kube_internal]
-}
-
-data "aws_vpc" "target" {
-  count = length(local.peer_vpc_ids)
-  id    = local.peer_vpc_ids[count.index]
-}
-
-data "aws_subnets" "target" {
-  count = length(local.peer_vpc_ids)
-  filter {
-    name   = "vpc-id"
-    values = [local.peer_vpc_ids[count.index]]
-  }
-}
-
-data "aws_route_table" "target" {
-  count     = length(local.peer_vpc_ids)
-  subnet_id = data.aws_subnets.target[count.index].ids[0]
-}
-
-resource "aws_route" "target" {
-  count                     = length(local.peer_vpc_ids)
-  route_table_id            = data.aws_route_table.target[count.index].id
-  destination_cidr_block    = module.vpc.cidr_block
-  vpc_peering_connection_id = aws_vpc_peering_connection.kube[count.index].id
-  depends_on                = [aws_route_table.kube_internal]
+module "vpc-peering" {
+  count                  = length(local.peer_vpc_ids) == 0 ? 0 : 1
+  source                 = "../../../terraform-modules/vpc-peering"
+  prefix                 = local.prefix
+  tags                   = local.tags
+  vpc_id                 = module.vpc.id
+  peer_vpc_ids           = local.peer_vpc_ids
+  region                 = var.providerClusterConfiguration.provider.region
+  route_table_id         = aws_route_table.kube_internal.id
+  destination_cidr_block = module.vpc.cidr_block
 }

--- a/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/main.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/main.tf
@@ -252,6 +252,10 @@ resource "aws_eip_association" "bastion" {
 
 // vpc peering
 
+locals {
+  peer_vpc_ids = lookup(var.providerClusterConfiguration, "peeredVPCs", [])
+}
+
 data "aws_caller_identity" "kube" {}
 
 resource "aws_vpc_peering_connection" "kube" {

--- a/candi/cloud-providers/aws/layouts/without-nat/base-infrastructure/main.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/base-infrastructure/main.tf
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 module "vpc" {
-  source = "../../../terraform-modules/vpc"
-  prefix = local.prefix
+  source          = "../../../terraform-modules/vpc"
+  prefix          = local.prefix
   existing_vpc_id = local.existing_vpc_id
-  cidr_block = local.vpc_network_cidr
-  tags = local.tags
+  cidr_block      = local.vpc_network_cidr
+  tags            = local.tags
 }
 
 module "security-groups" {
-  source = "../../../terraform-modules/security-groups"
-  prefix = local.prefix
+  source       = "../../../terraform-modules/security-groups"
+  prefix       = local.prefix
   cluster_uuid = var.clusterUUID
   vpc_id = module.vpc.id
   tags = local.tags
@@ -32,7 +32,7 @@ module "security-groups" {
 data "aws_availability_zones" "available" {}
 
 locals {
-  az_count = length(data.aws_availability_zones.available.names)
+  az_count    = length(data.aws_availability_zones.available.names)
   subnet_cidr = lookup(var.providerClusterConfiguration, "nodeNetworkCIDR", module.vpc.cidr_block)
 }
 
@@ -44,9 +44,9 @@ resource "aws_subnet" "kube_public" {
   map_public_ip_on_launch = true
 
   tags = merge(local.tags, {
-    Name = "${local.prefix}-public-${count.index}"
+    Name                                       = "${local.prefix}-public-${count.index}"
     "kubernetes.io/cluster/${var.clusterUUID}" = "shared"
-    "kubernetes.io/cluster/${local.prefix}" = "shared"
+    "kubernetes.io/cluster/${local.prefix}"    = "shared"
   })
 }
 
@@ -62,9 +62,9 @@ resource "aws_route_table" "kube_public" {
   vpc_id = module.vpc.id
 
   tags = merge(local.tags, {
-    Name = "${local.prefix}-public"
+    Name                                       = "${local.prefix}-public"
     "kubernetes.io/cluster/${var.clusterUUID}" = "shared"
-    "kubernetes.io/cluster/${local.prefix}" = "shared"
+    "kubernetes.io/cluster/${local.prefix}"    = "shared"
   })
 }
 
@@ -130,10 +130,27 @@ resource "aws_iam_instance_profile" "node" {
 }
 
 resource "aws_key_pair" "ssh" {
-  key_name = local.prefix
+  key_name   = local.prefix
   public_key = var.providerClusterConfiguration.sshPublicKey
 
   tags = merge(local.tags, {
     Cluster = local.prefix
   })
+}
+
+// vpc peering
+locals {
+  peer_vpc_ids = lookup(var.providerClusterConfiguration, "peeredVPCs", [])
+}
+
+module "vpc-peering" {
+  count                  = length(local.peer_vpc_ids) == 0 ? 0 : 1
+  source                 = "../../../terraform-modules/vpc-peering"
+  prefix                 = local.prefix
+  tags                   = local.tags
+  vpc_id                 = module.vpc.id
+  peer_vpc_ids           = local.peer_vpc_ids
+  region                 = var.providerClusterConfiguration.provider.region
+  route_table_id         = aws_route_table.kube_public.id
+  destination_cidr_block = module.vpc.cidr_block
 }

--- a/candi/cloud-providers/aws/terraform-modules/vpc-peering/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/vpc-peering/main.tf
@@ -1,0 +1,70 @@
+# Copyright 2021 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "aws_caller_identity" "kube" {}
+
+resource "aws_vpc_peering_connection" "kube" {
+  count         = length(var.peer_vpc_ids)
+  vpc_id        = var.vpc_id
+  peer_vpc_id   = var.peer_vpc_ids[count.index]
+  peer_owner_id = data.aws_caller_identity.kube.account_id // peer_owner_id and our local account_id are equal cause we only support peering within single account
+  peer_region   = var.region
+  auto_accept   = false
+
+  tags = merge(var.tags, {
+    Name = var.prefix
+  })
+}
+
+resource "aws_vpc_peering_connection_accepter" "kube" {
+  count                     = length(var.peer_vpc_ids)
+  vpc_peering_connection_id = aws_vpc_peering_connection.kube[count.index].id
+  auto_accept               = true
+
+  tags = merge(var.tags, {
+    Name = var.prefix
+  })
+}
+
+resource "aws_route" "kube" {
+  count                     = length(var.peer_vpc_ids)
+  route_table_id            = var.route_table_id
+  destination_cidr_block    = data.aws_vpc.target[count.index].cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.kube[count.index].id
+}
+
+data "aws_vpc" "target" {
+  count = length(var.peer_vpc_ids)
+  id    = var.peer_vpc_ids[count.index]
+}
+
+data "aws_subnets" "target" {
+  count = length(var.peer_vpc_ids)
+  filter {
+    name   = "vpc-id"
+    values = [var.peer_vpc_ids[count.index]]
+  }
+}
+
+data "aws_route_table" "target" {
+  count     = length(var.peer_vpc_ids)
+  subnet_id = data.aws_subnets.target[count.index].ids[0]
+}
+
+resource "aws_route" "target" {
+  count                     = length(var.peer_vpc_ids)
+  route_table_id            = data.aws_route_table.target[count.index].id
+  destination_cidr_block    = var.destination_cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection.kube[count.index].id
+}

--- a/candi/cloud-providers/aws/terraform-modules/vpc-peering/variables.tf
+++ b/candi/cloud-providers/aws/terraform-modules/vpc-peering/variables.tf
@@ -1,0 +1,41 @@
+# Copyright 2021 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "prefix" {
+  type = string
+}
+
+variable "tags" {
+  type = map(string)
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "peer_vpc_ids" {
+  type = list(string)
+}
+
+variable "region" {
+  type = string
+}
+
+variable "route_table_id" {
+  type = string
+}
+
+variable "destination_cidr_block" {
+  type = string
+}


### PR DESCRIPTION
## Description
Added the ability to configure peering connections to the without-nat and standard layouts.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
This is necessary to simplify the configuration of the peering connection and eliminate possible errors during manual configuration.
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: cloud-provider-aws
type: feature
description: Added the ability to configure peering connections to the without-nat and standard layouts.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
