### PR TITLE
[docs] Fix instructions for switching registry and image copier

### DIFF
--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -118,7 +118,7 @@ The following parameters must be set if the [Nexus](https://github.com/sonatype/
   * Change `path` to point to a repo in the third-party registry (e.g., `/deckhouse/fe`).
   * If necessary, change `scheme` to `http` (if the third-party registry uses HTTP scheme).
   * If necessary, change or add the `ca` field with the root CA certificate that validates the third-party registry's https certificate (if the third-party registry uses self-signed certificates).
-* Restart the Deckhouse Pod.
+* Update the `image` field in the `d8-system/deckhouse` deployment to contain the address of the Deckhouse image in the third-party-registry.
 * Wait for the Deckhouse Pod to become Ready.
 * Wait for bashible to apply the new settings on the master node. The bashible log on the master node (`journalctl -u bashible`) should contain the message `Configuration is in sync, nothing to do`.
-* Update the `image` field in the `d8-system/deckhouse` deployment to contain the address of the Deckhouse image in the third-party-registry.
+* Remove `releaseChannel` setting from configmap `d8-system/deckhouse`

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -120,7 +120,7 @@ deckhouse: |
   * Исправить `path` на путь к репозиторию Deckhouse в новом registry (например, `/deckhouse/fe`).
   * При необходимости, изменить `scheme` на `http` (если используется HTTP registry).
   * Если registry использует самоподписные сертификаты, то изменить или добавить поле `ca` куда внести корневой сертификат соответствующего сертификата registry.
-* Выполнить рестарт Pod'а Deckhouse'а.
+* Изменить поле `image` в Deployment `d8-system/deckhouse` на адрес образа Deckhouse в новом registry.
 * Дождаться перехода Pod'а Deckhouse в статус Ready.
 * Дождаться применения bashible новых настроек на master-узле. В журнале bashible на master-узле (`journalctl -u bashible`) должно появится сообщение `Configuration is in sync, nothing to do`.
-* Изменить поле `image` в Deployment `d8-system/deckhouse` на адрес образа Deckhouse в новом registry.
+* Удалить releaseChannel из конфигмапы `d8-system/deckhouse` 

--- a/modules/020-deckhouse/docs/internal/IMAGE_COPIER.md
+++ b/modules/020-deckhouse/docs/internal/IMAGE_COPIER.md
@@ -29,7 +29,7 @@ The hook then deletes the Secret, Job, and Pod if copying is successful.
 
 ## Copying Images 
 
-- Run the `../images/images-copier/generate-copier-secret.sh` script and specify target registry credentials.
+- Run [the script](../../images/images-copier/generate-copier-secret.sh) and specify target registry credentials.
   
   Example: 
   `REPO_USER="u" REPO_PASSWORD='Pass"Word' IMAGE_WITH_TAG="client.registry/repo/deckhouse:test" ./generate-copier-secret.sh`
@@ -57,16 +57,5 @@ The hook then deletes the Secret, Job, and Pod if copying is successful.
 Caution! If you delete Secret, the Job and Pod will be deleted as well regardless of the status of the Job.
 
 ## Switching the repository
-The `generate-copier-secret.sh` script generates the following two commands in addition to the Secret:
-- the first one replaces the `deckhouse-registry` Secret;
-- the second one replaces the `deckhouse-controller` image name.
 
-Execute them in the given order and wait for all the Pods to re-deploy. 
-
-The command below displays the list of images in use:
-```shell
-kubectl get pods --all-namespaces -o jsonpath="{.items[*].spec.containers[*].image}" |\
-tr -s '[[:space:]]' '\n' |\
-sort |\
-uniq -c
-```
+Use this [instruction](https://deckhouse.io/en/documentation/v1/deckhouse-faq.html#how-do-i-switch-a-running-deckhouse-cluster-to-use-a-third-party-registry)

--- a/modules/020-deckhouse/images/images-copier/generate-copier-secret.sh
+++ b/modules/020-deckhouse/images/images-copier/generate-copier-secret.sh
@@ -71,8 +71,6 @@ new_auth=$(echo -n "$usr:$pass" | base64 -w 0)
 new_registry="{\"auths\":{\"$new_registry\":{\"auth\":\"$new_auth\"}}}"
 
 patch_auth="{\"data\":{\".dockerconfigjson\":\"$(echo -n "$new_registry" | base64 -w 0)\"}}"
-patch_secret_cmd="kubectl -n d8-system patch secret deckhouse-registry --patch '$patch_auth'"
-patch_deployment_cmd="kubectl -n d8-system patch deploy/deckhouse -p '{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"deckhouse\",\"image\":\"$image\"}]}}}}'"
 
 echo -e " Use 'kubectl create -f' with next secret for run image copier in cluster
 ---
@@ -84,11 +82,5 @@ metadata:
 data:
   dest-repo.json: $encoded
 ---
-
-After completed repush use next two command for switch repository:
-
-$patch_secret_cmd
-
-$patch_deployment_cmd
 "
 


### PR DESCRIPTION
## Description
Fix instructions for switching registry and image copier

## Why do we need it, and what problem does it solve?
Instructions had errors and users cannot switch registry

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: docs
type: fix
description: Fix instructions for switching registry and image copier
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
