### PR TITLE
Fix alert instruction for apiserver logs

### DIFF
--- a/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kubernetes.tpl
+++ b/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kubernetes.tpl
@@ -5,7 +5,7 @@ If you see this alert, it's probably because someone uses stale kubeconfig on ci
 
 To find who it is and where stale kubeconfig is located, you need to search in a kube-apiserver logs.
 ```
-kubectl -n kube-system logs -l component=kube-apiserver --tail=-1 --timestamps | grep "expire"
+kubectl -n kube-system logs -l component=kube-apiserver --tail=-1 --timestamps -c kube-apiserver | grep "expire"
 ```
   {{- else }}
 You need to use `kubeadm` to check control plane certificates.


### PR DESCRIPTION
## Description

Fix command recommendation

## Why do we need it, and what problem does it solve?

Proper instruction

## Changelog entries

```changes
module: monitoring-kubernetes-control-plane
type: fix 
description: Proper kubectl command in alert description
```
