### PR TITLE
[istio][multicluster] multiclustersNeedIngressGateway fix

### DIFF
--- a/ee/modules/110-istio/hooks/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/alliance_metadata_merge.go
@@ -181,6 +181,11 @@ federationsLoop:
 multiclustersLoop:
 	for _, multicluster := range input.Snapshots["multiclusters"] {
 		multiclusterInfo := multicluster.(IstioMulticlusterMergeCrdInfo)
+
+		if multiclusterInfo.EnableIngressGateway {
+			multiclustersNeedIngressGateway = true
+		}
+
 		if multiclusterInfo.Public == nil {
 			input.LogEntry.Warnf("public metadata for IstioMulticluster %s wasn't fetched yet", multiclusterInfo.Name)
 			continue multiclustersLoop
@@ -192,12 +197,10 @@ multiclustersLoop:
 			input.LogEntry.Warnf("private metadata for IstioMulticluster %s wasn't fetched yet", multiclusterInfo.Name)
 			continue multiclustersLoop
 		}
-		if multiclusterInfo.EnableIngressGateway {
-			if multiclusterInfo.IngressGateways == nil || len(*multiclusterInfo.IngressGateways) == 0 {
-				input.LogEntry.Warnf("ingressGateways for IstioMulticluster %s weren't fetched yet", multiclusterInfo.Name)
-				continue multiclustersLoop
-			}
-			multiclustersNeedIngressGateway = true
+		if multiclusterInfo.EnableIngressGateway &&
+			(multiclusterInfo.IngressGateways == nil || len(*multiclusterInfo.IngressGateways) == 0) {
+			input.LogEntry.Warnf("ingressGateways for IstioMulticluster %s weren't fetched yet", multiclusterInfo.Name)
+			continue multiclustersLoop
 		}
 
 		privKey := []byte(input.Values.Get("istio.internal.remoteAuthnKeypair.priv").String())


### PR DESCRIPTION
## Description
Correct decision to deploy ingressgateway for multiclusters.

## Why do we need it, and what problem does it solve?
It was impossible to set up ingressgateways for multicluster from scratch. Loop dependency.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: istio
type: fix
description: Correct decision to deploy ingressgateway for multiclusters.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
