### PR TITLE
[ci] feat: elapsed time in comments, hide details on finish 

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -2,7 +2,8 @@
 # <template: go_generate_template>
 runs-on: [self-hosted, regular]
 steps:
-  {!{ tmpl.Exec "checkout_step" . | strings.Indent 2 }!}
+  {!{ tmpl.Exec "started_at_output"            . | strings.Indent 2 }!}
+  {!{ tmpl.Exec "checkout_step"                . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}
 
   - name: Run go generate
@@ -22,6 +23,7 @@ steps:
 # <template: build_template>
 runs-on: [self-hosted, regular]
 steps:
+  {!{ tmpl.Exec "started_at_output" $ctx | strings.Indent 2 }!}
   {!{ tmpl.Exec "checkout_full_step" $ctx | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_dev_registry_step" $ctx | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_readonly_registry_step" $ctx | strings.Indent 2 }!}

--- a/.github/ci_templates/scripts.yml
+++ b/.github/ci_templates/scripts.yml
@@ -15,31 +15,50 @@
 # </template: update_comment_on_start>
 {!{- end -}!}
 
+{!{/*
+Update a comment on job or workflow finish.
+
+Use statusConfig to set status source and render options.
+"job" - get status from job context
+"workflow" - calculate workflow status from needs context
+"one-line" - Report job status as one line to form one huge multiline.
+"separate" - Report job statuses on separate lines.
+"no-skipped" - do not report skipped and cancelled jobs
+"final" - restore statuses from needs context, wrap comment with details and add summary status for the workflow.
+*/}!}
 {!{ define "update_comment_on_finish" }!}
-{!{- $statusSource := index . 0 -}!}
+{!{- $statusConfig := index . 0 -}!}
 {!{- $name := index . 1 -}!}
 
 # <template: update_comment_on_finish>
 - name: Update comment on finish
+  id: update_comment_on_finish
   if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-  continue-on-error: true
   env:
     NEEDS_CONTEXT: ${{ toJSON(needs) }}
     JOB_CONTEXT: ${{ toJSON(job) }}
+    STEPS_CONTEXT: ${{ toJSON(steps) }}
   uses: {!{ index (ds "actions") "actions/github-script" }!}
   with:
     github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
     script: |
-      const statusSource = '{!{ $statusSource }!}';
+      const statusConfig = '{!{ $statusConfig }!}';
       const name = '{!{ $name }!}';
       const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
       const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+      const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+      let jobNames = null
+      if (process.env.JOB_NAMES) {
+        jobNames = JSON.parse(process.env.JOB_NAMES);
+      }
 
-      console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-      console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+      core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+      core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+      core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+      core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
       const ci = require('./.github/scripts/js/ci');
-      return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+      return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
 # </template: update_comment_on_finish>
 {!{- end -}!}
 

--- a/.github/ci_templates/steps.yml
+++ b/.github/ci_templates/steps.yml
@@ -87,3 +87,13 @@
     channel: ${{env.WERF_CHANNEL}}
 # </template: werf_install_step>
 {!{- end -}!}
+
+{!{ define "started_at_output" }!}
+# <template: started_at_output>
+- name: Job started timestamp
+  id: started_at
+  run: |
+    unixTimestamp=$(date +%s)
+    echo "::set-output name=started_at::${unixTimestamp}"
+# </template: started_at_output>
+{!{- end -}!}

--- a/.github/ci_templates/tests.yml
+++ b/.github/ci_templates/tests.yml
@@ -52,6 +52,7 @@ docker_options: '-w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg'
 {!{- $run       := coll.Merge (tmpl.Exec $args_tmpl | yaml) $default }!}
 runs-on: [self-hosted, regular]
 steps:
+{!{ tmpl.Exec "started_at_output"             $ctx | strings.Indent 2 }!}
 {!{ tmpl.Exec "checkout_full_step"            $ctx | strings.Indent 2 }!}
 {!{ tmpl.Exec "login_dev_registry_step"       $ctx | strings.Indent 2 }!}
 {!{ tmpl.Exec "login_readonly_registry_step"  $ctx | strings.Indent 2 }!}

--- a/.github/ci_templates/web.yml
+++ b/.github/ci_templates/web.yml
@@ -2,6 +2,7 @@
 # <template: doc_web_build_template>
 runs-on: [self-hosted, regular]
 steps:
+  {!{ tmpl.Exec "started_at_output"            . | strings.Indent 2 }!}
   {!{ tmpl.Exec "checkout_full_step"           . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_flant_registry_step"    . | strings.Indent 2 }!}
@@ -21,6 +22,7 @@ steps:
 # <template: main_web_build_template>
 runs-on: [self-hosted, regular]
 steps:
+  {!{ tmpl.Exec "started_at_output"            . | strings.Indent 2 }!}
   {!{ tmpl.Exec "checkout_full_step"           . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_flant_registry_step"    . | strings.Indent 2 }!}
@@ -40,6 +42,7 @@ steps:
 # <template: web_links_test_template>
 runs-on: [self-hosted, regular]
 steps:
+  {!{ tmpl.Exec "started_at_output"            . | strings.Indent 2 }!}
   {!{ tmpl.Exec "checkout_full_step"           . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_flant_registry_step"    . | strings.Indent 2 }!}

--- a/.github/scripts/js/comments.js
+++ b/.github/scripts/js/comments.js
@@ -1,0 +1,163 @@
+/**
+ * Bot related functions.
+ */
+
+const WORKFLOW_START_MARKER = '<!-- workflow_start -->'
+module.exports.WORKFLOW_START_MARKER = WORKFLOW_START_MARKER;
+
+// Confirm recognition of the user command.
+module.exports.commentCommandRecognition = (userName, command) => {
+  return `Aye, aye, @${userName}. I've recognized your '${command}' command and started the workflow...\n${WORKFLOW_START_MARKER}`;
+};
+
+// Confirm label.
+module.exports.commentLabelRecognition = (userName, label) => {
+  return  `Aye, aye, @${userName}. I've started the workflow for label '${label}'...\n${WORKFLOW_START_MARKER}`;
+};
+
+module.exports.deleteBotComment = (text) => {
+  return text.replace(/^Aye,.*\n/m, '');
+}
+
+module.exports.releaseIssueHeader = (context, gitRefInfo) => {
+  let header = '';
+  if (gitRefInfo.isTag) {
+    header = `New tag **${gitRefInfo.tagName}** is created.\n${WORKFLOW_START_MARKER}`;
+  }
+  if (gitRefInfo.isBranch) {
+    const commitMiniSHA = context.payload.head_commit.id.slice(0, 6);
+    const commitUrl = context.payload.head_commit.url;
+    const commitInfo = `New commit [${commitMiniSHA}](${commitUrl}) in branch **${gitRefInfo.branchName}**:`;
+    // Format commit message.
+    const mdCodeMarker = '```';
+    const commitMsg = `${mdCodeMarker}\n${context.payload.head_commit.message}\n${mdCodeMarker}`;
+    header = `${commitInfo}\n${commitMsg}\n${WORKFLOW_START_MARKER}`;
+  }
+  return header;
+}
+
+module.exports.commentJobStarted = (jobName, ref, buildUrl) => {
+  return `:fast_forward:\u00a0\`${jobName}\` for \`${ref}\` [started](${buildUrl}).;`
+}
+
+module.exports.deleteJobStartedComments = (jobsReport) => {
+  return jobsReport.replace(/^.*:fast_forward:.*started.*\.\n\n?/gm, '');
+}
+
+const jobResultMarker = (name) => {
+  return `<!-- result-for: ${name} -->`
+}
+
+module.exports.hasJobResult = (comment, name) => {
+  return comment.includes(jobResultMarker(name));
+}
+
+
+
+module.exports.renderJobStatusOneLine  = (status, name, started_at) => {
+  const time_elapsed = getTimeElapsedForStatus(started_at);
+  let statusComment = `:white_check_mark:\u00a0\`${name}\` succeeded${time_elapsed}`;
+  if (status === 'failure') {
+    statusComment = `:x:\u00a0\`${name}\` failed${time_elapsed}`;
+  }
+  if (status === 'cancelled') {
+    statusComment = `:white_small_square:\u00a0\`${name}\` cancelled`;
+  }
+  if (status === 'skipped') {
+    statusComment = `:white_small_square:\u00a0\`${name}\` skipped`;
+  }
+
+  return `${statusComment}.${jobResultMarker(name)}`;
+};
+
+module.exports.renderJobStatusSeparate = (status, name, started_at) => {
+  const time_elapsed = getTimeElapsedForStatus(started_at);
+  let statusComment = `:green_circle:\u00a0\`${name}\` succeeded${time_elapsed}`;
+  if (status === 'failure') {
+    statusComment = `:red_circle:\u00a0\`${name}\` failed${time_elapsed}`;
+  }
+  if (status === 'cancelled') {
+    statusComment = `:white_circle:\u00a0\`${name}\` cancelled`;
+  }
+
+  return `\n${statusComment}.${jobResultMarker(name)}\n`;
+};
+
+module.exports.renderWorkflowStatusFinal = (status, name, ref, build_url, started_at) => {
+  const time_elapsed = getTimeElapsedForStatus(started_at);
+  let statusComment = `:green_circle:\u00a0\`${name}\` for \`${ref}\` [succeeded](${build_url})${time_elapsed}.`;
+  if (status === 'failure') {
+    statusComment = `:red_circle:\u00a0\`${name}\` for \`${ref}\` [failed](${build_url})${time_elapsed}.`;
+  }
+  if (status === 'cancelled') {
+    statusComment = `:white_circle:\u00a0\`${name}\` for \`${ref}\` [cancelled](${build_url}).`;
+  }
+  if (status === 'skipped') {
+    statusComment = `:white_circle:\u00a0\`${name}\` for \`${ref}\` [skipped](${build_url}).`;
+  }
+
+  return statusComment;
+};
+
+/**
+ * Return a human-readable duration.
+ *
+ * TODO Consider using a well-known library, e.g. https://date-fns.org/v2.28.0/docs/formatDistanceStrict
+ *
+ * @param duration_seconds - Duration in seconds.
+ * @returns {string}
+ */
+const humanDuration = (duration_seconds) => {
+  let res = '';
+
+  const d = parseInt(duration_seconds, 10);
+
+  // Seconds
+  const s = d % 60;
+  res = `${s}s`;
+
+  if (d >= 60) {
+    // Minutes
+    const m = ((d - s) / 60) % 60;
+    res = `${m}m${res}`;
+
+    if (d >= 3600) {
+      // Hours
+      const h = Math.floor(d / 3600);
+      res = `${h}h${res}`;
+    }
+  }
+
+  return res;
+};
+
+/**
+ * Return a human-readable duration between started_at timestamp and Date.now().
+ *
+ * @param started_at - A Unix timestamp.
+ * @returns {string}
+ */
+const getTimeElapsedForStatus = (started_at) => {
+  if (!started_at) {
+    console.log('No started_at time.');
+    return '';
+  }
+
+  const start_seconds = parseInt(started_at, 10);
+
+  const start_date = new Date();
+  start_date.setTime(start_seconds * 1000);
+
+  const now_date = new Date();
+  const now_seconds = Math.floor(now_date.getTime() / 1000);
+
+  const duration_seconds = now_seconds - start_seconds;
+  const duration_human = humanDuration(duration_seconds);
+
+  console.log(`started_at: ${start_seconds} '${start_date}'`);
+  console.log(`now:        ${now_seconds} '${now_date}'`);
+  console.log(`duration:   ${duration_seconds} '${duration_human}'`);
+
+  // Return string to embed in status.
+  return ` in ${duration_human}`;
+}

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -1,7 +1,9 @@
 # on push to default branch or on tags
 {!{- $ctx := dict -}!}
 {!{- $ctx = coll.Merge $ctx . -}!}
-{!{ $workflowName := "Build and test for release" }!}
+{!{- $jobNames := dict -}!}
+{!{- $workflowName := "Build and test for release" }!}
+
 name: {!{ $workflowName }!}
 
 on:
@@ -30,34 +32,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  started_at:
+    name: Save start timestamp
+    outputs:
+      started_at: ${{ steps.started_at.outputs.started_at }}
+    runs-on: "ubuntu-latest"
+    steps:
+{!{ tmpl.Exec "started_at_output" . | strings.Indent 6 }!}
+
 {!{ tmpl.Exec "git_info_job" $ctx | strings.Indent 2 }!}
 
   comment_on_start:
-    name: Add comment on start
+    name: Update issue comment
     runs-on: ubuntu-latest
     steps:
 {!{ tmpl.Exec "checkout_step" $ctx | strings.Indent 6 }!}
 {!{ tmpl.Exec "update_comment_on_start" "Build and test for release" | strings.Indent 6 }!}
 
+{!{ $jobNames = coll.Merge $jobNames (dict "go_generate" "Go Generate") }!}
   go_generate:
-    name: Go Generate
+    name: {!{ $jobNames.go_generate }!}
     needs:
       - git_info
 {!{ tmpl.Exec "go_generate_template" $ctx | strings.Indent 4 }!}
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Go Generate") | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.go_generate) | strings.Indent 6 }!}
 
+{!{ $jobNames = coll.Merge $jobNames (dict "build_fe" "Build FE") }!}
   build_fe:
-    name: Build FE
+    name: {!{ $jobNames.build_fe }!}
     needs:
       - git_info
       - go_generate
     env:
       WERF_ENV: "FE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Build FE") | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.build_fe) | strings.Indent 6 }!}
 
+{!{ $jobNames = coll.Merge $jobNames (dict "build_ee" "Build EE") }!}
   build_ee:
-    name: Build EE
+    name: {!{ $jobNames.build_ee }!}
     needs:
       - git_info
       - go_generate
@@ -65,10 +78,11 @@ jobs:
     env:
       WERF_ENV: "EE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Build EE") | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.build_ee) | strings.Indent 6 }!}
 
