### PR TITLE
[deckhouse] fix requirements semver

### DIFF
--- a/modules/040-control-plane-manager/hooks/requirements.go
+++ b/modules/040-control-plane-manager/hooks/requirements.go
@@ -19,29 +19,28 @@ package hooks
 import (
 	"errors"
 
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
 )
 
 func init() {
 	f := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
-		desiredVersion, err := semver.Parse(requirementValue)
+		desiredVersion, err := semver.NewVersion(requirementValue)
 		if err != nil {
 			return false, err
 		}
-
 		currentVersionStr := getter.Get("global.discovery.kubernetesVersion").String()
-		currentVersion, err := semver.Parse(currentVersionStr)
+		currentVersion, err := semver.NewVersion(currentVersionStr)
 		if err != nil {
 			return false, err
 		}
 
-		if currentVersion.GE(desiredVersion) {
-			return true, nil
+		if currentVersion.LessThan(desiredVersion) {
+			return false, errors.New("current kubernetes version is lower then required")
 		}
 
-		return false, errors.New("current kubernetes version is lower then required")
+		return true, nil
 	}
 
 	requirements.Register("k8s", f)

--- a/modules/040-control-plane-manager/hooks/requirements_test.go
+++ b/modules/040-control-plane-manager/hooks/requirements_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
+)
+
+func TestKubernetesVersionRequirement(t *testing.T) {
+	t.Run("requirement met", func(t *testing.T) {
+		getter := mockGetter{
+			Value: "1.19.16",
+		}
+		ok, err := requirements.CheckRequirement("k8s", "1.19", getter)
+		assert.True(t, ok)
+		require.NoError(t, err)
+	})
+
+	t.Run("requirement failed", func(t *testing.T) {
+		getter := mockGetter{
+			Value: "1.18.3",
+		}
+		ok, err := requirements.CheckRequirement("k8s", "1.19", getter)
+		assert.False(t, ok)
+		require.Error(t, err)
+	})
+}
+
+type mockGetter struct {
+	Value string
+}
+
+func (mg mockGetter) Get(_ string) gjson.Result {
+	return gjson.Result{
+		Type: gjson.String,
+		Str:  mg.Value,
+		Raw:  mg.Value,
+	}
+}


### PR DESCRIPTION
## Description
Wrong semver lib was used

## Why do we need it, and what problem does it solve?
Blang semver lib doesn't parse Major.Minor versions, like "1.19" while Mastermind lib does. We have both cases of kubernetes versions inside the Deckhouse. So, it's better to use Mastermind lib

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: deckhouse
type: fix 
description: Fix requirements check semver lib
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
