### PR TITLE
[cert-manager] fix docs about Certificate DNSNames

### DIFF
--- a/modules/101-cert-manager/docs/USAGE.md
+++ b/modules/101-cert-manager/docs/USAGE.md
@@ -17,7 +17,7 @@ spec:
     kind: ClusterIssuer                      # the link to the certificate "issuer", see more below
     name: letsencrypt
   commonName: example.com                    # the main certificate domain
-  dnsNames:                                  # additional domains (At least one of a DNS Name or IP address is required)
+  dnsNames:                                  # additional domains (At least one DNS Name or IP address is required)
   - www.example.com
   - admin.example.com
 ```

--- a/modules/101-cert-manager/docs/USAGE.md
+++ b/modules/101-cert-manager/docs/USAGE.md
@@ -17,7 +17,7 @@ spec:
     kind: ClusterIssuer                      # the link to the certificate "issuer", see more below
     name: letsencrypt
   commonName: example.com                    # the main certificate domain
-  dnsNames:                                  # additional domains (optional)
+  dnsNames:                                  # additional domains (At least one of a DNS Name or IP address is required)
   - www.example.com
   - admin.example.com
 ```

--- a/modules/101-cert-manager/docs/USAGE_RU.md
+++ b/modules/101-cert-manager/docs/USAGE_RU.md
@@ -17,7 +17,7 @@ spec:
     kind: ClusterIssuer                      # ссылка на "выдаватель" сертификатов, см. подробнее ниже
     name: letsencrypt
   commonName: example.com                    # основной домен сертификата
-  dnsNames:                                  # дополнительыне домены сертификата (Как минимум одно DNS имя bkb IP-адрес должен быть указан)
+  dnsNames:                                  # дополнительыне домены сертификата (Как минимум одно DNS имя или IP-адрес должен быть указан)
   - www.example.com
   - admin.example.com
 ```

--- a/modules/101-cert-manager/docs/USAGE_RU.md
+++ b/modules/101-cert-manager/docs/USAGE_RU.md
@@ -17,7 +17,7 @@ spec:
     kind: ClusterIssuer                      # ссылка на "выдаватель" сертификатов, см. подробнее ниже
     name: letsencrypt
   commonName: example.com                    # основной домен сертификата
-  dnsNames:                                  # дополнительыне домены сертификата, указывать не обязательно
+  dnsNames:                                  # дополнительыне домены сертификата (Как минимум одно DNS имя bkb IP-адрес должен быть указан)
   - www.example.com
   - admin.example.com
 ```


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Fix documentation

## Why do we need it, and what problem does it solve?
Certificate requirements were changed in a new cert-manager CRD and our documentation doesn't respect it

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: cert-manager
type: fix
description: fix certificate requirements documentation
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
