### PR TITLE
[registry-packages] fix containerd-fe build

### DIFF
--- a/candi/bashible/bundles/centos-7/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/centos-7/node-group/031_install_containerd.sh.tpl
@@ -78,9 +78,15 @@ if [[ "$should_install_containerd" == true ]]; then
 
   containerd_tag="{{ index .images.registrypackages (printf "containerdCentos7%s" ($desired_version | replace "containerd.io-" "" | replace "." "_" | replace "-" "_" | camelcase )) }}"
   crictl_tag="{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}"
-  containerd_fe_tag="{{ index .images.registrypackages "containerdFe146" | toString }}"
 
-  bb-rp-install "containerd-io:${containerd_tag}" "crictl:${crictl_tag}" "containerd-flant-edition:${containerd_fe_tag}"
+  bb-rp-install "containerd-io:${containerd_tag}" "crictl:${crictl_tag}"
+fi
+
+# Upgrade containerd-flant-edition if needed
+containerd_fe_tag="{{ index .images.registrypackages "containerdFe146" | toString }}"
+if ! bb-rp-is-installed? "containerd-flant-edition" "${containerd_fe_tag}" ; then
+  systemctl stop containerd.service
+  bb-rp-install "containerd-flant-edition:${containerd_fe_tag}"
 
   mkdir -p /etc/systemd/system/containerd.service.d
   bb-sync-file /etc/systemd/system/containerd.service.d/override.conf - << EOF

--- a/candi/bashible/bundles/debian/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/debian/node-group/031_install_containerd.sh.tpl
@@ -98,9 +98,15 @@ if [[ "$should_install_containerd" == true ]]; then
   fi
 
   crictl_tag="{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}"
-  containerd_fe_tag="{{ index .images.registrypackages "containerdFe146" | toString }}"
 
-  bb-rp-install "containerd-io:${containerd_tag}" "crictl:${crictl_tag}" "containerd-flant-edition:${containerd_fe_tag}"
+  bb-rp-install "containerd-io:${containerd_tag}" "crictl:${crictl_tag}"
+fi
+
+# Upgrade containerd-flant-edition if needed
+containerd_fe_tag="{{ index .images.registrypackages "containerdFe146" | toString }}"
+if ! bb-rp-is-installed? "containerd-flant-edition" "${containerd_fe_tag}" ; then
+  systemctl stop containerd.service
+  bb-rp-install "containerd-flant-edition:${containerd_fe_tag}"
 
   mkdir -p /etc/systemd/system/containerd.service.d
   bb-sync-file /etc/systemd/system/containerd.service.d/override.conf - << EOF

--- a/candi/bashible/bundles/ubuntu-lts/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/node-group/031_install_containerd.sh.tpl
@@ -91,9 +91,15 @@ if [[ "$should_install_containerd" == true ]]; then
 {{- end }}
 
   crictl_tag="{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}"
-  containerd_fe_tag="{{ index .images.registrypackages "containerdFe146" | toString }}"
 
-  bb-rp-install "containerd-io:${containerd_tag}" "crictl:${crictl_tag}" "containerd-flant-edition:${containerd_fe_tag}"
+  bb-rp-install "containerd-io:${containerd_tag}" "crictl:${crictl_tag}"
+fi
+
+# Upgrade containerd-flant-edition if needed
+containerd_fe_tag="{{ index .images.registrypackages "containerdFe146" | toString }}"
+if ! bb-rp-is-installed? "containerd-flant-edition" "${containerd_fe_tag}" ; then
+  systemctl stop containerd.service
+  bb-rp-install "containerd-flant-edition:${containerd_fe_tag}"
 
   mkdir -p /etc/systemd/system/containerd.service.d
   bb-sync-file /etc/systemd/system/containerd.service.d/override.conf - << EOF

--- a/modules/007-registrypackages/images/containerd-fe/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd-fe/werf.inc.yaml
@@ -23,6 +23,11 @@ git:
     stageDependencies:
       setup:
       - '**/*'
+  - add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+    to: /patches
+    stageDependencies:
+      install:
+      - '**/*'
 shell:
   beforeInstall:
   - apt-get update


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed build of containerd-fe registry package.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
After release of registry packages with content tagging, we lost patch in containerd-fe package 
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: registry-packages
type: fix
description: "Fixed build of containerd-fe registry package."
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
