### PR TITLE
[user-authn] Bitbucket migrate to workspaces

### DIFF
--- a/modules/150-user-authn/images/dex/Dockerfile
+++ b/modules/150-user-authn/images/dex/Dockerfile
@@ -4,11 +4,12 @@ ARG BASE_ALPINE
 FROM $BASE_GOLANG_16_ALPINE as artifact
 RUN apk add --no-cache git ca-certificates gcc build-base sqlite patch make curl
 WORKDIR /dex
-COPY patches/client-groups.patch patches/concurrent.patch patches/static-user-groups.patch /
+COPY patches/client-groups.patch patches/concurrent.patch patches/static-user-groups.patch patches/bitbucket-teams.patch /
 RUN wget https://github.com/dexidp/dex/archive/v2.30.0.tar.gz -O - | tar -xz --strip-components=1 \
   && git apply /client-groups.patch \
   && git apply /concurrent.patch \
-  && git apply /static-user-groups.patch
+  && git apply /static-user-groups.patch \
+  && git apply /bitbucket-teams.patch
 RUN go build ./cmd/dex
 
 FROM ghcr.io/dexidp/dex@sha256:63fc6ee14bcf1868ebfba90885aec76597e0f27bc8e89d1fd238b1f2ee3dea6e as dex

--- a/modules/150-user-authn/images/dex/patches/README.md
+++ b/modules/150-user-authn/images/dex/patches/README.md
@@ -20,3 +20,9 @@ As for now, Dex updates the lastUsed field of OfflineSession on every refresh to
 It causes unnecessary conflict errors for etcd and Kubernetes storages.
 
 Upstream PR - https://github.com/dexidp/dex/pull/2300/
+
+### Bitbucket teams
+
+Teams API was deprecated. This patch is a migration to use workspaces.
+
+Upstream PR - https://github.com/dexidp/dex/pull/2390/

