### PR TITLE
[vertical-pod-autoscaler] vpa improvements

### DIFF
--- a/ee/modules/110-istio/templates/alliance/metadata-exporter/deployment.yaml
+++ b/ee/modules/110-istio/templates/alliance/metadata-exporter/deployment.yaml
@@ -6,7 +6,7 @@ kind: VerticalPodAutoscaler
 metadata:
   name: metadata-exporter
   namespace: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "metadata-exporter" "workload-resource-policy.deckhouse.io" "every-node")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "metadata-exporter")) | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"

--- a/ee/modules/110-istio/templates/kiali/deployment.yaml
+++ b/ee/modules/110-istio/templates/kiali/deployment.yaml
@@ -5,7 +5,7 @@ kind: VerticalPodAutoscaler
 metadata:
   name: kiali
   namespace: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "kiali" "workload-resource-policy.deckhouse.io" "every-node")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kiali")) | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"

--- a/ee/modules/110-istio/templates/operator/deployment.yaml
+++ b/ee/modules/110-istio/templates/operator/deployment.yaml
@@ -6,7 +6,7 @@ kind: VerticalPodAutoscaler
 metadata:
   name: operator-{{ $revision }}
   namespace: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list $ (dict "app" "operator" "revision" $revision "workload-resource-policy.deckhouse.io" "every-node")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list $ (dict "app" "operator" "revision" $revision)) | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"

--- a/modules/302-vertical-pod-autoscaler/hooks/set_maxallowed.go
+++ b/modules/302-vertical-pod-autoscaler/hooks/set_maxallowed.go
@@ -344,7 +344,6 @@ func containerPoliciesTreshold(newPolicies []autoscaler.ContainerResourcePolicy,
 			}
 		}
 	}
