### PR TITLE
[istio] sipportedVersions array to module options

### DIFF
--- a/ee/modules/110-istio/docs/internal/DEVELOPMENT_RU.md
+++ b/ee/modules/110-istio/docs/internal/DEVELOPMENT_RU.md
@@ -16,7 +16,7 @@ searchable: false
 
 Для добавления новой версии:
 * Добавить images по аналогии с предыдущими версиями.
-* Добавить новую версию в values.yaml (`istio.internal.supportedVersions`).
+* Добавить новую версию в openapi/config-values.yaml (`istio.supportedVersions`).
 * Актуализировать crd-all.gen.yaml и crd-operator.yaml в папке crds.
 * Освежить дашборды графаны:
   * Извлечь json-описания дашборд из манифеста samples/addons/grafana.yaml, отформатировать их с помощью jq и сложить в соответствующие json-ки в /monitoring/grafana-dashboards/istio/XXX.json.

--- a/ee/modules/110-istio/hooks/revisions_discovery.go
+++ b/ee/modules/110-istio/hooks/revisions_discovery.go
@@ -132,7 +132,7 @@ func revisionsDiscovery(input *go_hook.HookInput, dc dependency.Container) error
 
 	var supportedRevisions []string
 
-	var supportedVersionsResult = input.Values.Get("istio.internal.supportedVersions").Array()
+	var supportedVersionsResult = input.Values.Get("istio.supportedVersions").Array()
 	for _, versionResult := range supportedVersionsResult {
 		supportedRevisions = append(supportedRevisions, versionToRevision(versionResult.String()))
 	}

--- a/ee/modules/110-istio/hooks/revisions_discovery_test.go
+++ b/ee/modules/110-istio/hooks/revisions_discovery_test.go
@@ -25,8 +25,8 @@ var _ = Describe("Istio hooks :: revisions_discovery ::", func() {
 	Context("Empty cluster and minimal settings", func() {
 		BeforeEach(func() {
 			values := `
-internal:
-  supportedVersions: ["1.2.3-beta.45"]
+supportedVersions: ["1.2.3-beta.45"]
+internal: {}
 `
 			f.ValuesSetFromYaml("istio", []byte(values))
 
@@ -49,8 +49,8 @@ internal:
 		BeforeEach(func() {
 			values := `
 globalVersion: "1.1.0"
-internal:
-  supportedVersions: ["1.0.0","1.1.0","1.5.0","1.7.4","1.8.0","1.8.0-alpha.2","1.9.0","1.2.3-beta.45"]
+supportedVersions: ["1.0.0","1.1.0","1.5.0","1.7.4","1.8.0","1.8.0-alpha.2","1.9.0","1.2.3-beta.45"]
+internal: {}
 `
 			f.ValuesSetFromYaml("istio", []byte(values))
 			f.BindingContexts.Set(f.KubeStateSet(`
@@ -177,8 +177,8 @@ metadata:
 		BeforeEach(func() {
 			values := `
 globalVersion: "1.1.0"
-internal:
-  supportedVersions: ["1.1.0","1.2.3-beta.45","1.3.1"]
+supportedVersions: ["1.1.0","1.2.3-beta.45","1.3.1"]
+internal: {}
 `
 			f.ValuesSetFromYaml("istio", []byte(values))
 			f.BindingContexts.Set(f.KubeStateSet(`

--- a/ee/modules/110-istio/openapi/config-values.yaml
+++ b/ee/modules/110-istio/openapi/config-values.yaml
@@ -2,7 +2,17 @@ type: object
 properties:
   globalVersion:
     type: string
-    x-examples: [1.8.5]
+    description: Specific version of Istio control-plane which handles unspecific versions of data-plane (namespaces with `istio-injection=enabled` label, not with `istio.io/rev=`). Must be in `supportedVersions` list. By default — the latest version in `supportedVersions`.
+    x-examples: [1.10.1]
+  supportedVersions:
+    type: array
+    description: Istio control plane supported versions list. Technical option for advanced users. The default value is under Deckhouse maintainers' control.
+    items:
+      type: string
+    default:
+    - 1.10.1
+    x-examples:
+    - ["1.10.1"]
   tlsMode:
     type: string
     enum: ["Off", MutualPermissive, Mutual]

--- a/ee/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -1,5 +1,9 @@
 type: object
 properties:
+  globalVersion:
+    description: Явно заданная версия control-plane Istio, который обслуживает data-plane с неопределённой версией (Namespace с лейблом `istio-injection=enabled`, но не `istio.io/rev=`). По умолчанию — последняя версия из списка `supportedVersions`.
+  supportedVersions:
+    description: Список поддерживаемых версий Istio control plane. Технический параметр для продвинутых пользователей, значение по умолчанию контролируется разработчиками Deckhouse.
   tlsMode:
     description: |
       Режим прозрачного шифрования трафика между Pod'ами ([Mutual TLS](https://istio.io/latest/docs/tasks/security/authentication/mtls-migration/)).

--- a/ee/modules/110-istio/openapi/values.yaml
+++ b/ee/modules/110-istio/openapi/values.yaml
@@ -83,14 +83,6 @@ properties:
           priv:
             type: string
             x-examples: ["---PRIV KEY---"]
-      supportedVersions:
-        type: array
-        items:
-          type: string
-        default:
-        - 1.10.1
-        x-examples:
-        - ["1.10.1"]
       globalRevision:
         type: string
         x-examples: [v1x10x1] # must be real


### PR DESCRIPTION
## Description
`supportedVersions` option for istio module to limit supported versions.

## Why do we need it, and what problem does it solve?
The option is needed to keep documentation about supported versions up-to-date. Also, it could be used to prevent installation of unwanted versions.

## Changelog entries

```changes
module: istio
type: fix
description: `supportedVersions` option to limit supported versions.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
