### PR TITLE
[user-authn] Fix DexAuthenticator validation webhook

### DIFF
--- a/modules/150-user-authn/webhooks/validating/dex_authenticator
+++ b/modules/150-user-authn/webhooks/validating/dex_authenticator
@@ -57,6 +57,13 @@ function __main__() {
     newAuthNamespace=$(context::jq -r '.review.request.object.metadata.namespace')
     newAuthName=$(context::jq -r '.review.request.object.metadata.name')
     existingAuth=$(echo "$result" | jq -r '.namespace + "/" + .name')
+    # Update previously existing DexAuthenticator with the same name allowed
+    if [[ "$existingAuth" == "$newAuthNamespace/$newAuthName" ]]; then
+      cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":true}
+EOF
+      return 0;
+    fi
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":false, "message":"Desired DexAuthenticator '$newAuthNamespace/$newAuthName' conflicts with the existing DexAuthenticator '$existingAuth'" }
 EOF


### PR DESCRIPTION
## Description
Fix webhook

## Why do we need it, and what problem does it solve?
Webhook denies the request to update an existing DexAuthenticator. Ignore updating object with the same namespace/name

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: user-authn
type: fix
description: Ignore updating an existing DexAuthenticator
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
