### PR TITLE
[ci] Fix google cloud platform e2e test running

### DIFF
--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -11,7 +11,7 @@ const labels = {
   e2e: [
     'e2e/run/aws',
     'e2e/run/azure',
-    'e2e/run/gce',
+    'e2e/run/gcp',
     'e2e/run/openstack',
     'e2e/run/vsphere',
     'e2e/run/yandex-cloud',
@@ -66,7 +66,7 @@ module.exports.labelsSrv = {
 const providers = [
   //
   'aws',
-  'gce',
+  'gcp',
   'azure',
   'openstack',
   'yandex-cloud',


### PR DESCRIPTION
## Description
Fix google cloud platform e2e test running

## Why do we need it, and what problem does it solve?
Google cloud platform e2e tests don't run

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
