### PR TITLE
[ingress-nginx] add pcre_jit on in nginx.tmpl for controller-0.46 and above

### DIFF
--- a/modules/402-ingress-nginx/images/controller-0-46/patches/nginx-tpl.patch
+++ b/modules/402-ingress-nginx/images/controller-0-46/patches/nginx-tpl.patch
@@ -1,8 +1,18 @@
 --- a/etc/nginx/template/nginx.tmpl
 +++ b/etc/nginx/template/nginx.tmpl
-@@ -95,11 +95,11 @@
+@@ -12,6 +12,9 @@
+ # setup custom paths that do not require root access
+ pid {{ .PID }};
+ 
++# enables the use of “just-in-time compilation” for the regular expressions known by the time of configuration parsing
++pcre_jit on;
++
+ {{ if $cfg.UseGeoIP2 }}
+ load_module /etc/nginx/modules/ngx_http_geoip2_module.so;
+ {{ end }}
+@@ -95,11 +98,11 @@
          end
-
+ 
          {{ if $all.EnableMetrics }}
 -        ok, res = pcall(require, "monitor")
 +        ok, res = pcall(require, "pbmetrics")
@@ -13,25 +23,25 @@
 +          pbmetrics = res
          end
          {{ end }}
-
-@@ -124,11 +124,10 @@
+ 
+@@ -124,11 +127,10 @@
      init_worker_by_lua_block {
          lua_ingress.init_worker()
          balancer.init_worker()
 -        {{ if $all.EnableMetrics }}
 -        monitor.init_worker({{ $all.MonitorMaxBatchSize }})
 -        {{ end }}
-
+ 
          plugins.run()
 +
 +        pbmetrics.init_worker()
      }
-
+ 
      {{/* Enable the real_ip module only if we use either X-Forwarded headers or Proxy Protocol. */}}
-@@ -624,6 +623,24 @@
-
+@@ -624,6 +626,24 @@
+ 
      {{ end }}
-
+ 
 +    server {
 +        listen 8080;
 +
@@ -53,8 +63,8 @@
      # backend for when default-backend-service is not configured or it does not have endpoints
      server {
          listen {{ $all.ListenPorts.Default }} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }};
-@@ -852,9 +869,7 @@
-
+@@ -852,9 +872,7 @@
+ 
              proxy_pass            http://upstream_balancer;
              log_by_lua_block {
 -                {{ if $enableMetrics }}
@@ -64,28 +74,28 @@
              }
          }
          {{ end }}
-@@ -1094,6 +1109,10 @@
+@@ -1094,6 +1112,10 @@
              set $location_path  {{ $ing.Path | escapeLiteralDollar | quote }};
              set $global_rate_limit_exceeding n;
-
+ 
 +            set $content_kind "";
 +            set $total_upstream_response_time "0";
 +            set $upstream_retries "0";
 +
              {{ buildOpentracingForLocation $all.Cfg.EnableOpentracing $location }}
-
+ 
              {{ if $location.Mirror.Source }}
-@@ -1124,11 +1143,10 @@
-
+@@ -1124,11 +1146,10 @@
+ 
              log_by_lua_block {
                  balancer.log()
 -                {{ if $all.EnableMetrics }}
 -                monitor.call()
 -                {{ end }}
-
+ 
                  plugins.run()
 +
 +                pbmetrics.call()
              }
-
+ 
              {{ if not $location.Logs.Access }}

--- a/modules/402-ingress-nginx/images/controller-0-48/patches/nginx-tpl.patch
+++ b/modules/402-ingress-nginx/images/controller-0-48/patches/nginx-tpl.patch
@@ -1,8 +1,18 @@
 --- a/etc/nginx/template/nginx.tmpl
 +++ b/etc/nginx/template/nginx.tmpl
-@@ -95,11 +95,11 @@
+@@ -12,6 +12,9 @@
+ # setup custom paths that do not require root access
+ pid {{ .PID }};
+ 
++# enables the use of “just-in-time compilation” for the regular expressions known by the time of configuration parsing
++pcre_jit on;
++
+ {{ if $cfg.UseGeoIP2 }}
+ load_module /etc/nginx/modules/ngx_http_geoip2_module.so;
+ {{ end }}
+@@ -95,11 +98,11 @@
          end
-
+ 
          {{ if $all.EnableMetrics }}
 -        ok, res = pcall(require, "monitor")
 +        ok, res = pcall(require, "pbmetrics")
@@ -13,25 +23,25 @@
 +          pbmetrics = res
          end
          {{ end }}
