### PR TITLE
[ci] fix: remove double BASE_SCRATCH from image_versions

### DIFF
--- a/.gitlab/ci_includes/image_versions.yml
+++ b/.gitlab/ci_includes/image_versions.yml
@@ -2,7 +2,6 @@
 # https://github.com/google/go-containerregistry/blob/main/cmd/crane/doc/crane.md
 # Note: update github workflows after edit! cd .github; ./render-workflows.sh
 variables:
-  BASE_SCRATCH: "${BASE_IMAGES_REGISTRY_PATH}spotify/scratch@sha256:db4cabf15c8b9eb70dabe1da385b6d9b2cac6d658b813fbb57dc5231ddd52420"
   BASE_ALPINE: "${BASE_IMAGES_REGISTRY_PATH}alpine:3.12.1@sha256:c0e9560cda118f9ec63ddefb4a173a2b2a0347082d7dff7dc14272e7841a5b5a"
   BASE_ALPINE_3_15: "{!{$BASE_IMAGES_REGISTRY_PATH}!}alpine:3.15@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300"
   BASE_DEBIAN: "${BASE_IMAGES_REGISTRY_PATH}debian:buster-20210111@sha256:b16f66714660c4b3ea14d273ad8c35079b81b35d65d1e206072d226c7ff78299"


### PR DESCRIPTION

## Description

Remove excess `BASE_SCRATCH` key from `.gitlab/image_versions.yml`.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Github workflows render script fails if image_versions has double keys

<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: ci
type: fix
description: |
  remove excess `BASE_SCRATCH` key from `.gitlab/image_versions.yml`.
note: <what to expect>
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
