### PR TITLE
[cert-manager] Remove support "v1" admissionReviewVersion for annotation converter webhook

### DIFF
--- a/modules/101-cert-manager/templates/annotations-converter/mutatingwebhookconfiguration.yaml
+++ b/modules/101-cert-manager/templates/annotations-converter/mutatingwebhookconfiguration.yaml
@@ -6,7 +6,7 @@ metadata:
 {{ include "helm_lib_module_labels" (list . (dict "app" "annotations-converter")) | indent 2 }}
 webhooks:
 - name: webhook.cert-manager.io
-  admissionReviewVersions: ["v1", "v1beta1"]
+  admissionReviewVersions: ["v1beta1"]
   failurePolicy: Fail
   {{- if semverCompare ">=1.15" .Values.global.discovery.kubernetesVersion }}
   matchPolicy: Equivalent


### PR DESCRIPTION
## Description
Remove support "v1" admissionReviewVersion from mutation webhook config for annotation converter hook

## Why do we need it, and what problem does it solve?
Certificates don't deploy to cluster because annotation converter webhook does not support "v1" admission review version 

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: cert-manager
type: fix
description: Remove support "v1" admissionReviewVersion for annotation converter webhook
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