-	return
 }
 
 func isInfinity(value float64) bool {

--- a/modules/302-vertical-pod-autoscaler/hooks/set_maxallowed.go
+++ b/modules/302-vertical-pod-autoscaler/hooks/set_maxallowed.go
@@ -323,20 +323,20 @@ func getPathFloat64(input *go_hook.HookInput, path string) (float64, error) {
 }
 
 func containerPoliciesTreshold(newPolicies []autoscaler.ContainerResourcePolicy, oldPolicies []autoscaler.ContainerResourcePolicy) {
-	for i, newPolicy := range newPolicies {
-		cpu := newPolicy.MaxAllowed.Cpu().MilliValue()
-		memory := newPolicy.MaxAllowed.Memory().Value()
-		for _, oldPolicy := range oldPolicies {
-			if oldPolicy.ContainerName != newPolicy.ContainerName {
+	for i := range newPolicies {
+		cpu := newPolicies[i].MaxAllowed.Cpu().MilliValue()
+		memory := newPolicies[i].MaxAllowed.Memory().Value()
+		for j := range oldPolicies {
+			if oldPolicies[j].ContainerName != newPolicies[i].ContainerName {
 				continue
 			}
-			cpuPercent := calculatePercent(cpu, oldPolicy.MaxAllowed.Cpu().MilliValue())
-			memoryPercent := calculatePercent(memory, oldPolicy.MaxAllowed.Memory().Value())
+			cpuPercent := calculatePercent(cpu, oldPolicies[j].MaxAllowed.Cpu().MilliValue())
+			memoryPercent := calculatePercent(memory, oldPolicies[j].MaxAllowed.Memory().Value())
 			if inTreshold(cpuPercent) {
-				cpu = oldPolicy.MaxAllowed.Cpu().MilliValue()
+				cpu = oldPolicies[j].MaxAllowed.Cpu().MilliValue()
 			}
 			if inTreshold(memoryPercent) {
-				memory = oldPolicy.MaxAllowed.Memory().Value()
+				memory = oldPolicies[j].MaxAllowed.Memory().Value()
 			}
 			newPolicies[i].MaxAllowed = v1.ResourceList{
 				v1.ResourceCPU:    *resource.NewMilliQuantity(cpu, resource.BinarySI),

--- a/modules/302-vertical-pod-autoscaler/hooks/set_maxallowed_test.go
+++ b/modules/302-vertical-pod-autoscaler/hooks/set_maxallowed_test.go
@@ -264,10 +264,10 @@ status:
 	Context("Cluster with two VPAs without container recommendationsm Deckhouse pod is ready", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(DeckhousePodIsReady + TwoVpasWithoutRecommendations))
-			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuMaster", "1024")
-			f.ValuesSet("global.internal.modules.resourcesRequests.memoryMaster", "520093696")
-			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuEveryNode", "1024")
-			f.ValuesSet("global.internal.modules.resourcesRequests.memoryEveryNode", "520093696")
+			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuMaster", 1024)
+			f.ValuesSet("global.internal.modules.resourcesRequests.memoryMaster", 520093696)
+			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuEveryNode", 1024)
+			f.ValuesSet("global.internal.modules.resourcesRequests.memoryEveryNode", 520093696)
 			f.RunHook()
 		})
 
@@ -293,10 +293,10 @@ name: node-exporter
 	})
 	Context("Cluster with two VPAs and set of global.internal.modules.resourcesRequests variables, Deckhouse pod is ready", func() {
 		BeforeEach(func() {
-			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuMaster", "1850")
-			f.ValuesSet("global.internal.modules.resourcesRequests.memoryMaster", "3864053781")
-			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuEveryNode", "300")
-			f.ValuesSet("global.internal.modules.resourcesRequests.memoryEveryNode", "536870912")
+			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuMaster", 1850)
+			f.ValuesSet("global.internal.modules.resourcesRequests.memoryMaster", 3864053781)
+			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuEveryNode", 300)
+			f.ValuesSet("global.internal.modules.resourcesRequests.memoryEveryNode", 536870912)
 			f.BindingContexts.Set(f.KubeStateSet(DeckhousePodIsReady + TwoVpas))
 			f.RunHook()
 		})
@@ -344,10 +344,10 @@ name: node-exporter
 	Context("Cluster with two VPAs, and another set of global.internal.modules.resourcesRequests variables, Deckhouse pod is ready", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(DeckhousePodIsReady + TwoVpas))
-			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuMaster", "4096")
-			f.ValuesSet("global.internal.modules.resourcesRequests.memoryMaster", "8589934592")
-			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuEveryNode", "750")
-			f.ValuesSet("global.internal.modules.resourcesRequests.memoryEveryNode", "134217728")
+			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuMaster", 4096)
+			f.ValuesSet("global.internal.modules.resourcesRequests.memoryMaster", 8589934592)
+			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuEveryNode", 750)
+			f.ValuesSet("global.internal.modules.resourcesRequests.memoryEveryNode", 134217728)
 			f.RunHook()
 		})
 
@@ -395,10 +395,10 @@ name: node-exporter
 	Context("Cluster with two VPAs, maxAllowed values near newly calculated values, Deckhouse pod is ready", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(DeckhousePodIsReady + TwoVpasInTreshold))
-			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuMaster", "4096")
-			f.ValuesSet("global.internal.modules.resourcesRequests.memoryMaster", "8589934592")
-			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuEveryNode", "750")
-			f.ValuesSet("global.internal.modules.resourcesRequests.memoryEveryNode", "134217728")
+			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuMaster", 4096)
+			f.ValuesSet("global.internal.modules.resourcesRequests.memoryMaster", 8589934592)
+			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuEveryNode", 750)
+			f.ValuesSet("global.internal.modules.resourcesRequests.memoryEveryNode", 134217728)
 			f.RunHook()
 		})
 

--- a/modules/302-vertical-pod-autoscaler/hooks/set_maxallowed_test.go
+++ b/modules/302-vertical-pod-autoscaler/hooks/set_maxallowed_test.go
@@ -250,7 +250,7 @@ status:
 		})
 
 	})
-	Context("Cluster without global.modules.resourcesRequests.internal variables, Deckhouse pod is ready", func() {
+	Context("Cluster without global.internal.modules.resourcesRequests variables, Deckhouse pod is ready", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(DeckhousePodIsReady))
 			f.RunHook()
@@ -264,10 +264,10 @@ status:
 	Context("Cluster with two VPAs without container recommendationsm Deckhouse pod is ready", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(DeckhousePodIsReady + TwoVpasWithoutRecommendations))
-			f.ValuesSet("global.modules.resourcesRequests.internal.milliCpuMaster", "1024")
-			f.ValuesSet("global.modules.resourcesRequests.internal.memoryMaster", "520093696")
-			f.ValuesSet("global.modules.resourcesRequests.internal.milliCpuEveryNode", "1024")
-			f.ValuesSet("global.modules.resourcesRequests.internal.memoryEveryNode", "520093696")
+			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuMaster", "1024")
+			f.ValuesSet("global.internal.modules.resourcesRequests.memoryMaster", "520093696")
+			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuEveryNode", "1024")
+			f.ValuesSet("global.internal.modules.resourcesRequests.memoryEveryNode", "520093696")
 			f.RunHook()
 		})
 
