### PR TITLE
[cert-manager] Disable legacy cert-manager for K8s >= 1.22

### DIFF
--- a/modules/101-cert-manager/templates/annotations-converter/mutatingwebhookconfiguration.yaml
+++ b/modules/101-cert-manager/templates/annotations-converter/mutatingwebhookconfiguration.yaml
@@ -6,7 +6,7 @@ metadata:
 {{ include "helm_lib_module_labels" (list . (dict "app" "annotations-converter")) | indent 2 }}
 webhooks:
 - name: webhook.cert-manager.io
-  admissionReviewVersions: ["v1beta1"]
+  admissionReviewVersions: ["v1", "v1beta1"]
   failurePolicy: Fail
   {{- if semverCompare ">=1.15" .Values.global.discovery.kubernetesVersion }}
   matchPolicy: Equivalent

--- a/modules/101-cert-manager/templates/legacy/cert-manager/deployment.yaml
+++ b/modules/101-cert-manager/templates/legacy/cert-manager/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "< 1.22" .Values.global.discovery.kubernetesVersion }}
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
 ---
 apiVersion: autoscaling.k8s.io/v1beta2
@@ -100,3 +101,4 @@ spec:
           resources:
             requests:
 {{- include "helm_lib_module_ephemeral_storage_only_logs" . | indent 14 }}
+{{- end }}

--- a/modules/101-cert-manager/templates/legacy/cert-manager/pdb.yaml
+++ b/modules/101-cert-manager/templates/legacy/cert-manager/pdb.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "< 1.22" .Values.global.discovery.kubernetesVersion }}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
@@ -13,3 +14,4 @@ spec:
   selector:
     matchLabels:
       app: legacy-cert-manager
+{{- end }}

--- a/modules/101-cert-manager/templates/legacy/cert-manager/podmonitor.yaml
+++ b/modules/101-cert-manager/templates/legacy/cert-manager/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "< 1.22" .Values.global.discovery.kubernetesVersion }}
 {{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -34,4 +35,5 @@ spec:
   namespaceSelector:
     matchNames:
     - d8-cert-manager
+{{- end }}
 {{- end }}

--- a/modules/101-cert-manager/templates/legacy/webhook/apiservice.yaml
+++ b/modules/101-cert-manager/templates/legacy/webhook/apiservice.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "< 1.22" .Values.global.discovery.kubernetesVersion }}
 ---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
@@ -13,3 +14,4 @@ spec:
     name: legacy-cert-manager-webhook
     namespace: d8-cert-manager
   version: v1beta1
+{{- end }}

--- a/modules/101-cert-manager/templates/legacy/webhook/deployment.yaml
+++ b/modules/101-cert-manager/templates/legacy/webhook/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "< 1.22" .Values.global.discovery.kubernetesVersion }}
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
 ---
 apiVersion: autoscaling.k8s.io/v1beta2
@@ -70,3 +71,4 @@ spec:
           secretName: cert-manager-webhook-tls
       - name: tmp
         emptyDir: {}
+{{- end }}

--- a/modules/101-cert-manager/templates/legacy/webhook/pdb.yaml
+++ b/modules/101-cert-manager/templates/legacy/webhook/pdb.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "< 1.22" .Values.global.discovery.kubernetesVersion }}
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
@@ -13,3 +14,4 @@ spec:
   selector:
     matchLabels:
       app: legacy-webhook
+{{- end }}

--- a/modules/101-cert-manager/templates/legacy/webhook/service.yaml
+++ b/modules/101-cert-manager/templates/legacy/webhook/service.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "< 1.22" .Values.global.discovery.kubernetesVersion }}
 ---
 apiVersion: v1
 kind: Service
@@ -13,3 +14,4 @@ spec:
     targetPort: 6443
   selector:
     app: legacy-webhook
+{{- end }}

--- a/modules/101-cert-manager/templates/webhook/mutatingwebhookconfiguration.yaml
+++ b/modules/101-cert-manager/templates/webhook/mutatingwebhookconfiguration.yaml
@@ -39,6 +39,7 @@ webhooks:
         name: cert-manager-webhook
         namespace: d8-cert-manager
         path: /mutate
+{{- if semverCompare "< 1.22" .Values.global.discovery.kubernetesVersion }}
   - name: webhook.certmanager.k8s.io
     rules:
       - apiGroups:
@@ -64,4 +65,4 @@ webhooks:
         name: kubernetes
         namespace: default
         path: /apis/webhook.certmanager.k8s.io/v1beta1/mutations
-
+{{- end }}

--- a/modules/101-cert-manager/templates/webhook/validatingwebhookconfiguration.yaml
+++ b/modules/101-cert-manager/templates/webhook/validatingwebhookconfiguration.yaml
@@ -48,6 +48,7 @@ webhooks:
         namespace: d8-cert-manager
         path: /validate
   # legacy hook
+{{- if semverCompare "< 1.22" .Values.global.discovery.kubernetesVersion }}
   - name: webhook.certmanager.k8s.io
     namespaceSelector:
       matchExpressions:
@@ -81,3 +82,4 @@ webhooks:
         name: kubernetes
         namespace: default
         path: /apis/webhook.certmanager.k8s.io/v1beta1/validations
+{{- end }}


### PR DESCRIPTION
## Description
Disable legacy cert-manager (0.10.1) for 1.22 kubernetes

## Why do we need it, and what problem does it solve?
Legacy cert-manager APIs for webhooks and APIServices are not supported by 1.22 K8s. It leads to wrong behavior (ex. NS is stuck on deleting). We have to disable unsupported versions of the APIs by disabling legacy cert-manager.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: cert-manager
type: fix
description:  Disable legacy cert-manager for >= 1.22 kubernetes
note: Legacy cert-manager resources (`certmanager.k8s.io`) will not be supported in 1.22+ clusters
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
