### PR TITLE
[user-authz] Doc: fix subject access groups option name

### DIFF
--- a/modules/140-user-authz/docs/USAGE.md
+++ b/modules/140-user-authz/docs/USAGE.md
@@ -218,7 +218,7 @@ Changes to the `kube-apiserver` manifest that will occur after enabling multi-te
 Execute the command below with the following parameters:
 * `resourceAttributes` (the same as in RBAC) - target resources;
 * `user` - the name of the user;
-* `group` - user groups;
+* `groups` - user groups;
 
 P.S. You can use Dex logs to find out groups and a username if this module is used together with the `user-authn` module (`kubectl -n d8-user-authn logs -l app=dex`); logs available only if the user is authorized).
 
@@ -235,7 +235,7 @@ cat  <<EOF | 2>&1 kubectl  create --raw  /apis/authorization.k8s.io/v1/subjectac
       "resource": "pods"
     },
     "user": "system:kube-controller-manager",
-    "group": [
+    "groups": [
       "Admins"
     ]
   }
@@ -267,7 +267,7 @@ cat  <<EOF | 2>&1 kubectl --kubeconfig /etc/kubernetes/deckhouse/extra-files/web
       "resource": "pods"
     },
     "user": "system:kube-controller-manager",
-    "group": [
+    "groups": [
       "Admins"
     ]
   }

--- a/modules/140-user-authz/docs/USAGE_RU.md
+++ b/modules/140-user-authz/docs/USAGE_RU.md
@@ -219,7 +219,7 @@ spec:
 Необходимо выполнить следующую команду, в которой будут указаны:
 * `resourceAttributes` (как в RBAC) — к чему мы проверяем доступ
 * `user` — имя пользователя
-* `group` — группы пользователя
+* `groups` — группы пользователя
 
 P.S. При совместном использовании с модулем `user-authn`, группы и имя пользователя можно посмотреть в логах Dex — `kubectl -n d8-user-authn logs -l app=dex` (видны только при авторизации)
 
@@ -236,7 +236,7 @@ cat  <<EOF | 2>&1 kubectl  create --raw  /apis/authorization.k8s.io/v1/subjectac
       "resource": "pods"
     },
     "user": "system:kube-controller-manager",
-    "group": [
+    "groups": [
       "Admins"
     ]
   }
@@ -268,7 +268,7 @@ cat  <<EOF | 2>&1 kubectl --kubeconfig /etc/kubernetes/deckhouse/extra-files/web
       "resource": "pods"
     },
     "user": "system:kube-controller-manager",
-    "group": [
+    "groups": [
       "Admins"
     ]
   }


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Fix doc

## Why do we need it, and what problem does it solve?
The right option is the `groups`
