### PR TITLE
[istio] canary usage doc fix

### DIFF
--- a/ee/modules/110-istio/docs/USAGE.md
+++ b/ee/modules/110-istio/docs/USAGE.md
@@ -205,7 +205,7 @@ To use Ingress, you need to:
   * `nginx.ingress.kubernetes.io/upstream-vhost: myservice.myns.svc` — using this annotation, the sidecar can identify the application service that serves requests.
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: productpage
@@ -219,9 +219,12 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: productpage
-            servicePort: 9080
+            service:
+              name: productpage
+              port:
+                number: 9080
 ```
 ```yaml
 apiVersion: v1

--- a/ee/modules/110-istio/docs/USAGE.md
+++ b/ee/modules/110-istio/docs/USAGE.md
@@ -144,7 +144,6 @@ spec:
         host: productpage
         subset: v1 # reference to the subset defined in DestinationRule 
       weight: 90 # the percentage of traffic to send to pods labeled version: v1.
-  - route:
     - destination:
         host: productpage
         subset: v2

--- a/ee/modules/110-istio/docs/USAGE_RU.md
+++ b/ee/modules/110-istio/docs/USAGE_RU.md
@@ -169,7 +169,6 @@ spec:
         host: reviews.prod.svc.cluster.local
         subset: testv1 # ссылка на subset из DestinationRule
       weight: 25
-  - route:
     - destination:
         host: reviews.prod.svc.cluster.local
         subset: testv3

--- a/ee/modules/110-istio/docs/USAGE_RU.md
+++ b/ee/modules/110-istio/docs/USAGE_RU.md
@@ -207,7 +207,7 @@ spec:
   * `nginx.ingress.kubernetes.io/upstream-vhost: myservice.myns.svc` — с данной аннотацией сайдкар сможет идентифицировать прикладной сервис, для которого предназначен запрос.
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: productpage
@@ -221,9 +221,12 @@ spec:
       http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
-            serviceName: productpage
-            servicePort: 9080
+            service:
+              name: productpage
+              port:
+                number: 9080
 ```
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
## Description
Canary usage doc fix.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: istio
type: fix
description: Canary usage doc fix.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
