### PR TITLE
[cloud-provider-vsphere] support of non-drs installations

### DIFF
--- a/docs/site/_includes/getting_started/vsphere/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/vsphere/partials/config.yml.standard.ee.inc
@@ -95,14 +95,20 @@ zones:
 # [<en>] public SSH key for accessing cloud nodes
 # [<ru>] публичная часть SSH-ключа для доступа к узлам облака
 sshPublicKey: ssh-rsa <SSH_PUBLIC_KEY>
-# [<en>] name of External Network which has access to the Internet.
-# [<en>] it must contain a DHCP server
+# [<en>] name of External Network which has access to the Internet
+# [<en>] ip addresses from External Network sets as ExternalIP of Node object
+# [<en>] optional parameter
 # [<ru>] имя External Network, у которой есть доступ в Интернет
-# [<ru>] в ней должен быть DHCP сервер
+# [<ru>] ip адреса из External Network проставляются как ExternalIP объекта Node
+# [<ru>] опциональный параметр
 externalNetworkNames:
 - *!CHANGE_NETWORK_NAME*
 # [<en>] name of Internal Network that will be used for traffic between nodes
+# [<en>] ip addresses from Internal Network sets as InternalIP of Node object
+# [<en>] optional parameter
 # [<ru>] имя Internal Network, которая будет использоваться для трафика между нодами, в данном примере идентично externalNetworkNames
+# [<ru>] ip адреса из Internal Network проставляются как InternalIP объекта Node
+# [<ru>] опциональный параметр
 internalNetworkNames:
 - *!CHANGE_NETWORK_NAME*
 # [<en>] address space of the cluster's nodes
@@ -124,10 +130,12 @@ masterNodeGroup:
     # [<ru>] имя образа, созданного в шаге "Сборка образа виртуальных машин"
     template: *!CHANGE_TEMPLATE_NAME*
     datastore: *!CHANGE_DATASTORE_NAME*
-    # [<en>] should be the same as externalNetworkNames
-    # [<ru>] идентично externalNetworkNames
+    # [<en>] main network connected to node
+    # [<ru>] основная сеть подключенная к узлу
     mainNetwork: *!CHANGE_NETWORK_NAME*
-    # [<en>] should be the same as internalNetworkNames
-    # [<ru>] идентично internalNetworkNames
+    # [<en>] additional networks connected to node
+    # [<en>] optional parameter
+    # [<ru>] дополнительные сети, подключенные к узлу
+    # [<ru>] опциональный параметр
     additionalNetworks:
     - *!CHANGE_NETWORK_NAME*

--- a/ee/candi/cloud-providers/vsphere/docs/CLUSTER_CONFIGURATION.md
+++ b/ee/candi/cloud-providers/vsphere/docs/CLUSTER_CONFIGURATION.md
@@ -113,6 +113,7 @@ A particular placement strategy is defined via the `VsphereClusterConfiguration`
   * An optional parameter; It is set to `true` by default;
 * `region` — is a tag added to the vSphere Datacenter where all actions will occur: provisioning VirtualMachines, storing virtual disks on datastores, connecting to the network.
 * `baseResourcePool` — a path (relative to vSphere Cluster) to the existing parent `resourcePool` for all `resourcePool` created in each zone;
+* `useNestedResourcePool` - create nested resource pool (`true`) or use main resource pool (`false`). Default - `true`;
 * `sshPublicKey` — a public key for accessing nodes;
 * `externalNetworkNames` — names of networks (just the name and not the full path) connected to VirtualMachines and used by vsphere-cloud-controller-manager to insert ExternalIP into the `.status.addresses` field in the Node API object.
   * Format — an array of strings. For example:

--- a/ee/candi/cloud-providers/vsphere/docs/CLUSTER_CONFIGURATION_RU.md
+++ b/ee/candi/cloud-providers/vsphere/docs/CLUSTER_CONFIGURATION_RU.md
@@ -113,6 +113,7 @@ title: "Cloud provider — VMware vSphere: настройки провайдер
   * Опциональный параметр. По умолчанию `true`.
 * `region` — тэг, прикреплённый к vSphere Datacenter, в котором будут происходить все операции: заказ VirtualMachines, размещение их дисков на datastore, подключение к network.
 * `baseResourcePool` — относительный (от vSphere Cluster) путь до существующего родительского `resourcePool` для всех создаваемых (в каждой зоне) `resourcePool`'ов.
