### PR TITLE
[ingress-ngnix] proper validating webhook configuration for 1.22 k8s

### DIFF
--- a/modules/402-ingress-nginx/templates/controller/admission.yaml
+++ b/modules/402-ingress-nginx/templates/controller/admission.yaml
@@ -9,18 +9,23 @@ metadata:
   {{ include "helm_lib_module_labels" (list . ) | nindent 2 }}
 webhooks:
     {{- range $crd := $context.Values.ingressNginx.internal.ingressControllers }}
-      {{- if $crd.spec.validationEnabled }}
+    {{- $controllerVersion := ($crd.spec.controllerVersion | default $context.Values.ingressNginx.defaultControllerVersion) }}
+    {{- if $crd.spec.validationEnabled }}
         # there is a bug https://github.com/kubernetes/ingress-nginx/issues/4916
         # admission webhook was speed up in 0.48 https://github.com/kubernetes/ingress-nginx/pull/7298
         # before that fix sometime we get context deadline on a large installation
-        {{- if semverCompare ">=0.48" ($crd.spec.controllerVersion | default $context.Values.ingressNginx.defaultControllerVersion) }}
+        {{- if semverCompare ">=0.48" $controllerVersion }}
   - name: {{ $crd.name }}.validate.d8-ingress-nginx
     matchPolicy: Equivalent
     rules:
       - apiGroups:
           - networking.k8s.io
         apiVersions:
+          {{- if semverCompare ">=1.0" $controllerVersion }}
+          - v1
+          {{- else }}
           - v1beta1
+          {{- end }}
         operations:
           - CREATE
           - UPDATE
@@ -31,13 +36,21 @@ webhooks:
     sideEffects: None
     timeoutSeconds: 15
     admissionReviewVersions:
+      {{- if semverCompare ">=1.0" $controllerVersion }}
+      - v1
+      {{- else }}
       - v1
       - v1beta1
+      {{- end }}
     clientConfig:
       service:
         namespace: d8-ingress-nginx
         name: {{ $crd.name }}-admission
+        {{- if semverCompare ">=1.0" $controllerVersion }}
+        path: /networking/v1/ingresses
+        {{- else }}
         path: /networking/v1beta1/ingresses
+        {{- end }}
       caBundle: {{ $context.Values.ingressNginx.internal.admissionCertificate.ca | b64enc }}
         {{- end }}
       {{- end }}

--- a/modules/402-ingress-nginx/templates/controller/admission.yaml
+++ b/modules/402-ingress-nginx/templates/controller/admission.yaml
@@ -21,11 +21,7 @@ webhooks:
       - apiGroups:
           - networking.k8s.io
         apiVersions:
-          {{- if semverCompare ">=1.0" $controllerVersion }}
           - v1
-          {{- else }}
-          - v1beta1
-          {{- end }}
         operations:
           - CREATE
           - UPDATE
@@ -36,21 +32,12 @@ webhooks:
     sideEffects: None
     timeoutSeconds: 15
     admissionReviewVersions:
-      {{- if semverCompare ">=1.0" $controllerVersion }}
       - v1
-      {{- else }}
-      - v1
-      - v1beta1
-      {{- end }}
     clientConfig:
       service:
         namespace: d8-ingress-nginx
         name: {{ $crd.name }}-admission
-        {{- if semverCompare ">=1.0" $controllerVersion }}
         path: /networking/v1/ingresses
-        {{- else }}
-        path: /networking/v1beta1/ingresses
-        {{- end }}
       caBundle: {{ $context.Values.ingressNginx.internal.admissionCertificate.ca | b64enc }}
         {{- end }}
       {{- end }}


### PR DESCRIPTION
## Description
Provide proper validating webhook configuration for Ingress Nginx Controller v1.0.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Ingress Nginx Controller supports only modern versions of ingresses and different validation path.
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: ingress-ngnix
type: fix
description: |
  Proper validating webhook configuration for k8s 1.22+.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
