### PR TITLE
[ci] use head commit of PR for predictable builds

### DIFF
--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -83,7 +83,8 @@ git_info:
 
 # Only useful with pull_request_target.
 #
-# Checks out merge commit, checks for dangerous changes, and if none found, returns the ref.
+# Checkout the head commit, checks if changes are safe and returns the ref.
+# Job fails if changes seem dangerous.
 {!{ define "pull_request_info_job" }!}
 # <template: pull_request_info>
 pull_request_info:
@@ -156,11 +157,11 @@ pull_request_info:
             }
           }
 
-    # Checkhout the merge commit
-    - name: Checkout PR merge commit
+    # Checkhout the head commit of the PR branch.
+    - name: Checkout PR head commit
       uses: {!{ index (ds "actions") "actions/checkout" }!}
       with:
-        ref: "refs/pull/${{ github.event.number }}/merge"
+        ref: "refs/pull/${{ github.event.number }}/head"
 
     # Detect dangerous changes in external PR.
     - name: Check for dangerous changes
@@ -189,12 +190,12 @@ pull_request_info:
           core.setFailed('External PR contains dangerous changes.')
 
     # Set output.
-    - name: Return PR merge commit ref
+    - name: Return PR head commit ref
       id: ref
       uses: {!{ index (ds "actions") "actions/github-script" }!}
       with:
         script: |
-          const ref = `refs/pull/${ context.issue.number }/merge`
+          const ref = `refs/pull/${ context.issue.number }/head`
           core.info(`ref: '${ref}'`)
           core.setOutput('ref', ref)
 # </template: pull_request_info>

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -621,7 +621,7 @@ module.exports.runWorkflowForReleaseIssue = async ({ github, context, core }) =>
  * @param {object} inputs.github - A pre-authenticated octokit/rest.js client with pagination plugins.
  * @param {object} inputs.context - An object containing the context of the workflow run.
  * @param {object} inputs.core - A reference to the '@actions/core' package.
- * @param {string} inputs.ref - A git ref to checkout merge commit for PR (e.g. refs/pull/133/merge).
+ * @param {string} inputs.ref - A git ref to checkout head commit for PR (e.g. refs/pull/133/head).
  * @returns {Promise<void>}
  */
 module.exports.runWorkflowForPullRequest = async ({ github, context, core, ref }) => {

--- a/.github/scripts/validation_run.sh
+++ b/.github/scripts/validation_run.sh
@@ -16,7 +16,7 @@
 
 # This script has just one purpose:
 # Fetch inputs for validation script:
-#   - title and description of merge request
+#   - title and description of pull request
 #   - diff content
 
 set -Eeo pipefail

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -151,11 +151,11 @@ jobs:
               }
             }
 
-      # Checkhout the merge commit
-      - name: Checkout PR merge commit
+      # Checkhout the head commit of the PR branch.
+      - name: Checkout PR head commit
         uses: actions/checkout@v2.4.0
         with:
-          ref: "refs/pull/${{ github.event.number }}/merge"
+          ref: "refs/pull/${{ github.event.number }}/head"
 
       # Detect dangerous changes in external PR.
       - name: Check for dangerous changes
@@ -184,12 +184,12 @@ jobs:
             core.setFailed('External PR contains dangerous changes.')
 
       # Set output.
-      - name: Return PR merge commit ref
+      - name: Return PR head commit ref
         id: ref
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const ref = `refs/pull/${ context.issue.number }/merge`
+            const ref = `refs/pull/${ context.issue.number }/head`
             core.info(`ref: '${ref}'`)
             core.setOutput('ref', ref)
   # </template: pull_request_info>

--- a/.github/workflows/on-pull-request-labeled.yml
+++ b/.github/workflows/on-pull-request-labeled.yml
@@ -83,11 +83,11 @@ jobs:
               }
             }
 
-      # Checkhout the merge commit
-      - name: Checkout PR merge commit
+      # Checkhout the head commit of the PR branch.
+      - name: Checkout PR head commit
         uses: actions/checkout@v2.4.0
         with:
-          ref: "refs/pull/${{ github.event.number }}/merge"
+          ref: "refs/pull/${{ github.event.number }}/head"
 
       # Detect dangerous changes in external PR.
       - name: Check for dangerous changes
@@ -116,12 +116,12 @@ jobs:
             core.setFailed('External PR contains dangerous changes.')
 
       # Set output.
-      - name: Return PR merge commit ref
+      - name: Return PR head commit ref
         id: ref
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const ref = `refs/pull/${ context.issue.number }/merge`
+            const ref = `refs/pull/${ context.issue.number }/head`
             core.info(`ref: '${ref}'`)
             core.setOutput('ref', ref)
   # </template: pull_request_info>

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -99,11 +99,11 @@ jobs:
               }
             }
 
-      # Checkhout the merge commit
-      - name: Checkout PR merge commit
+      # Checkhout the head commit of the PR branch.
+      - name: Checkout PR head commit
         uses: actions/checkout@v2.4.0
         with:
-          ref: "refs/pull/${{ github.event.number }}/merge"
+          ref: "refs/pull/${{ github.event.number }}/head"
 
       # Detect dangerous changes in external PR.
       - name: Check for dangerous changes
@@ -132,12 +132,12 @@ jobs:
             core.setFailed('External PR contains dangerous changes.')
 
       # Set output.
-      - name: Return PR merge commit ref
+      - name: Return PR head commit ref
         id: ref
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const ref = `refs/pull/${ context.issue.number }/merge`
+            const ref = `refs/pull/${ context.issue.number }/head`
             core.info(`ref: '${ref}'`)
             core.setOutput('ref', ref)
   # </template: pull_request_info>


### PR DESCRIPTION
## Description

Checkout PR sources using head commit (refs/pull/NUM/head) instead of virtual merge commit (refs/pull/NUM/merge).

## Why do we need it, and what problem does it solve?

`refs/pull/NUM/merge` refers to a PR branch merge into main branch. This commit may change during the build process. Later jobs will use different commit SHA and fail.


