### PR TITLE
[monitoring] Fix severity_level annotations

### DIFF
--- a/ee/fe/modules/340-monitoring-applications/monitoring/prometheus-rules/applications/nats/nats.yaml
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/prometheus-rules/applications/nats/nats.yaml
@@ -6,7 +6,7 @@
         (sum by (namespace, service) (up{job="nats"})) + 1 != 0
     for: 2m
     labels:
-      severity_level: 3
+      severity_level: "3"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: markdown
@@ -27,7 +27,7 @@
         (sum by (namespace, service) (nats_up{job="nats"})) + 1 != 0
     for: 2m
     labels:
-      severity_level: 3
+      severity_level: "3"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: markdown

--- a/ee/fe/modules/340-monitoring-applications/monitoring/prometheus-rules/applications/php-fpm/php-fpm.yaml
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/prometheus-rules/applications/php-fpm/php-fpm.yaml
@@ -4,7 +4,7 @@
     expr: (sum(phpfpm_processes_total{state="idle"} ) by (namespace, pod))/((sum(phpfpm_processes_total) by (namespace, pod))/100) < 10
     for: 5m
     labels:
-      severity_level: 4
+      severity_level: "4"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"

--- a/ee/fe/modules/340-monitoring-applications/monitoring/prometheus-rules/applications/rabbitmq/rabbitmq.yaml
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/prometheus-rules/applications/rabbitmq/rabbitmq.yaml
@@ -4,7 +4,7 @@
     expr: rabbitmq_node_mem_used{job="rabbitmq"} / rabbitmq_node_mem_limit{job="rabbitmq"} * 100 > 85
     for: 5m
     labels:
-      severity_level: 4
+      severity_level: "4"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: markdown
@@ -24,7 +24,7 @@
     expr: rabbitmq_node_mem_used{job="rabbitmq"} / rabbitmq_node_mem_limit{job="rabbitmq"} * 100 > 95
     for: 1m
     labels:
-      severity_level: 3
+      severity_level: "3"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: markdown

--- a/modules/030-cloud-provider-yandex/openapi/values.yaml
+++ b/modules/030-cloud-provider-yandex/openapi/values.yaml
@@ -134,7 +134,7 @@ properties:
                     x-doc-example: |
                       ```yaml
                       project: cms-production
-                      severity_level: 3
+                      severity_level: "3"
                       ```
                     additionalProperties:
                       type: string

--- a/modules/101-cert-manager/monitoring/prometheus-rules/certificate.yaml
+++ b/modules/101-cert-manager/monitoring/prometheus-rules/certificate.yaml
@@ -5,7 +5,7 @@
       max by (name, exported_namespace) (certmanager_certificate_expiration_timestamp_seconds{job="cert-manager"} - time() < 1209600)
     for: 1h
     labels:
-      severity_level: 4
+      severity_level: "4"
     annotations:
       plk_protocol_version: "1"
       plk_incident_initial_status: "todo"
@@ -17,7 +17,7 @@
       max by (name, exported_namespace) (certmanager_certificate_expiration_timestamp_seconds{job="cert-manager"} - time() < 0)
     for: 1h
     labels:
-      severity_level: 4
+      severity_level: "4"
     annotations:
       plk_protocol_version: "1"
       plk_incident_initial_status: "todo"

--- a/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kube-controller-manager.yaml
+++ b/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kube-controller-manager.yaml
@@ -4,7 +4,7 @@
     expr: absent(up{job="kube-controller-manager"} == 1)
     for: 5m
     labels:
-      severity_level: 3
+      severity_level: "3"
     annotations:
       plk_protocol_version: "1"
       description: There is no running kube-controller-manager. Deployments and replication

--- a/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kube-scheduler.yaml
+++ b/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kube-scheduler.yaml
@@ -49,7 +49,7 @@
     expr: absent(up{job="kube-scheduler"} == 1)
     for: 5m
     labels:
-      severity_level: 3
+      severity_level: "3"
     annotations:
       plk_protocol_version: "1"
       description: There is no running K8S scheduler. New pods are not being assigned

--- a/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kubernetes.tpl
+++ b/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kubernetes.tpl
@@ -76,7 +76,7 @@ It will be better for you to enable `control-plane-manager` module to be able to
     expr: absent(up{job="kube-apiserver"} == 1)
     for: 20m
     labels:
-      severity_level: 3
+      severity_level: "3"
     annotations:
       plk_protocol_version: "1"
       description: No API servers are reachable or all have disappeared from service

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/coreos/general.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/coreos/general.yaml
@@ -3,7 +3,7 @@
   - alert: DeadMansSwitch
     expr: vector(1)
     labels:
-      severity_level: 4
+      severity_level: "4"
     annotations:
       plk_protocol_version: "1"
       description: This is a DeadMansSwitch meant to ensure that the entire Alerting
@@ -15,7 +15,7 @@
     expr: max(predict_linear(fd_utilization{pod!=""}[1h], 3600 * 4)) BY (job, namespace, pod) > 1
     for: 10m
     labels:
-      severity_level: 4
+      severity_level: "4"
     annotations:
       plk_protocol_version: "1"
       description: '{{ $labels.job }}: {{ $labels.namespace }}/{{ $labels.pod }} instance
@@ -25,7 +25,7 @@
     expr: max(predict_linear(fd_utilization{pod=""}[1h], 3600 * 4)) BY (job, instance) > 1
     for: 10m
     labels:
