### PR TITLE
[CI] Skip checks for automation PRs

### DIFF
--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -24,6 +24,8 @@ git_info:
     ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
     ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
     github_sha: ${{ steps.git_info.outputs.github_sha }}
+  # Skip the CI for automation PRs, e.g. changelog
+  if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
   steps:
     - id: git_info
       name: Get tag name and SHA
@@ -89,6 +91,8 @@ pull_request_info:
   runs-on: ubuntu-latest
   outputs:
     ref: ${{ steps.ref.outputs.ref }}
+  # Skip the CI for automation PRs, e.g. changelog
+  if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
   steps:
     - name: Check if allow to run tests
       id: check
@@ -128,6 +132,7 @@ pull_request_info:
           const isDependabot = (context.actor === 'dependabot[bot]');
           const isChangelog = context.payload.pull_request.head.ref.startsWith('changelog/v');
           const okToTest = response.data[0].labels.some((l) => l.name === 'status/ok-to-test');
+
           core.info(`PR internal?          ${isInternal}`)
           core.info(`PR from dependabot?   ${isDependabot}`)
           core.info(`PR changelog?         ${isChangelog}`)

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -85,6 +85,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       ref: ${{ steps.ref.outputs.ref }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - name: Check if allow to run tests
         id: check
@@ -124,6 +126,7 @@ jobs:
             const isDependabot = (context.actor === 'dependabot[bot]');
             const isChangelog = context.payload.pull_request.head.ref.startsWith('changelog/v');
             const okToTest = response.data[0].labels.some((l) => l.name === 'status/ok-to-test');
+
             core.info(`PR internal?          ${isInternal}`)
             core.info(`PR from dependabot?   ${isDependabot}`)
             core.info(`PR changelog?         ${isChangelog}`)
@@ -195,6 +198,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -97,6 +97,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -60,6 +60,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -60,6 +60,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -60,6 +60,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -60,6 +60,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -60,6 +60,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/deploy-web-stage.yml
+++ b/.github/workflows/deploy-web-stage.yml
@@ -105,6 +105,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/deploy-web-test.yml
+++ b/.github/workflows/deploy-web-test.yml
@@ -105,6 +105,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -107,6 +107,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -107,6 +107,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -107,6 +107,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -107,6 +107,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -107,6 +107,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -107,6 +107,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -107,6 +107,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/on-pull-request-labeled.yml
+++ b/.github/workflows/on-pull-request-labeled.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       ref: ${{ steps.ref.outputs.ref }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - name: Check if allow to run tests
         id: check
@@ -57,6 +59,7 @@ jobs:
             const isDependabot = (context.actor === 'dependabot[bot]');
             const isChangelog = context.payload.pull_request.head.ref.startsWith('changelog/v');
             const okToTest = response.data[0].labels.some((l) => l.name === 'status/ok-to-test');
+
             core.info(`PR internal?          ${isInternal}`)
             core.info(`PR from dependabot?   ${isDependabot}`)
             core.info(`PR changelog?         ${isChangelog}`)

--- a/.github/workflows/schedule-cleanup.yml
+++ b/.github/workflows/schedule-cleanup.yml
@@ -88,6 +88,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/suspend-alpha.yml
+++ b/.github/workflows/suspend-alpha.yml
@@ -57,6 +57,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/suspend-beta.yml
+++ b/.github/workflows/suspend-beta.yml
@@ -57,6 +57,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/suspend-early-access.yml
+++ b/.github/workflows/suspend-early-access.yml
@@ -57,6 +57,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/suspend-rock-solid.yml
+++ b/.github/workflows/suspend-rock-solid.yml
@@ -57,6 +57,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/suspend-stable.yml
+++ b/.github/workflows/suspend-stable.yml
@@ -57,6 +57,8 @@ jobs:
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - id: git_info
         name: Get tag name and SHA

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -34,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       ref: ${{ steps.ref.outputs.ref }}
+    # Skip the CI for automation PRs, e.g. changelog
+    if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
       - name: Check if allow to run tests
         id: check
@@ -73,6 +75,7 @@ jobs:
             const isDependabot = (context.actor === 'dependabot[bot]');
             const isChangelog = context.payload.pull_request.head.ref.startsWith('changelog/v');
             const okToTest = response.data[0].labels.some((l) => l.name === 'status/ok-to-test');
+
             core.info(`PR internal?          ${isInternal}`)
             core.info(`PR from dependabot?   ${isDependabot}`)
             core.info(`PR changelog?         ${isChangelog}`)


### PR DESCRIPTION
## Description

Skip CI checks for Prs made by our bot.

## Why do we need it, and what problem does it solve?

Validations fail on changelog PRs. We want to avoid the inconvenience.
