### PR TITLE
[istio][openapi] missing customCertificateData fix

### DIFF
--- a/ee/modules/110-istio/openapi/values.yaml
+++ b/ee/modules/110-istio/openapi/values.yaml
@@ -118,3 +118,18 @@ properties:
       multiclustersNeedIngressGateway:
         type: boolean
         default: false
+      customCertificateData:
+        type: object
+        properties:
+          tls.crt:
+            type: string
+            x-examples:
+              - plainstring
+          tls.key:
+            type: string
+            x-examples:
+              - plainstring
+          ca.crt:
+            type: string
+            x-examples:
+              - plainstring


### PR DESCRIPTION
## Description
Missing customCertificateData in openapi fix.

## Why do we need it, and what problem does it solve?
There was an error:
```
Module hook start '110-istio/hooks/https/copy_custom_certificate'
Module hook start
Module hook failed, requeue task to retry after delay. Failed count is 13. Error: 2 errors occurred:
	* cannot apply values patch for module values
	* istio.internal.customCertificateData is a forbidden property
```

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: istio
type: fix
description: "Missing customCertificateData in openapi fix."
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: istio
type: fix
description: "Missing customCertificateData in openapi fix."
```

-->