+{!{ $jobNames = coll.Merge $jobNames (dict "build_ce" "Build CE") }!}
   build_ce:
-    name: Build CE
+    name: {!{ $jobNames.build_ce }!}
     needs:
       - git_info
       - go_generate
@@ -76,91 +90,101 @@ jobs:
     env:
       WERF_ENV: "CE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Build CE") | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.build_ce) | strings.Indent 6 }!}
 
+{!{ $jobNames = coll.Merge $jobNames (dict "doc_web_build" "Doc web build") }!}
   doc_web_build:
-    name: Doc web build
+    name: {!{ $jobNames.doc_web_build }!}
     # Wait for success build of modules.
     needs:
       - git_info
 {!{ tmpl.Exec "doc_web_build_template" $ctx | strings.Indent 4 }!}
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Doc web build") | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.doc_web_build) | strings.Indent 6 }!}
 
+{!{ $jobNames = coll.Merge $jobNames (dict "main_web_build" "Main web build") }!}
   main_web_build:
-    name: Main web build
+    name: {!{ $jobNames.main_web_build }!}
     # Wait for success build of modules.
     needs:
       - git_info
 {!{ tmpl.Exec "main_web_build_template" $ctx | strings.Indent 4 }!}
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Main web build") | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.main_web_build) | strings.Indent 6 }!}
 
+{!{ $jobNames = coll.Merge $jobNames (dict "tests" "Tests") }!}
   tests:
-    name: Tests
+    name: {!{ $jobNames.tests }!}
     needs:
       - git_info
       - build_fe
     continue-on-error: true
 {!{ tmpl.Exec "tests_template" (slice $ctx "unit") | strings.Indent 4 }!}
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Tests") | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.tests) | strings.Indent 6 }!}
 
+{!{ $jobNames = coll.Merge $jobNames (dict "matrix_tests" "Matrix tests") }!}
   matrix_tests:
-    name: Matrix tests
+    name: {!{ $jobNames.matrix_tests }!}
     needs:
       - git_info
       - build_fe
     continue-on-error: true
 {!{ tmpl.Exec "tests_template" (slice $ctx "matrix") | strings.Indent 4 }!}
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Matrix tests") | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.matrix_tests) | strings.Indent 6 }!}
 
+{!{ $jobNames = coll.Merge $jobNames (dict "dhctl_tests" "Matrix tests") }!}
   dhctl_tests:
-    name: Dhctl Tests
+    name: {!{ $jobNames.dhctl_tests }!}
     needs:
       - git_info
       - build_fe
     continue-on-error: true
 {!{ tmpl.Exec "tests_template" (slice $ctx "dhctl") | strings.Indent 4 }!}
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Dhctl Tests") | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.dhctl_tests) | strings.Indent 6 }!}
 
+{!{ $jobNames = coll.Merge $jobNames (dict "golangci_lint" "GolangCI Lint") }!}
   golangci_lint:
-    name: GolangCI Lint
+    name: {!{ $jobNames.golangci_lint }!}
     needs:
       - git_info
       - build_fe
     continue-on-error: true
 {!{ tmpl.Exec "tests_template" (slice $ctx "golangci_lint") | strings.Indent 4 }!}
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "GolangCI Lint") | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.golangci_lint) | strings.Indent 6 }!}
 
+{!{ $jobNames = coll.Merge $jobNames (dict "openapi_test_cases" "OpenAPI Test Cases") }!}
   openapi_test_cases:
-    name: OpenAPI Test Cases
+    name: {!{ $jobNames.openapi_test_cases }!}
     needs:
       - git_info
       - build_fe
     continue-on-error: true
 {!{ tmpl.Exec "tests_template" (slice $ctx "openapi_test_cases") | strings.Indent 4 }!}
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "OpenAPI Test Cases") | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.openapi_test_cases) | strings.Indent 6 }!}
 
+{!{ $jobNames = coll.Merge $jobNames (dict "web_links_test" "Web links test") }!}
   web_links_test:
-    name: Web links test
+    name: {!{ $jobNames.web_links_test }!}
     needs:
       - git_info
       - doc_web_build
       - main_web_build
     continue-on-error: true
 {!{ tmpl.Exec "web_links_test_template" $ctx | strings.Indent 4 }!}
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Web links test") | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.web_links_test) | strings.Indent 6 }!}
 
+{!{ $jobNames = coll.Merge $jobNames (dict "validators" "Validators") }!}
   validators:
-    name: Validators
+    name: {!{ $jobNames.validators }!}
     needs:
       - git_info
       - build_fe
     continue-on-error: true
 {!{ tmpl.Exec "tests_template" (slice $ctx "validators") | strings.Indent 4 }!}
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Validators") | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.validators) | strings.Indent 6 }!}
 
-  {!{/* Autodeploy site and docs to production env on push to main branch. */}!}
+{!{/* Autodeploy site and docs to production env on push to main branch. */}!}
+{!{ $jobNames = coll.Merge $jobNames (dict "deploy_latest_web" "Deploy latest doc and site") }!}
   deploy_latest_web:
-    name: Deploy latest doc and site
+    name: {!{ $jobNames.deploy_latest_web }!}
     needs:
       - git_info
       - doc_web_build
@@ -169,16 +193,18 @@ jobs:
     if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' }}
     runs-on: [self-hosted, regular]
     steps:
+{!{ tmpl.Exec "started_at_output" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "checkout_full_step" $ctx | strings.Indent 6}!}
 {!{ tmpl.Exec "login_flant_registry_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "doc_version_template" | strings.Indent 6 }!}
 {!{ tmpl.Exec "deploy_doc_template" "production" | strings.Indent 6 }!}
 {!{ tmpl.Exec "deploy_site_template" "production" | strings.Indent 6 }!}
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Deploy latest doc and site") | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.deploy_latest_web) | strings.Indent 6 }!}
 
-  {!{/* Autodeploy documentation to production and stage envs on a new tag */}!}
+{!{/* Autodeploy documentation to production and stage envs on a new tag */}!}
+{!{ $jobNames = coll.Merge $jobNames (dict "deploy_tagged_doc" "Deploy tagged documentation") }!}
   deploy_tagged_doc:
-    name: Deploy tagged documentation
+    name: {!{ $jobNames.deploy_tagged_doc }!}
     needs:
       - git_info
       - doc_web_build
@@ -186,16 +212,18 @@ jobs:
     if: ${{ needs.git_info.outputs.ci_commit_tag != '' }}
     runs-on: [self-hosted, regular]
     steps:
+{!{ tmpl.Exec "started_at_output" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "checkout_full_step" $ctx | strings.Indent 6}!}
 {!{ tmpl.Exec "login_flant_registry_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "doc_version_template" | strings.Indent 6 }!}
 {!{ tmpl.Exec "deploy_doc_template" "stage" | strings.Indent 6 }!}
 {!{ tmpl.Exec "deploy_doc_template" "production" | strings.Indent 6 }!}
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Deploy tagged doc") | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.deploy_tagged_doc) | strings.Indent 6 }!}
 
   last_comment:
     name: Update comment on finish
     needs:
+      - started_at
       - git_info
       - go_generate
       - build_fe
@@ -214,6 +242,9 @@ jobs:
       - validators
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    env:
+      JOB_NAMES: |
+        {!{ $jobNames | toJSON }!}
     steps:
 {!{ tmpl.Exec "checkout_step" $ctx | strings.Indent 6 }!}
-{!{ tmpl.Exec "update_comment_on_finish" (slice "workflow" $workflowName) | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "workflow,final,restore-one-line" $workflowName) | strings.Indent 6 }!}

--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -53,6 +53,7 @@ jobs:
       - git_info
     runs-on: [self-hosted, regular]
     steps:
+{!{ tmpl.Exec "started_at_output" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "checkout_from_event_ref_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "update_comment_on_start" $workflowName | strings.Indent 6 }!}
 {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 6 }!}
@@ -221,6 +222,6 @@ Destination registries:
           git checkout -b "${RELEASE_BRANCH_NAME}"
           git push --force origin "${RELEASE_BRANCH_NAME}"
 
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job" $workflowName) | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,final" $workflowName) | strings.Indent 6 }!}
 
 {!{ end -}!}

--- a/.github/workflow_templates/deploy-web.multi.yml
+++ b/.github/workflow_templates/deploy-web.multi.yml
@@ -30,6 +30,9 @@ on:
       pull_request_sha:
         description: 'Git SHA for restoring artifacts from cache'
         required: false
+      pull_request_head_label:
+        description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
+        required: false
 
 env:
 {!{ tmpl.Exec "werf_envs" | strings.Indent 2 }!}
@@ -56,6 +59,7 @@ jobs:
     name: Deploy site
     runs-on: [self-hosted, regular]
     steps:
+{!{ tmpl.Exec "started_at_output" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "checkout_from_event_ref_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "update_comment_on_start" $workflowName | strings.Indent 6 }!}
 {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 6 }!}
@@ -66,6 +70,6 @@ jobs:
 {!{ tmpl.Exec "doc_version_template" | strings.Indent 6 }!}
 {!{ tmpl.Exec "deploy_doc_template" .webEnv | strings.Indent 6 }!}
 
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job" $workflowName) | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,final" $workflowName) | strings.Indent 6 }!}
 
 {!{ end -}!}

