### PR TITLE
[documentation] Add experimental warning to namespace-configurator module

### DIFF
--- a/docs/site/_config.yml
+++ b/docs/site/_config.yml
@@ -119,6 +119,11 @@ defaults:
     values:
       versionType: experimental
   - scope:
+      path: "*/600-namespace-configurator"
+      type: "pages"
+    values:
+      versionType: experimental
+  - scope:
       path: "*/500-basic-auth"
       type: "pages"
     values:


### PR DESCRIPTION
## Description
Added the 'experimental' warning to namespace-configurator module documentation pages.

## Changelog entries
```changes
module: documentation
type: fix
description: "Add the 'experimental' warning to namespace-configurator module documentation pages"
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