--- a/modules/150-user-authn/images/dex/patches/bitbucket-teams.patch
+++ b/modules/150-user-authn/images/dex/patches/bitbucket-teams.patch
@@ -1,0 +1,124 @@
+diff --git a/connector/bitbucketcloud/bitbucketcloud.go b/connector/bitbucketcloud/bitbucketcloud.go
+index b9134e919..27eafb529 100644
+--- a/connector/bitbucketcloud/bitbucketcloud.go
++++ b/connector/bitbucketcloud/bitbucketcloud.go
+@@ -351,7 +351,7 @@ func (b *bitbucketConnector) userEmail(ctx context.Context, client *http.Client)
+
+ // getGroups retrieves Bitbucket teams a user is in, if any.
+ func (b *bitbucketConnector) getGroups(ctx context.Context, client *http.Client, groupScope bool, userLogin string) ([]string, error) {
+-	bitbucketTeams, err := b.userTeams(ctx, client)
++	bitbucketTeams, err := b.userWorkspaces(ctx, client)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+@@ -369,33 +369,33 @@ func (b *bitbucketConnector) getGroups(ctx context.Context, client *http.Client,
+ 	return nil, nil
+ }
+
+-type teamName struct {
+-	Name string `json:"username"` // The "username" from Bitbucket Cloud is actually the team name here
++type workspaceSlug struct {
++	Slug string `json:"slug"`
+ }
+
+-type team struct {
+-	Team teamName `json:"team"`
++type workspace struct {
++	Workspace workspaceSlug `json:"workspace"`
+ }
+
+-type userTeamsResponse struct {
++type userWorkspacesResponse struct {
+ 	pagedResponse
+-	Values []team
++	Values []workspace `json:"values"`
+ }
+
+-func (b *bitbucketConnector) userTeams(ctx context.Context, client *http.Client) ([]string, error) {
++func (b *bitbucketConnector) userWorkspaces(ctx context.Context, client *http.Client) ([]string, error) {
+ 	var teams []string
+-	apiURL := b.apiURL + "/user/permissions/teams"
++	apiURL := b.apiURL + "/user/permissions/workspaces"
+
+ 	for {
+-		// https://developer.atlassian.com/bitbucket/api/2/reference/resource/user/permissions/teams
+-		var response userTeamsResponse
++		// https://developer.atlassian.com/cloud/bitbucket/rest/api-group-workspaces/#api-workspaces-get
++		var response userWorkspacesResponse
+
+ 		if err := get(ctx, client, apiURL, &response); err != nil {
+ 			return nil, fmt.Errorf("bitbucket: get user teams: %v", err)
+ 		}
+
+ 		for _, value := range response.Values {
+-			teams = append(teams, value.Team.Name)
++			teams = append(teams, value.Workspace.Slug)
+ 		}
+
+ 		if response.Next == nil {
+diff --git a/connector/bitbucketcloud/bitbucketcloud_test.go b/connector/bitbucketcloud/bitbucketcloud_test.go
+index 3d984a8fc..9545ff09c 100644
+--- a/connector/bitbucketcloud/bitbucketcloud_test.go
++++ b/connector/bitbucketcloud/bitbucketcloud_test.go
+@@ -14,28 +14,28 @@ import (
+ )
+
+ func TestUserGroups(t *testing.T) {
+-	teamsResponse := userTeamsResponse{
++	teamsResponse := userWorkspacesResponse{
+ 		pagedResponse: pagedResponse{
+ 			Size:    3,
+ 			Page:    1,
+ 			PageLen: 10,
+ 		},
+-		Values: []team{
+-			{Team: teamName{Name: "team-1"}},
+-			{Team: teamName{Name: "team-2"}},
+-			{Team: teamName{Name: "team-3"}},
++		Values: []workspace{
++			{Workspace: workspaceSlug{Slug: "team-1"}},
++			{Workspace: workspaceSlug{Slug: "team-2"}},
++			{Workspace: workspaceSlug{Slug: "team-3"}},
+ 		},
+ 	}
+
+ 	s := newTestServer(map[string]interface{}{
+-		"/user/permissions/teams": teamsResponse,
+-		"/groups/team-1":          []group{{Slug: "administrators"}, {Slug: "members"}},
+-		"/groups/team-2":          []group{{Slug: "everyone"}},
+-		"/groups/team-3":          []group{},
++		"/user/permissions/workspaces": teamsResponse,
++		"/groups/team-1":               []group{{Slug: "administrators"}, {Slug: "members"}},
++		"/groups/team-2":               []group{{Slug: "everyone"}},
++		"/groups/team-3":               []group{},
+ 	})
+
+ 	connector := bitbucketConnector{apiURL: s.URL, legacyAPIURL: s.URL}
+-	groups, err := connector.userTeams(context.Background(), newClient())
++	groups, err := connector.userWorkspaces(context.Background(), newClient())
+
+ 	expectNil(t, err)
+ 	expectEquals(t, groups, []string{
+@@ -45,7 +45,7 @@ func TestUserGroups(t *testing.T) {
+ 	})
+
+ 	connector.includeTeamGroups = true
+-	groups, err = connector.userTeams(context.Background(), newClient())
++	groups, err = connector.userWorkspaces(context.Background(), newClient())
+
+ 	expectNil(t, err)
+ 	expectEquals(t, groups, []string{
+@@ -62,11 +62,11 @@ func TestUserGroups(t *testing.T) {
+
+ func TestUserWithoutTeams(t *testing.T) {
+ 	s := newTestServer(map[string]interface{}{
+-		"/user/permissions/teams": userTeamsResponse{},
++		"/user/permissions/workspaces": userWorkspacesResponse{},
+ 	})
+
+ 	connector := bitbucketConnector{apiURL: s.URL}
+-	groups, err := connector.userTeams(context.Background(), newClient())
++	groups, err := connector.userWorkspaces(context.Background(), newClient())
+
+ 	expectNil(t, err)
+ 	expectEquals(t, len(groups), 0)


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Patch added.

## Why do we need it, and what problem does it solve?
https://github.com/dexidp/dex/pull/2390

## Changelog entries

```changes
module: user-authn
type: fix
description: Migrate BitbucketCloud connector to utilizing workspaces API.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
