### PR TITLE
[ci] fix getting pull request info

### DIFF
--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -115,10 +115,16 @@ pull_request_info:
           const owner = context.payload.pull_request.head.repo.owner.login
           const repo = context.payload.pull_request.head.repo.name
           const commit_sha = context.payload.pull_request.head.sha
-          core.info(`List pull request inputs: ${JSON.stringify({ owner, repo, commit_sha })}`);
-          const response = await github.rest.repos.listPullRequestsAssociatedWithCommit({ owner, repo, commit_sha });
+          const head_label = context.payload.pull_request.head.label
+          core.info(`Pull request: ${JSON.stringify({ owner, repo, commit_sha, head_label })}`);
+          core.info(`Base repo: ${JSON.stringify({owner: context.repo.owner, repo: context.repo.repo})}`);
+          const response = await github.rest.pulls.list({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            head: head_label
+          });
           if (response.status != 200) {
-            return core.setFailed(`Cannot list PRs for commit ${commit_sha}: ${JSON.stringify(response)}`);
+            return core.setFailed(`Cannot list PRs for head ${head_label} (${commit_sha}): ${JSON.stringify(response)}`);
           }
 
           // No PR found, do not run next jobs.

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -109,10 +109,16 @@ jobs:
             const owner = context.payload.pull_request.head.repo.owner.login
             const repo = context.payload.pull_request.head.repo.name
             const commit_sha = context.payload.pull_request.head.sha
-            core.info(`List pull request inputs: ${JSON.stringify({ owner, repo, commit_sha })}`);
-            const response = await github.rest.repos.listPullRequestsAssociatedWithCommit({ owner, repo, commit_sha });
+            const head_label = context.payload.pull_request.head.label
+            core.info(`Pull request: ${JSON.stringify({ owner, repo, commit_sha, head_label })}`);
+            core.info(`Base repo: ${JSON.stringify({owner: context.repo.owner, repo: context.repo.repo})}`);
+            const response = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: head_label
+            });
             if (response.status != 200) {
-              return core.setFailed(`Cannot list PRs for commit ${commit_sha}: ${JSON.stringify(response)}`);
+              return core.setFailed(`Cannot list PRs for head ${head_label} (${commit_sha}): ${JSON.stringify(response)}`);
             }
 
             // No PR found, do not run next jobs.

--- a/.github/workflows/on-pull-request-labeled.yml
+++ b/.github/workflows/on-pull-request-labeled.yml
@@ -42,10 +42,16 @@ jobs:
             const owner = context.payload.pull_request.head.repo.owner.login
             const repo = context.payload.pull_request.head.repo.name
             const commit_sha = context.payload.pull_request.head.sha
-            core.info(`List pull request inputs: ${JSON.stringify({ owner, repo, commit_sha })}`);
-            const response = await github.rest.repos.listPullRequestsAssociatedWithCommit({ owner, repo, commit_sha });
+            const head_label = context.payload.pull_request.head.label
+            core.info(`Pull request: ${JSON.stringify({ owner, repo, commit_sha, head_label })}`);
+            core.info(`Base repo: ${JSON.stringify({owner: context.repo.owner, repo: context.repo.repo})}`);
+            const response = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: head_label
+            });
             if (response.status != 200) {
-              return core.setFailed(`Cannot list PRs for commit ${commit_sha}: ${JSON.stringify(response)}`);
+              return core.setFailed(`Cannot list PRs for head ${head_label} (${commit_sha}): ${JSON.stringify(response)}`);
             }
 
             // No PR found, do not run next jobs.

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -58,10 +58,16 @@ jobs:
             const owner = context.payload.pull_request.head.repo.owner.login
             const repo = context.payload.pull_request.head.repo.name
             const commit_sha = context.payload.pull_request.head.sha
-            core.info(`List pull request inputs: ${JSON.stringify({ owner, repo, commit_sha })}`);
-            const response = await github.rest.repos.listPullRequestsAssociatedWithCommit({ owner, repo, commit_sha });
+            const head_label = context.payload.pull_request.head.label
+            core.info(`Pull request: ${JSON.stringify({ owner, repo, commit_sha, head_label })}`);
+            core.info(`Base repo: ${JSON.stringify({owner: context.repo.owner, repo: context.repo.repo})}`);
+            const response = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: head_label
+            });
             if (response.status != 200) {
-              return core.setFailed(`Cannot list PRs for commit ${commit_sha}: ${JSON.stringify(response)}`);
+              return core.setFailed(`Cannot list PRs for head ${head_label} (${commit_sha}): ${JSON.stringify(response)}`);
             }
 
             // No PR found, do not run next jobs.


### PR DESCRIPTION
## Description

Use another API method to get fresh info about the pull request.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

API method [list-pull-requests-associated-with-a-commit](https://docs.github.com/en/rest/reference/commits#list-pull-requests-associated-with-a-commit) can't get open PRs for `main` branch in fork. Ooops.
Use [list pull requests](https://docs.github.com/en/rest/reference/pulls#list-pull-requests) method with head label to get opened PR.

<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
