### PR TITLE
[docs] Add an article about ingress-nginx HPA configuring

### DIFF
--- a/modules/402-ingress-nginx/docs/FAQ.md
+++ b/modules/402-ingress-nginx/docs/FAQ.md
@@ -177,7 +177,7 @@ spec:
     - 192.168.0.0/24
 ```
 
-## How to add extra log fields to a nginx-controller
+## How to add extra log fields to a nginx-controller?
 ```yaml
 apiVersion: deckhouse.io/v1
 kind: IngressNginxController
@@ -189,3 +189,16 @@ spec:
   additionalLogFields:
     my-cookie: "$cookie_MY_COOKIE"
 ```
+
+
+## How to enable HorizontalPodAutoscaling for IngressNginxController?
+
+> **Note!** HPA mode is possible only for controllers with inlet: `LoadBalancer` or `LoadBalancerWithProxyProtocol`.
+
+HPA is set with attributes `minReplicas` and `maxReplicas` in a [IngressNginxController CR](https://deckhouse.io/ru/documentation/v1/modules/402-ingress-nginx/cr.html#ingressnginxcontroller).
+
+`hpa-scaler` Deployment will be created with the HPA resource, which is observing custom metric `prometheus-metrics-adapter-d8-ingress-nginx-cpu-utilization-for-hpa`.
+
+If CPU utilization > 50% HPA-controller scales `hpa-scaler` Deployment with a new replica (with respect of `minReplicas` and `maxReplicas`).
+
+`hpa-scaler` Deployment has HardPodAntiAffinity and it will order a new Node (inside it's NodeGroup), where one more ingress-controller will be set.

--- a/modules/402-ingress-nginx/docs/FAQ_RU.md
+++ b/modules/402-ingress-nginx/docs/FAQ_RU.md
@@ -162,7 +162,7 @@ nginx.ingress.kubernetes.io/configuration-snippet: |
 Подробнее о том, как работает аутентификация по сертификатам, можно прочитать в [документации Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#x509-client-certs).
 
 
-## Как настроить работу через MetalLB с доступом только из внутренней сети
+## Как настроить работу через MetalLB с доступом только из внутренней сети?
 
 Пример MetalLB с доступом только из внутренней сети
 ```yaml
@@ -178,7 +178,7 @@ spec:
     - 192.168.0.0/24
 ```
 
-## Как добавить дополнительные поля для логирования в nginx-controller
+## Как добавить дополнительные поля для логирования в nginx-controller?
 ```yaml
 apiVersion: deckhouse.io/v1
 kind: IngressNginxController
@@ -190,3 +190,15 @@ spec:
   additionalLogFields:
     my-cookie: "$cookie_MY_COOKIE"
 ```
+
+## Как включить HorizontalPodAutoscaling для IngressNginxController?
+
+> **Важно!** Режим HPA возможен только для контроллеров с inlet: `LoadBalancer` или `LoadBalancerWithProxyProtocol`.
+
+HPA выставляется с помощью аттрибутов `minReplicas` и `maxReplicas` в [IngressNginxController CR](https://deckhouse.io/ru/documentation/v1/modules/402-ingress-nginx/cr.html#ingressnginxcontroller).
+
+При этом создается deployment `hpa-scaler` и HPA resource, который следит за предварительно созданной метрикой `prometheus-metrics-adapter-d8-ingress-nginx-cpu-utilization-for-hpa`.
+
+При CPU utilization > 50% HPA закажет новую реплику для `hpa-scaler` (в рамках minReplicas и maxReplicas).
+
+`hpa-scaler` deployment обладает HardPodAntiAffinity, поэтому он попытается заказать себе новый узел (если это возможно в рамках своей NodeGroup), куда автоматически будет размещен еще один ingress-controller.


### PR DESCRIPTION
## Description
Add documentation article "How to enable HorizontalPodAutoscaling for IngressNginxController".

## Why do we need it, and what problem does it solve?
To make users familiar with how Ingress HPA works

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: ingress-nginx
type: feature
description: Add documentation article "How to enable HorizontalPodAutoscaling for IngressNginxController".
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
