### PR TITLE
[ci] checkout sources before deploy site and docs

### DIFF
--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -210,6 +210,8 @@ jobs:
     if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' }}
     runs-on: [self-hosted, regular]
     steps:
+{!{ tmpl.Exec "checkout_full_step" $ctx | strings.Indent 6}!}
+{!{ tmpl.Exec "login_flant_registry_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "doc_version_template" | strings.Indent 6 }!}
 {!{ tmpl.Exec "deploy_doc_template" "production" | strings.Indent 6 }!}
 {!{ tmpl.Exec "deploy_site_template" "production" | strings.Indent 6 }!}
@@ -225,6 +227,8 @@ jobs:
     if: ${{ needs.git_info.outputs.ci_commit_tag != '' }}
     runs-on: [self-hosted, regular]
     steps:
+{!{ tmpl.Exec "checkout_full_step" $ctx | strings.Indent 6}!}
+{!{ tmpl.Exec "login_flant_registry_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "doc_version_template" | strings.Indent 6 }!}
 {!{ tmpl.Exec "deploy_doc_template" "stage" | strings.Indent 6 }!}
 {!{ tmpl.Exec "deploy_doc_template" "production" | strings.Indent 6 }!}

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -1883,6 +1883,23 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: checkout_full_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
+      # </template: checkout_full_step>
+
+      # <template: login_flant_registry_step>
+      - name: Login to flant registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.FLANT_REGISTRY_HOST }}
+          username: ${{ secrets.FLANT_REGISTRY_USER }}
+          password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_flant_registry_step>
+
       # <template: doc_version_template>
       - name: Set documentation version
         env:
@@ -1956,6 +1973,23 @@ jobs:
     if: ${{ needs.git_info.outputs.ci_commit_tag != '' }}
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: checkout_full_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
+      # </template: checkout_full_step>
+
+      # <template: login_flant_registry_step>
+      - name: Login to flant registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ${{ secrets.FLANT_REGISTRY_HOST }}
+          username: ${{ secrets.FLANT_REGISTRY_USER }}
+          password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_flant_registry_step>
 
       # <template: doc_version_template>
       - name: Set documentation version


### PR DESCRIPTION
## Description

werf converge requires checkout.

## Why do we need it, and what problem does it solve?

Checkout is a must for self-hosted runners. We end up deploying site and documentation to production environment using images built 2 days ago from PR.

<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

