### PR TITLE
[istio][ingressgateway] static port for NodePort inlet

### DIFF
--- a/ee/modules/110-istio/openapi/config-values.yaml
+++ b/ee/modules/110-istio/openapi/config-values.yaml
@@ -61,6 +61,17 @@ properties:
               - `LoadBalancer` — is a recommended method if you have a cloud-based cluster and it supports Load Balancing.
               - `NodePort` — for installations that do not have the LB.
             default: LoadBalancer
+          nodePort:
+            type: object
+            description: Special settings for NodePort inlet.
+            default: {}
+            x-examples: [{}, {"port": 30001}]
+            properties:
+              port:
+                type: integer
+                description: Static port number for NodePort-type Service. Must be in range, set by kube-apiserver --service-node-port-range argument (default is 30000-32767).
+                minimum: 1024
+                maximum: 65535
           serviceAnnotations:
             type: object
             additionalProperties:
@@ -266,7 +277,7 @@ properties:
         certManager:
           clusterIssuerName: letsencrypt
     description: |
-      What certificate type to use with Grafana/Prometheus.
+      What certificate type to use with module's public web interfaces.
 
       This parameter completely overrides the `global.modules.https` settings.
     properties:
@@ -337,7 +348,7 @@ properties:
         items:
           type: string
         description: |
-          An array of user groups that can access Grafana & Prometheus.
+          An array of user groups that can access module's public web interfaces.
 
           This parameter is used if the `user-authn` module is enabled or the `externalAuthentication` parameter is set.
 
@@ -348,7 +359,7 @@ properties:
           type: string
         x-examples:
           - [ "1.1.1.1/32" ]
-        description: An array if CIDRs that are allowed to authenticate in Grafana & Prometheus.
+        description: An array if CIDRs that are allowed to authenticate in module's public web interfaces.
       satisfyAny:
         type: boolean
         default: false

--- a/ee/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -35,6 +35,12 @@ properties:
               Способ публикации ingressgateway.
               - `LoadBalancer` — рекомендуется в случае, если площадка облачная и поддерживает LB.
               - `NodePort` — для площадок без LB.
+          nodePort:
+            description: Специальные настройки для ingressgateway с инлетом `NodePort`.
+            properties:
+              port:
+                type: integer
+                description: Статичный порт для сервиса с типом NodePort. Должен быть из диапазона, заданного аргументом kube-apiserver --service-node-port-range (по умолчанию 30000-32767).
           serviceAnnotations:
             description: Дополнительные аннотации для сервиса ingressgateway. Полезно, например, для настройки локального LB в Yandex.Cloud (аннотация `yandex.cpi.flant.com/listener-subnet-id`).
           nodeSelector:
@@ -122,7 +128,7 @@ properties:
       Если ничего не указано или указано `false` — будет [использоваться автоматика](https://deckhouse.io/ru/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).
   https:
     description: |
-      Тип сертификата используемого для Grafana/Prometheus.
+      Тип сертификата используемого для публичных веб-интерфейсов модуля.
 
       При использовании этого параметра полностью переопределяются глобальные настройки `global.modules.https`.
     properties:
@@ -169,13 +175,13 @@ properties:
           Используется, если не включен параметр `externalAuthentication`.
       allowedUserGroups:
         description: |
-          Массив групп, пользователям которых позволен доступ в Grafana и Prometheus.
+          Массив групп, пользователям которых позволен доступ в публичные веб-интерфейсы модуля.
 
           Используется, если включен модуль [user-authn](https://deckhouse.io/ru/documentation/v1/modules/150-user-authn/) или параметр `externalAuthentication`.
 
           **Внимание!** При использовании совместно с модулем [user-authn](https://deckhouse.io/ru/documentation/v1/modules/150-user-authn/) необходимо также добавить разрешенные группы в соответствующее поле в [настройках](https://deckhouse.io/ru/documentation/v1/modules/150-user-authn/cr.html#dexprovider) DexProvider.
       whitelistSourceRanges:
-        description: Массив CIDR, которым разрешено проходить авторизацию в Grafana и Prometheus.
+        description: Массив CIDR, которым разрешено проходить авторизацию в публичные веб-интерфейсы модуля.
       satisfyAny:
         description: |
           Разрешает пройти только одну из аутентификаций.

--- a/ee/modules/110-istio/template_tests/module_test.go
+++ b/ee/modules/110-istio/template_tests/module_test.go
@@ -91,6 +91,7 @@ const istioValues = `
     alliance:
       ingressGateway:
         inlet: LoadBalancer
+        nodePort: {}
     tracing: {}
 `
 

--- a/ee/modules/110-istio/templates/alliance/ingressgateway/service.yaml
+++ b/ee/modules/110-istio/templates/alliance/ingressgateway/service.yaml
@@ -16,6 +16,9 @@ spec:
   - name: tls
     port: 15443
     protocol: TCP
+  {{- if and (eq .Values.istio.alliance.ingressGateway.inlet "NodePort") .Values.istio.alliance.ingressGateway.nodePort.port }}
+    nodePort: {{ .Values.istio.alliance.ingressGateway.nodePort.port }}
+  {{- end }}
   selector:
     app: ingressgateway
   sessionAffinity: None


### PR DESCRIPTION
## Description
The module option `alliance.ingressGateway.nodePort.port` to set a static port for NodePort-type ingressgateway Service.

## Why do we need it, and what problem does it solve?
In some environments, we need to explicitly set the port number. So we will be able to configure some firewall rules for example.

## Changelog entries

```changes
module: istio
type: feature
description: `alliance.ingressGateway.nodePort.port` option to set a static port for NodePort-type ingressgateway Service.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