-      severity_level: 4
+      severity_level: "4"
     annotations:
       plk_protocol_version: "1"
       description: '{{ $labels.job }}: {{ $labels.instance }} instance
@@ -35,7 +35,7 @@
     expr: max(predict_linear(fd_utilization{pod!=""}[10m], 3600)) BY (job, namespace, pod) > 1
     for: 10m
     labels:
-      severity_level: 3
+      severity_level: "3"
     annotations:
       plk_protocol_version: "1"
       description: '{{ $labels.job }}: {{ $labels.namespace }}/{{ $labels.pod }} instance
@@ -45,7 +45,7 @@
     expr: max(predict_linear(fd_utilization{pod=""}[10m], 3600)) BY (job, instance) > 1
     for: 10m
     labels:
-      severity_level: 3
+      severity_level: "3"
     annotations:
       plk_protocol_version: "1"
       description: '{{ $labels.job }}: {{ $labels.instance }} instance

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/coreos/kube-state-metrics.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/coreos/kube-state-metrics.yaml
@@ -4,7 +4,7 @@
     expr: max(kube_deployment_status_observed_generation != kube_deployment_metadata_generation) by (namespace, deployment)
     for: 15m
     labels:
-      severity_level: 4
+      severity_level: "4"
     annotations:
       plk_protocol_version: "1"
       description: Observed deployment generation does not match expected one for
@@ -35,7 +35,7 @@
 #      unless (kube_deployment_spec_paused == 1)) by (namespace, deployment)
 #    for: 15m
 #    labels:
-#      severity_level: 4
+#      severity_level: "4"
 #    annotations:
 #      description: Replicas are not updated and available for deployment {{$labels.namespace}}/{{$labels.deployment}}
 #      summary: Deployment replicas are outdated
@@ -44,7 +44,7 @@
 #      * 100 < 100
 #    for: 15m
 #    labels:
-#      severity_level: 4
+#      severity_level: "4"
 #    annotations:
 #      description: Only {{$value}}% of desired pods scheduled and ready for daemon
 #        set {{$labels.namespace}}/{{$labels.daemonset}}
@@ -54,7 +54,7 @@
 #      > 0
 #    for: 10m
 #    labels:
-#      severity_level: 4
+#      severity_level: "4"
 #    annotations:
 #      description: '{{$value}} of desired pods are not scheduled for daemon set {{$labels.namespace}}/{{$labels.daemonset}}'
 #      summary: Daemonsets are not scheduled correctly
@@ -62,7 +62,7 @@
 #    expr: max(kube_daemonset_status_number_misscheduled) by (namespace, daemonset) > 0
 #    for: 10m
 #    labels:
-#      severity_level: 4
+#      severity_level: "4"
 #    annotations:
 #      description: '{{$value}} pods of daemon set {{$labels.namespace}}/{{$labels.daemonset}} are running where they are not supposed to run.'
 #      summary: Daemonsets are not scheduled correctly
@@ -70,7 +70,7 @@
 #    expr: max(increase(kube_pod_container_status_restarts_total[1h])) by (namespace, pod) > 5
 #    for: 10m
 #    labels:
-#      severity_level: 4
+#      severity_level: "4"
 #    annotations:
 #      description: Pod {{$labels.namespace}}/{{$labels.pod}} was restarted {{$value}}
 #        times within the last hour

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/coreos/kubelet.tpl
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/coreos/kubelet.tpl
@@ -4,7 +4,7 @@
     expr: min(kube_node_status_condition{condition="Ready",status="true"}) BY (node) == 0
     for: 10m
     labels:
-      severity_level: 3
+      severity_level: "3"
     annotations:
       plk_protocol_version: "1"
       description: The Kubelet on {{ `{{ $labels.node }}` }} has not checked in with the API,
@@ -16,7 +16,7 @@
       0) / count(kube_node_status_condition{condition="Ready",status="true"})) > 0.2
     for: 1m
     labels:
-      severity_level: 3
+      severity_level: "3"
     annotations:
       plk_protocol_version: "1"
       description: '{{ `{{ $value }}` }}% of Kubernetes nodes are not ready'
@@ -25,7 +25,7 @@
     expr: count(up{job="kubelet"} == 0) / count(up{job="kubelet"}) * 100 > 3
     for: 10m
     labels:
-      severity_level: 3
+      severity_level: "3"
     annotations:
       plk_protocol_version: "1"
       plk_group_for__target_down: "TargetDown,prometheus=deckhouse,job=kubelet"

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/coreos/node.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/coreos/node.yaml
@@ -21,7 +21,7 @@
     expr: absent(up{job="node-exporter"} == 1)
     for: 10m
     labels:
-      severity_level: 3
+      severity_level: "3"
     annotations:
       plk_protocol_version: "1"
       description: Prometheus could not scrape a node-exporter for more than 10m,


### PR DESCRIPTION
## Description

fixes regression bug introduced in [#534 ](https://github.com/deckhouse/deckhouse/pull/599)

## Why do we need it, and what problem does it solve?

As mentioned in https://github.com/deckhouse/deckhouse/pull/512#discussion_r776390092:
> The severity annotation is deprecated, please use severity_level [1-9] instead.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: monitoring
type: fix
description: "Fix severity_level annotations"
note: |
  The severity_level annotation value must be a string.
```