### PR TITLE
[chrony] fix ntp services list in bashible step

### DIFF
--- a/modules/470-chrony/templates/bashible-step.yaml
+++ b/modules/470-chrony/templates/bashible-step.yaml
@@ -24,7 +24,7 @@ spec:
 
     # Chrony module synchronizes the time on all nodes, so systemd-timesyncd system unit isn't used and must be disabled.
 
-    for ntp_service in systemd-timesyncd ntp.service ntpd.service openntpd.service time-sync.target; do
+    for ntp_service in systemd-timesyncd.service ntp.service ntpd.service openntpd.service time-sync.target; do
       if systemctl --no-legend --plain --no-pager | awk '{print $1}' | grep -q "^${ntp_service}$"; then
         systemctl stop $ntp_service
         systemctl disable $ntp_service

--- a/modules/470-chrony/templates/bashible-step.yaml
+++ b/modules/470-chrony/templates/bashible-step.yaml
@@ -24,8 +24,8 @@ spec:
 
     # Chrony module synchronizes the time on all nodes, so systemd-timesyncd system unit isn't used and must be disabled.
 
-    for ntp_service in systemd-timesyncd ntp.service ntpd.service; do
-      if systemctl --no-legend --plain --no-pager | grep -q $ntp_service; then
+    for ntp_service in systemd-timesyncd ntp.service ntpd.service openntpd.service; do
+      if systemctl --no-legend --plain --no-pager | awk '{print $1}' | grep -q "^${ntp_service}$"; then
         systemctl stop $ntp_service
         systemctl disable $ntp_service
       fi

--- a/modules/470-chrony/templates/bashible-step.yaml
+++ b/modules/470-chrony/templates/bashible-step.yaml
@@ -24,7 +24,7 @@ spec:
 
     # Chrony module synchronizes the time on all nodes, so systemd-timesyncd system unit isn't used and must be disabled.
 
-    for ntp_service in systemd-timesyncd ntp.service ntpd.service openntpd.service; do
+    for ntp_service in systemd-timesyncd ntp.service ntpd.service openntpd.service time-sync.target; do
       if systemctl --no-legend --plain --no-pager | awk '{print $1}' | grep -q "^${ntp_service}$"; then
         systemctl stop $ntp_service
         systemctl disable $ntp_service


### PR DESCRIPTION
## Description
Bashible step fix — missed openntpd.service and time-sync.target in list.

## Changelog entries
```changes
module: chrony
type: fix
description: Bashible step fix — missed openntpd.service and time-sync.target in list.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
