### PR TITLE
[monitoring-kubernetes] Match OOM kills only on systemd cgroup driver

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/ebpf-exporter.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/ebpf-exporter.yaml
@@ -6,7 +6,7 @@
         label_replace(kube_pod_info, "raw_pod_id", "$1$2$3$4$5", "uid", "(.+)-(.+)-(.+)-(.+)-(.+)")
         * on (raw_pod_id) group_left
         label_replace(
-          label_replace(ebpf_exporter_oom_kills{global_oom="0"}, "raw_pod_id", "$1", "cgroup_path", ".+-pod(.+).slice"),
+          label_replace(ebpf_exporter_oom_kills{global_oom="0", cgroup_path=~".*slice.*"}, "raw_pod_id", "$1", "cgroup_path", ".+-pod(.+).slice"),
           "raw_pod_id", "$1$2$3$4$5", "raw_pod_id", "(.+)_(.+)_(.+)_(.+)_(.+)"
         )
       )
@@ -15,5 +15,5 @@
       max by (namespace, pod, container) (
         label_replace(kube_pod_container_info, "raw_container_id", "$1", "container_id", "containerd://(.+)")
         * on (raw_container_id) group_left
-        max by (raw_container_id) (label_replace(ebpf_exporter_oom_kills{global_oom="0"}, "raw_container_id", "$1", "cgroup_path", ".+cri-containerd-(.+).scope"))
+        max by (raw_container_id) (label_replace(ebpf_exporter_oom_kills{global_oom="0", cgroup_path=~".*slice.*"}, "raw_container_id", "$1", "cgroup_path", ".+cri-containerd-(.+).scope"))
       )


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Match only systemd cgroup driver CRIs.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

`label_replace` regexes are not suitable for the kubelet cgroup driver.