### PR TITLE
[keepalived] Change VPA update mode to initial

### DIFF
--- a/ee/fe/modules/450-keepalived/templates/statefulset.yaml
+++ b/ee/fe/modules/450-keepalived/templates/statefulset.yaml
@@ -13,7 +13,7 @@ spec:
     kind: StatefulSet
     name: keepalived-{{ $instance_name }}
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "Initial"
   {{- end }}
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Change VPA update mode to initial.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This change will prevent unnecessary updates resources of keepalived pods. A restart of keepalived leads to traffic loss because virtual IP changes the host.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: keepalived
type: fix
description: Change VPA update mode to initial.
```