### PR TITLE
[docs]  Fix keepalived module examples node labels

### DIFF
--- a/ee/fe/modules/450-keepalived/docs/USAGE.md
+++ b/ee/fe/modules/450-keepalived/docs/USAGE.md
@@ -4,18 +4,18 @@ title: "The keepalived module: usage"
 
 ## Three public IP addresses
 
-Suppose there are three public IP addresses on three front nodes. Each virtual IP address is placed in a separate VRRP group. Thus, each address "jumps" independently of the others, and if there are three nodes in the cluster with the `node-role/frontend: ""` labels, then each IP gets its own MASTER node.
+Suppose there are three public IP addresses on three front nodes. Each virtual IP address is placed in a separate VRRP group. Thus, each address "jumps" independently of the others, and if there are three nodes in the cluster with the `node-role.deckhouse.io/frontend: ""` labels, then each IP gets its own MASTER node.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha1
+apiVersion: node-role.deckhouse.io/v1alpha1
 kind: KeepalivedInstance
 metadata:
   name: front
 spec:
   nodeSelector: # mandatory
-    node-role/frontend: ""
+    node-role.deckhouse.io/frontend: ""
   tolerations:  # optional
-  - key: dedicated
+  - key: dedicated.deckhouse.io
     operator: Equal
     value: frontend
   vrrpInstances:
@@ -46,9 +46,9 @@ metadata:
   name: mygateway
 spec:
   nodeSelector:
-    node-role/mygateway: ""
+    node-role.deckhouse.io/mygateway: ""
   tolerations:
-  - key: node-role/mygateway
+  - key: node-role.deckhouse.io/mygateway
     operator: Exists
   vrrpInstances:
   - id: 4 # since "1", "2", "3" IDs are used in the "front" KeepalivedInstance above

--- a/ee/fe/modules/450-keepalived/docs/USAGE.md
+++ b/ee/fe/modules/450-keepalived/docs/USAGE.md
@@ -7,7 +7,7 @@ title: "The keepalived module: usage"
 Suppose there are three public IP addresses on three front nodes. Each virtual IP address is placed in a separate VRRP group. Thus, each address "jumps" independently of the others, and if there are three nodes in the cluster with the `node-role.deckhouse.io/frontend: ""` labels, then each IP gets its own MASTER node.
 
 ```yaml
-apiVersion: node-role.deckhouse.io/v1alpha1
+apiVersion: deckhouse.io/v1alpha1
 kind: KeepalivedInstance
 metadata:
   name: front

--- a/ee/fe/modules/450-keepalived/docs/USAGE_RU.md
+++ b/ee/fe/modules/450-keepalived/docs/USAGE_RU.md
@@ -4,7 +4,7 @@ title: "Модуль keepalived: примеры конфигурации"
 
 ## Три публичных IP-адреса
 
-Три публичных IP-адреса на трёх фронтах. Каждый виртуальный IP-адрес вынесен в отдельную VRRP-группу, таким образом, каждый адрес "прыгает" независимо от других и если в кластере три узла с лейблами `node-role/frontend: ""`, то каждый IP получит по своей MASTER-ноде.
+Три публичных IP-адреса на трёх фронтах. Каждый виртуальный IP-адрес вынесен в отдельную VRRP-группу, таким образом, каждый адрес "прыгает" независимо от других и если в кластере три узла с лейблами `node-role.deckhouse.io/frontend: ""`, то каждый IP получит по своей MASTER-ноде.
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha1
@@ -13,9 +13,9 @@ metadata:
   name: front
 spec:
   nodeSelector: # обязательно
-    node-role/frontend: ""
+    node-role.deckhouse.io/frontend: ""
   tolerations:  # опционально
-  - key: dedicated
+  - key: dedicated.deckhouse.io
     operator: Equal
     value: frontend
   vrrpInstances:
@@ -46,9 +46,9 @@ metadata:
   name: mygateway
 spec:
   nodeSelector:
-    node-role/mygateway: ""
+    node-role.deckhouse.io/mygateway: ""
   tolerations:
-  - key: node-role/mygateway
+  - key: node-role.deckhouse.io/mygateway
     operator: Exists
   vrrpInstances:
   - id: 4 # id "1", "2", "3" уже заняты в KeepalivedInstance "front" выше


### PR DESCRIPTION
## Description
Fix keepalived module examples node labels

## Changelog entries
```changes
module: documentation
type: fix
description: Fix keepalived module examples in the documentation.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