--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -58,6 +58,9 @@ on:
       pull_request_sha:
         description: 'Git SHA for restoring artifacts from cache'
         required: false
+      pull_request_head_label:
+        description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
+        required: false
       cri:
         description: 'A comma-separated list of cri to test. Available: Docker and Containerd.'
         required: false
@@ -73,11 +76,21 @@ env:
 # Usually you run e2e and wait until it ends.
 
 jobs:
+  started_at:
+    name: Save start timestamp
+    outputs:
+      started_at: ${{ steps.started_at.outputs.started_at }}
+    runs-on: "ubuntu-latest"
+    steps:
+{!{ tmpl.Exec "started_at_output" . | strings.Indent 6 }!}
+
 {!{ tmpl.Exec "git_info_job" . | strings.Indent 2 }!}
 
 {!{ tmpl.Exec "check_e2e_labels_job" $ctx | strings.Indent 2 }!}
 
 {!{/* Jobs for each CRI and Kubernetes version */}!}
+{!{- $lastCommentNeeds := slice "started_at" -}!}
+{!{- $jobNames := dict -}!}
 {!{- range $criName := $ctx.criNames -}!}
 {!{-   range $kubernetesVersion := $ctx.kubernetesVersions -}!}
 {!{-     $kubernetesVersionSlug := $kubernetesVersion | replaceAll "." "_" | toLower -}!}
@@ -93,10 +106,26 @@ jobs:
 {!{-     if eq $ctx.provider "static"  -}!}
 {!{-       $layout = "Static" -}!}
 {!{-     end -}!}
-{!{-     $jobCtx := coll.Merge $ctx (dict "cri" $cri "criName" $criName "criEnv" $criEnv "layout" $layout "kubernetesVersion" $kubernetesVersion "kubernetesVersionSlug" $kubernetesVersionSlug "workflowName" $workflowName) }!}
+{!{-     $jobID := printf "run_%s_%s" $cri $kubernetesVersionSlug -}!}
+{!{-     $jobName := printf "%s, %s, Kubernetes %s" $workflowName $criName $kubernetesVersion -}!}
+{!{-     $lastCommentNeeds = $lastCommentNeeds | append $jobID -}!}
+{!{-     $jobNames = coll.Merge $jobNames (dict $jobID $jobName) }!}
+{!{-     $jobCtx := coll.Merge $ctx (dict "cri" $cri "criName" $criName "criEnv" $criEnv "layout" $layout "kubernetesVersion" $kubernetesVersion "kubernetesVersionSlug" $kubernetesVersionSlug "workflowName" $workflowName "jobName" $jobName "jobID" $jobID) }!}
 {!{     tmpl.Exec "e2e_run_job_template" $jobCtx | strings.Indent 2 }!}
 {!{-   end -}!}
 {!{- end }!}
+
+  last_comment:
+    name: Update comment on finish
+    needs: {!{ $lastCommentNeeds | toJSON }!}
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    env:
+      JOB_NAMES: |
+        {!{ $jobNames | toJSON }!}
+    steps:
+{!{ tmpl.Exec "checkout_step" $ctx | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "workflow,final,no-skipped,restore-separate" $workflowName) | strings.Indent 6 }!}
 # </template: e2e_workflow_template>
 {!{ end -}!}
 
@@ -109,8 +138,8 @@ jobs:
 {!{-   $runsOnLabel = "e2e-vsphere" -}!}
 {!{- end -}!}
 # <template: e2e_run_job_template>
-run_{!{ $ctx.cri }!}_{!{ $ctx.kubernetesVersionSlug }!}:
-  name: "{!{ $ctx.criName }!}, k8s {!{ $ctx.kubernetesVersion }!}"
+{!{ $ctx.jobID }!}:
+  name: "{!{ $ctx.jobName }!}"
   needs:
     - check_e2e_labels
     - git_info
@@ -119,12 +148,13 @@ run_{!{ $ctx.cri }!}_{!{ $ctx.kubernetesVersionSlug }!}:
     PROVIDER: {!{ $ctx.providerName }!}
     CRI: {!{ $ctx.criName }!}
     LAYOUT: {!{ $ctx.layout }!}
-    KUBERNETES_VERSION: {!{ $ctx.kubernetesVersion }!}
+    KUBERNETES_VERSION: "{!{ $ctx.kubernetesVersion }!}"
     EVENT_LABEL: ${{ github.event.label.name }}
   runs-on: [self-hosted, {!{ $runsOnLabel }!}]
   steps:
+{!{ tmpl.Exec "started_at_output" . | strings.Indent 4 }!}
 {!{ tmpl.Exec "checkout_from_event_ref_step" . | strings.Indent 4 }!}
-{!{ tmpl.Exec "update_comment_on_start" (printf "%s, %s, k8s %s" $ctx.workflowName $ctx.criName $ctx.kubernetesVersion) | strings.Indent 4 }!}
+{!{ tmpl.Exec "update_comment_on_start" $ctx.jobName | strings.Indent 4 }!}
 {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 4 }!}
 {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 4 }!}
 {!{ tmpl.Exec "login_rw_registry_step" . | strings.Indent 4 }!}
@@ -142,7 +172,9 @@ run_{!{ $ctx.cri }!}_{!{ $ctx.kubernetesVersionSlug }!}:
         sleep $delay
 
         # Calculate unique prefix for e2e test.
-        prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+        # GITHUB_RUN_ID is a unique number for each workflow run.
+        # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+        prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
         echo "::set-output name=prefix::${prefix}"
         echo "prefix=${prefix}"
 
@@ -260,7 +292,7 @@ run_{!{ $ctx.cri }!}_{!{ $ctx.kubernetesVersionSlug }!}:
           echo Not a directory.
         fi
 
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job" (printf "%s, Kubernetes %s" $ctx.workflowName $ctx.kubernetesVersion)) | strings.Indent 4 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,separate" $ctx.jobName) | strings.Indent 4 }!}
 
     - name: Alert on fail in default branch
       if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}

--- a/.github/workflow_templates/suspend-channel.multi.yml
+++ b/.github/workflow_templates/suspend-channel.multi.yml
@@ -50,6 +50,7 @@ jobs:
       - git_info
     runs-on: self-hosted
     steps:
+{!{ tmpl.Exec "started_at_output" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "checkout_from_event_ref_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "update_comment_on_start" $workflowName | strings.Indent 6 }!}
 {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 6 }!}
@@ -111,6 +112,6 @@ Destination registries:
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
 {!{- end }!}
 
-{!{ tmpl.Exec "update_comment_on_finish" (slice "job" $workflowName) | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,final" $workflowName) | strings.Indent 6 }!}
 
 {!{ end -}!}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -279,6 +279,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -316,6 +324,14 @@ jobs:
     # <template: build_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -464,6 +480,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -511,6 +535,14 @@ jobs:
     # <template: main_web_build_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -560,6 +592,14 @@ jobs:
     # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -614,6 +654,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -666,6 +714,14 @@ jobs:
     # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -720,6 +776,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -772,6 +836,14 @@ jobs:
     # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -826,6 +898,14 @@ jobs:
     # <template: web_links_test_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -940,6 +1020,14 @@ jobs:
     # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -3,6 +3,7 @@
 #
 
 # on push to default branch or on tags
+
 name: Build and test for release
 
 on:
@@ -87,6 +88,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  started_at:
+    name: Save start timestamp
+    outputs:
+      started_at: ${{ steps.started_at.outputs.started_at }}
+    runs-on: "ubuntu-latest"
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
 
   # <template: git_info_job>
 
@@ -162,7 +178,7 @@ jobs:
   # </template: git_info_job>
 
   comment_on_start:
-    name: Add comment on start
+    name: Update issue comment
     runs-on: ubuntu-latest
     steps:
 
@@ -185,6 +201,7 @@ jobs:
 
       # </template: update_comment_on_start>
 
+
   go_generate:
     name: Go Generate
     needs:
@@ -193,6 +210,14 @@ jobs:
     # <template: go_generate_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_step>
       - name: Checkout sources
@@ -222,26 +247,35 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job,inline';
+            const statusConfig = 'job,one-line';
             const name = 'Go Generate';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
 
   build_fe:
     name: Build FE
@@ -253,6 +287,14 @@ jobs:
     # <template: build_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -431,26 +473,35 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job,inline';
+            const statusConfig = 'job,one-line';
             const name = 'Build FE';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
 
   build_ee:
     name: Build EE
@@ -464,6 +515,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -641,26 +700,35 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job,inline';
+            const statusConfig = 'job,one-line';
             const name = 'Build EE';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
 
   build_ce:
     name: Build CE
@@ -674,6 +742,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -851,26 +927,35 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job,inline';
+            const statusConfig = 'job,one-line';
             const name = 'Build CE';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
 
   doc_web_build:
     name: Doc web build
@@ -880,6 +965,14 @@ jobs:
     # <template: doc_web_build_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -919,26 +1012,35 @@ jobs:
     # </template: doc_web_build_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job,inline';
+            const statusConfig = 'job,one-line';
             const name = 'Doc web build';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
 
   main_web_build:
     name: Main web build
@@ -948,6 +1050,14 @@ jobs:
     # <template: main_web_build_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -987,26 +1097,35 @@ jobs:
     # </template: main_web_build_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job,inline';
+            const statusConfig = 'job,one-line';
             const name = 'Main web build';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
 
   tests:
     name: Tests
@@ -1018,6 +1137,14 @@ jobs:
     # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -1061,26 +1188,35 @@ jobs:
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job,inline';
+            const statusConfig = 'job,one-line';
             const name = 'Tests';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
 
   matrix_tests:
     name: Matrix tests
@@ -1092,6 +1228,14 @@ jobs:
     # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -1135,29 +1279,38 @@ jobs:
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job,inline';
+            const statusConfig = 'job,one-line';
             const name = 'Matrix tests';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+
   dhctl_tests:
-    name: Dhctl Tests
+    name: Matrix tests
     needs:
       - git_info
       - build_fe
@@ -1166,6 +1319,14 @@ jobs:
     # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -1209,26 +1370,35 @@ jobs:
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job,inline';
-            const name = 'Dhctl Tests';
+            const statusConfig = 'job,one-line';
+            const name = 'Matrix tests';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
 
   golangci_lint:
     name: GolangCI Lint
@@ -1240,6 +1410,14 @@ jobs:
     # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -1283,26 +1461,35 @@ jobs:
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job,inline';
+            const statusConfig = 'job,one-line';
             const name = 'GolangCI Lint';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
 
   openapi_test_cases:
     name: OpenAPI Test Cases
@@ -1314,6 +1501,14 @@ jobs:
     # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -1357,26 +1552,35 @@ jobs:
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job,inline';
+            const statusConfig = 'job,one-line';
             const name = 'OpenAPI Test Cases';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
 
   web_links_test:
     name: Web links test
@@ -1388,6 +1592,14 @@ jobs:
     # <template: web_links_test_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -1492,26 +1704,35 @@ jobs:
     # </template: web_links_test_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job,inline';
+            const statusConfig = 'job,one-line';
             const name = 'Web links test';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
 
   validators:
     name: Validators
@@ -1523,6 +1744,14 @@ jobs:
     # <template: tests_template>
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -1566,26 +1795,35 @@ jobs:
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job,inline';
+            const statusConfig = 'job,one-line';
             const name = 'Validators';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
 
 
   deploy_latest_web:
@@ -1598,6 +1836,14 @@ jobs:
     if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' }}
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -1658,26 +1904,35 @@ jobs:
       # </template: deploy_site_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job,inline';
+            const statusConfig = 'job,one-line';
             const name = 'Deploy latest doc and site';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
 
 
   deploy_tagged_doc:
@@ -1689,6 +1944,14 @@ jobs:
     if: ${{ needs.git_info.outputs.ci_commit_tag != '' }}
     runs-on: [self-hosted, regular]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -1748,30 +2011,39 @@ jobs:
       # </template: deploy_doc_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job,inline';
-            const name = 'Deploy tagged doc';
+            const statusConfig = 'job,one-line';
+            const name = 'Deploy tagged documentation';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
   last_comment:
     name: Update comment on finish
     needs:
+      - started_at
       - git_info
       - go_generate
       - build_fe
@@ -1790,6 +2062,9 @@ jobs:
       - validators
     if: ${{ always() }}
     runs-on: ubuntu-latest
+    env:
+      JOB_NAMES: |
+        {"build_ce":"Build CE","build_ee":"Build EE","build_fe":"Build FE","deploy_latest_web":"Deploy latest doc and site","deploy_tagged_doc":"Deploy tagged documentation","dhctl_tests":"Matrix tests","doc_web_build":"Doc web build","go_generate":"Go Generate","golangci_lint":"GolangCI Lint","main_web_build":"Main web build","matrix_tests":"Matrix tests","openapi_test_cases":"OpenAPI Test Cases","tests":"Tests","validators":"Validators","web_links_test":"Web links test"}
     steps:
 
       # <template: checkout_step>
@@ -1799,23 +2074,31 @@ jobs:
       # </template: checkout_step>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'workflow';
+            const statusConfig = 'workflow,final,restore-one-line';
             const name = 'Build and test for release';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -126,6 +126,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -550,24 +558,32 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
+            const statusConfig = 'job,final';
             const name = 'Deploy to alpha';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -126,6 +126,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -550,24 +558,32 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
+            const statusConfig = 'job,final';
             const name = 'Deploy to beta';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -126,6 +126,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -550,24 +558,32 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
+            const statusConfig = 'job,final';
             const name = 'Deploy to early-access';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -126,6 +126,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -550,24 +558,32 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
+            const statusConfig = 'job,final';
             const name = 'Deploy to rock-solid';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -126,6 +126,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -550,24 +558,32 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
+            const statusConfig = 'job,final';
             const name = 'Deploy to stable';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 

--- a/.github/workflows/deploy-web-stage.yml
+++ b/.github/workflows/deploy-web-stage.yml
@@ -25,6 +25,9 @@ on:
       pull_request_sha:
         description: 'Git SHA for restoring artifacts from cache'
         required: false
+      pull_request_head_label:
+        description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
+        required: false
 
 env:
 
@@ -204,6 +207,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -299,24 +310,32 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
+            const statusConfig = 'job,final';
             const name = 'Deploy web to stage';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 

--- a/.github/workflows/deploy-web-test.yml
+++ b/.github/workflows/deploy-web-test.yml
@@ -25,6 +25,9 @@ on:
       pull_request_sha:
         description: 'Git SHA for restoring artifacts from cache'
         required: false
+      pull_request_head_label:
+        description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
+        required: false
 
 env:
 
@@ -204,6 +207,14 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -299,24 +310,32 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
+            const statusConfig = 'job,final';
             const name = 'Deploy web to test';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 

--- a/.github/workflows/dispatch-slash-command.yml
+++ b/.github/workflows/dispatch-slash-command.yml
@@ -2,7 +2,7 @@
 # THIS FILE IS GENERATED, PLEASE DO NOT EDIT.
 #
 
-name: Trigger slash command
+name: Dispatch slash command
 on:
   issue_comment:
     types: [created]

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -25,6 +25,9 @@ on:
       pull_request_sha:
         description: 'Git SHA for restoring artifacts from cache'
         required: false
+      pull_request_head_label:
+        description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
+        required: false
       cri:
         description: 'A comma-separated list of cri to test. Available: Docker and Containerd.'
         required: false
@@ -96,6 +99,21 @@ env:
 # Usually you run e2e and wait until it ends.
 
 jobs:
+  started_at:
+    name: Save start timestamp
+    outputs:
+      started_at: ${{ steps.started_at.outputs.started_at }}
+    runs-on: "ubuntu-latest"
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
 
   # <template: git_info_job>
 
@@ -205,7 +223,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_19:
-    name: "Docker, k8s 1.19"
+    name: "e2e: AWS, Docker, Kubernetes 1.19"
     needs:
       - check_e2e_labels
       - git_info
@@ -214,10 +232,18 @@ jobs:
       PROVIDER: AWS
       CRI: Docker
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.19
+      KUBERNETES_VERSION: "1.19"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -233,7 +259,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: AWS, Docker, k8s 1.19';
+            const name = 'e2e: AWS, Docker, Kubernetes 1.19';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -289,7 +315,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -487,25 +515,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: AWS, Kubernetes 1.19';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: AWS, Docker, Kubernetes 1.19';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -549,7 +585,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_20:
-    name: "Docker, k8s 1.20"
+    name: "e2e: AWS, Docker, Kubernetes 1.20"
     needs:
       - check_e2e_labels
       - git_info
@@ -558,10 +594,18 @@ jobs:
       PROVIDER: AWS
       CRI: Docker
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.20
+      KUBERNETES_VERSION: "1.20"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -577,7 +621,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: AWS, Docker, k8s 1.20';
+            const name = 'e2e: AWS, Docker, Kubernetes 1.20';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -633,7 +677,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -831,25 +877,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: AWS, Kubernetes 1.20';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: AWS, Docker, Kubernetes 1.20';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -893,7 +947,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_21:
-    name: "Docker, k8s 1.21"
+    name: "e2e: AWS, Docker, Kubernetes 1.21"
     needs:
       - check_e2e_labels
       - git_info
@@ -902,10 +956,18 @@ jobs:
       PROVIDER: AWS
       CRI: Docker
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.21
+      KUBERNETES_VERSION: "1.21"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -921,7 +983,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: AWS, Docker, k8s 1.21';
+            const name = 'e2e: AWS, Docker, Kubernetes 1.21';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -977,7 +1039,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1175,25 +1239,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: AWS, Kubernetes 1.21';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: AWS, Docker, Kubernetes 1.21';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1237,7 +1309,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_22:
-    name: "Docker, k8s 1.22"
+    name: "e2e: AWS, Docker, Kubernetes 1.22"
     needs:
       - check_e2e_labels
       - git_info
@@ -1246,10 +1318,18 @@ jobs:
       PROVIDER: AWS
       CRI: Docker
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.22
+      KUBERNETES_VERSION: "1.22"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1265,7 +1345,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: AWS, Docker, k8s 1.22';
+            const name = 'e2e: AWS, Docker, Kubernetes 1.22';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1321,7 +1401,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1519,25 +1601,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: AWS, Kubernetes 1.22';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: AWS, Docker, Kubernetes 1.22';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1581,7 +1671,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_19:
-    name: "Containerd, k8s 1.19"
+    name: "e2e: AWS, Containerd, Kubernetes 1.19"
     needs:
       - check_e2e_labels
       - git_info
@@ -1590,10 +1680,18 @@ jobs:
       PROVIDER: AWS
       CRI: Containerd
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.19
+      KUBERNETES_VERSION: "1.19"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1609,7 +1707,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: AWS, Containerd, k8s 1.19';
+            const name = 'e2e: AWS, Containerd, Kubernetes 1.19';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1665,7 +1763,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1863,25 +1963,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: AWS, Kubernetes 1.19';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: AWS, Containerd, Kubernetes 1.19';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1925,7 +2033,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_20:
-    name: "Containerd, k8s 1.20"
+    name: "e2e: AWS, Containerd, Kubernetes 1.20"
     needs:
       - check_e2e_labels
       - git_info
@@ -1934,10 +2042,18 @@ jobs:
       PROVIDER: AWS
       CRI: Containerd
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.20
+      KUBERNETES_VERSION: "1.20"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1953,7 +2069,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: AWS, Containerd, k8s 1.20';
+            const name = 'e2e: AWS, Containerd, Kubernetes 1.20';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2009,7 +2125,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2207,25 +2325,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: AWS, Kubernetes 1.20';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: AWS, Containerd, Kubernetes 1.20';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2269,7 +2395,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_21:
-    name: "Containerd, k8s 1.21"
+    name: "e2e: AWS, Containerd, Kubernetes 1.21"
     needs:
       - check_e2e_labels
       - git_info
@@ -2278,10 +2404,18 @@ jobs:
       PROVIDER: AWS
       CRI: Containerd
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.21
+      KUBERNETES_VERSION: "1.21"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2297,7 +2431,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: AWS, Containerd, k8s 1.21';
+            const name = 'e2e: AWS, Containerd, Kubernetes 1.21';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2353,7 +2487,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2551,25 +2687,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: AWS, Kubernetes 1.21';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: AWS, Containerd, Kubernetes 1.21';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2613,7 +2757,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_22:
-    name: "Containerd, k8s 1.22"
+    name: "e2e: AWS, Containerd, Kubernetes 1.22"
     needs:
       - check_e2e_labels
       - git_info
@@ -2622,10 +2766,18 @@ jobs:
       PROVIDER: AWS
       CRI: Containerd
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.22
+      KUBERNETES_VERSION: "1.22"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2641,7 +2793,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: AWS, Containerd, k8s 1.22';
+            const name = 'e2e: AWS, Containerd, Kubernetes 1.22';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2697,7 +2849,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2895,25 +3049,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: AWS, Kubernetes 1.22';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: AWS, Containerd, Kubernetes 1.22';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2955,4 +3117,50 @@ jobs:
             -d "${alertData}"
   # </template: e2e_run_job_template>
 
+
+  last_comment:
+    name: Update comment on finish
+    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22"]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    env:
+      JOB_NAMES: |
+        {"run_containerd_1_19":"e2e: AWS, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: AWS, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: AWS, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: AWS, Containerd, Kubernetes 1.22","run_docker_1_19":"e2e: AWS, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: AWS, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: AWS, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: AWS, Docker, Kubernetes 1.22"}
+    steps:
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'workflow,final,no-skipped,restore-separate';
+            const name = 'e2e: AWS';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -25,6 +25,9 @@ on:
       pull_request_sha:
         description: 'Git SHA for restoring artifacts from cache'
         required: false
+      pull_request_head_label:
+        description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
+        required: false
       cri:
         description: 'A comma-separated list of cri to test. Available: Docker and Containerd.'
         required: false
@@ -96,6 +99,21 @@ env:
 # Usually you run e2e and wait until it ends.
 
 jobs:
+  started_at:
+    name: Save start timestamp
+    outputs:
+      started_at: ${{ steps.started_at.outputs.started_at }}
+    runs-on: "ubuntu-latest"
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
 
   # <template: git_info_job>
 
@@ -205,7 +223,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_19:
-    name: "Docker, k8s 1.19"
+    name: "e2e: Azure, Docker, Kubernetes 1.19"
     needs:
       - check_e2e_labels
       - git_info
@@ -214,10 +232,18 @@ jobs:
       PROVIDER: Azure
       CRI: Docker
       LAYOUT: Standard
-      KUBERNETES_VERSION: 1.19
+      KUBERNETES_VERSION: "1.19"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -233,7 +259,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Azure, Docker, k8s 1.19';
+            const name = 'e2e: Azure, Docker, Kubernetes 1.19';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -289,7 +315,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -495,25 +523,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Azure, Kubernetes 1.19';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Azure, Docker, Kubernetes 1.19';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -557,7 +593,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_20:
-    name: "Docker, k8s 1.20"
+    name: "e2e: Azure, Docker, Kubernetes 1.20"
     needs:
       - check_e2e_labels
       - git_info
@@ -566,10 +602,18 @@ jobs:
       PROVIDER: Azure
       CRI: Docker
       LAYOUT: Standard
-      KUBERNETES_VERSION: 1.20
+      KUBERNETES_VERSION: "1.20"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -585,7 +629,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Azure, Docker, k8s 1.20';
+            const name = 'e2e: Azure, Docker, Kubernetes 1.20';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -641,7 +685,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -847,25 +893,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Azure, Kubernetes 1.20';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Azure, Docker, Kubernetes 1.20';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -909,7 +963,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_21:
-    name: "Docker, k8s 1.21"
+    name: "e2e: Azure, Docker, Kubernetes 1.21"
     needs:
       - check_e2e_labels
       - git_info
@@ -918,10 +972,18 @@ jobs:
       PROVIDER: Azure
       CRI: Docker
       LAYOUT: Standard
-      KUBERNETES_VERSION: 1.21
+      KUBERNETES_VERSION: "1.21"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -937,7 +999,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Azure, Docker, k8s 1.21';
+            const name = 'e2e: Azure, Docker, Kubernetes 1.21';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -993,7 +1055,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1199,25 +1263,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Azure, Kubernetes 1.21';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Azure, Docker, Kubernetes 1.21';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1261,7 +1333,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_22:
-    name: "Docker, k8s 1.22"
+    name: "e2e: Azure, Docker, Kubernetes 1.22"
     needs:
       - check_e2e_labels
       - git_info
@@ -1270,10 +1342,18 @@ jobs:
       PROVIDER: Azure
       CRI: Docker
       LAYOUT: Standard
-      KUBERNETES_VERSION: 1.22
+      KUBERNETES_VERSION: "1.22"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1289,7 +1369,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Azure, Docker, k8s 1.22';
+            const name = 'e2e: Azure, Docker, Kubernetes 1.22';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1345,7 +1425,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1551,25 +1633,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Azure, Kubernetes 1.22';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Azure, Docker, Kubernetes 1.22';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1613,7 +1703,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_19:
-    name: "Containerd, k8s 1.19"
+    name: "e2e: Azure, Containerd, Kubernetes 1.19"
     needs:
       - check_e2e_labels
       - git_info
@@ -1622,10 +1712,18 @@ jobs:
       PROVIDER: Azure
       CRI: Containerd
       LAYOUT: Standard
-      KUBERNETES_VERSION: 1.19
+      KUBERNETES_VERSION: "1.19"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1641,7 +1739,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Azure, Containerd, k8s 1.19';
+            const name = 'e2e: Azure, Containerd, Kubernetes 1.19';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1697,7 +1795,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1903,25 +2003,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Azure, Kubernetes 1.19';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Azure, Containerd, Kubernetes 1.19';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1965,7 +2073,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_20:
-    name: "Containerd, k8s 1.20"
+    name: "e2e: Azure, Containerd, Kubernetes 1.20"
     needs:
       - check_e2e_labels
       - git_info
@@ -1974,10 +2082,18 @@ jobs:
       PROVIDER: Azure
       CRI: Containerd
       LAYOUT: Standard
-      KUBERNETES_VERSION: 1.20
+      KUBERNETES_VERSION: "1.20"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1993,7 +2109,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Azure, Containerd, k8s 1.20';
+            const name = 'e2e: Azure, Containerd, Kubernetes 1.20';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2049,7 +2165,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2255,25 +2373,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Azure, Kubernetes 1.20';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Azure, Containerd, Kubernetes 1.20';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2317,7 +2443,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_21:
-    name: "Containerd, k8s 1.21"
+    name: "e2e: Azure, Containerd, Kubernetes 1.21"
     needs:
       - check_e2e_labels
       - git_info
@@ -2326,10 +2452,18 @@ jobs:
       PROVIDER: Azure
       CRI: Containerd
       LAYOUT: Standard
-      KUBERNETES_VERSION: 1.21
+      KUBERNETES_VERSION: "1.21"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2345,7 +2479,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Azure, Containerd, k8s 1.21';
+            const name = 'e2e: Azure, Containerd, Kubernetes 1.21';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2401,7 +2535,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2607,25 +2743,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Azure, Kubernetes 1.21';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Azure, Containerd, Kubernetes 1.21';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2669,7 +2813,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_22:
-    name: "Containerd, k8s 1.22"
+    name: "e2e: Azure, Containerd, Kubernetes 1.22"
     needs:
       - check_e2e_labels
       - git_info
@@ -2678,10 +2822,18 @@ jobs:
       PROVIDER: Azure
       CRI: Containerd
       LAYOUT: Standard
-      KUBERNETES_VERSION: 1.22
+      KUBERNETES_VERSION: "1.22"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2697,7 +2849,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Azure, Containerd, k8s 1.22';
+            const name = 'e2e: Azure, Containerd, Kubernetes 1.22';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2753,7 +2905,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2959,25 +3113,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Azure, Kubernetes 1.22';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Azure, Containerd, Kubernetes 1.22';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -3019,4 +3181,50 @@ jobs:
             -d "${alertData}"
   # </template: e2e_run_job_template>
 
+
+  last_comment:
+    name: Update comment on finish
+    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22"]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    env:
+      JOB_NAMES: |
+        {"run_containerd_1_19":"e2e: Azure, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: Azure, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: Azure, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: Azure, Containerd, Kubernetes 1.22","run_docker_1_19":"e2e: Azure, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: Azure, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: Azure, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: Azure, Docker, Kubernetes 1.22"}
+    steps:
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'workflow,final,no-skipped,restore-separate';
+            const name = 'e2e: Azure';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -25,6 +25,9 @@ on:
       pull_request_sha:
         description: 'Git SHA for restoring artifacts from cache'
         required: false
+      pull_request_head_label:
+        description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
+        required: false
       cri:
         description: 'A comma-separated list of cri to test. Available: Docker and Containerd.'
         required: false
@@ -96,6 +99,21 @@ env:
 # Usually you run e2e and wait until it ends.
 
 jobs:
+  started_at:
+    name: Save start timestamp
+    outputs:
+      started_at: ${{ steps.started_at.outputs.started_at }}
+    runs-on: "ubuntu-latest"
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
 
   # <template: git_info_job>
 
@@ -205,7 +223,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_19:
-    name: "Docker, k8s 1.19"
+    name: "e2e: GCP, Docker, Kubernetes 1.19"
     needs:
       - check_e2e_labels
       - git_info
@@ -214,10 +232,18 @@ jobs:
       PROVIDER: GCP
       CRI: Docker
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.19
+      KUBERNETES_VERSION: "1.19"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -233,7 +259,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: GCP, Docker, k8s 1.19';
+            const name = 'e2e: GCP, Docker, Kubernetes 1.19';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -289,7 +315,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -483,25 +511,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: GCP, Kubernetes 1.19';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: GCP, Docker, Kubernetes 1.19';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -545,7 +581,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_20:
-    name: "Docker, k8s 1.20"
+    name: "e2e: GCP, Docker, Kubernetes 1.20"
     needs:
       - check_e2e_labels
       - git_info
@@ -554,10 +590,18 @@ jobs:
       PROVIDER: GCP
       CRI: Docker
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.20
+      KUBERNETES_VERSION: "1.20"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -573,7 +617,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: GCP, Docker, k8s 1.20';
+            const name = 'e2e: GCP, Docker, Kubernetes 1.20';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -629,7 +673,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -823,25 +869,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: GCP, Kubernetes 1.20';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: GCP, Docker, Kubernetes 1.20';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -885,7 +939,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_21:
-    name: "Docker, k8s 1.21"
+    name: "e2e: GCP, Docker, Kubernetes 1.21"
     needs:
       - check_e2e_labels
       - git_info
@@ -894,10 +948,18 @@ jobs:
       PROVIDER: GCP
       CRI: Docker
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.21
+      KUBERNETES_VERSION: "1.21"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -913,7 +975,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: GCP, Docker, k8s 1.21';
+            const name = 'e2e: GCP, Docker, Kubernetes 1.21';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -969,7 +1031,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1163,25 +1227,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: GCP, Kubernetes 1.21';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: GCP, Docker, Kubernetes 1.21';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1225,7 +1297,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_22:
-    name: "Docker, k8s 1.22"
+    name: "e2e: GCP, Docker, Kubernetes 1.22"
     needs:
       - check_e2e_labels
       - git_info
@@ -1234,10 +1306,18 @@ jobs:
       PROVIDER: GCP
       CRI: Docker
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.22
+      KUBERNETES_VERSION: "1.22"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1253,7 +1333,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: GCP, Docker, k8s 1.22';
+            const name = 'e2e: GCP, Docker, Kubernetes 1.22';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1309,7 +1389,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1503,25 +1585,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: GCP, Kubernetes 1.22';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: GCP, Docker, Kubernetes 1.22';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1565,7 +1655,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_19:
-    name: "Containerd, k8s 1.19"
+    name: "e2e: GCP, Containerd, Kubernetes 1.19"
     needs:
       - check_e2e_labels
       - git_info
@@ -1574,10 +1664,18 @@ jobs:
       PROVIDER: GCP
       CRI: Containerd
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.19
+      KUBERNETES_VERSION: "1.19"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1593,7 +1691,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: GCP, Containerd, k8s 1.19';
+            const name = 'e2e: GCP, Containerd, Kubernetes 1.19';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1649,7 +1747,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1843,25 +1943,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: GCP, Kubernetes 1.19';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: GCP, Containerd, Kubernetes 1.19';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1905,7 +2013,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_20:
-    name: "Containerd, k8s 1.20"
+    name: "e2e: GCP, Containerd, Kubernetes 1.20"
     needs:
       - check_e2e_labels
       - git_info
@@ -1914,10 +2022,18 @@ jobs:
       PROVIDER: GCP
       CRI: Containerd
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.20
+      KUBERNETES_VERSION: "1.20"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1933,7 +2049,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: GCP, Containerd, k8s 1.20';
+            const name = 'e2e: GCP, Containerd, Kubernetes 1.20';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1989,7 +2105,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2183,25 +2301,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: GCP, Kubernetes 1.20';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: GCP, Containerd, Kubernetes 1.20';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2245,7 +2371,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_21:
-    name: "Containerd, k8s 1.21"
+    name: "e2e: GCP, Containerd, Kubernetes 1.21"
     needs:
       - check_e2e_labels
       - git_info
@@ -2254,10 +2380,18 @@ jobs:
       PROVIDER: GCP
       CRI: Containerd
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.21
+      KUBERNETES_VERSION: "1.21"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2273,7 +2407,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: GCP, Containerd, k8s 1.21';
+            const name = 'e2e: GCP, Containerd, Kubernetes 1.21';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2329,7 +2463,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2523,25 +2659,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: GCP, Kubernetes 1.21';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: GCP, Containerd, Kubernetes 1.21';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2585,7 +2729,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_22:
-    name: "Containerd, k8s 1.22"
+    name: "e2e: GCP, Containerd, Kubernetes 1.22"
     needs:
       - check_e2e_labels
       - git_info
@@ -2594,10 +2738,18 @@ jobs:
       PROVIDER: GCP
       CRI: Containerd
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.22
+      KUBERNETES_VERSION: "1.22"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2613,7 +2765,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: GCP, Containerd, k8s 1.22';
+            const name = 'e2e: GCP, Containerd, Kubernetes 1.22';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2669,7 +2821,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2863,25 +3017,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: GCP, Kubernetes 1.22';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: GCP, Containerd, Kubernetes 1.22';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2923,4 +3085,50 @@ jobs:
             -d "${alertData}"
   # </template: e2e_run_job_template>
 
+
+  last_comment:
+    name: Update comment on finish
+    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22"]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    env:
+      JOB_NAMES: |
+        {"run_containerd_1_19":"e2e: GCP, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: GCP, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: GCP, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: GCP, Containerd, Kubernetes 1.22","run_docker_1_19":"e2e: GCP, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: GCP, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: GCP, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: GCP, Docker, Kubernetes 1.22"}
+    steps:
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'workflow,final,no-skipped,restore-separate';
+            const name = 'e2e: GCP';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -25,6 +25,9 @@ on:
       pull_request_sha:
         description: 'Git SHA for restoring artifacts from cache'
         required: false
+      pull_request_head_label:
+        description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
+        required: false
       cri:
         description: 'A comma-separated list of cri to test. Available: Docker and Containerd.'
         required: false
@@ -96,6 +99,21 @@ env:
 # Usually you run e2e and wait until it ends.
 
 jobs:
+  started_at:
+    name: Save start timestamp
+    outputs:
+      started_at: ${{ steps.started_at.outputs.started_at }}
+    runs-on: "ubuntu-latest"
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
 
   # <template: git_info_job>
 
@@ -205,7 +223,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_19:
-    name: "Docker, k8s 1.19"
+    name: "e2e: OpenStack, Docker, Kubernetes 1.19"
     needs:
       - check_e2e_labels
       - git_info
@@ -214,10 +232,18 @@ jobs:
       PROVIDER: OpenStack
       CRI: Docker
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.19
+      KUBERNETES_VERSION: "1.19"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -233,7 +259,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: OpenStack, Docker, k8s 1.19';
+            const name = 'e2e: OpenStack, Docker, Kubernetes 1.19';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -289,7 +315,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -483,25 +511,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: OpenStack, Kubernetes 1.19';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: OpenStack, Docker, Kubernetes 1.19';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -545,7 +581,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_20:
-    name: "Docker, k8s 1.20"
+    name: "e2e: OpenStack, Docker, Kubernetes 1.20"
     needs:
       - check_e2e_labels
       - git_info
@@ -554,10 +590,18 @@ jobs:
       PROVIDER: OpenStack
       CRI: Docker
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.20
+      KUBERNETES_VERSION: "1.20"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -573,7 +617,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: OpenStack, Docker, k8s 1.20';
+            const name = 'e2e: OpenStack, Docker, Kubernetes 1.20';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -629,7 +673,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -823,25 +869,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: OpenStack, Kubernetes 1.20';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: OpenStack, Docker, Kubernetes 1.20';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -885,7 +939,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_21:
-    name: "Docker, k8s 1.21"
+    name: "e2e: OpenStack, Docker, Kubernetes 1.21"
     needs:
       - check_e2e_labels
       - git_info
@@ -894,10 +948,18 @@ jobs:
       PROVIDER: OpenStack
       CRI: Docker
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.21
+      KUBERNETES_VERSION: "1.21"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -913,7 +975,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: OpenStack, Docker, k8s 1.21';
+            const name = 'e2e: OpenStack, Docker, Kubernetes 1.21';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -969,7 +1031,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1163,25 +1227,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: OpenStack, Kubernetes 1.21';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: OpenStack, Docker, Kubernetes 1.21';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1225,7 +1297,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_22:
-    name: "Docker, k8s 1.22"
+    name: "e2e: OpenStack, Docker, Kubernetes 1.22"
     needs:
       - check_e2e_labels
       - git_info
@@ -1234,10 +1306,18 @@ jobs:
       PROVIDER: OpenStack
       CRI: Docker
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.22
+      KUBERNETES_VERSION: "1.22"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1253,7 +1333,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: OpenStack, Docker, k8s 1.22';
+            const name = 'e2e: OpenStack, Docker, Kubernetes 1.22';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1309,7 +1389,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1503,25 +1585,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: OpenStack, Kubernetes 1.22';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: OpenStack, Docker, Kubernetes 1.22';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1565,7 +1655,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_19:
-    name: "Containerd, k8s 1.19"
+    name: "e2e: OpenStack, Containerd, Kubernetes 1.19"
     needs:
       - check_e2e_labels
       - git_info
@@ -1574,10 +1664,18 @@ jobs:
       PROVIDER: OpenStack
       CRI: Containerd
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.19
+      KUBERNETES_VERSION: "1.19"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1593,7 +1691,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: OpenStack, Containerd, k8s 1.19';
+            const name = 'e2e: OpenStack, Containerd, Kubernetes 1.19';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1649,7 +1747,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1843,25 +1943,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: OpenStack, Kubernetes 1.19';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: OpenStack, Containerd, Kubernetes 1.19';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1905,7 +2013,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_20:
-    name: "Containerd, k8s 1.20"
+    name: "e2e: OpenStack, Containerd, Kubernetes 1.20"
     needs:
       - check_e2e_labels
       - git_info
@@ -1914,10 +2022,18 @@ jobs:
       PROVIDER: OpenStack
       CRI: Containerd
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.20
+      KUBERNETES_VERSION: "1.20"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1933,7 +2049,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: OpenStack, Containerd, k8s 1.20';
+            const name = 'e2e: OpenStack, Containerd, Kubernetes 1.20';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1989,7 +2105,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2183,25 +2301,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: OpenStack, Kubernetes 1.20';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: OpenStack, Containerd, Kubernetes 1.20';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2245,7 +2371,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_21:
-    name: "Containerd, k8s 1.21"
+    name: "e2e: OpenStack, Containerd, Kubernetes 1.21"
     needs:
       - check_e2e_labels
       - git_info
@@ -2254,10 +2380,18 @@ jobs:
       PROVIDER: OpenStack
       CRI: Containerd
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.21
+      KUBERNETES_VERSION: "1.21"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2273,7 +2407,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: OpenStack, Containerd, k8s 1.21';
+            const name = 'e2e: OpenStack, Containerd, Kubernetes 1.21';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2329,7 +2463,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2523,25 +2659,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: OpenStack, Kubernetes 1.21';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: OpenStack, Containerd, Kubernetes 1.21';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2585,7 +2729,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_22:
-    name: "Containerd, k8s 1.22"
+    name: "e2e: OpenStack, Containerd, Kubernetes 1.22"
     needs:
       - check_e2e_labels
       - git_info
@@ -2594,10 +2738,18 @@ jobs:
       PROVIDER: OpenStack
       CRI: Containerd
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.22
+      KUBERNETES_VERSION: "1.22"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2613,7 +2765,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: OpenStack, Containerd, k8s 1.22';
+            const name = 'e2e: OpenStack, Containerd, Kubernetes 1.22';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2669,7 +2821,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2863,25 +3017,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: OpenStack, Kubernetes 1.22';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: OpenStack, Containerd, Kubernetes 1.22';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2923,4 +3085,50 @@ jobs:
             -d "${alertData}"
   # </template: e2e_run_job_template>
 
+
+  last_comment:
+    name: Update comment on finish
+    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22"]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    env:
+      JOB_NAMES: |
+        {"run_containerd_1_19":"e2e: OpenStack, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: OpenStack, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: OpenStack, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: OpenStack, Containerd, Kubernetes 1.22","run_docker_1_19":"e2e: OpenStack, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: OpenStack, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: OpenStack, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: OpenStack, Docker, Kubernetes 1.22"}
+    steps:
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'workflow,final,no-skipped,restore-separate';
+            const name = 'e2e: OpenStack';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -25,6 +25,9 @@ on:
       pull_request_sha:
         description: 'Git SHA for restoring artifacts from cache'
         required: false
+      pull_request_head_label:
+        description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
+        required: false
       cri:
         description: 'A comma-separated list of cri to test. Available: Docker and Containerd.'
         required: false
@@ -96,6 +99,21 @@ env:
 # Usually you run e2e and wait until it ends.
 
 jobs:
+  started_at:
+    name: Save start timestamp
+    outputs:
+      started_at: ${{ steps.started_at.outputs.started_at }}
+    runs-on: "ubuntu-latest"
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
 
   # <template: git_info_job>
 
@@ -205,7 +223,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_19:
-    name: "Docker, k8s 1.19"
+    name: "e2e: Static, Docker, Kubernetes 1.19"
     needs:
       - check_e2e_labels
       - git_info
@@ -214,10 +232,18 @@ jobs:
       PROVIDER: Static
       CRI: Docker
       LAYOUT: Static
-      KUBERNETES_VERSION: 1.19
+      KUBERNETES_VERSION: "1.19"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -233,7 +259,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Static, Docker, k8s 1.19';
+            const name = 'e2e: Static, Docker, Kubernetes 1.19';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -289,7 +315,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -483,25 +511,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Static, Kubernetes 1.19';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Static, Docker, Kubernetes 1.19';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -545,7 +581,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_20:
-    name: "Docker, k8s 1.20"
+    name: "e2e: Static, Docker, Kubernetes 1.20"
     needs:
       - check_e2e_labels
       - git_info
@@ -554,10 +590,18 @@ jobs:
       PROVIDER: Static
       CRI: Docker
       LAYOUT: Static
-      KUBERNETES_VERSION: 1.20
+      KUBERNETES_VERSION: "1.20"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -573,7 +617,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Static, Docker, k8s 1.20';
+            const name = 'e2e: Static, Docker, Kubernetes 1.20';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -629,7 +673,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -823,25 +869,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Static, Kubernetes 1.20';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Static, Docker, Kubernetes 1.20';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -885,7 +939,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_21:
-    name: "Docker, k8s 1.21"
+    name: "e2e: Static, Docker, Kubernetes 1.21"
     needs:
       - check_e2e_labels
       - git_info
@@ -894,10 +948,18 @@ jobs:
       PROVIDER: Static
       CRI: Docker
       LAYOUT: Static
-      KUBERNETES_VERSION: 1.21
+      KUBERNETES_VERSION: "1.21"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -913,7 +975,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Static, Docker, k8s 1.21';
+            const name = 'e2e: Static, Docker, Kubernetes 1.21';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -969,7 +1031,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1163,25 +1227,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Static, Kubernetes 1.21';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Static, Docker, Kubernetes 1.21';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1225,7 +1297,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_22:
-    name: "Docker, k8s 1.22"
+    name: "e2e: Static, Docker, Kubernetes 1.22"
     needs:
       - check_e2e_labels
       - git_info
@@ -1234,10 +1306,18 @@ jobs:
       PROVIDER: Static
       CRI: Docker
       LAYOUT: Static
-      KUBERNETES_VERSION: 1.22
+      KUBERNETES_VERSION: "1.22"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1253,7 +1333,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Static, Docker, k8s 1.22';
+            const name = 'e2e: Static, Docker, Kubernetes 1.22';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1309,7 +1389,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1503,25 +1585,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Static, Kubernetes 1.22';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Static, Docker, Kubernetes 1.22';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1565,7 +1655,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_19:
-    name: "Containerd, k8s 1.19"
+    name: "e2e: Static, Containerd, Kubernetes 1.19"
     needs:
       - check_e2e_labels
       - git_info
@@ -1574,10 +1664,18 @@ jobs:
       PROVIDER: Static
       CRI: Containerd
       LAYOUT: Static
-      KUBERNETES_VERSION: 1.19
+      KUBERNETES_VERSION: "1.19"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1593,7 +1691,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Static, Containerd, k8s 1.19';
+            const name = 'e2e: Static, Containerd, Kubernetes 1.19';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1649,7 +1747,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1843,25 +1943,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Static, Kubernetes 1.19';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Static, Containerd, Kubernetes 1.19';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1905,7 +2013,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_20:
-    name: "Containerd, k8s 1.20"
+    name: "e2e: Static, Containerd, Kubernetes 1.20"
     needs:
       - check_e2e_labels
       - git_info
@@ -1914,10 +2022,18 @@ jobs:
       PROVIDER: Static
       CRI: Containerd
       LAYOUT: Static
-      KUBERNETES_VERSION: 1.20
+      KUBERNETES_VERSION: "1.20"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1933,7 +2049,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Static, Containerd, k8s 1.20';
+            const name = 'e2e: Static, Containerd, Kubernetes 1.20';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1989,7 +2105,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2183,25 +2301,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Static, Kubernetes 1.20';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Static, Containerd, Kubernetes 1.20';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2245,7 +2371,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_21:
-    name: "Containerd, k8s 1.21"
+    name: "e2e: Static, Containerd, Kubernetes 1.21"
     needs:
       - check_e2e_labels
       - git_info
@@ -2254,10 +2380,18 @@ jobs:
       PROVIDER: Static
       CRI: Containerd
       LAYOUT: Static
-      KUBERNETES_VERSION: 1.21
+      KUBERNETES_VERSION: "1.21"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2273,7 +2407,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Static, Containerd, k8s 1.21';
+            const name = 'e2e: Static, Containerd, Kubernetes 1.21';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2329,7 +2463,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2523,25 +2659,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Static, Kubernetes 1.21';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Static, Containerd, Kubernetes 1.21';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2585,7 +2729,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_22:
-    name: "Containerd, k8s 1.22"
+    name: "e2e: Static, Containerd, Kubernetes 1.22"
     needs:
       - check_e2e_labels
       - git_info
@@ -2594,10 +2738,18 @@ jobs:
       PROVIDER: Static
       CRI: Containerd
       LAYOUT: Static
-      KUBERNETES_VERSION: 1.22
+      KUBERNETES_VERSION: "1.22"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2613,7 +2765,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Static, Containerd, k8s 1.22';
+            const name = 'e2e: Static, Containerd, Kubernetes 1.22';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2669,7 +2821,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2863,25 +3017,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Static, Kubernetes 1.22';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Static, Containerd, Kubernetes 1.22';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2923,4 +3085,50 @@ jobs:
             -d "${alertData}"
   # </template: e2e_run_job_template>
 
+
+  last_comment:
+    name: Update comment on finish
+    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22"]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    env:
+      JOB_NAMES: |
+        {"run_containerd_1_19":"e2e: Static, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: Static, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: Static, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: Static, Containerd, Kubernetes 1.22","run_docker_1_19":"e2e: Static, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: Static, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: Static, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: Static, Docker, Kubernetes 1.22"}
+    steps:
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'workflow,final,no-skipped,restore-separate';
+            const name = 'e2e: Static';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -25,6 +25,9 @@ on:
       pull_request_sha:
         description: 'Git SHA for restoring artifacts from cache'
         required: false
+      pull_request_head_label:
+        description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
+        required: false
       cri:
         description: 'A comma-separated list of cri to test. Available: Docker and Containerd.'
         required: false
@@ -96,6 +99,21 @@ env:
 # Usually you run e2e and wait until it ends.
 
 jobs:
+  started_at:
+    name: Save start timestamp
+    outputs:
+      started_at: ${{ steps.started_at.outputs.started_at }}
+    runs-on: "ubuntu-latest"
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
 
   # <template: git_info_job>
 
@@ -205,7 +223,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_19:
-    name: "Docker, k8s 1.19"
+    name: "e2e: vSphere, Docker, Kubernetes 1.19"
     needs:
       - check_e2e_labels
       - git_info
@@ -214,10 +232,18 @@ jobs:
       PROVIDER: vSphere
       CRI: Docker
       LAYOUT: Standard
-      KUBERNETES_VERSION: 1.19
+      KUBERNETES_VERSION: "1.19"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -233,7 +259,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: vSphere, Docker, k8s 1.19';
+            const name = 'e2e: vSphere, Docker, Kubernetes 1.19';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -289,7 +315,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -487,25 +515,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: vSphere, Kubernetes 1.19';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: vSphere, Docker, Kubernetes 1.19';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -549,7 +585,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_20:
-    name: "Docker, k8s 1.20"
+    name: "e2e: vSphere, Docker, Kubernetes 1.20"
     needs:
       - check_e2e_labels
       - git_info
@@ -558,10 +594,18 @@ jobs:
       PROVIDER: vSphere
       CRI: Docker
       LAYOUT: Standard
-      KUBERNETES_VERSION: 1.20
+      KUBERNETES_VERSION: "1.20"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -577,7 +621,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: vSphere, Docker, k8s 1.20';
+            const name = 'e2e: vSphere, Docker, Kubernetes 1.20';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -633,7 +677,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -831,25 +877,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: vSphere, Kubernetes 1.20';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: vSphere, Docker, Kubernetes 1.20';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -893,7 +947,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_21:
-    name: "Docker, k8s 1.21"
+    name: "e2e: vSphere, Docker, Kubernetes 1.21"
     needs:
       - check_e2e_labels
       - git_info
@@ -902,10 +956,18 @@ jobs:
       PROVIDER: vSphere
       CRI: Docker
       LAYOUT: Standard
-      KUBERNETES_VERSION: 1.21
+      KUBERNETES_VERSION: "1.21"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -921,7 +983,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: vSphere, Docker, k8s 1.21';
+            const name = 'e2e: vSphere, Docker, Kubernetes 1.21';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -977,7 +1039,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1175,25 +1239,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: vSphere, Kubernetes 1.21';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: vSphere, Docker, Kubernetes 1.21';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1237,7 +1309,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_22:
-    name: "Docker, k8s 1.22"
+    name: "e2e: vSphere, Docker, Kubernetes 1.22"
     needs:
       - check_e2e_labels
       - git_info
@@ -1246,10 +1318,18 @@ jobs:
       PROVIDER: vSphere
       CRI: Docker
       LAYOUT: Standard
-      KUBERNETES_VERSION: 1.22
+      KUBERNETES_VERSION: "1.22"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1265,7 +1345,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: vSphere, Docker, k8s 1.22';
+            const name = 'e2e: vSphere, Docker, Kubernetes 1.22';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1321,7 +1401,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1519,25 +1601,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: vSphere, Kubernetes 1.22';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: vSphere, Docker, Kubernetes 1.22';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1581,7 +1671,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_19:
-    name: "Containerd, k8s 1.19"
+    name: "e2e: vSphere, Containerd, Kubernetes 1.19"
     needs:
       - check_e2e_labels
       - git_info
@@ -1590,10 +1680,18 @@ jobs:
       PROVIDER: vSphere
       CRI: Containerd
       LAYOUT: Standard
-      KUBERNETES_VERSION: 1.19
+      KUBERNETES_VERSION: "1.19"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1609,7 +1707,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: vSphere, Containerd, k8s 1.19';
+            const name = 'e2e: vSphere, Containerd, Kubernetes 1.19';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1665,7 +1763,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1863,25 +1963,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: vSphere, Kubernetes 1.19';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: vSphere, Containerd, Kubernetes 1.19';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1925,7 +2033,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_20:
-    name: "Containerd, k8s 1.20"
+    name: "e2e: vSphere, Containerd, Kubernetes 1.20"
     needs:
       - check_e2e_labels
       - git_info
@@ -1934,10 +2042,18 @@ jobs:
       PROVIDER: vSphere
       CRI: Containerd
       LAYOUT: Standard
-      KUBERNETES_VERSION: 1.20
+      KUBERNETES_VERSION: "1.20"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1953,7 +2069,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: vSphere, Containerd, k8s 1.20';
+            const name = 'e2e: vSphere, Containerd, Kubernetes 1.20';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2009,7 +2125,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2207,25 +2325,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: vSphere, Kubernetes 1.20';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: vSphere, Containerd, Kubernetes 1.20';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2269,7 +2395,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_21:
-    name: "Containerd, k8s 1.21"
+    name: "e2e: vSphere, Containerd, Kubernetes 1.21"
     needs:
       - check_e2e_labels
       - git_info
@@ -2278,10 +2404,18 @@ jobs:
       PROVIDER: vSphere
       CRI: Containerd
       LAYOUT: Standard
-      KUBERNETES_VERSION: 1.21
+      KUBERNETES_VERSION: "1.21"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2297,7 +2431,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: vSphere, Containerd, k8s 1.21';
+            const name = 'e2e: vSphere, Containerd, Kubernetes 1.21';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2353,7 +2487,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2551,25 +2687,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: vSphere, Kubernetes 1.21';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: vSphere, Containerd, Kubernetes 1.21';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2613,7 +2757,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_22:
-    name: "Containerd, k8s 1.22"
+    name: "e2e: vSphere, Containerd, Kubernetes 1.22"
     needs:
       - check_e2e_labels
       - git_info
@@ -2622,10 +2766,18 @@ jobs:
       PROVIDER: vSphere
       CRI: Containerd
       LAYOUT: Standard
-      KUBERNETES_VERSION: 1.22
+      KUBERNETES_VERSION: "1.22"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2641,7 +2793,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: vSphere, Containerd, k8s 1.22';
+            const name = 'e2e: vSphere, Containerd, Kubernetes 1.22';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2697,7 +2849,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2895,25 +3049,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: vSphere, Kubernetes 1.22';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: vSphere, Containerd, Kubernetes 1.22';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2955,4 +3117,50 @@ jobs:
             -d "${alertData}"
   # </template: e2e_run_job_template>
 
+
+  last_comment:
+    name: Update comment on finish
+    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22"]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    env:
+      JOB_NAMES: |
+        {"run_containerd_1_19":"e2e: vSphere, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: vSphere, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: vSphere, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: vSphere, Containerd, Kubernetes 1.22","run_docker_1_19":"e2e: vSphere, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: vSphere, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: vSphere, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: vSphere, Docker, Kubernetes 1.22"}
+    steps:
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'workflow,final,no-skipped,restore-separate';
+            const name = 'e2e: vSphere';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -25,6 +25,9 @@ on:
       pull_request_sha:
         description: 'Git SHA for restoring artifacts from cache'
         required: false
+      pull_request_head_label:
+        description: 'Head label of pull request. e.g. my_repo:my_feature_branch'
+        required: false
       cri:
         description: 'A comma-separated list of cri to test. Available: Docker and Containerd.'
         required: false
@@ -96,6 +99,21 @@ env:
 # Usually you run e2e and wait until it ends.
 
 jobs:
+  started_at:
+    name: Save start timestamp
+    outputs:
+      started_at: ${{ steps.started_at.outputs.started_at }}
+    runs-on: "ubuntu-latest"
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
 
   # <template: git_info_job>
 
@@ -205,7 +223,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_19:
-    name: "Docker, k8s 1.19"
+    name: "e2e: Yandex.Cloud, Docker, Kubernetes 1.19"
     needs:
       - check_e2e_labels
       - git_info
@@ -214,10 +232,18 @@ jobs:
       PROVIDER: Yandex.Cloud
       CRI: Docker
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.19
+      KUBERNETES_VERSION: "1.19"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -233,7 +259,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Yandex.Cloud, Docker, k8s 1.19';
+            const name = 'e2e: Yandex.Cloud, Docker, Kubernetes 1.19';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -289,7 +315,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -491,25 +519,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Yandex.Cloud, Kubernetes 1.19';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Yandex.Cloud, Docker, Kubernetes 1.19';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -553,7 +589,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_20:
-    name: "Docker, k8s 1.20"
+    name: "e2e: Yandex.Cloud, Docker, Kubernetes 1.20"
     needs:
       - check_e2e_labels
       - git_info
@@ -562,10 +598,18 @@ jobs:
       PROVIDER: Yandex.Cloud
       CRI: Docker
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.20
+      KUBERNETES_VERSION: "1.20"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -581,7 +625,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Yandex.Cloud, Docker, k8s 1.20';
+            const name = 'e2e: Yandex.Cloud, Docker, Kubernetes 1.20';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -637,7 +681,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -839,25 +885,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Yandex.Cloud, Kubernetes 1.20';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Yandex.Cloud, Docker, Kubernetes 1.20';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -901,7 +955,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_21:
-    name: "Docker, k8s 1.21"
+    name: "e2e: Yandex.Cloud, Docker, Kubernetes 1.21"
     needs:
       - check_e2e_labels
       - git_info
@@ -910,10 +964,18 @@ jobs:
       PROVIDER: Yandex.Cloud
       CRI: Docker
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.21
+      KUBERNETES_VERSION: "1.21"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -929,7 +991,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Yandex.Cloud, Docker, k8s 1.21';
+            const name = 'e2e: Yandex.Cloud, Docker, Kubernetes 1.21';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -985,7 +1047,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1187,25 +1251,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Yandex.Cloud, Kubernetes 1.21';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Yandex.Cloud, Docker, Kubernetes 1.21';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1249,7 +1321,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_docker_1_22:
-    name: "Docker, k8s 1.22"
+    name: "e2e: Yandex.Cloud, Docker, Kubernetes 1.22"
     needs:
       - check_e2e_labels
       - git_info
@@ -1258,10 +1330,18 @@ jobs:
       PROVIDER: Yandex.Cloud
       CRI: Docker
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.22
+      KUBERNETES_VERSION: "1.22"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1277,7 +1357,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Yandex.Cloud, Docker, k8s 1.22';
+            const name = 'e2e: Yandex.Cloud, Docker, Kubernetes 1.22';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1333,7 +1413,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1535,25 +1617,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Yandex.Cloud, Kubernetes 1.22';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Yandex.Cloud, Docker, Kubernetes 1.22';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1597,7 +1687,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_19:
-    name: "Containerd, k8s 1.19"
+    name: "e2e: Yandex.Cloud, Containerd, Kubernetes 1.19"
     needs:
       - check_e2e_labels
       - git_info
@@ -1606,10 +1696,18 @@ jobs:
       PROVIDER: Yandex.Cloud
       CRI: Containerd
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.19
+      KUBERNETES_VERSION: "1.19"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1625,7 +1723,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Yandex.Cloud, Containerd, k8s 1.19';
+            const name = 'e2e: Yandex.Cloud, Containerd, Kubernetes 1.19';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -1681,7 +1779,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1883,25 +1983,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Yandex.Cloud, Kubernetes 1.19';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Yandex.Cloud, Containerd, Kubernetes 1.19';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -1945,7 +2053,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_20:
-    name: "Containerd, k8s 1.20"
+    name: "e2e: Yandex.Cloud, Containerd, Kubernetes 1.20"
     needs:
       - check_e2e_labels
       - git_info
@@ -1954,10 +2062,18 @@ jobs:
       PROVIDER: Yandex.Cloud
       CRI: Containerd
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.20
+      KUBERNETES_VERSION: "1.20"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1973,7 +2089,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Yandex.Cloud, Containerd, k8s 1.20';
+            const name = 'e2e: Yandex.Cloud, Containerd, Kubernetes 1.20';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2029,7 +2145,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2231,25 +2349,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Yandex.Cloud, Kubernetes 1.20';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Yandex.Cloud, Containerd, Kubernetes 1.20';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2293,7 +2419,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_21:
-    name: "Containerd, k8s 1.21"
+    name: "e2e: Yandex.Cloud, Containerd, Kubernetes 1.21"
     needs:
       - check_e2e_labels
       - git_info
@@ -2302,10 +2428,18 @@ jobs:
       PROVIDER: Yandex.Cloud
       CRI: Containerd
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.21
+      KUBERNETES_VERSION: "1.21"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2321,7 +2455,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Yandex.Cloud, Containerd, k8s 1.21';
+            const name = 'e2e: Yandex.Cloud, Containerd, Kubernetes 1.21';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2377,7 +2511,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2579,25 +2715,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Yandex.Cloud, Kubernetes 1.21';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Yandex.Cloud, Containerd, Kubernetes 1.21';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2641,7 +2785,7 @@ jobs:
 
   # <template: e2e_run_job_template>
   run_containerd_1_22:
-    name: "Containerd, k8s 1.22"
+    name: "e2e: Yandex.Cloud, Containerd, Kubernetes 1.22"
     needs:
       - check_e2e_labels
       - git_info
@@ -2650,10 +2794,18 @@ jobs:
       PROVIDER: Yandex.Cloud
       CRI: Containerd
       LAYOUT: WithoutNAT
-      KUBERNETES_VERSION: 1.22
+      KUBERNETES_VERSION: "1.22"
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2669,7 +2821,7 @@ jobs:
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const name = 'e2e: Yandex.Cloud, Containerd, k8s 1.22';
+            const name = 'e2e: Yandex.Cloud, Containerd, Kubernetes 1.22';
 
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnStart({github, context, core, name})
@@ -2725,7 +2877,9 @@ jobs:
           sleep $delay
 
           # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2927,25 +3081,33 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
-            const name = 'e2e: Yandex.Cloud, Kubernetes 1.22';
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Yandex.Cloud, Containerd, Kubernetes 1.22';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
       - name: Alert on fail in default branch
@@ -2987,4 +3149,50 @@ jobs:
             -d "${alertData}"
   # </template: e2e_run_job_template>
 
+
+  last_comment:
+    name: Update comment on finish
+    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22"]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    env:
+      JOB_NAMES: |
+        {"run_containerd_1_19":"e2e: Yandex.Cloud, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: Yandex.Cloud, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: Yandex.Cloud, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: Yandex.Cloud, Containerd, Kubernetes 1.22","run_docker_1_19":"e2e: Yandex.Cloud, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: Yandex.Cloud, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: Yandex.Cloud, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: Yandex.Cloud, Docker, Kubernetes 1.22"}
+    steps:
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'workflow,final,no-skipped,restore-separate';
+            const name = 'e2e: Yandex.Cloud';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
 # </template: e2e_workflow_template>

--- a/.github/workflows/suspend-alpha.yml
+++ b/.github/workflows/suspend-alpha.yml
@@ -123,6 +123,14 @@ jobs:
     runs-on: self-hosted
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -311,24 +319,32 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
+            const statusConfig = 'job,final';
             const name = 'Suspend the alpha';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 

--- a/.github/workflows/suspend-beta.yml
+++ b/.github/workflows/suspend-beta.yml
@@ -123,6 +123,14 @@ jobs:
     runs-on: self-hosted
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -311,24 +319,32 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
+            const statusConfig = 'job,final';
             const name = 'Suspend the beta';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 

--- a/.github/workflows/suspend-early-access.yml
+++ b/.github/workflows/suspend-early-access.yml
@@ -123,6 +123,14 @@ jobs:
     runs-on: self-hosted
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -311,24 +319,32 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
+            const statusConfig = 'job,final';
             const name = 'Suspend the early-access';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 

--- a/.github/workflows/suspend-rock-solid.yml
+++ b/.github/workflows/suspend-rock-solid.yml
@@ -123,6 +123,14 @@ jobs:
     runs-on: self-hosted
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -311,24 +319,32 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
+            const statusConfig = 'job,final';
             const name = 'Suspend the rock-solid';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 

--- a/.github/workflows/suspend-stable.yml
+++ b/.github/workflows/suspend-stable.yml
@@ -123,6 +123,14 @@ jobs:
     runs-on: self-hosted
     steps:
 
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -311,24 +319,32 @@ jobs:
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish
+        id: update_comment_on_finish
         if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-        continue-on-error: true
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
           JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
         uses: actions/github-script@v5.0.0
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
-            const statusSource = 'job';
+            const statusConfig = 'job,final';
             const name = 'Suspend the stable';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
 
-            console.log(`needsContext: ${JSON.stringify(needsContext)}`);
-            console.log(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
 
             const ci = require('./.github/scripts/js/ci');
-            return await ci.updateCommentOnFinish({github, context, core, statusSource, name, needsContext, jobContext});
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 


### PR DESCRIPTION
## Description

- report elapsed time for jobs
- hide all jobs on finish under 'details' tag
- restore overridden statuses on workflow finish (e2e, build)
- fix success result for failed jobs (build)

Note: heavily based on #706

Highlights:

<img width="611" src="https://user-images.githubusercontent.com/1055474/152025424-23d562b4-b10b-4f5d-a258-a6d473c324fa.png">


<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Comments from the bot become compact and more useful.
 
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
section: ci
type: feature
description: Compact and more useful job reports in release issues and PRs
impact_level: low
impact: Decrease visual noise in release issues and PRs
```