@@ -291,12 +291,12 @@ name: node-exporter
 `))
 		})
 	})
-	Context("Cluster with two VPAs and set of global.modules.resourcesRequests.internal variables, Deckhouse pod is ready", func() {
+	Context("Cluster with two VPAs and set of global.internal.modules.resourcesRequests variables, Deckhouse pod is ready", func() {
 		BeforeEach(func() {
-			f.ValuesSet("global.modules.resourcesRequests.internal.milliCpuMaster", "1850")
-			f.ValuesSet("global.modules.resourcesRequests.internal.memoryMaster", "3864053781")
-			f.ValuesSet("global.modules.resourcesRequests.internal.milliCpuEveryNode", "300")
-			f.ValuesSet("global.modules.resourcesRequests.internal.memoryEveryNode", "536870912")
+			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuMaster", "1850")
+			f.ValuesSet("global.internal.modules.resourcesRequests.memoryMaster", "3864053781")
+			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuEveryNode", "300")
+			f.ValuesSet("global.internal.modules.resourcesRequests.memoryEveryNode", "536870912")
 			f.BindingContexts.Set(f.KubeStateSet(DeckhousePodIsReady + TwoVpas))
 			f.RunHook()
 		})
@@ -341,13 +341,13 @@ name: node-exporter
 `))
 		})
 	})
-	Context("Cluster with two VPAs, and another set of global.modules.resourcesRequests.internal variables, Deckhouse pod is ready", func() {
+	Context("Cluster with two VPAs, and another set of global.internal.modules.resourcesRequests variables, Deckhouse pod is ready", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(DeckhousePodIsReady + TwoVpas))
-			f.ValuesSet("global.modules.resourcesRequests.internal.milliCpuMaster", "4096")
-			f.ValuesSet("global.modules.resourcesRequests.internal.memoryMaster", "8589934592")
-			f.ValuesSet("global.modules.resourcesRequests.internal.milliCpuEveryNode", "750")
-			f.ValuesSet("global.modules.resourcesRequests.internal.memoryEveryNode", "134217728")
+			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuMaster", "4096")
+			f.ValuesSet("global.internal.modules.resourcesRequests.memoryMaster", "8589934592")
+			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuEveryNode", "750")
+			f.ValuesSet("global.internal.modules.resourcesRequests.memoryEveryNode", "134217728")
 			f.RunHook()
 		})
 
@@ -395,10 +395,10 @@ name: node-exporter
 	Context("Cluster with two VPAs, maxAllowed values near newly calculated values, Deckhouse pod is ready", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(DeckhousePodIsReady + TwoVpasInTreshold))
-			f.ValuesSet("global.modules.resourcesRequests.internal.milliCpuMaster", "4096")
-			f.ValuesSet("global.modules.resourcesRequests.internal.memoryMaster", "8589934592")
-			f.ValuesSet("global.modules.resourcesRequests.internal.milliCpuEveryNode", "750")
-			f.ValuesSet("global.modules.resourcesRequests.internal.memoryEveryNode", "134217728")
+			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuMaster", "4096")
+			f.ValuesSet("global.internal.modules.resourcesRequests.memoryMaster", "8589934592")
+			f.ValuesSet("global.internal.modules.resourcesRequests.milliCpuEveryNode", "750")
+			f.ValuesSet("global.internal.modules.resourcesRequests.memoryEveryNode", "134217728")
 			f.RunHook()
 		})
 

--- a/testing/matrix/linter/apply.go
+++ b/testing/matrix/linter/apply.go
@@ -19,7 +19,7 @@ package linter
 import (
 	"fmt"
 
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 
 	"github.com/deckhouse/deckhouse/testing/matrix/linter/rules"
 	"github.com/deckhouse/deckhouse/testing/matrix/linter/rules/errors"

--- a/testing/matrix/linter/apply.go
+++ b/testing/matrix/linter/apply.go
@@ -19,7 +19,7 @@ package linter
 import (
 	"fmt"
 
-	"sigs.k8s.io/yaml"
+	"gopkg.in/yaml.v3"
 
 	"github.com/deckhouse/deckhouse/testing/matrix/linter/rules"
 	"github.com/deckhouse/deckhouse/testing/matrix/linter/rules/errors"
@@ -30,7 +30,9 @@ import (
 
 func ApplyLintRules(module utils.Module, values string, objectStore *storage.UnstructuredObjectStore) error {
 	var v struct {
-		Global struct{ EnabledModules []string }
+		Global struct {
+			EnabledModules []string `yaml:"enabledModules"`
+		} `yaml:"global"`
 	}
 	err := yaml.Unmarshal([]byte(values), &v)
 	if err != nil {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR improves hook max_allowed work.
1. If the new calculated max_allowed values for pods are less than 10% less than the old values, the values are not changed.
2. Hook starts only when Deckhouse pod becomes ready.

Also this PR fixes VPA linter and fixes some errors in vpa in istio module.
 
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Vpa hook which set max_allowed values causes to massive pod restart on deckhouse version update.
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: vertical-pod-autoscaler
type: fix
description: |
  1. If the new calculated max_allowed values for pods are less than 10% of old values, the values are not changed.
  2. Hook starts only when Deckhouse pod becomes ready.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
