### PR TITLE
[flant-integration] Getting rid of deprecated flantIntegration.kubeal…

### DIFF
--- a/ee/modules/600-flant-integration/docs/CONFIGURATION_RU.md
+++ b/ee/modules/600-flant-integration/docs/CONFIGURATION_RU.md
@@ -15,7 +15,6 @@ flantIntegration: |
   licenseKey: s6f8766314a9426faa2b3
   madisonAuthKey: abc9ydhshy32plkj
   kubeall:
-    team: myteam
     host: myproject.kube-master-0
     kubeconfig: /etc/kubernetes/admin.conf
 ```

--- a/ee/modules/600-flant-integration/images/flant-pricing/hooks/cluster_metrics.sh
+++ b/ee/modules/600-flant-integration/images/flant-pricing/hooks/cluster_metrics.sh
@@ -58,7 +58,7 @@ function __main__() {
   output_metric "flant_pricing_auxiliary_cluster" "$FP_AUXILIARY_CLUSTER"
   output_metric "flant_pricing_nodes_discount" "$FP_NODES_DISCOUNT"
 
-  if [[ "$FP_KUBEALL_TEAM" != "" && "$FP_KUBEALL_HOST" != "" ]]; then
+  if [[ "$FP_KUBEALL_HOST" != "" ]]; then
     echo '
     {
       "name": "flant_pricing_kubeall",

--- a/ee/modules/600-flant-integration/openapi/config-values.yaml
+++ b/ee/modules/600-flant-integration/openapi/config-values.yaml
@@ -76,7 +76,7 @@ properties:
     default: {}
     description: |
       Parameters for generating the kubeall registry.
-    required: [team, host]
+    required: [host]
     properties:
       team:
         type: string

--- a/ee/modules/600-flant-integration/openapi/openapi-case-tests.yaml
+++ b/ee/modules/600-flant-integration/openapi/openapi-case-tests.yaml
@@ -1,7 +1,6 @@
 positive:
   configValues:
     - kubeall:
-        team: test
         host: test.control-plane
       metrics: false
       madisonAuthKey: false

--- a/ee/modules/600-flant-integration/template_tests/module_test.go
+++ b/ee/modules/600-flant-integration/template_tests/module_test.go
@@ -55,7 +55,6 @@ nodesDiscount: 10
 metrics:
   url: "https://example.com/remote_write"
 kubeall:
-  team: ""
   host: ""
   kubectl: "sudo kubectl"
   kubeconfig: "/root/.kube/config"
@@ -92,7 +91,6 @@ nodesDiscount: 10
 metrics:
   url: "https://example.com/remote_write"
 kubeall:
-  team: ""
   host: ""
   kubectl: "sudo kubectl"
   kubeconfig: "/root/.kube/config"
@@ -197,8 +195,6 @@ var _ = Describe("Module :: flant-integration :: helm template ::", func() {
   value: "true"
 - name: DEBUG_UNIX_SOCKET
   value: /tmp/shell-operator-debug.socket
-- name: FP_KUBEALL_TEAM
-  value: ""
 - name: FP_KUBEALL_HOST
   value: ""
 - name: FP_KUBEALL_KUBECTL

--- a/ee/modules/600-flant-integration/templates/pricing/daemonset.yaml
+++ b/ee/modules/600-flant-integration/templates/pricing/daemonset.yaml
@@ -98,8 +98,6 @@ spec:
           value: {{ .Values.flantIntegration.internal.terraformManagerEnabled | quote }}
         - name: DEBUG_UNIX_SOCKET
           value: /tmp/shell-operator-debug.socket
-        - name: FP_KUBEALL_TEAM
-          value: {{ .Values.flantIntegration.kubeall.team | quote }}
         - name: FP_KUBEALL_HOST
           value: {{ .Values.flantIntegration.kubeall.host | quote }}
         - name: FP_KUBEALL_KUBECTL


### PR DESCRIPTION
## Description
Getting rid of deprecated `flantIntegration.kubeall.team` config value spec.

## Why do we need it, and what problem does it solve?
The `team` value is under lience server control now.

## Changelog entries
```changes
module: flant-integration
type: fix
description: Getting rid of deprecated `flantIntegration.kubeall.team` config value spec.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