-
-@@ -124,11 +124,10 @@
+ 
+@@ -124,11 +127,10 @@
      init_worker_by_lua_block {
          lua_ingress.init_worker()
          balancer.init_worker()
 -        {{ if $all.EnableMetrics }}
 -        monitor.init_worker({{ $all.MonitorMaxBatchSize }})
 -        {{ end }}
-
+ 
          plugins.run()
 +
 +        pbmetrics.init_worker()
      }
-
+ 
      {{/* Enable the real_ip module only if we use either X-Forwarded headers or Proxy Protocol. */}}
-@@ -624,6 +623,24 @@
-
+@@ -624,6 +626,24 @@
+ 
      {{ end }}
-
+ 
 +    server {
 +        listen 8080;
 +
@@ -53,8 +63,8 @@
      # backend for when default-backend-service is not configured or it does not have endpoints
      server {
          listen {{ $all.ListenPorts.Default }} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }};
-@@ -852,9 +869,7 @@
-
+@@ -852,9 +872,7 @@
+ 
              proxy_pass            http://upstream_balancer;
              log_by_lua_block {
 -                {{ if $enableMetrics }}
@@ -64,28 +74,28 @@
              }
          }
          {{ end }}
-@@ -1094,6 +1109,10 @@
+@@ -1094,6 +1112,10 @@
              set $location_path  {{ $ing.Path | escapeLiteralDollar | quote }};
              set $global_rate_limit_exceeding n;
-
+ 
 +            set $content_kind "";
 +            set $total_upstream_response_time "0";
 +            set $upstream_retries "0";
 +
              {{ buildOpentracingForLocation $all.Cfg.EnableOpentracing $location }}
-
+ 
              {{ if $location.Mirror.Source }}
-@@ -1124,11 +1143,10 @@
-
+@@ -1124,11 +1146,10 @@
+ 
              log_by_lua_block {
                  balancer.log()
 -                {{ if $all.EnableMetrics }}
 -                monitor.call()
 -                {{ end }}
-
+ 
                  plugins.run()
 +
 +                pbmetrics.call()
              }
-
+ 
              {{ if not $location.Logs.Access }}

--- a/modules/402-ingress-nginx/images/controller-0-49/patches/nginx-tpl.patch
+++ b/modules/402-ingress-nginx/images/controller-0-49/patches/nginx-tpl.patch
@@ -1,8 +1,18 @@
 --- a/etc/nginx/template/nginx.tmpl
 +++ b/etc/nginx/template/nginx.tmpl
-@@ -95,11 +95,11 @@
+@@ -12,6 +12,9 @@
+ # setup custom paths that do not require root access
+ pid {{ .PID }};
+ 
++# enables the use of “just-in-time compilation” for the regular expressions known by the time of configuration parsing
++pcre_jit on;
++
+ {{ if $cfg.UseGeoIP2 }}
+ load_module /etc/nginx/modules/ngx_http_geoip2_module.so;
+ {{ end }}
+@@ -95,11 +98,11 @@
          end
-
+ 
          {{ if $all.EnableMetrics }}
 -        ok, res = pcall(require, "monitor")
 +        ok, res = pcall(require, "pbmetrics")
@@ -13,25 +23,25 @@
 +          pbmetrics = res
          end
          {{ end }}
-
-@@ -124,11 +124,10 @@
+ 
+@@ -124,11 +127,10 @@
      init_worker_by_lua_block {
          lua_ingress.init_worker()
          balancer.init_worker()
 -        {{ if $all.EnableMetrics }}
 -        monitor.init_worker({{ $all.MonitorMaxBatchSize }})
 -        {{ end }}
-
+ 
          plugins.run()
 +
 +        pbmetrics.init_worker()
      }
-
+ 
      {{/* Enable the real_ip module only if we use either X-Forwarded headers or Proxy Protocol. */}}
-@@ -624,6 +623,24 @@
-
+@@ -624,6 +626,24 @@
+ 
      {{ end }}
-
+ 
 +    server {
 +        listen 8080;
 +
@@ -53,8 +63,8 @@
      # backend for when default-backend-service is not configured or it does not have endpoints
      server {
          listen {{ $all.ListenPorts.Default }} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }};
-@@ -852,9 +869,7 @@
-
+@@ -852,9 +872,7 @@
+ 
              proxy_pass            http://upstream_balancer;
              log_by_lua_block {
 -                {{ if $enableMetrics }}
@@ -64,28 +74,28 @@
              }
          }
          {{ end }}
