### PR TITLE
[github] feat(ci): editions parameter to filter editions on deploy

### DIFF
--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -22,6 +22,9 @@ on:
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
         required: false
+      editions:
+        description: 'Comma separated editions to deploy. Example: ee,fe,ce'
+        required: false
 
 env:
 {!{ tmpl.Exec "werf_envs" | strings.Indent 2 }!}
@@ -56,6 +59,30 @@ jobs:
 {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "login_rw_registry_step" . | strings.Indent 6 }!}
 
+      - name: Filter editions
+        id: filter_editions
+        env:
+          EDITIONS: ${{ github.event.inputs.editions }}
+        run: |
+          echo "Input allowed editions: '${EDITIONS}'"
+
+          RESTRICTED=no
+
+          for edition in CE EE FE ; do
+            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
+              echo "  - enable deploy of ${edition} edition."
+              echo "::set-output name=DEPLOY_${edition}::yes"
+              RESTRICTED=yes
+            fi
+          done
+
+          if [[ $RESTRICTED == "no" ]] ; then
+            echo "No restrictions. Enable deploy to all editions."
+            for edition in CE EE FE ; do
+              echo "::set-output name=DEPLOY_${edition}::yes"
+            done
+          fi
+
 {!{/*
 Pull deckhouse images from cache, tag with channel name and push to dev and prod registries.
 Images:
@@ -68,12 +95,17 @@ Destination registries:
 */}!}
 {!{ range $werfEnv := slice "CE" "EE" "FE" }!}
       - name: Publish release images for {!{ $werfEnv }!}
