### PR TITLE
[testing] Add monitoring linter

### DIFF
--- a/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/podmonitor.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/cert-exporter/podmonitor.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.extendedMonitoring.certificates.exporterEnabled }}
+  {{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -28,4 +29,5 @@ spec:
   namespaceSelector:
     matchNames:
     - d8-monitoring
+  {{- end }}
 {{- end }}

--- a/ee/fe/modules/340-extended-monitoring/templates/events-exporter/podmonitor.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/events-exporter/podmonitor.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.extendedMonitoring.events.exporterEnabled }}
+  {{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -28,4 +29,5 @@ spec:
   namespaceSelector:
     matchNames:
     - d8-monitoring
+  {{- end }}
 {{- end }}

--- a/ee/fe/modules/340-extended-monitoring/templates/extended-monitoring-exporter/podmonitor.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/extended-monitoring-exporter/podmonitor.yaml
@@ -1,4 +1,4 @@
-
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -33,3 +33,4 @@ spec:
   namespaceSelector:
     matchNames:
     - d8-monitoring
+{{- end }}

--- a/ee/fe/modules/340-extended-monitoring/templates/image-availability-exporter/podmonitor.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/image-availability-exporter/podmonitor.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.extendedMonitoring.imageAvailability.exporterEnabled }}
+  {{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -28,4 +29,5 @@ spec:
   namespaceSelector:
     matchNames:
     - d8-monitoring
+  {{- end }}
 {{- end }}

--- a/ee/fe/modules/500-okmeter/templates/monitoring.yaml
+++ b/ee/fe/modules/500-okmeter/templates/monitoring.yaml
@@ -1,0 +1,1 @@
+{{- include "helm_lib_prometheus_rules" (list . "d8-okmeter") }}

--- a/ee/fe/modules/600-secret-copier/templates/empty-helm-workaround.yaml
+++ b/ee/fe/modules/600-secret-copier/templates/empty-helm-workaround.yaml
@@ -1,0 +1,8 @@
+{{- if not (.Values.global.enabledModules | has "operator-prometheus-crd") }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-empty-helm-workaround
+  {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
+{{- end }}

--- a/ee/fe/modules/600-secret-copier/templates/monitoring.yaml
+++ b/ee/fe/modules/600-secret-copier/templates/monitoring.yaml
@@ -1,10 +1,1 @@
-{{- if .Values.global.enabledModules | has "prometheus" }}
-  {{- include "helm_lib_prometheus_rules" (list . "d8-monitoring") }}
-{{- else }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Chart.Name }}-empty-helm-workaround
-  {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
-{{- end }}
+{{- include "helm_lib_prometheus_rules" (list . "d8-monitoring") }}

--- a/ee/modules/110-istio/templates/monitoring.yaml
+++ b/ee/modules/110-istio/templates/monitoring.yaml
@@ -1,4 +1,2 @@
-{{- if (.Values.global.enabledModules | has "prometheus") }}
-  {{- include "helm_lib_prometheus_rules" (list . "d8-istio") }}
-  {{- include "helm_lib_grafana_dashboard_definitions" . }}
-{{- end }}
+{{- include "helm_lib_grafana_dashboard_definitions" . }}
+{{- include "helm_lib_prometheus_rules" (list . "d8-istio") }}

--- a/ee/modules/350-node-local-dns/templates/monitoring.yaml
+++ b/ee/modules/350-node-local-dns/templates/monitoring.yaml
@@ -1,4 +1,2 @@
-{{- if (.Values.global.enabledModules | has "prometheus") }}
-  {{- include "helm_lib_grafana_dashboard_definitions" . }}
-  {{- include "helm_lib_prometheus_rules" (list . "d8-system") }}
-{{- end }}
+{{- include "helm_lib_grafana_dashboard_definitions" . }}
+{{- include "helm_lib_prometheus_rules" (list . "d8-system") }}

--- a/helm_lib/templates/_monitoring_grafana_dashboards.tpl
+++ b/helm_lib/templates/_monitoring_grafana_dashboards.tpl
@@ -48,5 +48,7 @@ spec:
 {{- /* returns dashboard-definintions from monitoring/grafana-dashboards/ */ -}}
 {{- define "helm_lib_grafana_dashboard_definitions" -}}
   {{- $context := . }}
-  {{- include "helm_lib_grafana_dashboard_definitions_recursion" (list $context "monitoring/grafana-dashboards") }}
+  {{- if ( $context.Values.global.enabledModules | has "prometheus-crd" ) }}
+{{- include "helm_lib_grafana_dashboard_definitions_recursion" (list $context "monitoring/grafana-dashboards") }}
+  {{- end }}
 {{- end }}

--- a/helm_lib/templates/_monitoring_prometheus_rules.tpl
+++ b/helm_lib/templates/_monitoring_prometheus_rules.tpl
@@ -55,5 +55,7 @@ spec:
 {{- define "helm_lib_prometheus_rules" -}}
   {{- $context := index . 0 }}
   {{- $namespace := index . 1 }}
-  {{- include "helm_lib_prometheus_rules_recursion" (list $context $namespace "monitoring/prometheus-rules") }}
+  {{- if ( $context.Values.global.enabledModules | has "operator-prometheus-crd" ) }}
+{{- include "helm_lib_prometheus_rules_recursion" (list $context $namespace "monitoring/prometheus-rules") }}
+  {{- end }}
 {{- end }}

--- a/modules/020-deckhouse/templates/monitoring.yaml
+++ b/modules/020-deckhouse/templates/monitoring.yaml
@@ -1,4 +1,2 @@
-{{- if (.Values.global.enabledModules | has "prometheus") }}
-  {{- include "helm_lib_grafana_dashboard_definitions" . }}
-  {{- include "helm_lib_prometheus_rules" (list . "d8-system") }}
-{{- end }}
+{{- include "helm_lib_grafana_dashboard_definitions" . }}
+{{- include "helm_lib_prometheus_rules" (list . "d8-system") }}

--- a/modules/040-control-plane-manager/templates/monitoring.yaml
+++ b/modules/040-control-plane-manager/templates/monitoring.yaml
@@ -1,3 +1,1 @@
-{{- if (.Values.global.enabledModules | has "prometheus") }}
-  {{- include "helm_lib_prometheus_rules" (list . "d8-system") }}
-{{- end }}
+{{- include "helm_lib_prometheus_rules" (list . "d8-system") }}

--- a/modules/040-node-manager/templates/monitoring.yaml
+++ b/modules/040-node-manager/templates/monitoring.yaml
@@ -1,3 +1,1 @@
-{{- if (.Values.global.enabledModules | has "prometheus") }}
-  {{- include "helm_lib_prometheus_rules" (list . "d8-cloud-instance-manager") }}
-{{- end }}
+{{- include "helm_lib_prometheus_rules" (list . "d8-cloud-instance-manager") }}

--- a/modules/040-terraform-manager/templates/terraform-auto-converger/podmonitor.yaml
+++ b/modules/040-terraform-manager/templates/terraform-auto-converger/podmonitor.yaml
@@ -1,4 +1,4 @@
-
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -34,3 +34,4 @@ spec:
   namespaceSelector:
     matchNames:
     - d8-system
+{{- end }}

--- a/modules/040-terraform-manager/templates/terraform-state-exporter/podmonitor.yaml
+++ b/modules/040-terraform-manager/templates/terraform-state-exporter/podmonitor.yaml
@@ -1,4 +1,4 @@
-
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -34,3 +34,4 @@ spec:
   namespaceSelector:
     matchNames:
     - d8-system
+{{- end }}

--- a/modules/050-network-policy-engine/templates/podmonitor.yaml
+++ b/modules/050-network-policy-engine/templates/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -20,3 +21,4 @@ spec:
   selector:
     matchLabels:
       app: kube-router
+{{- end }}

--- a/modules/101-cert-manager/templates/monitoring.yaml
+++ b/modules/101-cert-manager/templates/monitoring.yaml
@@ -1,3 +1,1 @@
-{{- if (.Values.global.enabledModules | has "prometheus") }}
-  {{- include "helm_lib_prometheus_rules" (list . "d8-cert-manager") }}
-{{- end }}
+{{- include "helm_lib_prometheus_rules" (list . "d8-cert-manager") }}

--- a/modules/402-ingress-nginx/templates/monitoring.yaml
+++ b/modules/402-ingress-nginx/templates/monitoring.yaml
@@ -1,4 +1,2 @@
-{{- if .Values.global.enabledModules | has "prometheus" }}
-  {{- include "helm_lib_grafana_dashboard_definitions" . }}
-  {{- include "helm_lib_prometheus_rules" (list . "d8-ingress-nginx") }}
-{{- end }}
+{{- include "helm_lib_grafana_dashboard_definitions" . }}
+{{- include "helm_lib_prometheus_rules" (list . "d8-ingress-nginx") }}

--- a/modules/460-log-shipper/templates/monitoring.yaml
+++ b/modules/460-log-shipper/templates/monitoring.yaml
@@ -1,6 +1,2 @@
-{{ $ns := printf "d8-%s" $.Chart.Name }}
----
-{{- if and (.Values.global.enabledModules | has "prometheus") (.Values.logShipper.internal.activated) }}
-  {{- include "helm_lib_grafana_dashboard_definitions" . }}
-  {{- include "helm_lib_prometheus_rules" (list . $ns) }}
-{{- end }}
+{{- include "helm_lib_grafana_dashboard_definitions" . }}
+{{- include "helm_lib_prometheus_rules" (list . "d8-log-shipper") }}

--- a/modules/470-chrony/templates/monitoring.yaml
+++ b/modules/470-chrony/templates/monitoring.yaml
@@ -1,3 +1,1 @@
-{{- if .Values.global.enabledModules | has "chrony" }}
-  {{- include "helm_lib_prometheus_rules" (list . "d8-chrony") }}
-{{- end }}
+{{- include "helm_lib_prometheus_rules" (list . "d8-chrony") }}

--- a/modules/500-upmeter/templates/monitoring.yaml
+++ b/modules/500-upmeter/templates/monitoring.yaml
@@ -1,3 +1,1 @@
-{{- if .Values.global.enabledModules | has "prometheus" }}
-  {{- include "helm_lib_prometheus_rules" (list . "d8-upmeter") }}
-{{- end }}
+{{- include "helm_lib_prometheus_rules" (list . "d8-upmeter") }}

--- a/modules/999-helm/templates/empty-helm-workaround.yaml
+++ b/modules/999-helm/templates/empty-helm-workaround.yaml
@@ -1,0 +1,8 @@
+{{- if not (.Values.global.enabledModules | has "operator-prometheus-crd") }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-empty-helm-workaround
+  {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
+{{- end }}

--- a/modules/999-helm/templates/monitoring.yaml
+++ b/modules/999-helm/templates/monitoring.yaml
@@ -1,10 +1,1 @@
-{{- if .Values.global.enabledModules | has "prometheus" }}
-  {{- include "helm_lib_prometheus_rules" (list . "d8-monitoring") }}
-{{- else }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Chart.Name }}-empty-helm-workaround
-  {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
-{{- end }}
+{{- include "helm_lib_prometheus_rules" (list . "d8-monitoring") }}

--- a/testing/matrix/linter/rules/modules/modules.go
+++ b/testing/matrix/linter/rules/modules/modules.go
@@ -251,6 +251,7 @@ func lintModuleStructure(lintRuleErrorsList *errors.LintRuleErrorsList, modulePa
 	}
 
 	lintRuleErrorsList.Merge(ossModuleRule(moduleName, modulePath))
+	lintRuleErrorsList.Add(monitoringModuleRule(moduleName, modulePath, namespace))
 
 	module := utils.Module{Name: name, Path: modulePath, Namespace: namespace}
 	return module, true

--- a/testing/matrix/linter/rules/modules/monitoring.go
+++ b/testing/matrix/linter/rules/modules/monitoring.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package modules
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/deckhouse/deckhouse/testing/matrix/linter/rules/errors"
+)
+
+func dirExists(moduleName, modulePath string, path ...string) (bool, errors.LintRuleError) {
+	searchPath := filepath.Join(append([]string{modulePath}, path...)...)
+	info, err := os.Stat(searchPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, errors.EmptyRuleError
+		}
+		return false, errors.NewLintRuleError(
+			"MODULE060",
+			moduleLabel(moduleName),
+			path,
+			err.Error(),
+		)
+	}
+	return info.IsDir(), errors.EmptyRuleError
+}
+
+func monitoringModuleRule(moduleName, modulePath, moduleNamespace string) errors.LintRuleError {
+	switch moduleName {
+	// These modules deploy common rules and dashboards to the cluster according to their configurations.
+	// That's why they have custom monitoring templates.
+	case "340-extended-monitoring", "340-monitoring-applications":
+		return errors.EmptyRuleError
+	}
+
+	folderEx, lerr := dirExists(moduleName, modulePath, "monitoring")
+	if !lerr.IsEmpty() {
+		return lerr
+	}
+
+	if !folderEx {
+		return errors.EmptyRuleError
+	}
+
+	rulesEx, lerr := dirExists(moduleName, modulePath, "monitoring", "prometheus-rules")
+	if !lerr.IsEmpty() {
+		return lerr
+	}
+
+	dashboardsEx, lerr := dirExists(moduleName, modulePath, "monitoring", "grafana-dashboards")
+	if !lerr.IsEmpty() {
+		return lerr
+	}
+
+	searchingFilePath := filepath.Join(modulePath, "templates", "monitoring.yaml")
+	info, _ := os.Stat(searchingFilePath)
+	if info == nil {
+		return errors.NewLintRuleError(
+			"MODULE060",
+			moduleLabel(moduleName),
+			searchingFilePath,
+			"Module with the 'monitoring' folder should have the 'templates/monitoring.yaml' file",
+		)
+	}
+
+	content, err := os.ReadFile(searchingFilePath)
+	if err != nil {
+		return errors.NewLintRuleError(
+			"MODULE060",
+			moduleLabel(moduleName),
+			searchingFilePath,
+			err.Error(),
+		)
+	}
+
+	desiredContentBuilder := strings.Builder{}
+	if dashboardsEx {
+		desiredContentBuilder.WriteString("{{- include \"helm_lib_grafana_dashboard_definitions\" . }}\n")
+	}
+
+	if rulesEx {
+		desiredContentBuilder.WriteString(
+			"{{- include \"helm_lib_prometheus_rules\" (list . %q) }}\n",
+		)
+	}
+
+	var res bool
+	for _, namespace := range []string{moduleNamespace, "d8-system", "d8-monitoring"} {
+		desiredContent := fmt.Sprintf(desiredContentBuilder.String(), namespace)
+		res = res || desiredContent == string(content)
+	}
+
+	if !res {
+		return errors.NewLintRuleError(
+			"MODULE060",
+			moduleLabel(moduleName),
+			searchingFilePath,
+			"The content of the 'templates/monitoring.yaml' should be equal to:\n%s\nGot:\n%s",
+			fmt.Sprintf(desiredContentBuilder.String(), "YOUR NAMESAPCE TO DEPLOY RULES: d8-monitoring, d8-system or module namespaces"),
+			string(content),
+		)
+	}
+
+	return errors.EmptyRuleError
+}
+
+func compareContent(content, namespace string, rules, dashboards bool) bool {
+	desiredContentBuilder := strings.Builder{}
+	if dashboards {
+		desiredContentBuilder.WriteString("{{- include \"helm_lib_grafana_dashboard_definitions\" . }}\n")
+	}
+
+	if rules {
+		desiredContentBuilder.WriteString(
+			"{{- include \"helm_lib_prometheus_rules\" (list . %q) }}\n",
+		)
+	}
+
+	return content == desiredContentBuilder.String()
+}


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
* Move clause to deploy Prometheus CRDs to the helm_lib code
* Refactor monitroing.yaml files
* Add linter

## Why do we need it, and what problem does it solve?
We need this linter to not forget to add enable monitoring if there are dashboards and alert rules. The content of the trigger file is predictable, so we can also validate it to avoid logical mistakes.

## Changelog entries

```changes
module: testing
type: feature
description: Add monitoring trigger linter for modules
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
