### PR TITLE
[site] Fix getting started

### DIFF
--- a/docs/site/_includes/getting_started/bm/step_cluster_setup.html
+++ b/docs/site/_includes/getting_started/bm/step_cluster_setup.html
@@ -7,11 +7,12 @@
     </label>
     <input class="textfield"
       type="text" id="clusterdomain"
-      name="domain" placeholder="%s.example.com"
+      name="domain" placeholder="%s.domain.my"
       autocomplete="off" />
-    <span class="info invalid-message">Enter a domain name template containing <code>%s</code>, e.g., <code>%s.example.com</code> or <code>%s-kube.example.com</code>.</span>
+    <span class="info invalid-message">Enter a domain name template containing <code>%s</code>, e.g., <code>%s.domain.my</code> or <code>%s-kube.domain.my</code>.</span>
+    <span class="info invalid-message invalid-message-example-com">Please don't use the <code>example.com</code> domain name.</span>
     <span class="info">
-      This template is used for system apps domains within the cluster, e.g., Grafana for <code>%s.example.com</code> will be available as <code>grafana.example.com</code>.<br />
+      This template is used for system apps domains within the cluster, e.g., Grafana for <code>%s.domain.my</code> will be available as <code>grafana.domain.my</code>.<br />
       This tutorial assumes the use of a public domain directed to a public cluster address.
       This is necessary to obtain <a href="https://letsencrypt.org/">Let's Encrypt</a> certificates for Deckhouse services.
       If using existing certificates (including Self-Signed), you need to change the <a href="/en/documentation/v1/deckhouse-configure-global.html#parameters">global settings</a> in the <code>modules.https</code> section.
@@ -20,5 +21,5 @@
 </div>
 
 <script type="text/javascript">
-{% include getting_started/global/partials/getting-started-setup.js %}
+{% include getting_started/global/partials/getting-started-setup.js.liquid %}
 </script>

--- a/docs/site/_includes/getting_started/bm/step_cluster_setup_ru.html
+++ b/docs/site/_includes/getting_started/bm/step_cluster_setup_ru.html
@@ -7,11 +7,12 @@
     </label>
     <input class="textfield"
       type="text" id="clusterdomain"
-      name="domain" placeholder="%s.example.com"
+      name="domain" placeholder="%s.domain.my"
       autocomplete="off" />
-    <span class="info invalid-message">Введите шаблон доменного имени, содержащий <code>%s</code>, например <code>%s.example.com</code> или <code>%s-kube.example.com</code>.</span>
+    <span class="info invalid-message">Введите шаблон доменного имени, содержащий <code>%s</code>, например <code>%s.domain.my</code> или <code>%s-kube.domain.my</code>.</span>
+    <span class="info invalid-message invalid-message-example-com">Пожалуйста, не используйте домен <code>example.com</code> в шаблоне.</span>
     <span class="info">
-      Используется для формирования доменных имён системных приложений в кластере. Например, Grafana для шаблона <code>%s.example.com</code> будет доступна как <code>grafana.example.com</code>.<br />
+      Используется для формирования доменных имён системных приложений в кластере. Например, Grafana для шаблона <code>%s.domain.my</code> будет доступна как <code>grafana.domain.mym</code>.<br />
       В данном руководстве предполагается использование публичного домена, направленного на публичный адрес кластера.
       Это необходимо для получения сертификатов <a href="https://letsencrypt.org/">Let's Encrypt</a> сервисам Deckhouse.
       В случае использования уже имеющихся сертификатов (включая Self-Signed), необходимо изменить <a href="https://deckhouse.io/ru/documentation/v1/deckhouse-configure-global.html#параметры">глобальные настройки</a> в секции <code>modules.https</code>.
@@ -20,5 +21,5 @@
 </div>
 
 <script type="text/javascript">
-{% include getting_started/global/partials/getting-started-setup.js %}
+{% include getting_started/global/partials/getting-started-setup.js.liquid %}
 </script>