+        if: ${{ steps.filter_editions.outputs.DEPLOY_{!{ $werfEnv }!} == 'yes' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: {!{ $werfEnv }!}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          echo Publish {!{ $werfEnv }!} edition.
+
+          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -16,6 +16,9 @@ on:
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
         required: false
+      editions:
+        description: 'Comma separated editions to deploy. Example: ee,fe,ce'
+        required: false
 
 env:
 
@@ -212,15 +215,44 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
+      - name: Filter editions
+        id: filter_editions
+        env:
+          EDITIONS: ${{ github.event.inputs.editions }}
+        run: |
+          echo "Input allowed editions: '${EDITIONS}'"
+
+          RESTRICTED=no
+
+          for edition in CE EE FE ; do
+            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
+              echo "  - enable deploy of ${edition} edition."
+              echo "::set-output name=DEPLOY_${edition}::yes"
+              RESTRICTED=yes
+            fi
+          done
+
+          if [[ $RESTRICTED == "no" ]] ; then
+            echo "No restrictions. Enable deploy to all editions."
+            for edition in CE EE FE ; do
+              echo "::set-output name=DEPLOY_${edition}::yes"
+            done
+          fi
+
 
 
       - name: Publish release images for CE
+        if: ${{ steps.filter_editions.outputs.DEPLOY_CE == 'yes' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: CE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          echo Publish CE edition.
+
+          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
@@ -322,12 +354,17 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
+        if: ${{ steps.filter_editions.outputs.DEPLOY_EE == 'yes' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: EE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          echo Publish EE edition.
+
+          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
@@ -429,12 +466,17 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
+        if: ${{ steps.filter_editions.outputs.DEPLOY_FE == 'yes' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: FE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          echo Publish FE edition.
+
+          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -16,6 +16,9 @@ on:
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
         required: false
+      editions:
+        description: 'Comma separated editions to deploy. Example: ee,fe,ce'
+        required: false
 
 env:
 
@@ -212,15 +215,44 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
+      - name: Filter editions
+        id: filter_editions
+        env:
+          EDITIONS: ${{ github.event.inputs.editions }}
+        run: |
+          echo "Input allowed editions: '${EDITIONS}'"
+
+          RESTRICTED=no
+
+          for edition in CE EE FE ; do
+            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
+              echo "  - enable deploy of ${edition} edition."
+              echo "::set-output name=DEPLOY_${edition}::yes"
+              RESTRICTED=yes
+            fi
+          done
+
+          if [[ $RESTRICTED == "no" ]] ; then
+            echo "No restrictions. Enable deploy to all editions."
+            for edition in CE EE FE ; do
+              echo "::set-output name=DEPLOY_${edition}::yes"
+            done
+          fi
+
 
 
       - name: Publish release images for CE
+        if: ${{ steps.filter_editions.outputs.DEPLOY_CE == 'yes' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: CE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          echo Publish CE edition.
+
+          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
@@ -322,12 +354,17 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
+        if: ${{ steps.filter_editions.outputs.DEPLOY_EE == 'yes' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: EE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          echo Publish EE edition.
+
+          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
@@ -429,12 +466,17 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
+        if: ${{ steps.filter_editions.outputs.DEPLOY_FE == 'yes' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: FE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          echo Publish FE edition.
+
+          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -16,6 +16,9 @@ on:
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
         required: false
+      editions:
+        description: 'Comma separated editions to deploy. Example: ee,fe,ce'
+        required: false
 
 env:
 
@@ -212,15 +215,44 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
+      - name: Filter editions
+        id: filter_editions
+        env:
+          EDITIONS: ${{ github.event.inputs.editions }}
+        run: |
+          echo "Input allowed editions: '${EDITIONS}'"
+
+          RESTRICTED=no
+
+          for edition in CE EE FE ; do
+            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
+              echo "  - enable deploy of ${edition} edition."
+              echo "::set-output name=DEPLOY_${edition}::yes"
+              RESTRICTED=yes
+            fi
+          done
+
+          if [[ $RESTRICTED == "no" ]] ; then
+            echo "No restrictions. Enable deploy to all editions."
+            for edition in CE EE FE ; do
+              echo "::set-output name=DEPLOY_${edition}::yes"
+            done
+          fi
+
 
 
       - name: Publish release images for CE
+        if: ${{ steps.filter_editions.outputs.DEPLOY_CE == 'yes' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: CE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          echo Publish CE edition.
+
+          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
@@ -322,12 +354,17 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
+        if: ${{ steps.filter_editions.outputs.DEPLOY_EE == 'yes' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: EE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          echo Publish EE edition.
+
+          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
@@ -429,12 +466,17 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
+        if: ${{ steps.filter_editions.outputs.DEPLOY_FE == 'yes' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: FE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          echo Publish FE edition.
+
+          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -16,6 +16,9 @@ on:
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
         required: false
+      editions:
+        description: 'Comma separated editions to deploy. Example: ee,fe,ce'
+        required: false
 
 env:
 
@@ -212,15 +215,44 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
+      - name: Filter editions
+        id: filter_editions
+        env:
+          EDITIONS: ${{ github.event.inputs.editions }}
+        run: |
+          echo "Input allowed editions: '${EDITIONS}'"
+
+          RESTRICTED=no
+
+          for edition in CE EE FE ; do
+            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
+              echo "  - enable deploy of ${edition} edition."
+              echo "::set-output name=DEPLOY_${edition}::yes"
+              RESTRICTED=yes
+            fi
+          done
+
+          if [[ $RESTRICTED == "no" ]] ; then
+            echo "No restrictions. Enable deploy to all editions."
+            for edition in CE EE FE ; do
+              echo "::set-output name=DEPLOY_${edition}::yes"
+            done
+          fi
+
 
 
       - name: Publish release images for CE
+        if: ${{ steps.filter_editions.outputs.DEPLOY_CE == 'yes' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: CE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          echo Publish CE edition.
+
+          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
@@ -322,12 +354,17 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
+        if: ${{ steps.filter_editions.outputs.DEPLOY_EE == 'yes' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: EE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          echo Publish EE edition.
+
+          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
@@ -429,12 +466,17 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
+        if: ${{ steps.filter_editions.outputs.DEPLOY_FE == 'yes' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: FE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          echo Publish FE edition.
+
+          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -16,6 +16,9 @@ on:
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
         required: false
+      editions:
+        description: 'Comma separated editions to deploy. Example: ee,fe,ce'
+        required: false
 
 env:
 
@@ -212,15 +215,44 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
+      - name: Filter editions
+        id: filter_editions
+        env:
+          EDITIONS: ${{ github.event.inputs.editions }}
+        run: |
+          echo "Input allowed editions: '${EDITIONS}'"
+
+          RESTRICTED=no
+
+          for edition in CE EE FE ; do
+            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
+              echo "  - enable deploy of ${edition} edition."
+              echo "::set-output name=DEPLOY_${edition}::yes"
+              RESTRICTED=yes
+            fi
+          done
+
+          if [[ $RESTRICTED == "no" ]] ; then
+            echo "No restrictions. Enable deploy to all editions."
+            for edition in CE EE FE ; do
+              echo "::set-output name=DEPLOY_${edition}::yes"
+            done
+          fi
+
 
 
       - name: Publish release images for CE
+        if: ${{ steps.filter_editions.outputs.DEPLOY_CE == 'yes' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: CE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          echo Publish CE edition.
+
+          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
@@ -322,12 +354,17 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
+        if: ${{ steps.filter_editions.outputs.DEPLOY_EE == 'yes' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: EE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          echo Publish EE edition.
+
+          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
@@ -429,12 +466,17 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
+        if: ${{ steps.filter_editions.outputs.DEPLOY_FE == 'yes' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: FE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          echo Publish FE edition.
+
+          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then


### PR DESCRIPTION
## Description

Add 'editions' parameter to deploy only specified editions.

## Why do we need it, and what problem does it solve?

We don't want to deploy pre-release tags for CE edition before testing FE edition.

<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
