### PR TITLE
Changelog CI: allow adding from external PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,6 +1,6 @@
 name: Changelog
 on:
-  pull_request:
+  pull_request_target:
     types:
       - "closed"
       - "edited"


### PR DESCRIPTION
## Description

Fixes passing secrets to the workflow for external PRs


## Why do we need it, and what problem does it solve?

Changelog workflow cannot collect changes from external PRs
