### PR TITLE
[bashible] Fix remove of docker

### DIFF
--- a/candi/bashible/bundles/centos-7/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/centos-7/node-group/031_install_containerd.sh.tpl
@@ -40,6 +40,7 @@ if bb-yum-package? docker-ce; then
   # Remove mounts
   umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true
   bb-rp-remove docker-ce containerd-io
+  bb-yum-remove docker.io docker-ce containerd-io
   rm -rf /var/lib/docker/ /var/run/docker.sock /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
   # Pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /usr/local/bin/crictl

--- a/candi/bashible/bundles/debian/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/debian/node-group/031_install_containerd.sh.tpl
@@ -39,8 +39,8 @@ if bb-apt-package? docker-ce || bb-apt-package? docker.io; then
   kill $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}') 2>/dev/null || true
   # Remove mounts
   umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true
-  bb-apt-remove docker.io
   bb-rp-remove docker-ce containerd-io
+  bb-apt-remove docker.io docker-ce containerd-io
   rm -rf /var/lib/docker/ /var/run/docker.sock /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
   # Pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /usr/local/bin/crictl

--- a/candi/bashible/bundles/ubuntu-lts/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/node-group/031_install_containerd.sh.tpl
@@ -39,8 +39,8 @@ if bb-apt-package? docker-ce || bb-apt-package? docker.io; then
   kill $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}') 2>/dev/null || true
   # Remove mounts
   umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true
-  bb-apt-remove docker.io
   bb-rp-remove docker-ce containerd-io
+  bb-apt-remove docker.io docker-ce containerd-io
   rm -rf /var/lib/docker/ /var/run/docker.sock /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
   # Pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /usr/local/bin/crictl


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
There can be a situation when docker-ce is installed not from registry packages. So bashible fails on the next step because it assumes that containerd is installed correctly.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix switch from docker to containerd.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: bashible
type: fix
description: Fix remove of docker
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