+* `useNestedResourcePool` - создавать вложенный пул (`true`) или использовать основной пул (`false`). По-умолчанию - `true`.
 * `sshPublicKey` — публичный ключ для доступа на узлы.
 * `externalNetworkNames` — имена сетей (не полный путь, а просто имя), подключённые к VirtualMachines, и используемые vsphere-cloud-controller-manager для проставления ExternalIP в `.status.addresses` в Node API объект.
   * Формат — массив строк. Например,

--- a/ee/candi/cloud-providers/vsphere/layouts/standard/base-infrastructure/main.tf
+++ b/ee/candi/cloud-providers/vsphere/layouts/standard/base-infrastructure/main.tf
@@ -40,6 +40,7 @@ data "vsphere_dynamic" "cluster_id" {
 
 locals {
   base_resource_pool = trim(lookup(var.providerClusterConfiguration, "baseResourcePool", ""), "/")
+  use_nested_resource_pool = lookup(var.providerClusterConfiguration, "useNestedResourcePool", true)
 }
 
 data "vsphere_resource_pool" "parent_resource_pool" {
@@ -49,7 +50,7 @@ data "vsphere_resource_pool" "parent_resource_pool" {
 }
 
 resource "vsphere_resource_pool" "resource_pool" {
-  for_each = toset([for s in data.vsphere_resource_pool.parent_resource_pool: s.id])
+  for_each = toset(local.use_nested_resource_pool == true ? [for s in data.vsphere_resource_pool.parent_resource_pool: s.id ] : [])
   name          = local.prefix
   parent_resource_pool_id = each.key
 

--- a/ee/candi/cloud-providers/vsphere/layouts/standard/base-infrastructure/outputs.tf
+++ b/ee/candi/cloud-providers/vsphere/layouts/standard/base-infrastructure/outputs.tf
@@ -6,6 +6,6 @@ output "cloud_discovery_data" {
     "apiVersion" = "deckhouse.io/v1"
     "kind" = "VsphereCloudDiscoveryData"
     "vmFolderPath" = vsphere_folder.main.path
-    "resourcePoolPath" = local.base_resource_pool != "" ? join("/", [local.base_resource_pool, local.prefix]) : local.prefix
+    "resourcePoolPath" = local.use_nested_resource_pool == true ? (local.base_resource_pool != "" ? join("/", [local.base_resource_pool, local.prefix]) : local.prefix) : ""
   }
 }

--- a/ee/candi/cloud-providers/vsphere/openapi/cloud_discovery_data.yaml
+++ b/ee/candi/cloud-providers/vsphere/openapi/cloud_discovery_data.yaml
@@ -17,4 +17,3 @@ apiVersions:
         minLength: 1
       resourcePoolPath:
         type: string
-        minLength: 1

--- a/ee/candi/cloud-providers/vsphere/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vsphere/openapi/cluster_configuration.yaml
@@ -230,6 +230,8 @@ apiVersions:
         uniqueItems: true
       baseResourcePool:
         type: string
+      useNestedResourcePool:
+        type: boolean
       layout:
         type: string
       provider:

--- a/ee/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
+++ b/ee/candi/cloud-providers/vsphere/terraform-modules/master-node/main.tf
@@ -37,7 +37,7 @@ data "vsphere_datastore" "datastore" {
 }
 
 data "vsphere_resource_pool" "resource_pool" {
-  count         = length(local.resource_pool) == 0 ? 0 : 1
+  count         = 1
   name          = join("/", [data.vsphere_dynamic.cluster_id.inventory_path, "Resources", local.resource_pool])
   datacenter_id = data.vsphere_dynamic.datacenter_id.id
 }
@@ -131,7 +131,7 @@ resource "vsphere_virtual_disk" "kubernetes_data" {
 
 resource "vsphere_virtual_machine" "master" {
   name             = join("-", [local.prefix, "master", var.nodeIndex])
-  resource_pool_id = length(local.resource_pool) == 0 ? null : data.vsphere_resource_pool.resource_pool[0].id
+  resource_pool_id = data.vsphere_resource_pool.resource_pool[0].id
   datastore_id     = data.vsphere_datastore.datastore.id
   folder           = var.providerClusterConfiguration.vmFolderPath
 

--- a/ee/candi/cloud-providers/vsphere/terraform-modules/master-node/variables.tf
+++ b/ee/candi/cloud-providers/vsphere/terraform-modules/master-node/variables.tf
@@ -43,8 +43,9 @@ locals {
   zones           = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", null) != null ? tolist(setintersection(local.actual_zones, var.providerClusterConfiguration.masterNodeGroup["zones"])) : local.actual_zones
   zone            = element(local.zones, var.nodeIndex)
 
+  use_nested_resource_pool = lookup(var.providerClusterConfiguration, "useNestedResourcePool", true)
   base_resource_pool    = trim(lookup(var.providerClusterConfiguration, "baseResourcePool", ""), "/")
-  default_resource_pool = join("/", local.base_resource_pool != "" ? [local.base_resource_pool, local.prefix] : [local.prefix])
+  default_resource_pool = local.use_nested_resource_pool == true ? join("/", local.base_resource_pool != "" ? [local.base_resource_pool, local.prefix] : [local.prefix]) : ""
 
   resource_pool      = lookup(local.master_instance_class, "resourcePool", local.default_resource_pool)
   additionalNetworks = lookup(local.master_instance_class, "additionalNetworks", [])

--- a/ee/candi/cloud-providers/vsphere/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/vsphere/terraform-modules/static-node/main.tf
@@ -37,7 +37,7 @@ data "vsphere_datastore" "datastore" {
 }
 
 data "vsphere_resource_pool" "resource_pool" {
-  count         = length(local.resource_pool) == 0 ? 0 : 1
+  count         = 1
   name          = join("/", [data.vsphere_dynamic.cluster_id.inventory_path, "Resources", local.resource_pool])
   datacenter_id = data.vsphere_dynamic.datacenter_id.id
 }

--- a/ee/candi/cloud-providers/vsphere/terraform-modules/static-node/variables.tf
+++ b/ee/candi/cloud-providers/vsphere/terraform-modules/static-node/variables.tf
@@ -49,14 +49,14 @@ locals {
   zones           = lookup(local.ng, "zones", null) != null ? tolist(setintersection(local.actual_zones, local.ng["zones"])) : local.actual_zones
   zone            = element(local.zones, var.nodeIndex)
 
+  use_nested_resource_pool = lookup(var.providerClusterConfiguration, "useNestedResourcePool", true)
   base_resource_pool    = trim(lookup(var.providerClusterConfiguration, "baseResourcePool", ""), "/")
-  default_resource_pool = join("/", local.base_resource_pool != "" ? [local.base_resource_pool, local.prefix] : [local.prefix])
+  default_resource_pool = local.use_nested_resource_pool == true ? join("/", local.base_resource_pool != "" ? [local.base_resource_pool, local.prefix] : [local.prefix]) : ""
 
   resource_pool = lookup(local.instance_class, "resourcePool", local.default_resource_pool)
 
   additionalNetworks = lookup(local.instance_class, "additionalNetworks", [])
   main_ip_addresses  = lookup(local.instance_class, "mainNetworkIPAddresses", [])
-
 
   runtime_options               = lookup(local.instance_class, "runtimeOptions", {})
   calculated_memory_reservation = lookup(local.runtime_options, "memoryReservation", 80)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added ability to install deckhouse in vsphere installations with disabled DRS ability.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->
When DRS in vsphere vcenter is disabled, we cannot create additional resource pools and deckhouse installation fails.

```changes
module: cloud-provider-vsphere
type: feature
description: "Added ability to install deckhouse in vsphere installations with disabled DRS ability."
note: 
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
