### PR TITLE
[deckhouse] Add image pull policy Always to deckhouse template

### DIFF
--- a/modules/020-deckhouse/templates/deployment.yaml
+++ b/modules/020-deckhouse/templates/deployment.yaml
@@ -75,6 +75,7 @@ spec:
           command:
             - /deckhouse/deckhouse
           image: {{ .Values.deckhouse.internal.currentReleaseImageName }}
+          imagePullPolicy: Always
           env:
 {{- if not .Values.global.clusterIsBootstrapped }}
 # KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT are needed on the bootstrap phase to make Deckhouse work without kube-proxy


### PR DESCRIPTION
## Description
Add image pull policy Always to deckhouse template

## Why do we need it, and what problem does it solve?
Prevent to restart deckhouse with incorrect creds passed into `deckhouse-registry` secret  

## Changelog entries

```changes
module: deckhouse
type: fix
description: Add image pull policy Always to deckhouse template
note: Deckhouse-controller can be restarted while updating
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
