### PR TITLE
[global] Refact x-examples on global values and fix helm_lib_module_uri_scheme

### DIFF
--- a/candi/openapi/cluster_configuration.yaml
+++ b/candi/openapi/cluster_configuration.yaml
@@ -5,6 +5,22 @@ apiVersions:
     type: object
     additionalProperties: false
     required: [apiVersion, kind, clusterType, kubernetesVersion, podSubnetCIDR, serviceSubnetCIDR, clusterDomain]
+    x-examples:
+    - apiVersion: deckhouse.io/v1
+      kind: ClusterConfiguration
+      podSubnetNodeCIDRPrefix: "24"
+      podSubnetCIDR: 10.244.0.0/16
+      serviceSubnetCIDR: 192.168.0.0/16
+      kubernetesVersion: "1.21"
+      clusterDomain: test
+      clusterType: "Cloud"
+      cloud:
+        prefix: test
+        provider: Yandex
+      packagesProxy:
+        uri: https://example.com
+        username: user
+        password: passwd
     properties:
       apiVersion:
         type: string

--- a/global-hooks/openapi/config-values.yaml
+++ b/global-hooks/openapi/config-values.yaml
@@ -16,6 +16,7 @@ properties:
       A global switch to enable the HA mode for modules that support it.
 
       The parameter is not defined by default; the decision is made based on the `global.discovery.clusterControlPlaneIsHighlyAvailable` parameter.
+    x-examples: [ true, false ]
   modules:
     description: |
       Parameters of service components.
@@ -28,6 +29,7 @@ properties:
         default: nginx
         description: |
           The class of the Ingress controller used for service components.
+        x-examples: [ "nginx" ]
       publicDomainTemplate:
         type: string
         # only check that is containing %s
@@ -42,6 +44,7 @@ properties:
 
           If this parameter is omitted, no Ingress resources will be created.
         x-doc-example: '%s.kube.company.my'
+        x-examples: [ "%s.kube.company.my" ]
       placement:
         description: |
           Parameters regulating the layout of Deckhouse components.
@@ -61,11 +64,22 @@ properties:
             type: array
             items:
               type: string
+            x-examples:
+            - [ "dedicated.example.com" ]
       https:
         description: |
           The HTTPS implementation used by the service components.
         type: object
         additionalProperties: false
+        x-examples:
+        - certManager:
+            clusterIssuerName: letsencrypt
+          mode: CertManager
+        - mode: Disabled
+        - mode: OnlyInURI
+        - mode: CustomCertificate
+          customCertificate:
+            secretName: plainstring
         properties:
           mode:
             type: string
@@ -118,6 +132,9 @@ properties:
             additionalProperties: false
             description: |
               System components running on every cluster node (usually DaemonSets)
+            x-examples:
+            - cpu: 100m
+              memory: 150M
             properties:
               cpu:
                 description: |
@@ -138,6 +155,9 @@ properties:
               System components (control plane and system components on the master nodes).
 
               **Caution!** Deckhouse does not manage control plane components in managed clusters, so all resources are allocated to the system components.
+            x-examples:
+            - cpu: "1"
+              memory: 150Mi
             properties:
               cpu:
                 description: |

--- a/global-hooks/openapi/values.yaml
+++ b/global-hooks/openapi/values.yaml
@@ -23,26 +23,32 @@ properties:
                 type: number
                 format: double
                 minimum: 0
+                x-examples: [ 123456 ]
               memoryEveryNode:
                 type: integer
                 format: int64
                 minimum: 0
+                x-examples: [ 123456 ]
               milliCpuControlPlane:
                 type: integer
                 format: int64
                 minimum: 0
+                x-examples: [ 1024 ]
               memoryControlPlane:
                 type: integer
                 format: int64
                 minimum: 0
+                x-examples: [ 536870912 ]
               milliCpuMaster:
                 type: integer
                 format: int64
                 minimum: 0
+                x-examples: [ 123456 ]
               memoryMaster:
                 type: integer
                 format: int64
                 minimum: 0
+                x-examples: [ 123456 ]
   clusterConfiguration:
     $ref: '/deckhouse/candi/openapi/cluster_configuration.yaml#/apiVersions/0/openAPISpec'
   clusterIsBootstrapped:
