### PR TITLE
[prometheus][deckhouse] Add supporting ServiceMonitors and PodMonitors from user-space

### DIFF
--- a/modules/020-deckhouse/templates/namespace.yaml
+++ b/modules/020-deckhouse/templates/namespace.yaml
@@ -5,7 +5,7 @@ metadata:
   name: d8-monitoring
   annotations:
     extended-monitoring.flant.com/enabled: ""
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/monitor-watcher-enabled" "true")) | nindent 2 }}
 ---
 apiVersion: v1
 kind: Namespace

--- a/modules/300-prometheus/docs/FAQ.md
+++ b/modules/300-prometheus/docs/FAQ.md
@@ -328,3 +328,33 @@ spec:
 
 After the resources deployment, Prometheus metrics will be available at address `lens-proxy/prometheus-lens-proxy:8080`.
 Lens Prometheus type - `Prometheus Operator`.
+
+## How do I set up a ServiceMonitor or PodMonitor to work with Prometheus?
+
+Add the `prometheus: main` label to the PodMonitor or ServiceMonitor.
+Add the label `prometheus.deckhouse.io/monitor-watcher-enabled: "true"` to the namespace where the PodMonitor or ServiceMonitor was created.
+
+Example:
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: frontend
+  labels:
+    prometheus.deckhouse.io/monitor-watcher-enabled: "true"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: example-app
+  namespace: frontend
+  labels:
+    prometheus: main
+spec:
+  selector:
+    matchLabels:
+      app: example-app
+  endpoints:
+    - port: web
+```

--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -328,3 +328,33 @@ spec:
 
 После деплоя ресурсов, метрики Prometheus будут доступны по адресу `lens-proxy/prometheus-lens-proxy:8080`.
 Тип Prometheus в Lens - `Prometheus Operator`.
+
+## Как настроить ServiceMonitor или PodMonitor для работы с Prometheus? 
+
+Добавьте лейбл `prometheus: main` к Pod/Service Monitor.
+Добавьте в namespace, в котором находится Pod/Service Monitor, лейбл `prometheus.deckhouse.io/monitor-watcher-enabled: "true"`. 
+
+Пример:
+```yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: frontend
+  labels:
+    prometheus.deckhouse.io/monitor-watcher-enabled: "true"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: example-app
+  namespace: frontend
+  labels:
+    prometheus: main
+spec:
+  selector:
+    matchLabels:
+      app: example-app
+  endpoints:
+    - port: web
+```

--- a/modules/300-prometheus/docs/internal/PROMETHEUS_TARGETS_DEVELOPMENT.md
+++ b/modules/300-prometheus/docs/internal/PROMETHEUS_TARGETS_DEVELOPMENT.md
@@ -11,6 +11,7 @@ General information
 * The most common operation is adding a target for a new application (redis, rabbitmq, etc.). In most cases, you only need to copy one of the existing service monitors in the `applications` directory and edit the names.
 * However, if you need to do something more complex or mere copying does not produce the expected result, refer to the [Prometheus Operator](../../modules/200-operator-prometheus/) module documentation.
 * All existing targets are located in the `prometheus-targets` directory. They usually consist of a service monitor, some Prometheus exporter, and the necessary wrapping that binds them together.
+* All internal ServiceMonitors and PodMonitors should be created in the namespace `d8-monitoring`.
 
 Best practices
 ---------------

--- a/modules/300-prometheus/docs/internal/PROMETHEUS_TARGETS_DEVELOPMENT_RU.md
+++ b/modules/300-prometheus/docs/internal/PROMETHEUS_TARGETS_DEVELOPMENT_RU.md
@@ -11,6 +11,7 @@ search: Разработка target'ов Prometheus, prometheus target
 * Наиболее частая операция — добавление target'а для нового application'а (Redis, RabbitMQ и др.). Скорей всего для этого будет достаточно просто скопировать один из существующих service monitor'ов в директории `applications` и поправить названия.
 * Но если вам нужно сделать что-то более сложное, или если простое копирование не дает ожидаемого результата — придется разбираться и читать документацию модуля [Prometheus Operator](../../modules/200-operator-prometheus/).
 * Все существующие target'ы лежат в директории `prometheus-targets`, они обычно состоят из service monitor'а, некоторого exporter'а для Prometheus и необходимой обвязки, которая их стыкует.
+* Все внутренние ServiceMonitor'ы и PodMonitor'ы deckhouse должны быть созданы в неймспейсе `d8-monitoring`.
 
 Лучшие практики
 ---------------

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -93,10 +93,10 @@ spec:
   serviceAccountName: prometheus
   podMonitorNamespaceSelector:
     matchLabels:
-      heritage: deckhouse
+      prometheus.deckhouse.io/monitor-watcher-enabled: "true"
   serviceMonitorNamespaceSelector:
     matchLabels:
-      heritage: deckhouse
+      prometheus.deckhouse.io/monitor-watcher-enabled: "true"
   ruleNamespaceSelector:
     matchLabels:
       heritage: deckhouse

--- a/modules/340-monitoring-custom/monitoring/prometheus-rules/warnings/warnings.yaml
+++ b/modules/340-monitoring-custom/monitoring/prometheus-rules/warnings/warnings.yaml
@@ -1,6 +1,6 @@
 - name: d8.monitoring-custom.warnings
   rules:
-  - alert: D8CustomServiceMonitorFoundInCluster
+  - alert: CustomServiceMonitorFoundInD8Namespace
     expr: |
       max(d8_monitoring_custom_unknown_service_monitor_total{job="deckhouse"} > 0)
     labels:
@@ -11,16 +11,16 @@
       plk_incident_initial_status: "todo"
       plk_grouped_by__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,prometheus=deckhouse"
       description: |-
-        There are ServiceMonitors in the cluster that were not created by Deckhouse.
+        There are ServiceMonitors in Deckhouse namespace that were not created by Deckhouse.
 
         Use the following command for filtering: `kubectl get servicemonitors --all-namespaces -l heritage!=deckhouse`.
 
-        They must be abandoned and replaced with the Deckhouse-specific project customization solutions.
+        They must be moved from Deckhouse namespace to user-spec namespace (was not labeled as `heritage: deckhouse`).
 
         The detailed description of the metric collecting process is available in the [documentation](https://deckhouse.io/en/documentation/v1/modules/300-prometheus/faq.html).
-      summary: There are ServiceMonitors in the cluster that were not created by Deckhouse.
+      summary: There are ServiceMonitors in Deckhouse namespace that were not created by Deckhouse.
 
-  - alert: D8CustomPodMonitorFoundInCluster
+  - alert: CustomPodMonitorFoundInCluster
     expr: |
       max(d8_monitoring_custom_unknown_pod_monitor_total{job="deckhouse"} > 0)
     labels:
@@ -31,14 +31,14 @@
       plk_incident_initial_status: "todo"
       plk_grouped_by__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,prometheus=deckhouse"
       description: |-
-        There are PodMonitors in the cluster that were not created by Deckhouse.
+        There are PodMonitors in Deckhouse namespace that were not created by Deckhouse.
 
         Use the following command for filtering: `kubectl get podmonitors --all-namespaces -l heritage!=deckhouse`.
 
-        They must be abandoned and replaced with the Deckhouse-specific project customization solutions.
+        They must be moved from Deckhouse namespace to user-spec namespace (was not labeled as `heritage: deckhouse`).
 
         The detailed description of the metric collecting process is available in the [documentation](https://deckhouse.io/en/documentation/v1/modules/300-prometheus/faq.html).
-      summary: There are PodMonitors in the cluster that were not created by Deckhouse.
+      summary: There are PodMonitors in Deckhouse namespace that were not created by Deckhouse.
 
   - alert: D8CustomPrometheusRuleFoundInCluster
     expr: |


### PR DESCRIPTION
## Description
Change `podMonitorNamespaceSelector` and `serviceMonitorNamespaceSelector` from label `heritage: deckhouse` to new custom `prometheus.deckhouse.io/monitor-watcher-enabled` label. Because we do not want give an opportunity for usage `heritage: deckhouse` label for non-deckhouse namespaces, but we need pass namespace selectors into Prometheus resource. We can not implement OR logic with LabelSelector and we should change labels.

Add `prometheus.deckhouse.io/monitor-watcher-enabled` to `d8-monitoring` namespace. All own Pod and Service Monitor located in `d8-monitoring` namespace.

Add FAQ for connect user-space Service/Pod Monitors to Prometheus.

Change alert description about custom monitors.

Custom monitors alert logic did not change, because it already has correct logic.

## Why do we need it, and what problem does it solve?

There is no way to connect custom ServiceMonitor to Prometheus from Deckhouse. However, all modern helm charts are bundled with a ServiceMonitor. Users have to alter charts to provide monitoring.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: prometheus
type: feature
description: Add supporting ServiceMonitors and PodMonitors from user-space
note: Prometheus will be restarted
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
```

-->
