### PR TITLE
[validators] handle export validator case with pointer

### DIFF
--- a/global-hooks/calculate_resources_requests.go
+++ b/global-hooks/calculate_resources_requests.go
@@ -35,8 +35,8 @@ const (
 )
 
 type Node struct {
-	allocatableMilliCPU int64
-	allocatableMemory   int64
+	AllocatableMilliCPU int64
+	AllocatableMemory   int64
 }
 
 func applyNodesResourcesFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -48,8 +48,8 @@ func applyNodesResourcesFilter(obj *unstructured.Unstructured) (go_hook.FilterRe
 
 	n := &Node{}
 
-	n.allocatableMilliCPU = node.Status.Allocatable.Cpu().MilliValue()
-	n.allocatableMemory = node.Status.Allocatable.Memory().Value()
+	n.AllocatableMilliCPU = node.Status.Allocatable.Cpu().MilliValue()
+	n.AllocatableMemory = node.Status.Allocatable.Memory().Value()
 
 	return n, nil
 }
@@ -96,11 +96,11 @@ func calculateResourcesRequests(input *go_hook.HookInput) error {
 		discoveryMasterNodeMemory = hardLimitMemory
 		for _, snapshot := range snapshots {
 			n := snapshot.(*Node)
-			if n.allocatableMilliCPU < discoveryMasterNodeMilliCPU {
-				discoveryMasterNodeMilliCPU = n.allocatableMilliCPU
+			if n.AllocatableMilliCPU < discoveryMasterNodeMilliCPU {
+				discoveryMasterNodeMilliCPU = n.AllocatableMilliCPU
 			}
-			if n.allocatableMemory < discoveryMasterNodeMemory {
-				discoveryMasterNodeMemory = n.allocatableMemory
+			if n.AllocatableMemory < discoveryMasterNodeMemory {
+				discoveryMasterNodeMemory = n.AllocatableMemory
 			}
 		}
 	} else {


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Export struct validator skips structs called like ` n := &Struct{}` or `n := new(Struct)`

## Why do we need it, and what problem does it solve?
We check FilterResult with unexported fields and such kind of declaration is out of the validator scope

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: testing
type: fix
description: Fix export struct validator corner case
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
