### PR TITLE
[ci] fix: remove exit 0

### DIFF
--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -105,8 +105,6 @@ Destination registries:
 
           echo Publish {!{ $werfEnv }!} edition.
 
-          exit 0
-
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -254,8 +254,6 @@ jobs:
 
           echo Publish CE edition.
 
-          exit 0
-
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -366,8 +364,6 @@ jobs:
 
           echo Publish EE edition.
 
-          exit 0
-
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -477,8 +473,6 @@ jobs:
           ## Source: .gitlab/ci_templates/deploy.yml
 
           echo Publish FE edition.
-
-          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -254,8 +254,6 @@ jobs:
 
           echo Publish CE edition.
 
-          exit 0
-
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -366,8 +364,6 @@ jobs:
 
           echo Publish EE edition.
 
-          exit 0
-
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -477,8 +473,6 @@ jobs:
           ## Source: .gitlab/ci_templates/deploy.yml
 
           echo Publish FE edition.
-
-          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -254,8 +254,6 @@ jobs:
 
           echo Publish CE edition.
 
-          exit 0
-
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -366,8 +364,6 @@ jobs:
 
           echo Publish EE edition.
 
-          exit 0
-
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -477,8 +473,6 @@ jobs:
           ## Source: .gitlab/ci_templates/deploy.yml
 
           echo Publish FE edition.
-
-          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -254,8 +254,6 @@ jobs:
 
           echo Publish CE edition.
 
-          exit 0
-
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -366,8 +364,6 @@ jobs:
 
           echo Publish EE edition.
 
-          exit 0
-
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -477,8 +473,6 @@ jobs:
           ## Source: .gitlab/ci_templates/deploy.yml
 
           echo Publish FE edition.
-
-          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -254,8 +254,6 @@ jobs:
 
           echo Publish CE edition.
 
-          exit 0
-
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -366,8 +364,6 @@ jobs:
 
           echo Publish EE edition.
 
-          exit 0
-
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -477,8 +473,6 @@ jobs:
           ## Source: .gitlab/ci_templates/deploy.yml
 
           echo Publish FE edition.
-
-          exit 0
 
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then


### PR DESCRIPTION
## Description

Remove debug lines.

## Why do we need it, and what problem does it solve?

`exit 0` line makes deploy to channel jobs stop immediately.
