### PR TITLE
[deckhouse] Cleanup and fix deckhouse releases

### DIFF
--- a/modules/020-deckhouse/hooks/cleanup_deckhouse_releases.go
+++ b/modules/020-deckhouse/hooks/cleanup_deckhouse_releases.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"sort"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+
+	"github.com/deckhouse/deckhouse/modules/020-deckhouse/hooks/internal/v1alpha1"
+)
+
+/*
+  This hook handle invalid situation when more then 1 Deployed release exists at the moment:
+    Hook move all releases except the latest one to the Outdated state
+
+  The hook will keep only 10 Outdated releases, removing others
+*/
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/deckhouse/cleanup_deckhouse_release",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "releases",
+			ApiVersion: "deckhouse.io/v1alpha1",
+			Kind:       "DeckhouseRelease",
+			FilterFunc: filterDeckhouseRelease,
+		},
+	},
+}, cleanupReleases)
+
+func cleanupReleases(input *go_hook.HookInput) error {
+	snap := input.Snapshots["releases"]
+	if len(snap) == 0 {
+		return nil
+	}
+
+	releases := make([]deckhouseRelease, 0, len(snap))
+	for _, sn := range snap {
+		releases = append(releases, sn.(deckhouseRelease))
+	}
+
+	sort.Sort(sort.Reverse(byVersion(releases)))
+
+	var (
+		deployedReleasesIndexes []int
+		outdatedReleasesIndexes []int
+	)
+
+	for i, release := range releases {
+		if release.Phase == v1alpha1.PhaseDeployed {
+			deployedReleasesIndexes = append(deployedReleasesIndexes, i)
+		} else if release.Phase == v1alpha1.PhaseOutdated {
+			outdatedReleasesIndexes = append(outdatedReleasesIndexes, i)
+		}
+	}
+
+	if len(deployedReleasesIndexes) > 1 {
+		// cleanup releases stacked in Deployed status
+		sp := statusPatch{
+			Phase: v1alpha1.PhaseOutdated,
+		}
+		// everything except the last Deployed release
+		for i := 1; i < len(deployedReleasesIndexes); i++ {
+			release := releases[i]
+			input.PatchCollector.MergePatch(sp, "deckhouse.io/v1alpha1", "DeckhouseRelease", "", release.Name, object_patch.WithSubresource("/status"))
+		}
+	}
+
+	// save only last 10 outdated releases
+	if len(outdatedReleasesIndexes) > 10 {
+		for i := 10; i < len(outdatedReleasesIndexes); i++ {
+			release := releases[i]
+			input.PatchCollector.Delete("deckhouse.io/v1alpha1", "DeckhouseRelease", "", release.Name, object_patch.InBackground())
+		}
+	}
+
+	return nil
+}

--- a/modules/020-deckhouse/hooks/cleanup_deckhouse_releases_test.go
+++ b/modules/020-deckhouse/hooks/cleanup_deckhouse_releases_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: deckhouse :: hooks :: cleanup deckhouse releases ::", func() {
+	f := HookExecutionConfigInit(`{"deckhouse":{}}`, `{}`)
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "DeckhouseRelease", false)
+
+	Context("Have a few Deployed Releases", func() {
+		BeforeEach(func() {
+			state := generateReleases(4, 0)
+			bc := f.KubeStateSetAndWaitForBindingContexts(state, 1)
+			f.BindingContexts.Set(bc)
+			f.RunHook()
+		})
+		It("Wrong deployed releases should be Outdated", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			rl1 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-28-0")
+			Expect(rl1.Field("status.phase").String()).Should(Equal("Outdated"))
+			rl2 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-28-1")
+			Expect(rl2.Field("status.phase").String()).Should(Equal("Outdated"))
+			rl3 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-28-2")
+			Expect(rl3.Field("status.phase").String()).Should(Equal("Outdated"))
+			rl4 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-28-3")
+			Expect(rl4.Field("status.phase").String()).Should(Equal("Deployed"))
+		})
+	})
+
+	Context("Have 15 Outdated Releases", func() {
+		BeforeEach(func() {
+			state := generateReleases(0, 15)
+			bc := f.KubeStateSetAndWaitForBindingContexts(state, 1)
+			f.BindingContexts.Set(bc)
+			f.RunHook()
+		})
+		It("Outdated releases (>10) should be deleted", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ll, _ := f.KubeClient().Dynamic().Resource(schema.GroupVersionResource{Resource: "deckhousereleases", Group: "deckhouse.io", Version: "v1alpha1"}).List(context.TODO(), v1.ListOptions{})
+			Expect(ll.Items).Should(HaveLen(10))
+		})
+	})
+
+	Context("Have 1 Deployed release and 5 Outdated Releases", func() {
+		BeforeEach(func() {
+			state := generateReleases(1, 5)
+			bc := f.KubeStateSetAndWaitForBindingContexts(state, 1)
+			f.BindingContexts.Set(bc)
+			f.RunHook()
+		})
+		It("Shouldn't touch releases", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			rl1 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-28-0")
+			Expect(rl1.Field("status.phase").String()).Should(Equal("Deployed"))
+
+			ll, _ := f.KubeClient().Dynamic().Resource(schema.GroupVersionResource{Resource: "deckhousereleases", Group: "deckhouse.io", Version: "v1alpha1"}).List(context.TODO(), v1.ListOptions{})
+			Expect(ll.Items).Should(HaveLen(6))
+		})
+	})
+})
+
+func generateReleases(deployedReleasesCount, outdatedReleasesCount int) string {
+	s := strings.Builder{}
+
+	for i := 0; i < deployedReleasesCount; i++ {
+		rl := fmt.Sprintf(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1-28-%d
+spec:
+  version: "v1.28.%d"
+status:
+  phase: Deployed
+`, i, i)
+		s.WriteString(rl)
+	}
+
+	for i := 0; i < outdatedReleasesCount; i++ {
+		rl := fmt.Sprintf(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1-27-%d
+spec:
+  version: "v1.27.%d"
+status:
+  phase: Outdated
+`, i, i)
+		s.WriteString(rl)
+	}
+
+	return s.String()
+}


### PR DESCRIPTION
## Description
Hook for fixing and cleaning Deckhouse Releases

## Why do we need it, and what problem does it solve?
Old releases could have the situation when more than 1 Deployed releases exist. We have to fix this situation.
Also, we have to cleanup Outdated releases, left only last 10

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: deckhouse
type: feature
description: Cleanup deckhouse Outdated releases (> 10)
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
