### PR TITLE
[cert-manager] Add dynamic annotation for orphan-secrets alert description

### DIFF
--- a/modules/101-cert-manager/hooks/legacy_orphan_secrets_metrics.go
+++ b/modules/101-cert-manager/hooks/legacy_orphan_secrets_metrics.go
@@ -83,6 +83,7 @@ func legacyOrphanSecretsMetrics(input *go_hook.HookInput) error {
 			map[string]string{
 				"namespace":   secretInfoVal.Namespace,
 				"secret_name": secretInfoVal.Name,
+				"annotation":  "certmanager.k8s.io/certificate-name",
 			},
 			metrics.WithGroup(legacyMetricsGroup),
 		)

--- a/modules/101-cert-manager/hooks/legacy_orphan_secrets_metrics_test.go
+++ b/modules/101-cert-manager/hooks/legacy_orphan_secrets_metrics_test.go
@@ -129,6 +129,7 @@ type: kubernetes.io/tls
 				Labels: map[string]string{
 					"namespace":   "d8-dashboard",
 					"secret_name": "ingress-tls",
+					"annotation":  "certmanager.k8s.io/certificate-name",
 				},
 			}
 			Expect(ops[1]).To(BeEquivalentTo(expectedMetric))

--- a/modules/101-cert-manager/hooks/orphan_secrets_metrics.go
+++ b/modules/101-cert-manager/hooks/orphan_secrets_metrics.go
@@ -142,6 +142,7 @@ func orphanSecretsMetrics(input *go_hook.HookInput) error {
 			map[string]string{
 				"namespace":   secretInfoVal.Namespace,
 				"secret_name": secretInfoVal.Name,
+				"annotation":  "cert-manager.io/certificate-name",
 			},
 			metrics.WithGroup(metricsGroup),
 		)

--- a/modules/101-cert-manager/hooks/orphan_secrets_metrics_test.go
+++ b/modules/101-cert-manager/hooks/orphan_secrets_metrics_test.go
@@ -127,6 +127,7 @@ type: kubernetes.io/tls
 				Labels: map[string]string{
 					"namespace":   "non-d8-dashboard",
 					"secret_name": "ingress-tls",
+					"annotation":  "cert-manager.io/certificate-name",
 				},
 			}
 			Expect(ops[1]).To(BeEquivalentTo(expectedMetric))

--- a/modules/101-cert-manager/monitoring/prometheus-rules/certificate.yaml
+++ b/modules/101-cert-manager/monitoring/prometheus-rules/certificate.yaml
@@ -49,15 +49,16 @@
 - name: kubernetes.certmanager.orphan_certificate
   rules:
     - alert: D8CertmanagerOrphanSecretsWithoutCorrespondingCertificateResources
-      expr: max by (namespace, secret_name) (d8_orphan_secrets_without_corresponding_certificate_resources==1)
+      expr: max by (namespace, secret_name, annotation) (d8_orphan_secrets_without_corresponding_certificate_resources==1)
       labels:
         severity_level: "8"
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
         plk_incident_initial_status: "todo"
+        plk_ignore_labels: "annotation"
         plk_create_group_if_not_exists__d8_certmanager_orphan_secrets_checks_failed: D8CertmanagerOrphanSecretsChecksFailed,tier=~tier
         plk_grouped_by__d8_certmanager_orphan_secrets_checks_failed: D8CertmanagerOrphanSecretsChecksFailed,tier=~tier
         description: |
-          Secret {{$labels.namespace}}/{{$labels.secret_name}} has link to non-existent Certificate resource. It is probably garbage. Either delete the secret or remove the `certmanager.k8s.io/certificate-name` label.
+          Secret {{$labels.namespace}}/{{$labels.secret_name}} has link to non-existent Certificate resource. It is probably garbage. Either delete the secret or remove the `{{$labels.annotation}}` label.
         summary: Secret without corresponding Certificate CR


### PR DESCRIPTION
## Description
Add dynamic annotation for alert description

## Why do we need it, and what problem does it solve?
We have 2 hooks for orphan secrets - for legacy and actual cert-manager. But annotation was hardcoded into the alert's description. I propose to add label with desired annotation and pass it to the description

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: cert-manager
type: feature
description: Actualize annotation to delete in the orphan secrets alert description
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
