### PR TITLE
[dhctl][global] Add control-plane role for master node group

### DIFF
--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -216,7 +216,8 @@ func (m *MetaConfig) MasterNodeGroupManifest() map[string]interface{} {
 		},
 		"nodeTemplate": map[string]interface{}{
 			"labels": map[string]interface{}{
-				"node-role.kubernetes.io/master": "",
+				"node-role.kubernetes.io/master":        "",
+				"node-role.kubernetes.io/control-plane": "",
 			},
 			"taints": []map[string]interface{}{
 				{

--- a/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng.go
+++ b/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng.go
@@ -1,0 +1,51 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+// TODO remove after 1.32 release
+// add control-plane role for all master nodes over master node group
+// At current moment, first bootstrapped master get 'control-plane' role,
+// but other master nodes don't get this role, because
+// first master bootstrapped with kubeadm (kubeadm set role to node over label), but
+// master node group was created on bootstrap does not contain label with role
+// we will add label to nodegroup template for existing clusters
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+)
+
+const controlPlaneRoleLabel = "node-role.kubernetes.io/control-plane"
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnAfterHelm: &go_hook.OrderedConfig{Order: 10},
+}, addControlPlaneRoleToMasterNodeGroup)
+
+func addControlPlaneRoleToMasterNodeGroup(input *go_hook.HookInput) error {
+	patch := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"nodeTemplate": map[string]interface{}{
+				"labels": map[string]interface{}{
+					"node-role.kubernetes.io/control-plane": "",
+				},
+			},
+		},
+	}
+
+	input.PatchCollector.MergePatch(patch, "deckhouse.io/v1", "NodeGroup", "", "master", object_patch.IgnoreMissingObject())
+
+	return nil
+}

--- a/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng_test.go
+++ b/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng_test.go
@@ -1,0 +1,164 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Global hooks :: migrate :: add_control_plane_role_to_master_ng_test ::", func() {
+	f := HookExecutionConfigInit(`{}`, `{}`)
+
+	var nodeGroupResource = schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1", Resource: "nodegroups"}
+	f.RegisterCRD(nodeGroupResource.Group, nodeGroupResource.Version, "NodeGroup", false)
+
+	const (
+		workerNgYAML = `
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: worker
+spec:
+  cloudInstances:
+    classReference:
+      kind: OpenStackInstanceClass
+      name: worker-big
+    maxPerZone: 1
+    maxSurgePerZone: 1
+    maxUnavailablePerZone: 0
+    minPerZone: 1
+  disruptions:
+    approvalMode: Automatic
+  nodeTemplate:
+    labels:
+      node.deckhouse.io/group: worker-big
+  nodeType: CloudEphemeral
+`
+		masterNgWithoutRole = `
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: master
+spec:
+  disruptions:
+    approvalMode: Manual
+  nodeTemplate:
+    labels:
+      node-role.kubernetes.io/master: ""
+    taints:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+  nodeType: CloudStatic
+`
+		masterNgWithRole = `
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: master
+spec:
+  disruptions:
+    approvalMode: Manual
+  nodeTemplate:
+    labels:
+      node-role.kubernetes.io/master: ""
+      node-role.kubernetes.io/control-plane: ""
+    taints:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+  nodeType: CloudStatic
+`
+	)
+
+	Context("Cluster without node groups", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(""))
+			f.RunHook()
+		})
+
+		It("Hook execute successfully and node groups should not created", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			nodeGroups, err := f.KubeClient().Dynamic().Resource(nodeGroupResource).Namespace("").List(context.TODO(), v1.ListOptions{})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodeGroups.Items).To(HaveLen(0))
+		})
+	})
+
+	Context("Cluster has master node group without role", func() {
+		BeforeEach(func() {
+			JoinKubeResourcesAndSet(f, masterNgWithoutRole, workerNgYAML)
+			f.RunHook()
+		})
+
+		It("Sets role for master node group and not affect another labels", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			masterNg := f.KubernetesResource("NodeGroup", "", "master")
+			labels := masterNg.Field("spec.nodeTemplate.labels").Map()
+
+			Expect(labels).To(HaveKey(controlPlaneRoleLabel))
+			Expect(labels).To(HaveKey("node-role.kubernetes.io/master"))
+		})
+
+		It("Should not affect another fields in spec", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			masterNg := f.KubernetesResource("NodeGroup", "", "master")
+			labels := masterNg.Field("spec.nodeTemplate.labels").Map()
+
+			Expect(labels).To(HaveKey("node-role.kubernetes.io/master"))
+
+			taints := masterNg.Field("spec.nodeTemplate.taints").Array()
+
+			Expect(taints).To(HaveLen(1))
+			Expect(taints[0].Value()).To(Equal(map[string]interface{}{
+				"effect": "NoSchedule",
+				"key":    "node-role.kubernetes.io/master",
+			}))
+		})
+
+		It("Does not affect another ng", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			workerNg := f.KubernetesResource("NodeGroup", "", "worker")
+			Expect(workerNg.ToYaml()).To(MatchYAML(workerNgYAML))
+		})
+	})
+
+	Context("Cluster has master node group with role", func() {
+		BeforeEach(func() {
+			JoinKubeResourcesAndSet(f, masterNgWithRole, workerNgYAML)
+			f.RunHook()
+		})
+
+		It("Should not affect node groups", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			masterNg := f.KubernetesResource("NodeGroup", "", "master")
+			workerNg := f.KubernetesResource("NodeGroup", "", "worker")
+
+			Expect(masterNg.ToYaml()).To(MatchYAML(masterNgWithRole))
+			Expect(workerNg.ToYaml()).To(MatchYAML(workerNgYAML))
+		})
+	})
+})


### PR DESCRIPTION
## Description
Add label `node-role.kubernetes.io/control-plane` for master node group when cluster bootstrap.
Add migration to add label `node-role.kubernetes.io/control-plane` to node template for master nodegroup

## Why do we need it, and what problem does it solve?
Only one master node has `control-plane` role

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: dhctl
type: fix
description: All master nodes will have `control-plane` role in new clusters.
```

```changes
module: global
type: feature
description: All master nodes will have `control-plane` role in new exist clusters. 
note: Add migration for adding role. Bashible steps will be rerunned on master nodes.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
