### PR TITLE
[chore] remove extra semver lib

### DIFF
--- a/deckhouse-controller/pkg/helpers/openstack/supports-online-disk-resize.go
+++ b/deckhouse-controller/pkg/helpers/openstack/supports-online-disk-resize.go
@@ -17,21 +17,12 @@ package openstack
 import (
 	"fmt"
 
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/apiversions"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 )
 
-var onlineResizeMinVersion = semVerMustParseTolerant("3.42")
-
-func semVerMustParseTolerant(ver string) semver.Version {
-	semVersion, err := semver.ParseTolerant(ver)
-	if err != nil {
-		panic(err)
-	}
-
-	return semVersion
-}
+var onlineResizeMinVersion = semver.MustParse("3.42")
 
 func SupportsOnlineDiskResize() error {
 	client, err := clientconfig.NewServiceClient("volume", nil)
@@ -58,10 +49,10 @@ func SupportsOnlineDiskResize() error {
 		return fmt.Errorf("cannot determine current API version for 3.0 block-storage")
 	}
 
-	currentVersionSemVer := semVerMustParseTolerant(currentVersion)
+	currentVersionSemVer := semver.MustParse(currentVersion)
 
 	var stdout string
-	if currentVersionSemVer.GE(onlineResizeMinVersion) {
+	if currentVersionSemVer.GreaterThan(onlineResizeMinVersion) || currentVersionSemVer.Equal(onlineResizeMinVersion) {
 		stdout = "yes"
 	} else {
 		stdout = "no"

--- a/ee/modules/600-flant-integration/hooks/pricing/envs_from_global_values_and_kubectl.go
+++ b/ee/modules/600-flant-integration/hooks/pricing/envs_from_global_values_and_kubectl.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 
@@ -25,7 +25,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 func handleGlobalValuesAndKubectl(input *go_hook.HookInput, dc dependency.Container) error {
 	var (
 		cloudProvider           = "none"
-		controlPlaneVersion     semver.Version
+		controlPlaneVersion     *semver.Version
 		clusterType             = "Cloud"
 		terraformManagerEnabled bool
 	)
@@ -53,7 +53,7 @@ func handleGlobalValuesAndKubectl(input *go_hook.HookInput, dc dependency.Contai
 		return fmt.Errorf("can't get Kubernetes version: %v", err)
 	}
 	serverVersion := version.String()
-	controlPlaneVersion, err = semver.Make(serverVersion[1:])
+	controlPlaneVersion, err = semver.NewVersion(serverVersion[1:])
 	if err != nil {
 		return fmt.Errorf("can't parse Kubernetes version: %v", err)
 	}
@@ -75,7 +75,7 @@ func handleGlobalValuesAndKubectl(input *go_hook.HookInput, dc dependency.Contai
 
 	input.Values.Set("flantIntegration.internal.cloudProvider", cloudProvider)
 	input.Values.Set("flantIntegration.internal.controlPlaneVersion",
-		fmt.Sprintf("%d.%d", controlPlaneVersion.Major, controlPlaneVersion.Minor))
+		fmt.Sprintf("%d.%d", controlPlaneVersion.Major(), controlPlaneVersion.Minor()))
 
 	input.Values.Set("flantIntegration.internal.clusterType", clusterType)
 	input.Values.Set("flantIntegration.internal.terraformManagerEnabled", terraformManagerEnabled)

--- a/ee/modules/600-flant-integration/hooks/pricing/envs_from_nodes.go
+++ b/ee/modules/600-flant-integration/hooks/pricing/envs_from_nodes.go
@@ -8,7 +8,7 @@ package pricing
 import (
 	"fmt"
 
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	v1 "k8s.io/api/core/v1"
@@ -86,17 +86,17 @@ func nodeHandler(input *go_hook.HookInput) error {
 		return nil
 	}
 
-	var minNodeVersion semver.Version
+	var minNodeVersion *semver.Version
 	stats := NodeStats{}
 
 	for _, s := range snaps {
 		node := s.(*Node)
 
-		nodeVersion, err := semver.Make(node.Version)
+		nodeVersion, err := semver.NewVersion(node.Version)
 		if err != nil {
 			return fmt.Errorf("can't parse Node version: %v", err)
 		}
-		if minNodeVersion.Equals(semver.Version{}) || nodeVersion.LT(minNodeVersion) {
+		if minNodeVersion == nil || nodeVersion.LessThan(minNodeVersion) {
 			minNodeVersion = nodeVersion
 		}
 
@@ -125,7 +125,7 @@ func nodeHandler(input *go_hook.HookInput) error {
 		}
 	}
 
-	stats.MinimalKubeletVersion = fmt.Sprintf("%d.%d", minNodeVersion.Major, minNodeVersion.Minor)
+	stats.MinimalKubeletVersion = fmt.Sprintf("%d.%d", minNodeVersion.Major(), minNodeVersion.Minor())
 
 	input.Values.Set("flantIntegration.internal.nodeStats", stats)
 	return nil

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
@@ -176,12 +176,12 @@ func getKubeVersionForServer(endpoint string, cl d8http.Client) (*semver.Version
 		return nil, err
 	}
 
-	ver, err := semver.ParseTolerant(info.GitVersion)
+	ver, err := semver.NewVersion(info.GitVersion)
 	if err != nil {
 		return nil, err
 	}
 
-	return &ver, nil
+	return ver, nil
 }
 
 func apiServerEndpoints(input *go_hook.HookInput) ([]string, error) {
@@ -257,7 +257,7 @@ func k8sVersions(input *go_hook.HookInput, dc dependency.Container) error {
 			return err
 		}
 
-		if minVer == nil || ver.LT(*minVer) {
+		if minVer == nil || ver.LessThan(minVer) {
 			minVer = ver
 		}
 		versions = append(versions, ver.String())

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/aws/aws-sdk-go v1.34.28
 	github.com/benjamintf1/unmarshalledmatchers v0.0.0-20190408201839-bb1c1f34eaea
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/clarketm/json v1.15.7
 	github.com/cloudflare/cfssl v1.5.0
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -117,7 +117,6 @@ github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngE
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=

--- a/modules/340-monitoring-kubernetes/hooks/choose_nodes_for_ebpf_exporter.go
+++ b/modules/340-monitoring-kubernetes/hooks/choose_nodes_for_ebpf_exporter.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/blang/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	v1 "k8s.io/api/core/v1"
@@ -57,12 +57,12 @@ func getNodeNameWithSupportedDistro(obj *unstructured.Unstructured) (go_hook.Fil
 	}
 	kernelSemVerStr := matches[1]
 
-	kernelSemVer, err := semver.New(kernelSemVerStr)
+	kernelSemVer, err := semver.NewVersion(kernelSemVerStr)
 	if err != nil {
 		return nil, fmt.Errorf("cannot use %q as semver: %s", kernelSemVerStr, err)
 	}
 
-	if kernelSemVer.GE(minSupportedKernelSemVer) {
+	if kernelSemVer.GreaterThan(minSupportedKernelSemVer) || kernelSemVer.Equal(minSupportedKernelSemVer) {
 		nodeEligibility.IsEbpfSupported = true
 	}
 


### PR DESCRIPTION
## Description
Remove extra semver lib usage

## Why do we need it, and what problem does it solve?
We use 2 semver libs, from Mastermind and Blang. They have a bit different behavior in some cases, so we decided to left only Mastermind library to avoid bugs. 

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: chore
type: fix
description: Remove extra semver lib
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
