### PR TITLE
[global] delete empty ca.crt entry in cert map

### DIFF
--- a/go_lib/hooks/copy_custom_certificate/hook.go
+++ b/go_lib/hooks/copy_custom_certificate/hook.go
@@ -113,6 +113,9 @@ func copyCustomCertificatesHandler(moduleName string) func(input *go_hook.HookIn
 		if err != nil {
 			return err
 		}
+		if len(storeData["ca.crt"]) == 0 {
+			delete(storeData, "ca.crt")
+		}
 		input.Values.Set(fmt.Sprintf("%s.internal.customCertificateData", moduleName), storeData)
 		return nil
 	}


### PR DESCRIPTION
## Description

Refactor to use structs instead of maps on serialization

## Why do we need it, and what problem does it solve?

When serializing empty slices in `map[string][]byte`, they are omitted in values.

## Changelog entries

```changes
module: global
type: fix
description: Fix serialization of empty strings in secrets
```
