### PR TITLE
[ci] fix: pull release-channel-version image before tagging

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -80,7 +80,10 @@ steps:
       werf build
 
       # Put tags on produced images and push to dev and release repositories.
+
+      echo Pull dev image.
       docker pull $(werf stage image dev)
+      echo Pull dev/install image.
       docker pull $(werf stage image dev/install)
 
       REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
@@ -105,20 +108,33 @@ steps:
           DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG_SLUG};
           DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG_SLUG};
           DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG_SLUG};
+          echo Tag dev image.
           docker image tag $(werf stage image dev) ${DECKHOUSE_DESTINATION_IMAGE};
+          echo Tag dev/install image.
           docker image tag $(werf stage image dev/install) ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
+          echo Pull and tag release-channel-version image.
+          docker pull $(werf stage image release-channel-version)
           docker image tag $(werf stage image release-channel-version) ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
+          echo Push dev image.
           docker image push ${DECKHOUSE_DESTINATION_IMAGE};
+          echo Push dev/install image.
           docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
+          echo Push release-channel-version image.
           docker image push ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
+          echo Remove local tags.
           docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
           docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
           docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true;
         fi;
+        echo Tag dev image.
         docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
+        echo Tag dev/install image.
         docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
+        echo Push dev image.
         docker image push ${DESTINATION_IMAGE};
+        echo Push dev/install image.
         docker image push ${DESTINATION_INSTALL_IMAGE};
+        echo Remove local tags.
         docker image rmi ${DESTINATION_IMAGE} || true;
         docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
       fi
@@ -131,10 +147,15 @@ steps:
           DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}/dev:${CI_COMMIT_REF_SLUG};
           DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/dev/install:${CI_COMMIT_REF_SLUG};
         fi;
+        echo Tag dev image.
         docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
+        echo Tag dev/install image.
         docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
+        echo Push dev image.
         docker image push ${DESTINATION_IMAGE};
+        echo Push dev/install image.
         docker image push ${DESTINATION_INSTALL_IMAGE};
+        echo Remove local tags.
         docker image rmi ${DESTINATION_IMAGE} || true;
         docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
       fi

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -495,7 +495,10 @@ jobs:
           werf build
 
           # Put tags on produced images and push to dev and release repositories.
+
+          echo Pull dev image.
           docker pull $(werf stage image dev)
+          echo Pull dev/install image.
           docker pull $(werf stage image dev/install)
 
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
@@ -520,20 +523,33 @@ jobs:
               DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG_SLUG};
               DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG_SLUG};
               DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG_SLUG};
+              echo Tag dev image.
               docker image tag $(werf stage image dev) ${DECKHOUSE_DESTINATION_IMAGE};
+              echo Tag dev/install image.
               docker image tag $(werf stage image dev/install) ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
+              echo Pull and tag release-channel-version image.
+              docker pull $(werf stage image release-channel-version)
               docker image tag $(werf stage image release-channel-version) ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
+              echo Push dev image.
               docker image push ${DECKHOUSE_DESTINATION_IMAGE};
+              echo Push dev/install image.
               docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
+              echo Push release-channel-version image.
               docker image push ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
+              echo Remove local tags.
               docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
               docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
               docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true;
             fi;
+            echo Tag dev image.
             docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
+            echo Tag dev/install image.
             docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
+            echo Push dev image.
             docker image push ${DESTINATION_IMAGE};
+            echo Push dev/install image.
             docker image push ${DESTINATION_INSTALL_IMAGE};
+            echo Remove local tags.
             docker image rmi ${DESTINATION_IMAGE} || true;
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
@@ -546,10 +562,15 @@ jobs:
               DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}/dev:${CI_COMMIT_REF_SLUG};
               DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/dev/install:${CI_COMMIT_REF_SLUG};
             fi;
+            echo Tag dev image.
             docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
+            echo Tag dev/install image.
             docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
+            echo Push dev image.
             docker image push ${DESTINATION_IMAGE};
+            echo Push dev/install image.
             docker image push ${DESTINATION_INSTALL_IMAGE};
+            echo Remove local tags.
             docker image rmi ${DESTINATION_IMAGE} || true;
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -689,7 +689,10 @@ jobs:
           werf build
 
           # Put tags on produced images and push to dev and release repositories.
+
+          echo Pull dev image.
           docker pull $(werf stage image dev)
+          echo Pull dev/install image.
           docker pull $(werf stage image dev/install)
 
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
@@ -714,20 +717,33 @@ jobs:
               DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG_SLUG};
               DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG_SLUG};
               DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG_SLUG};
+              echo Tag dev image.
               docker image tag $(werf stage image dev) ${DECKHOUSE_DESTINATION_IMAGE};
+              echo Tag dev/install image.
               docker image tag $(werf stage image dev/install) ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
+              echo Pull and tag release-channel-version image.
+              docker pull $(werf stage image release-channel-version)
               docker image tag $(werf stage image release-channel-version) ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
+              echo Push dev image.
               docker image push ${DECKHOUSE_DESTINATION_IMAGE};
+              echo Push dev/install image.
               docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
+              echo Push release-channel-version image.
               docker image push ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
+              echo Remove local tags.
               docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
               docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
               docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true;
             fi;
+            echo Tag dev image.
             docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
