### PR TITLE
[helm] Add deprecation guide link to alerts

### DIFF
--- a/modules/999-helm/monitoring/prometheus-rules/deprecated-versions.yaml
+++ b/modules/999-helm/monitoring/prometheus-rules/deprecated-versions.yaml
@@ -16,6 +16,8 @@
         To see all resources please use the  expr `max without(instance, pod, hook, job, tier, module) (resource_versions_compatibility) == 1` in prometheus.
         For more details, please follow the link https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/
 
+        Deprecation guide: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22
+
   - alert: ClusterHasProblemsWithHelmReleasesWithResourceVersions
     expr: |
       count by (alertname) (ALERTS{alertname=~"HelmReleaseHasResourcesWithDeprecatedVersions", alertstate="firing"})
@@ -45,3 +47,5 @@
       description: |
         To see all resources please use the  expr `max without(instance, pod, hook, job, tier, module) (resource_versions_compatibility) == 1` in prometheus.
         For more details, please follow the link https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/
+
+        Deprecation guide: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
By following the deprecation guide, you can clarify any API version upgrade nuances.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: helm
type: fix
description: Add deprecation guide link to deprecated resources alerts.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
