### PR TITLE
[user-authn] Add DexAuthenticator validation webhook

### DIFF
--- a/modules/150-user-authn/webhooks/validating/dex_authenticator
+++ b/modules/150-user-authn/webhooks/validating/dex_authenticator
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /shell_lib.sh
+
+function __config__(){
+  cat <<EOF
+configVersion: v1
+kubernetes:
+  - name: dexauthenticators
+    apiVersion: deckhouse.io/v1
+    kind: DexAuthenticator
+    queue: "dexauthenticators-list"
+    group: main
+    executeHookOnEvent: []
+    executeHookOnSynchronization: false
+    keepFullObjectsInMemory: false
+    jqFilter: |
+      {
+        "name": .metadata.name,
+        "namespace": .metadata.namespace,
+        "applicationDomain": .spec.applicationDomain,
+        "ingressClass": .spec.applicationIngressClassName
+      }
+kubernetesValidating:
+- name: dexauthenticators-unique.deckhouse.io
+  group: main
+  rules:
+  - apiGroups:   ["deckhouse.io"]
+    apiVersions: ["v1", "v1alpha1"]
+    operations:  ["CREATE", "UPDATE"]
+    resources:   ["dexauthenticators"]
+    scope:       "Namespaced"
+EOF
+}
+
+function __main__() {
+  newAuthDomain=$(context::jq -r '.review.request.object.spec.applicationDomain')
+  newAuthIngressClass=$(context::jq -r '.review.request.object.spec.applicationIngressClassName')
+
+  result=$(context::jq -r --arg domain "$newAuthDomain" --arg class "$newAuthIngressClass" '.snapshots.dexauthenticators[].filterResult | select(.applicationDomain == $domain and .ingressClass == $class)')
+
+  if [ "$result" ]; then
+    newAuthNamespace=$(context::jq -r '.review.request.object.metadata.namespace')
+    newAuthName=$(context::jq -r '.review.request.object.metadata.name')
+    existingAuth=$(echo "$result" | jq -r '.namespace + "/" + .name')
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"Desired DexAuthenticator '$newAuthNamespace/$newAuthName' conflicts with the existing DexAuthenticator '$existingAuth'" }
+EOF
+  else
+    # dexauthenticator with such values does not exist
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":true}
+EOF
+  fi
+}
+
+hook::run "$@"


### PR DESCRIPTION
## Description
Add validation webhook for DexAuthenticators

Close https://github.com/deckhouse/deckhouse/issues/453

## Why do we need it, and what problem does it solve?
Pair `applicationName` and `applicationIngressClassName` have to be unique through all DexAuthenticators. Without this check duplicated DexAuthenticator will fail inside the Deckhouse queue, which makes it hard to debug. We can handle this situation in the very beginning and prevent duplicated DexAuthenticator to be created.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: user-authn
type: feature
description: Validation webhook for preventing duplicate DexAuthenticators to be created.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