@@ -51,15 +57,20 @@ properties:
       It indicates the cluster is bootstraped.
       The cluster is considered bootstrapped if configmap d8-system/d8-cluster-is-bootstraped exists or
       cluster has at least one non-master node
+    x-examples: [ true ]
   deckhouseVersion:
     type: string
+    x-examples: [ dev ]
   deckhouseEdition:
     type: string
     enum: [Unknown, CE, FE, EE ]
+    x-examples: [ FE ]
   enabledModules:
     type: array
     items:
       type: string
+    x-examples:
+    - ["cert-manager", "vertical-pod-autoscaler-crd", "prometheus", "priority-class"]
   discovery:
     additionalProperties: true
     type: object
@@ -68,19 +79,23 @@ properties:
       clusterControlPlaneIsHighlyAvailable:
         type: boolean
         default: false
+        x-examples: [ true, false ]
       clusterMasterCount:
         type: integer
         minimum: 0
+        x-examples: [ 1, 3 ]
       podSubnet:
         type: string
         pattern: '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$'
         description: |
           Network subnet for pods
+        x-examples: [ "10.222.0.0/24" ]
       serviceSubnet:
         type: string
         pattern: '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$'
         description: |
           Network subnet for k8s services
+        x-examples: [ "10.222.0.0/24" ]
       defaultStorageClass:
         type: string
         # it is name of resource in kubernetes
@@ -88,30 +103,37 @@ properties:
         description: |
           Default storage class for cluster
           It gets form storage class annotated as "storageclass.beta.kubernetes.io/is-default-class" or "storageclass.kubernetes.io/is-default-class"
+        x-examples: [ "default" ]
       clusterDNSAddress:
         type: string
         pattern: '^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})$'
         description: |
           DNS server in-cluster address
           It gets form service in kube-system namespace labeled as "kube-dns" or "coredns"
+        x-examples: [ "10.222.0.1" ]
       kubernetesCA:
         type: string
         description: |
           Kubernetes apiserver CA certificate.
           It gets from /var/run/secrets/kubernetes.io/serviceaccount/ca.crt file
+        x-examples:
+          - "K8S\nCA\nMultilne"
       prometheusScrapeInterval:
         type: integer
         default: 30
         minimum: 1
         description: |
           Scrape interval for prometheus. In seconds
+        x-examples: [ 1 ]
       clusterUUID:
         type: string
         description: |
           Unique cluster identifier
+        x-examples: [ "f76f54dc-7ea0-11ec-899e-c70701aef75e" ]
       clusterDomain:
         type: string
         pattern: '^[0-9a-zA-Z._-]+$'
+        x-examples: [ "cluster.local" ]
       d8SpecificNodeCountByRole:
         # it is map node_role => count
         # we can have multiple roles, for example every module has our own role
@@ -122,6 +144,8 @@ properties:
           Map node-role => count.
           Node will have role 'some-role' if it has label with prefix node-role.deckhouse.io/
           Do not use label with prefix node-role.deckhouse.io/ on workers nodes!
+        x-examples:
+        - system: 2
       kubernetesVersions:
         type: array
         items:
@@ -130,17 +154,22 @@ properties:
           pattern: ^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
         description: |
           K8s versions for each control-plane node
+        x-examples:
+        - [ "1.21.2", "1.21.3", "1.21.2" ]
       kubernetesVersion:
         type: string
         # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         pattern: ^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
         description: |
           Effective (minimal from each control plane node) k8s version
+        x-examples: [ "1.21.2" ]
       extensionAPIServerAuthenticationRequestheaderClientCA:
         type: string
         description: |
           The CA for verification requests to our custom modules from clients inside cluster.
           It gets from kube-system/extension-apiserver-authentication config map
+        x-examples:
+        - "extention\nCA\nMultiline"
   modulesImages:
     additionalProperties: true
     type: object
@@ -150,19 +179,23 @@ properties:
         type: string
         description: |
           Path part of deckhuse repo
+        x-examples: [ "/deckhouse/fe" ]
       registryAddress:
         type: string
         description: |
           Domain part of deckhuse repo
+        x-examples: [ "registry.deckhouse.io" ]
       registryCA:
         type: string
         description: |
           Registry CA certificate
+        x-examples: [ "registry\nCA\nMultiline" ]
       registryScheme:
         type: string
         enum: ["http", "https"]
         description: |
           Scheme for registry
