### PR TITLE
[user-authn] Fix. No fill kubernetesDexClientAppSecret value

### DIFF
--- a/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret.go
+++ b/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret.go
@@ -61,7 +61,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 
 func kubernetesDexClientAppSecret(input *go_hook.HookInput) error {
 	secretPath := "userAuthn.internal.kubernetesDexClientAppSecret"
-	if input.Values.Exists(secretPath) {
+	if input.Values.Exists(secretPath) && input.Values.Get(secretPath).String() != "" {
 		return nil
 	}
 

--- a/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret_test.go
+++ b/modules/150-user-authn/hooks/generate_kubernetes_dex_client_app_secret_test.go
@@ -43,11 +43,26 @@ data:
 			f.RunHook()
 		})
 
-		It("Should fill internal values", func() {
+		It("Should fill internal values from secret", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
 
 			Expect(f.ValuesGet("userAuthn.internal.kubernetesDexClientAppSecret").String()).To(Equal("ABC"))
+		})
+
+		Context("With  empty value", func() {
+			BeforeEach(func() {
+				f.ValuesSet("userAuthn.internal.kubernetesDexClientAppSecret", "")
+
+				f.RunHook()
+			})
+
+			It("Should fill internal values from secret", func() {
+				Expect(f).To(ExecuteSuccessfully())
+				Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
+
+				Expect(f.ValuesGet("userAuthn.internal.kubernetesDexClientAppSecret").String()).To(Equal("ABC"))
+			})
 		})
 	})
 
@@ -62,6 +77,17 @@ data:
 			Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
 
 			Expect(f.ValuesGet("userAuthn.internal.kubernetesDexClientAppSecret").Exists()).To(BeTrue())
+			v := f.ValuesGet("userAuthn.internal.kubernetesDexClientAppSecret").String()
+			Expect(v).NotTo(BeEmpty())
+		})
+
+		It("Should fill internal values", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
+
+			Expect(f.ValuesGet("userAuthn.internal.kubernetesDexClientAppSecret").Exists()).To(BeTrue())
+			v := f.ValuesGet("userAuthn.internal.kubernetesDexClientAppSecret").String()
+			Expect(v).NotTo(BeEmpty())
 		})
 
 		Context("With another run", func() {
@@ -79,6 +105,23 @@ data:
 				Expect(f.ValuesGet("userAuthn.internal.kubernetesDexClientAppSecret").Exists()).To(BeTrue())
 				Expect(f.ValuesGet("userAuthn.internal.kubernetesDexClientAppSecret").String()).To(Equal(clientAppSecret))
 			})
+		})
+	})
+
+	Context("With default empty value", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(""))
+			f.ValuesSet("userAuthn.internal.kubernetesDexClientAppSecret", "")
+
+			f.RunHook()
+		})
+
+		It("Should fill non empty internal values", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
+
+			Expect(f.ValuesGet("userAuthn.internal.kubernetesDexClientAppSecret").Exists()).To(BeTrue())
+			Expect(f.ValuesGet("userAuthn.internal.kubernetesDexClientAppSecret").String()).NotTo(BeEmpty())
 		})
 	})
 })


### PR DESCRIPTION
## Description
No fill kubernetesDexClientAppSecret value because default empty is present in openapi spec.

## Why do we need it, and what problem does it solve?
Deckhouse does not converge

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
