### PR TITLE
[bashible] Fix `<no value>` if registry auth is empty

### DIFF
--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -122,7 +122,7 @@ function main() {
   export REGISTRY_ADDRESS="{{ .registry.address }}"
   export SCHEME="{{ .registry.scheme }}"
   export REGISTRY_PATH="{{ .registry.path }}"
-  export REGISTRY_AUTH="$(base64 -d <<< "{{ .registry.auth }}")"
+  export REGISTRY_AUTH="$(base64 -d <<< "{{ .registry.auth | default "" }}")"
 {{- end }}
 
   if type kubectl >/dev/null 2>&1 && test -f /etc/kubernetes/kubelet.conf ; then

--- a/candi/bashible/bundles/centos-7/bootstrap.sh.tpl
+++ b/candi/bashible/bundles/centos-7/bootstrap.sh.tpl
@@ -33,7 +33,7 @@ REGISTRY_ADDRESS="{{ .registry.address }}"
 SCHEME="{{ .registry.scheme }}"
 REGISTRY_PATH="{{ .registry.path }}"
 {{- if hasKey .registry "auth" }}
-REGISTRY_AUTH="$(base64 -d <<< "{{ .registry.auth }}")"
+REGISTRY_AUTH="$(base64 -d <<< "{{ .registry.auth | default "" }}")"
 {{- else }}
 REGISTRY_AUTH="$(base64 -d <<< "{{ .registry.dockerCfg }}" | python -c 'import json; import sys; dockerCfg = sys.stdin.read(); parsed = json.loads(dockerCfg); parsed["auths"]["'${REGISTRY_ADDRESS}'"].setdefault("auth", ""); print(parsed["auths"]["'${REGISTRY_ADDRESS}'"]["auth"]);' | base64 -d)"
 {{- end }}

--- a/candi/bashible/common-steps/node-group/050_configure_and_start_containerd.sh.tpl
+++ b/candi/bashible/common-steps/node-group/050_configure_and_start_containerd.sh.tpl
@@ -135,7 +135,7 @@ oom_score = 0
           endpoint = ["{{ .registry.scheme }}://{{ .registry.address }}"]
       [plugins."io.containerd.grpc.v1.cri".registry.configs]
         [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .registry.address }}".auth]
-          auth = "{{ .registry.auth }}"
+          auth = "{{ .registry.auth | default "" }}"
   {{- if eq .registry.scheme "http" }}
         [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .registry.address }}".tls]
           insecure_skip_verify = true

--- a/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
@@ -459,7 +459,7 @@ type registry struct {
 	Scheme    string `json:"scheme" yaml:"scheme"`
 	CA        string `json:"ca,omitempty" yaml:"ca,omitempty"`
 	DockerCFG []byte `json:"dockerCfg" yaml:"dockerCfg"`
-	Auth      string `json:"auth,omitempty" yaml:"auth,omitempty"`
+	Auth      string `json:"auth" yaml:"auth"`
 }
 
 // input from secret


### PR DESCRIPTION
## Description


## Why do we need it, and what problem does it solve?
If registry auth was not found. bashible render  `<no value>` string instead empty value

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: bashible
type: fix 
description: fix incorrect auth value for containerd config only
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