+        x-examples: [ "https" ]
       registryDockercfg:
         type: string
         # source https://regex101.com/r/Pj4Ako/1
@@ -178,6 +211,7 @@ properties:
           Deckhouse images repo.
           It uses in helm teplates for generating container image address.
           Almost always, concatinateds with tag from modulesImages.tag
+        x-examples: [ "registry.deckhouse.io/deckhouse/fe" ]
       tags:
         type: object
         default: {}
@@ -189,158 +223,7 @@ properties:
           That file generated on build stage.
           See modules_images_werf and modules_images_werf.yaml for additional information.
           Values from this map uses in helm teplates for generating container image address in deployments sts...
-x-examples:
-- storageClass: "storage-class"
-  highAvailability: true
-  modules:
-    ingressClass: "my-ingress"
-    publicDomainTemplate: "%s.example.com"
-    placement:
-      customTolerationKeys:
-        - dedicated.example.com
-        - node-dedicated.example.com/master
-    https:
-      certManager:
-        clusterIssuerName: letsencrypt
-      mode: CertManager
-    resourcesRequests:
-      everyNode:
-        cpu: "100m"
-        memory: "1G"
-      masterNode:
-        cpu: "1"
-        memory: "1Gi"
-  internal:
-    modules:
-      resourcesRequests:
-        milliCpuControlPlane: 1024
-        memoryControlPlane: 536870912
-  clusterConfiguration:
-    apiVersion: deckhouse.io/v1
-    kind: ClusterConfiguration
-    podSubnetNodeCIDRPrefix: "24"
-    podSubnetCIDR: 10.244.0.0/16
-    serviceSubnetCIDR: 192.168.0.0/16
-    kubernetesVersion: "1.19"
-    clusterDomain: test
-    clusterType: "Cloud"
-    cloud:
-      prefix: test
-      provider: OpenStack
-    packagesProxy:
-      uri: https://example.com
-      username: user
-      password: passwd
-  clusterIsBootstrapped: true
-  deckhouseVersion: dev
-  deckhouseEdition: FE
-  enabledModules: ["cert-manager", "vertical-pod-autoscaler-crd", "prometheus", "priority-class"]
-  discovery:
-    clusterControlPlaneIsHighlyAvailable: true
-    clusterMasterCount: 3
-    podSubnet: "10.10.10.10/24"
-    serviceSubnet: "10.20.10.10/24"
-    defaultStorageClass: "some-storage-class"
-    clusterDNSAddress: "10.10.20.10"
-    kubernetesCA: |
-      K8S
-      CA
-      Multilne
-    prometheusScrapeInterval: 30
-    clusterUUID: deadbeef-4bda-11ec-81d3-0242ac130003
-    clusterDomain: cluster.local
-    d8SpecificNodeCountByRole:
-      system: 2
-    kubernetesVersions: [ "1.21.2", "1.21.3", "1.21.2" ]
-    kubernetesVersion: "1.21.2"
-    extensionAPIServerAuthenticationRequestheaderClientCA: |
-      Extention Api server
-      CA
-      Multiline
-  modulesImages:
-    registry: registry.deckhouse.io/deckhouse/fe
-    registryDockercfg: Y2ZnCg==
-    registryAddress: registry.deckhouse.io
-    registryPath: /deckhouse/fe
-    registryScheme: https
-    registryCA: testCA
-    tags:
-      module:
-        image: hash
-- storageClass: "storage-class"
-  highAvailability: true
-  modules:
-    ingressClass: "my-ingress"
-    publicDomainTemplate: "%s.example.com"
-    placement:
-      customTolerationKeys:
-        - dedicated.example.com
-        - node-dedicated.example.com/master
-    https:
-      mode: CustomCertificate
-      customCertificate:
-        secretName: plainstring
-    resourcesRequests:
-      everyNode:
-        cpu: "100m"
-        memory: "1G"
-      masterNode:
-        cpu: "1"
-        memory: "1Gi"
-  internal:
-    modules:
-      resourcesRequests:
-        milliCpuControlPlane: 1024
-        memoryControlPlane: 536870912
-  clusterConfiguration:
-    apiVersion: deckhouse.io/v1
-    kind: ClusterConfiguration
-    podSubnetNodeCIDRPrefix: "24"
-    podSubnetCIDR: 10.244.0.0/16
-    serviceSubnetCIDR: 192.168.0.0/16
-    kubernetesVersion: "1.19"
-    clusterDomain: test
-    clusterType: "Cloud"
-    cloud:
-      prefix: test
-      provider: OpenStack
-    packagesProxy:
-      uri: https://example.com
-      username: user
-      password: passwd
-  clusterIsBootstrapped: true
-  deckhouseVersion: dev
-  deckhouseEdition: FE
-  enabledModules: ["cert-manager", "vertical-pod-autoscaler-crd", "prometheus", "priority-class"]
-  discovery:
-    clusterControlPlaneIsHighlyAvailable: true
-    clusterMasterCount: 3
-    podSubnet: "10.10.10.10/24"
-    serviceSubnet: "10.20.10.10/24"
-    defaultStorageClass: "some-storage-class"
-    clusterDNSAddress: "10.10.20.10"
-    kubernetesCA: |
-      K8S
-      CA
-      Multilne
-    prometheusScrapeInterval: 30
-    clusterUUID: deadbeef-4bda-11ec-81d3-0242ac130003
-    clusterDomain: cluster.local
-    d8SpecificNodeCountByRole:
-      system: 2
-    kubernetesVersions: [ "1.21.2", "1.21.3", "1.21.2" ]
-    kubernetesVersion: "1.21.2"
-    extensionAPIServerAuthenticationRequestheaderClientCA: |
-      Extention Api server
-      CA
-      Multiline
-  modulesImages:
-    registry: registry.deckhouse.io/deckhouse/fe
-    registryDockercfg: Y2ZnCg==
-    registryAddress: registry.deckhouse.io
-    registryPath: /deckhouse/fe
-    registryScheme: https
-    registryCA: testCA
-    tags:
-      module:
-        image: hash
+        x-examples:
+        - tags:
+            module:
+              image: hash

