### PR TITLE
[helm] provide actual alerts description

### DIFF
--- a/modules/999-helm/monitoring/prometheus-rules/deprecated-versions.yaml
+++ b/modules/999-helm/monitoring/prometheus-rules/deprecated-versions.yaml
@@ -11,10 +11,10 @@
       plk_markup_format: markdown
       plk_protocol_version: "1"
       plk_pending_until_firing_for: "10m"
-      summary: One of HELM-Releases contains at least one resource with unsupported apiVersion in kubernetes 1.16+
+      summary: One of HELM-Releases contains at least one resource with unsupported apiVersion in kubernetes 1.22+
       description: |
         To see all resources please use the  expr `max without(instance, pod, hook, job, tier, module) (resource_versions_compatibility) == 1` in prometheus.
-        For more details, please follow the link https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
+        For more details, please follow the link https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/
 
   - alert: ClusterHasProblemsWithHelmReleasesWithResourceVersions
     expr: |
@@ -27,7 +27,7 @@
       plk_protocol_version: "1"
       plk_alert_type: "group"
       plk_group_for__helm_release_resource_versions_deprecated: HelmReleaseHasResourcesWithDeprecatedVersions,prometheus=deckhouse
-      summary: One of HELM-Releases contains at least one resource with unsupported apiVersion in kubernetes 1.16+
+      summary: One of HELM-Releases contains at least one resource with unsupported apiVersion in kubernetes 1.22+
       description: |
         Examine groupped alerts to find the cause.
 
@@ -41,7 +41,7 @@
       plk_markup_format: markdown
       plk_protocol_version: "1"
       plk_pending_until_firing_for: "10m"
-      summary: One of HELM-Releases contains at least one resource with unsupported apiVersion in kubernetes 1.16+
+      summary: One of HELM-Releases contains at least one resource with unsupported apiVersion in kubernetes 1.22+
       description: |
         To see all resources please use the  expr `max without(instance, pod, hook, job, tier, module) (resource_versions_compatibility) == 1` in prometheus.
-        For more details, please follow the link https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
+        For more details, please follow the link https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/


### PR DESCRIPTION
## Description
Provide an actual description for deprecated resources API versions alerts.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Our alerts about deprecated resources API versions contain description about Kubernetes 1.16+.
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: helm
type: fix
description: |
  Provide an actual description for deprecated resources API versions alerts.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
