### PR TITLE
Fix deckhouse-web internal schema

### DIFF
--- a/modules/810-deckhouse-web/openapi/values.yaml
+++ b/modules/810-deckhouse-web/openapi/values.yaml
@@ -28,3 +28,7 @@ properties:
             type: string
             x-examples:
               - plainstring
+          ca.crt:
+            type: string
+            x-examples:
+              - plainstring


### PR DESCRIPTION
## Description

Add missing fields in schema for custom certificate copy.

## Why do we need it, and what problem does it solve?

The missing 'ca.crt' hangd deckhouse queue

## Changelog entries


```changes
module: deckhouse-web
type: fix 
description: "Added missing 'ca.crt' field to internal values schema"
```