-@@ -1094,6 +1109,10 @@
+@@ -1094,6 +1112,10 @@
              set $location_path  {{ $ing.Path | escapeLiteralDollar | quote }};
              set $global_rate_limit_exceeding n;
-
+ 
 +            set $content_kind "";
 +            set $total_upstream_response_time "0";
 +            set $upstream_retries "0";
 +
              {{ buildOpentracingForLocation $all.Cfg.EnableOpentracing $location }}
-
+ 
              {{ if $location.Mirror.Source }}
-@@ -1124,11 +1143,10 @@
-
+@@ -1124,11 +1146,10 @@
+ 
              log_by_lua_block {
                  balancer.log()
 -                {{ if $all.EnableMetrics }}
 -                monitor.call()
 -                {{ end }}
-
+ 
                  plugins.run()
 +
 +                pbmetrics.call()
              }
-
+ 
              {{ if not $location.Logs.Access }}

--- a/modules/402-ingress-nginx/images/controller-1-0/patches/nginx-tpl.patch
+++ b/modules/402-ingress-nginx/images/controller-1-0/patches/nginx-tpl.patch
@@ -1,8 +1,18 @@
 --- a/etc/nginx/template/nginx.tmpl
 +++ b/etc/nginx/template/nginx.tmpl
-@@ -95,11 +95,11 @@
+@@ -12,6 +12,9 @@
+ # setup custom paths that do not require root access
+ pid {{ .PID }};
+ 
++# enables the use of “just-in-time compilation” for the regular expressions known by the time of configuration parsing
++pcre_jit on;
++
+ {{ if $cfg.UseGeoIP2 }}
+ load_module /etc/nginx/modules/ngx_http_geoip2_module.so;
+ {{ end }}
+@@ -95,11 +98,11 @@
          end
-
+ 
          {{ if $all.EnableMetrics }}
 -        ok, res = pcall(require, "monitor")
 +        ok, res = pcall(require, "pbmetrics")
@@ -13,25 +23,25 @@
 +          pbmetrics = res
          end
          {{ end }}
-
-@@ -124,11 +124,10 @@
+ 
+@@ -124,11 +127,10 @@
      init_worker_by_lua_block {
          lua_ingress.init_worker()
          balancer.init_worker()
 -        {{ if $all.EnableMetrics }}
 -        monitor.init_worker({{ $all.MonitorMaxBatchSize }})
 -        {{ end }}
-
+ 
          plugins.run()
 +
 +        pbmetrics.init_worker()
      }
-
+ 
      {{/* Enable the real_ip module only if we use either X-Forwarded headers or Proxy Protocol. */}}
-@@ -624,6 +623,24 @@
-
+@@ -624,6 +626,24 @@
+ 
      {{ end }}
-
+ 
 +    server {
 +        listen 8080;
 +
@@ -53,8 +63,8 @@
      # backend for when default-backend-service is not configured or it does not have endpoints
      server {
          listen {{ $all.ListenPorts.Default }} default_server {{ if $all.Cfg.ReusePort }}reuseport{{ end }} backlog={{ $all.BacklogSize }};
-@@ -852,9 +869,7 @@
-
+@@ -852,9 +872,7 @@
+ 
              proxy_pass            http://upstream_balancer;
              log_by_lua_block {
 -                {{ if $enableMetrics }}
@@ -64,28 +74,28 @@
              }
          }
          {{ end }}
-@@ -1094,6 +1109,10 @@
+@@ -1094,6 +1112,10 @@
              set $location_path  {{ $ing.Path | escapeLiteralDollar | quote }};
              set $global_rate_limit_exceeding n;
-
+ 
 +            set $content_kind "";
 +            set $total_upstream_response_time "0";
 +            set $upstream_retries "0";
 +
              {{ buildOpentracingForLocation $all.Cfg.EnableOpentracing $location }}
-
+ 
              {{ if $location.Mirror.Source }}
-@@ -1124,11 +1143,10 @@
-
+@@ -1124,11 +1146,10 @@
+ 
              log_by_lua_block {
                  balancer.log()
 -                {{ if $all.EnableMetrics }}
 -                monitor.call()
 -                {{ end }}
-
+ 
                  plugins.run()
 +
 +                pbmetrics.call()
              }
-
+ 
              {{ if not $location.Logs.Access }}


### PR DESCRIPTION
## Description
Added "pcre_jit on" to nginx.tmpl for controller-0.46 and above.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
For controller versions 0.46 and above, this parameter has been lost.
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: ingress-nginx
type: fix
description: Added "pcre_jit on" to nginx.tmpl for controller-0.46 and above
note: |
  Ingress Controller >= 0.46 will be restarted
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
