### PR TITLE
[site] Use the Stable version of the documentation by default

### DIFF
--- a/docs/site/.helm/values.yaml
+++ b/docs/site/.helm/values.yaml
@@ -11,7 +11,7 @@ resources:
 vrouter:
   defaultGroup: "v1"
   defaultChannel: "stable"
-  defaultChannel4DefaultGroup: "latest"
+  defaultChannel4DefaultGroup: "v1-stable"
   showLatestChannel: "true"
   i18nType: "location"
   logLevel:


### PR DESCRIPTION
Use the Stable version of the documentation by default on the site (instead of the Latest version).
