### PR TITLE
[user-authz] Allow empty group and api version

### DIFF
--- a/ee/modules/140-user-authz/images/webhook/web/hook/handler_test.go
+++ b/ee/modules/140-user-authz/images/webhook/web/hook/handler_test.go
@@ -115,17 +115,31 @@ func TestAuthorizeRequest(t *testing.T) {
 			ResultStatus: WebhookRequestStatus{},
 		},
 		{
-			Name:  "Cluster scoped. Bad request - group and version are empty",
+			Name:  "Cluster scoped. Group and version are empty, search in the v1 apiVersion. Allowed.",
 			Group: []string{"normal"},
 			Attributes: WebhookResourceAttributes{
 				Group:     "",
 				Version:   "",
-				Resource:  "object1",
+				Resource:  "namespaces",
+				Namespace: "",
+			},
+			ResultStatus: WebhookRequestStatus{
+				Denied: false,
+				Reason: "",
+			},
+		},
+		{
+			Name:  "Cluster scoped. Group and version are empty, search in the v1 apiVersion. Denied.",
+			Group: []string{"normal"},
+			Attributes: WebhookResourceAttributes{
+				Group:     "",
+				Version:   "",
+				Resource:  "services",
 				Namespace: "",
 			},
 			ResultStatus: WebhookRequestStatus{
 				Denied: true,
-				Reason: "webhook: bad request, group and groupVersion are empty",
+				Reason: "making cluster scoped requests for namespaced resources are not allowed",
 			},
 		},
 		{
@@ -240,6 +254,10 @@ func TestAuthorizeRequest(t *testing.T) {
 						"test/v1": {
 							"object1": true,
 							"object2": false,
+						},
+						"v1": {
+							"namespaces": false,
+							"services":   true,
 						},
 					},
 					preferredVersions: map[string]string{


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Allow empty group and API version subject access reviews 

## Why do we need it, and what problem does it solve?
Some tools like `k9s` and `kubectl can-i` do not bother filling API versions correctly, so we must satisfy their puzzling desires.

## Changelog entries

```changes
module: user-authz
type: fix 
description: Allow empty group and apiVersion requests in user-authz webhook
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
