### PR TITLE
[core][dhctl] Fix potential panic for bashible logs in `dhctl bootstrap` command

### DIFF
--- a/dhctl/pkg/log/process_test.go
+++ b/dhctl/pkg/log/process_test.go
@@ -1,0 +1,101 @@
+// Copyright 2022 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessStack(t *testing.T) {
+	s := &processStack{}
+
+	s.push(&logProcessDescriptor{
+		StartedAt: time.Now(),
+		Msg:       "process1",
+	})
+
+	require.Len(t, s.activeProcesses, 1, "process1 does not added to stack")
+
+	s.push(&logProcessDescriptor{
+		StartedAt: time.Now(),
+		Msg:       "process2",
+	})
+
+	require.Len(t, s.activeProcesses, 2, "process2 does not added to stack")
+
+	assertPop := func(t *testing.T, len int, process string) {
+		p := s.pop()
+
+		require.NotNilf(t, p, "%s does not pop", process)
+		require.Lenf(t, s.activeProcesses, len, "process1 does not remove from stack")
+		require.Equalf(t, p.Msg, process, "incorrect process %s; should be %s", p.Msg, process)
+	}
+
+	assertPop(t, 1, "process2")
+	assertPop(t, 0, "process1")
+
+	p := s.pop()
+
+	require.Nil(t, p, "returns none nil process from empty stack")
+	require.Len(t, s.activeProcesses, 0, "pop from empty stack affect stack size")
+}
+
+func TestProcessLoggers(t *testing.T) {
+	oldStdout := os.Stdout
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	loggers := []struct {
+		logger ProcessLogger
+		name   string
+	}{
+		{
+			logger: newWrappedProcessLogger(&SilentLogger{}),
+			name:   "wrapped logger",
+		},
+
+		{
+			logger: newPrettyProcessLogger(),
+			name:   "pretty logger",
+		},
+	}
+
+	for _, l := range loggers {
+		t.Run(l.name, func(t *testing.T) {
+			t.Run("Do not panic done process without start", func(t *testing.T) {
+				l.logger.LogProcessEnd()
+
+				l.logger.LogProcessStart("process done")
+				l.logger.LogProcessEnd()
+
+				l.logger.LogProcessEnd()
+			})
+
+			t.Run("Do not panic failed process without start", func(t *testing.T) {
+				l.logger.LogProcessFail()
+
+				l.logger.LogProcessStart("process fail")
+				l.logger.LogProcessFail()
+
+				l.logger.LogProcessFail()
+			})
+		})
+	}
+}

--- a/dhctl/pkg/log/process_test.go
+++ b/dhctl/pkg/log/process_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Flant JSC
+// Copyright 2021 Flant JSC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Close [issue](https://github.com/deckhouse/deckhouse/issues/272) 

Add all process to stack for pretty process logger for prevent panic from logboek

## Why do we need it, and what problem does it solve?
Cluster bootstrap can not be bootstrapped
## Changelog entries
```changes
module: dhctl
type: fix 
description: Fix potential panic for bashible logs in `dhctl bootstrap` command
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
