### PR TITLE
[bashible] fix redhat version detection

### DIFF
--- a/candi/bashible/bashbooster/55_distro_version.sh
+++ b/candi/bashible/bashbooster/55_distro_version.sh
@@ -25,7 +25,7 @@ bb-is-ubuntu-version?() {
 bb-is-centos-version?() {
   local CENTOS_VERSION=$1
   source /etc/os-release
-  if [ "${VERSION_ID}" == "${CENTOS_VERSION}" ] ; then
+    if [[ "${VERSION_ID}" =~ ${CENTOS_VERSION}.* ]] ; then
     return 0
   else
     return 1

--- a/candi/bashible/bashbooster/55_distro_version.sh
+++ b/candi/bashible/bashbooster/55_distro_version.sh
@@ -25,7 +25,7 @@ bb-is-ubuntu-version?() {
 bb-is-centos-version?() {
   local CENTOS_VERSION=$1
   source /etc/os-release
-    if [[ "${VERSION_ID}" =~ ${CENTOS_VERSION}.* ]] ; then
+  if [[ "${VERSION_ID}" =~ ${CENTOS_VERSION}.* ]] ; then
     return 0
   else
     return 1


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed redhat version detection in bashible.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Bashible detection of distro version fails in case of Redhat distro due to VERSION_ID from /etc/os-release has minor part (for example 7.7 instead of 7 in Centos).

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: bashible
type: fix
description:"Fixed redhat version detection in bashible."
note:
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
