### PR TITLE
[Changelog CI] Fix missing changes

### DIFF
--- a/.github/actions/milestone-changelog/action.yml
+++ b/.github/actions/milestone-changelog/action.yml
@@ -24,11 +24,13 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
+      # Pick at most 1000 PRs with possible changes blocks
       run: |
         prs="$(gh pr list \
           --repo '${{ github.repository }}' \
           --search 'milestone:${{ steps.args.outputs.milestone_title }}' \
           --state merged \
+          --limit 1000 \
           --json number,url,title,body,state,milestone)"
         echo "::set-output name=prs::${prs}"
 


### PR DESCRIPTION
## Description

Changelog fetches only 30 last PRs since it is default `gh pr list` behavior. We ensure we get all of the changes. E.g. there at least 131 PRs for milestone v1.30.0.


## Why do we need it, and what problem does it solve?

Our changelog is incomplete.

