### PR TITLE
[docs] Regenerate password in getting started

### DIFF
--- a/docs/site/_includes/getting_started/aws/partials/resources.yml.ha.inc
+++ b/docs/site/_includes/getting_started/aws/partials/resources.yml.ha.inc
@@ -112,9 +112,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/aws/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/aws/partials/resources.yml.minimal.inc
@@ -112,9 +112,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/aws/partials/resources.yml.production.inc
+++ b/docs/site/_includes/getting_started/aws/partials/resources.yml.production.inc
@@ -229,9 +229,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/aws/partials/resources.yml.unonode.inc
+++ b/docs/site/_includes/getting_started/aws/partials/resources.yml.unonode.inc
@@ -54,9 +54,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/azure/partials/resources.yml.ha.inc
+++ b/docs/site/_includes/getting_started/azure/partials/resources.yml.ha.inc
@@ -110,9 +110,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/azure/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/azure/partials/resources.yml.minimal.inc
@@ -110,9 +110,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/azure/partials/resources.yml.production.inc
+++ b/docs/site/_includes/getting_started/azure/partials/resources.yml.production.inc
@@ -258,9 +258,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/azure/partials/resources.yml.unonode.inc
+++ b/docs/site/_includes/getting_started/azure/partials/resources.yml.unonode.inc
@@ -51,9 +51,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_BM.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_BM.md
@@ -1,5 +1,6 @@
 <script type="text/javascript" src='{{ assets["getting-started.js"].digest_path }}'></script>
 <script type="text/javascript" src='{{ assets["getting-started-access.js"].digest_path }}'></script>
+<script type="text/javascript" src='{{ assets["bcrypt.js"].digest_path }}'></script>
 
 At this point, you have created a basic **single-master** cluster.
 
@@ -83,7 +84,7 @@ EOF
 
 <script type="text/javascript">
 $(document).ready(function () {
-    generate_password();
+    generate_password(true);
     update_parameter('dhctl-user-password-hash', 'password', '<GENERATED_PASSWORD_HASH>', null, null);
     update_parameter('dhctl-user-password-hash', null, '<GENERATED_PASSWORD_HASH>', null, '[user-yml]');
     update_parameter('dhctl-user-password', null, '<GENERATED_PASSWORD>', null, '[user-yml]');

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_BM_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_BM_RU.md
@@ -1,5 +1,6 @@
 <script type="text/javascript" src='{{ assets["getting-started.js"].digest_path }}'></script>
 <script type="text/javascript" src='{{ assets["getting-started-access.js"].digest_path }}'></script>
+<script type="text/javascript" src='{{ assets["bcrypt.js"].digest_path }}'></script>
 
 На данном этапе вы создали кластер, который состоит из **единственного** master-узла.
 
@@ -89,7 +90,7 @@ EOF
 
 <script type="text/javascript">
 $(document).ready(function () {
-    generate_password();
+    generate_password(true);
     update_parameter('dhctl-user-password-hash', 'password', '<GENERATED_PASSWORD_HASH>', null, null);
     update_parameter('dhctl-user-password-hash', null, '<GENERATED_PASSWORD_HASH>', null, '[user-yml]');
     update_parameter('dhctl-user-password', null, '<GENERATED_PASSWORD>', null, '[user-yml]');

--- a/docs/site/_includes/getting_started/bm/partials/user.yml.inc
+++ b/docs/site/_includes/getting_started/bm/partials/user.yml.inc
@@ -27,8 +27,12 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
+  # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
+  # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить
   password: <GENERATED_PASSWORD_HASH>

--- a/docs/site/_includes/getting_started/gcp/partials/resources.yml.ha.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/resources.yml.ha.inc
@@ -89,9 +89,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/gcp/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/resources.yml.minimal.inc
@@ -89,9 +89,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/gcp/partials/resources.yml.production.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/resources.yml.production.inc
@@ -200,9 +200,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/global/select_revision.html
+++ b/docs/site/_includes/getting_started/global/select_revision.html
@@ -66,7 +66,7 @@ Resources for the **"{{ preset[1].name[page.lang] }}"** preset.
 
 <script>
 $(document).ready(function() {
-  generate_password();
+  generate_password(true);
   replace_snippet_password();
   sessionStorage.setItem('dhctl-revision','{% if page.ee_only == true %}ee{% else %}ce{% endif %}');
 

--- a/docs/site/_includes/getting_started/openstack/partials/resources.yml.ha.inc
+++ b/docs/site/_includes/getting_started/openstack/partials/resources.yml.ha.inc
@@ -105,9 +105,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/openstack/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/openstack/partials/resources.yml.minimal.inc
@@ -105,9 +105,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/openstack/partials/resources.yml.production.inc
+++ b/docs/site/_includes/getting_started/openstack/partials/resources.yml.production.inc
@@ -203,9 +203,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/openstack/partials/resources.yml.unonode.inc
+++ b/docs/site/_includes/getting_started/openstack/partials/resources.yml.unonode.inc
@@ -47,9 +47,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/vsphere/partials/resources.yml.ha.inc
+++ b/docs/site/_includes/getting_started/vsphere/partials/resources.yml.ha.inc
@@ -171,9 +171,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/vsphere/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/vsphere/partials/resources.yml.minimal.inc
@@ -103,9 +103,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/vsphere/partials/resources.yml.production.inc
+++ b/docs/site/_includes/getting_started/vsphere/partials/resources.yml.production.inc
@@ -238,9 +238,11 @@ spec:
   # [<en>] user e-mail
   # [<ru>] e-mail пользователя
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/yandex/partials/resources.yml.ha.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/resources.yml.ha.inc
@@ -68,9 +68,11 @@ metadata:
   name: admin
 spec:
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/yandex/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/resources.yml.minimal.inc
@@ -70,9 +70,11 @@ metadata:
   name: admin
 spec:
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/_includes/getting_started/yandex/partials/resources.yml.production.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/resources.yml.production.inc
@@ -138,9 +138,11 @@ metadata:
   name: admin
 spec:
   email: admin@example.com
-  # [<en>] this is a hash for generated password: <GENERATED_PASSWORD>
-  # [<ru>] это хэш сгенерированного пароля: <GENERATED_PASSWORD>
+  # [<en>] this is a hash of the password <GENERATED_PASSWORD>, generated  now
+  # [<en>] generate your own or use it at your own risk (for testing purposes)
   # [<en>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
+  # [<ru>] это хэш пароля <GENERATED_PASSWORD>, сгенерированного сейчас
+  # [<ru>] сгенерируйте свой или используйте этот, но только для тестирования
   # [<ru>] echo "<GENERATED_PASSWORD>" | htpasswd -BinC 10 "" | cut -d: -f2
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить

--- a/docs/site/js/getting-started.js
+++ b/docs/site/js/getting-started.js
@@ -195,8 +195,8 @@ function update_license_parameters(newtoken = '') {
     }
 }
 
-function generate_password() {
-    if (sessionStorage.getItem("dhctl-user-password-hash") === null || sessionStorage.getItem("dhctl-user-password") === null) {
+function generate_password(force = false) {
+    if ( force || sessionStorage.getItem("dhctl-user-password-hash") === null || sessionStorage.getItem("dhctl-user-password") === null) {
         var bcrypt = dcodeIO.bcrypt;
         var salt = bcrypt.genSaltSync(10);
         var password = Math.random().toString(36).slice(-10);


### PR DESCRIPTION
Generate a new password on the install step in the getting started for security purposes. Add a notice to use the generated password only for testing.

