### PR TITLE
[global] copy custom certificate: serialize with struct, not map

### DIFF
--- a/go_lib/hooks/copy_custom_certificate/hook.go
+++ b/go_lib/hooks/copy_custom_certificate/hook.go
@@ -108,12 +108,20 @@ func copyCustomCertificatesHandler(moduleName string) func(input *go_hook.HookIn
 			return fmt.Errorf("custom certificate secret name is configured, but secret with this name doesn't exist")
 		}
 
-		storeData := make(map[string][]byte)
-		err := yaml.Unmarshal(secretData, &storeData)
+		var c cert
+		err := yaml.Unmarshal(secretData, &c)
 		if err != nil {
 			return err
 		}
-		input.Values.Set(fmt.Sprintf("%s.internal.customCertificateData", moduleName), storeData)
+
+		path := fmt.Sprintf("%s.internal.customCertificateData", moduleName)
+		input.Values.Set(path, c)
 		return nil
 	}
+}
+
+type cert struct {
+	CA      string `json:"ca.crt,omitempty"`
+	TLSKey  string `json:"tls.key,omitempty"`
+	TLSCert string `json:"tls.crt,omitempty"`
 }


### PR DESCRIPTION
## Description

Refactor to use structs instead of maps on serialization

## Why do we need it, and what problem does it solve?

When serializing empty slices in `map[string][]byte`, they are omitted in values.

## Changelog entries

```changes
module: global
type: fix
description: Fix serialization of empty strings in secrets
```
