### PR TITLE
[docs] OpenAPI generation updates

### DIFF
--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -223,12 +223,7 @@ spec:
                         List of availability zones to create instances in.
 
                         The default value depends on the cloud provider selected and usually corresponds to all zones of the region being used.
-                      x-doc-example: |
-                        ```yaml
-                        - Helsinki
-                        - Espoo
-                        - Tampere
-                        ```
+                      x-doc-example: [["Helsinki","Espoo","Tampere"]]
                       type: array
                       items:
                         type: string

--- a/docs/documentation/_data/i18n.yml
+++ b/docs/documentation/_data/i18n.yml
@@ -53,6 +53,9 @@ common:
   example:
     en: example
     ru: пример
+  examples:
+    en: examples
+    ru: примеры
   x-kubernetes-int-or-string:
     en: integer or string
     ru: строка или число
@@ -62,6 +65,12 @@ common:
   length:
     en: length
     ru: длина
+  min_length:
+    en: minimal length
+    ru: минимальная длина
+  max_length:
+    en: maximum length
+    ru: максимальная длина
   required_value_sentence:
     en: Required value
     ru: Обязательный параметр


### PR DESCRIPTION
## Description
OpenAPI specification site render updates:
- Show examples from OpenAPI specs as YAML
- Don't  show minimal length for string type if it is 1

## Changelog entries
```changes
module: documentation
type: fix
description: Show examples from OpenAPI specs (module configuration and CR page) as YAML.
```