### PR TITLE
[deckhouse][image-copier] Change order of commands in docs and secret generator

### DIFF
--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -132,13 +132,13 @@ Thus, Deckhouse images will be available at `https://your-harbor.com/d8s/deckhou
 
 ## How do I switch a running Deckhouse cluster to use a third-party registry?
 
+* Update the `image` field in the `d8-system/deckhouse` deployment to contain the address of the Deckhouse image in the third-party-registry.
 * Edit the `d8-system/deckhouse-registry` secret (note that all parameters are BASE64-encoded):
   * Insert third-party registry credentials into `.dockerconfigjson`.
   * Replace `address` with the third-party registry's host address (e.g., `registry.example.com`).
   * Change `path` to point to a repo in the third-party registry (e.g., `/deckhouse/fe`).
   * If necessary, change `scheme` to `http` (if the third-party registry uses HTTP scheme).
   * If necessary, change or add the `ca` field with the root CA certificate that validates the third-party registry's https certificate (if the third-party registry uses self-signed certificates).
-* Update the `image` field in the `d8-system/deckhouse` deployment to contain the address of the Deckhouse image in the third-party-registry.
-* Wait for the Deckhouse Pod to become Ready.
+* Wait for the Deckhouse Pod to become Ready. Restart Deckhouse Pod if it will be in `ImagePullBackoff` state.
 * Wait for bashible to apply the new settings on the master node. The bashible log on the master node (`journalctl -u bashible`) should contain the message `Configuration is in sync, nothing to do`.
 * Only if Deckhouse won't be updated using a third-party registry, then you have to remove `releaseChannel` setting from configmap `d8-system/deckhouse`

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -134,13 +134,13 @@ deckhouse: |
 
 ## Как переключить работающий кластер Deckhouse на использование стороннего registry?
 
+* Изменить поле `image` в Deployment `d8-system/deckhouse` на адрес образа Deckhouse в новом registry.
 * Изменить секрет `d8-system/deckhouse-registry` (все параметры хранятся в кодировке BASE64):
   * Исправить `.dockerconfigjson` с учетом авторизации в новом registry.
   * Исправить `address` на адрес нового registry (например, `registry.example.com`).
   * Исправить `path` на путь к репозиторию Deckhouse в новом registry (например, `/deckhouse/fe`).
   * При необходимости, изменить `scheme` на `http` (если используется HTTP registry).
   * Если registry использует самоподписные сертификаты, то изменить или добавить поле `ca` куда внести корневой сертификат соответствующего сертификата registry.
-* Изменить поле `image` в Deployment `d8-system/deckhouse` на адрес образа Deckhouse в новом registry.
-* Дождаться перехода Pod'а Deckhouse в статус Ready.
+* Дождаться перехода Pod'а Deckhouse в статус Ready. Если Pod будет находиться в статусе `ImagePullBackoff`, то перезапустите его.
 * Дождаться применения bashible новых настроек на master-узле. В журнале bashible на master-узле (`journalctl -u bashible`) должно появится сообщение `Configuration is in sync, nothing to do`.
 * Только если обновление Deckhouse через сторонний registry не планируется, то следует удалить releaseChannel из конфигмапа `d8-system/deckhouse` 

--- a/modules/020-deckhouse/docs/internal/IMAGE_COPIER.md
+++ b/modules/020-deckhouse/docs/internal/IMAGE_COPIER.md
@@ -57,4 +57,11 @@ Caution! If you delete Secret, the Job and Pod will be deleted as well regardles
 
 ## Switching the repository
 
-Use this [instruction](https://deckhouse.io/en/documentation/v1/deckhouse-faq.html#how-do-i-switch-a-running-deckhouse-cluster-to-use-a-third-party-registry)
+Execute commands another commands from `generate-copier-secret.sh` output:
+
+* Change Deckhouse Deployment image.
+* Change `d8-system/deckhouse-registry secret.
+* Wait for Deckhouse pod ready (restart pod if it is in ImagePullBackoff state).
+* Check bashible on master node restart correctly.
+
+Or use this [instruction](https://deckhouse.io/en/documentation/v1/deckhouse-faq.html#how-do-i-switch-a-running-deckhouse-cluster-to-use-a-third-party-registry)

--- a/modules/020-deckhouse/images/images-copier/generate-copier-secret.sh
+++ b/modules/020-deckhouse/images/images-copier/generate-copier-secret.sh
@@ -120,11 +120,17 @@ EndOfSecret
 
 # Wait for sync images. After finish sync images, run next commands:
 
+# change deckhouse image
+$patch_deployment_cmd
+
 # patch d8-system/deckhouse-registry
 $patch_secret_cmd
 
-# change deckhouse image
-$patch_deployment_cmd
+# check deckhouse pod
+kubectl -n d8-system get po -l app=deckhouse
+
+# if it is in ImagePullBackoff, restart it
+kubectl -n d8-system rollout restart deployment deckhouse
 
 # Wait for the Deckhouse Pod to become Ready.
 # Wait for bashible to apply the new settings on the master node.


### PR DESCRIPTION
## Description
Change command order (begin patch Deckhouse Deployment, after patch deckhouse-registry secret)

## Why do we need it, and what problem does it solve?
It is more safety than change deckhouse-registry secret first, because kube-apiserver, etcd images can changed to new incorrect registry and connot be pulled

<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