+            echo Tag dev/install image.
             docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
+            echo Push dev image.
             docker image push ${DESTINATION_IMAGE};
+            echo Push dev/install image.
             docker image push ${DESTINATION_INSTALL_IMAGE};
+            echo Remove local tags.
             docker image rmi ${DESTINATION_IMAGE} || true;
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
@@ -740,10 +756,15 @@ jobs:
               DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}/dev:${CI_COMMIT_REF_SLUG};
               DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/dev/install:${CI_COMMIT_REF_SLUG};
             fi;
+            echo Tag dev image.
             docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
+            echo Tag dev/install image.
             docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
+            echo Push dev image.
             docker image push ${DESTINATION_IMAGE};
+            echo Push dev/install image.
             docker image push ${DESTINATION_INSTALL_IMAGE};
+            echo Remove local tags.
             docker image rmi ${DESTINATION_IMAGE} || true;
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
@@ -865,7 +886,10 @@ jobs:
           werf build
 
           # Put tags on produced images and push to dev and release repositories.
+
+          echo Pull dev image.
           docker pull $(werf stage image dev)
+          echo Pull dev/install image.
           docker pull $(werf stage image dev/install)
 
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
@@ -890,20 +914,33 @@ jobs:
               DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG_SLUG};
               DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG_SLUG};
               DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG_SLUG};
+              echo Tag dev image.
               docker image tag $(werf stage image dev) ${DECKHOUSE_DESTINATION_IMAGE};
+              echo Tag dev/install image.
               docker image tag $(werf stage image dev/install) ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
+              echo Pull and tag release-channel-version image.
+              docker pull $(werf stage image release-channel-version)
               docker image tag $(werf stage image release-channel-version) ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
+              echo Push dev image.
               docker image push ${DECKHOUSE_DESTINATION_IMAGE};
+              echo Push dev/install image.
               docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
+              echo Push release-channel-version image.
               docker image push ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
+              echo Remove local tags.
               docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
               docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
               docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true;
             fi;
+            echo Tag dev image.
             docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
+            echo Tag dev/install image.
             docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
+            echo Push dev image.
             docker image push ${DESTINATION_IMAGE};
+            echo Push dev/install image.
             docker image push ${DESTINATION_INSTALL_IMAGE};
+            echo Remove local tags.
             docker image rmi ${DESTINATION_IMAGE} || true;
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
@@ -916,10 +953,15 @@ jobs:
               DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}/dev:${CI_COMMIT_REF_SLUG};
               DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/dev/install:${CI_COMMIT_REF_SLUG};
             fi;
+            echo Tag dev image.
             docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
+            echo Tag dev/install image.
             docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
+            echo Push dev image.
             docker image push ${DESTINATION_IMAGE};
+            echo Push dev/install image.
             docker image push ${DESTINATION_INSTALL_IMAGE};
+            echo Remove local tags.
             docker image rmi ${DESTINATION_IMAGE} || true;
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
@@ -1041,7 +1083,10 @@ jobs:
           werf build
 
           # Put tags on produced images and push to dev and release repositories.
+
+          echo Pull dev image.
           docker pull $(werf stage image dev)
+          echo Pull dev/install image.
           docker pull $(werf stage image dev/install)
 
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
@@ -1066,20 +1111,33 @@ jobs:
               DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG_SLUG};
               DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG_SLUG};
               DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG_SLUG};
+              echo Tag dev image.
               docker image tag $(werf stage image dev) ${DECKHOUSE_DESTINATION_IMAGE};
+              echo Tag dev/install image.
               docker image tag $(werf stage image dev/install) ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
+              echo Pull and tag release-channel-version image.
+              docker pull $(werf stage image release-channel-version)
               docker image tag $(werf stage image release-channel-version) ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
+              echo Push dev image.
               docker image push ${DECKHOUSE_DESTINATION_IMAGE};
+              echo Push dev/install image.
               docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
+              echo Push release-channel-version image.
               docker image push ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
+              echo Remove local tags.
               docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
               docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
               docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true;
             fi;
+            echo Tag dev image.
             docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
+            echo Tag dev/install image.
             docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
+            echo Push dev image.
             docker image push ${DESTINATION_IMAGE};
+            echo Push dev/install image.
             docker image push ${DESTINATION_INSTALL_IMAGE};
+            echo Remove local tags.
             docker image rmi ${DESTINATION_IMAGE} || true;
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
@@ -1092,10 +1150,15 @@ jobs:
               DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}/dev:${CI_COMMIT_REF_SLUG};
               DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/dev/install:${CI_COMMIT_REF_SLUG};
             fi;
+            echo Tag dev image.
             docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
+            echo Tag dev/install image.
             docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
+            echo Push dev image.
             docker image push ${DESTINATION_IMAGE};
+            echo Push dev/install image.
             docker image push ${DESTINATION_INSTALL_IMAGE};
+            echo Remove local tags.
             docker image rmi ${DESTINATION_IMAGE} || true;
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi


### PR DESCRIPTION
## Description

Pull release-channel-version image before tagging.

## Why do we need it, and what problem does it solve?

'Build EDITION' jobs fail with 'No such image' error if release-channel-version image not available on the runner.

<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: ci
type: fix
description: |
  Pull release-channel-version image before tagging.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
