### PR TITLE
[registry-packages] fix build of nginx package for ubuntu 16

### DIFF
--- a/modules/007-registrypackages/images/nginx-ubuntu/werf.inc.yaml
+++ b/modules/007-registrypackages/images/nginx-ubuntu/werf.inc.yaml
@@ -1,7 +1,7 @@
 {{- $version := "" }}
 {{- range $distro := tuple "focal" "bionic" "xenial" }}
   {{- if eq $distro "xenial" }}
-    {{- $version = "1.20.1 }}
+    {{- $version = "1.20.1" }}
   {{- else }}
     {{- $version = "1.20.2" }}
   {{- end }}

--- a/modules/007-registrypackages/images/nginx-ubuntu/werf.inc.yaml
+++ b/modules/007-registrypackages/images/nginx-ubuntu/werf.inc.yaml
@@ -1,6 +1,11 @@
-{{- $version := "1.20.2" }}
-{{- $image_version := $version | replace "." "-" }}
+{{- $version := "" }}
 {{- range $distro := tuple "focal" "bionic" "xenial" }}
+  {{- if eq $distro "xenial" }}
+    {{- $version = "1.20.1 }}
+  {{- else }}
+    {{- $version = "1.20.2" }}
+  {{- end }}
+  {{- $image_version := $version | replace "." "-" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}-{{ $distro }}
 from: {{ env "BASE_SCRATCH" }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix build of nginx package for ubuntu 16.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: registry-packages
type: fix
description: "Fix build of nginx package for ubuntu 16."
note:
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