--- a/docs/site/_includes/getting_started/global/partials/getting-started-setup.js.liquid
+++ b/docs/site/_includes/getting_started/global/partials/getting-started-setup.js.liquid
@@ -25,9 +25,12 @@ $(document).ready(function(){
   let publicDomainTemplatePattern = /^([a-zA-Z0-9][a-zA-Z0-9-.]+)?%s([a-zA-Z0-9-]+)?\.[a-zA-Z0-9-.]+/;
   restoreData();
 	$('#clusterdomain').change(function(){
-	    if (!$(this).val().match(publicDomainTemplatePattern)) {
+	    if (!$(this).val().match(publicDomainTemplatePattern))  {
             $(this).addClass('invalid');
-            $(this).parent().find('.invalid-message').addClass('active');
+            $(this).parent().find('.invalid-message-main').addClass('active');
+        } else if ($(this).val().match(/\.example\.com/))  {
+            $(this).addClass('invalid');
+            $(this).parent().find('.invalid-message-example-com').addClass('active');
         } else {
             $(this).removeClass('invalid');
             $(this).parent().find('.invalid-message').removeClass('active');

--- a/docs/site/_includes/getting_started/global/step_cluster_setup.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup.html
@@ -7,11 +7,12 @@
     </label>
     <input class="textfield"
       type="text" id="clusterdomain"
-      name="domain" placeholder="%s.example.com"
+      name="domain" placeholder="%s.domain.my"
       autocomplete="off" />
-    <span class="info invalid-message">Enter a domain name template containing <code>%s</code>, e.g., <code>%s.example.com</code> or <code>%s-kube.example.com</code>.</span>
+    <span class="info invalid-message invalid-message-main">Enter a domain name template containing <code>%s</code>, e.g., <code>%s.domain.my</code> or <code>%s-kube.domain.my</code>.</span>
+    <span class="info invalid-message invalid-message-example-com">Please don't use the <code>example.com</code> domain name.</span>
     <span class="info">
-      This template is used for system apps domains within the cluster, e.g., Grafana for <code>%s.example.com</code> will be available as <code>grafana.example.com</code>.<br />
+      This template is used for system apps domains within the cluster, e.g., Grafana for <code>%s.domain.my</code> will be available as <code>grafana.domain.my</code>.<br />
       This tutorial assumes the use of a public domain directed to a public cluster address.
       This is necessary to obtain <a href="https://letsencrypt.org/">Let's Encrypt</a> certificates for Deckhouse services.
       If using existing certificates (including Self-Signed), you need to change the <a href="/en/documentation/v1/deckhouse-configure-global.html#parameters">global settings</a> in the <code>modules.https</code> section.
@@ -88,5 +89,5 @@ Preset — the structure of nodes in the cluster. There are several pre-defined 
 {% endfor %}
 
 <script type="text/javascript">
-{% include getting_started/global/partials/getting-started-setup.js %}
+{% include getting_started/global/partials/getting-started-setup.js.liquid %}
 </script>

--- a/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
@@ -7,11 +7,12 @@
     </label>
     <input class="textfield"
       type="text" id="clusterdomain"
-      name="domain" placeholder="%s.example.com"
+      name="domain" placeholder="%s.domain.my"
       autocomplete="off" />
-    <span class="info invalid-message">Введите шаблон доменного имени, содержащий <code>%s</code>, например <code>%s.example.com</code> или <code>%s-kube.example.com</code>.</span>
+    <span class="info invalid-message invalid-message-main">Введите шаблон доменного имени, содержащий <code>%s</code>, например <code>%s.domain.my</code> или <code>%s-kube.domain.my</code>. Пожалуйста, не используйте домен <code>example.com</code>.</span>
+    <span class="info invalid-message invalid-message-example-com">Пожалуйста, не используйте домен <code>example.com</code> в шаблоне.</span>
     <span class="info">
-      Используется для формирования доменов системных приложений в кластере. Например, Grafana для шаблона <code>%s.example.com</code> будет доступна как <code>grafana.example.com</code>.<br />
+      Используется для формирования доменов системных приложений в кластере. Например, Grafana для шаблона <code>%s.domain.my</code> будет доступна как <code>grafana.domain.my</code>.<br />
       В данном руководстве предполагается использование публичного домена, направленного на публичный адрес кластера.
       Это необходимо для получения сертификатов <a href="https://letsencrypt.org/">Let's Encrypt</a> сервисам Deckhouse.
       В случае использования уже имеющихся сертификатов (включая Self-Signed), необходимо изменить <a href="/ru/documentation/v1/deckhouse-configure-global.html#параметры">глобальные настройки</a> в секции <code>modules.https</code>.
@@ -85,5 +86,5 @@
 {% endfor %}
 
 <script type="text/javascript">
-{% include getting_started/global/partials/getting-started-setup.js %}
+{% include getting_started/global/partials/getting-started-setup.js.liquid %}
 </script>


### PR DESCRIPTION
Don't let use the `example.com` in publicDomainTemplate in Getting Started.