### PR TITLE
[node-manager] Fix Static node template annotations updating

### DIFF
--- a/modules/040-node-manager/hooks/handle_node_templates.go
+++ b/modules/040-node-manager/hooks/handle_node_templates.go
@@ -290,7 +290,7 @@ func applyNodeTemplate(nodeObj *v1.Node, node NodeSettings, nodeGroup NodeSettin
 		if labelsChanged {
 			nodeObj.SetLabels(newLabels)
 		}
-		if labelsChanged {
+		if annotationsChanged {
 			nodeObj.SetAnnotations(newAnnotations)
 		}
 	}
@@ -311,7 +311,7 @@ func applyNodeTemplate(nodeObj *v1.Node, node NodeSettings, nodeGroup NodeSettin
 func ApplyTemplateMap(actual, template, lastApplied map[string]string) (map[string]string, bool) {
 	changed := false
 	excess := ExcessMapKeys(lastApplied, template)
-	newLabels := map[string]string{}
+	newMap := map[string]string{}
 
 	for k, v := range actual {
 		// Ignore keys removed from template.
@@ -319,19 +319,19 @@ func ApplyTemplateMap(actual, template, lastApplied map[string]string) (map[stri
 			changed = true
 			continue
 		}
-		newLabels[k] = v
+		newMap[k] = v
 	}
 
 	// Merge with values from template.
 	for k, v := range template {
-		oldVal, ok := newLabels[k]
+		oldVal, ok := newMap[k]
 		if !ok || oldVal != v {
 			changed = true
 		}
-		newLabels[k] = v
+		newMap[k] = v
 	}
 
-	return newLabels, changed
+	return newMap, changed
 }
 
 // ExcessMapKeys returns keys from a without keys from b.

--- a/modules/040-node-manager/hooks/handle_node_templates_test.go
+++ b/modules/040-node-manager/hooks/handle_node_templates_test.go
@@ -555,6 +555,44 @@ spec:
 		})
 	})
 
+	Context("Update NG: NodeGroup with labels adding annotation", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: wor-ker
+spec:
+  nodeType: Static
+  nodeTemplate:
+    annotations:
+      test: test
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: wor-ker
+  labels:
+    node.deckhouse.io/type: Static
+    node.deckhouse.io/group: wor-ker
+    node-role.kubernetes.io/wor-ker: ""
+spec:
+  taints:
+  - key: a
+    effect: NoSchedule
+`))
+			f.RunHook()
+		})
+
+		It("Must add annotation", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			node := f.KubernetesGlobalResource("Node", "wor-ker").Parse()
+			Expect(node.Get("metadata.annotations").Map()["test"].String()).To(Equal("test"))
+		})
+	})
+
 	Context("Update NG: set empty nodeTemplate", func() {
 		BeforeEach(func() {
 
@@ -617,5 +655,4 @@ spec:
 			Expect(taintKeys).ToNot(HaveKey("a"), "taint with key 'a' should be removed")
 		})
 	})
-
 })


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Fix clause to change node object annotations

## Why do we need it, and what problem does it solve?
Closing https://github.com/deckhouse/deckhouse/issues/243

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: node-manager
type: fix
description: Fix Static node template annotations updating
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