--- a/helm_lib/templates/_module_https.tpl
+++ b/helm_lib/templates/_module_https.tpl
@@ -2,8 +2,21 @@
 {{- /* return module uri scheme "http" or "https" */ -}}
 {{- define "helm_lib_module_uri_scheme" -}}
   {{- $context := . -}}
+  {{- $mode := "" -}}
 
-  {{- if eq "Disabled" (include "helm_lib_module_https_mode" $context) -}}
+  {{- $module_values := include "helm_lib_module_values" $context | fromYaml -}}
+  {{- if hasKey $module_values "https" -}}
+    {{- if hasKey $module_values.https "mode" -}}
+      {{- $mode = $module_values.https.mode -}}
+    {{- else }}
+      {{- $mode = $context.Values.global.modules.https.mode | default "" -}}
+    {{- end }}
+  {{- else }}
+    {{- $mode = $context.Values.global.modules.https.mode | default "" -}}
+  {{- end }}
+
+
+  {{- if eq "Disabled" $mode -}}
     http
   {{- else -}}
     https

--- a/testing/matrix/linter/controller.go
+++ b/testing/matrix/linter/controller.go
@@ -158,7 +158,7 @@ func (c *ModuleController) RunRender(values string, objectStore *storage.Unstruc
 		if r := recover(); r != nil {
 			lintError = fmt.Errorf(
 				manifestErrorMessage,
-				"panic during unmarshalling (probably because of yaml file is invalid)",
+				fmt.Errorf("panic during unmarshalling (probably because of yaml file is invalid): %v", r),
 				lastTest,
 			)
 		}
@@ -169,9 +169,16 @@ func (c *ModuleController) RunRender(values string, objectStore *storage.Unstruc
 		dec := yaml.NewDecoder(strings.NewReader(bigFile))
 		for {
 			var node map[string]interface{}
-			if err := dec.Decode(&node); err == io.EOF {
+			err := dec.Decode(&node)
+
+			if err == io.EOF {
 				break
 			}
+
+			if err != nil {
+				panic(fmt.Errorf("parsing failed: %s", err))
+			}
+
 			if node == nil {
 				continue
 			}


### PR DESCRIPTION
## Description
Add more x-examples for matrix tests purposes.

Refact `helm_lib_module_uri_scheme` template util, because it needed enabled `cert-manager` and we want use it before enabling `cert-manager` module.  


## Why do we need it, and what problem does it solve?
Need more matrix testes for better covering template testing.

Cluster does not bootstrap without refactor `helm_lib_module_uri_scheme`.


<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
