### PR TITLE
[global] Add number type for `modules.resourcesRequests.everyNode.cpu` and `modules.resourcesRequests.masterNode.cpu`

### DIFF
--- a/global-hooks/openapi/config-values.yaml
+++ b/global-hooks/openapi/config-values.yaml
@@ -139,9 +139,11 @@ properties:
               cpu:
                 description: |
                   The combined CPU requests for all the components on each node.
-                type: string
                 default: "300m"
-                pattern: '^[0-9]+m?$'
+                oneOf:
+                  - type: string
+                    pattern: "^[0-9]+m?$"
+                  - type: number
               memory:
                 description: |
                   The combined memory requests for all the components on each node.
@@ -164,8 +166,10 @@ properties:
                   The combined CPU requests for the system components on master nodes in addition to `everyNode`.
                     * For a Deckhouse-controlled cluster, the default value is calculated automatically: `.status.allocatable.cpu` of the smallest master node (no more than 4 cores) minus `everyNode`.
                     * For a managed cluster, the default value is 1 core minus `everyNode`.
-                type: string
-                pattern: '^[0-9]+m?$'
+                oneOf:
+                  - type: string
+                    pattern: "^[0-9]+m?$"
+                  - type: number
               memory:
                 description: |
                   The total amount of memory allocated to system components on master nodes in addition to `everyNode`.

--- a/global-hooks/openapi/openapi-case-tests.yaml
+++ b/global-hooks/openapi/openapi-case-tests.yaml
@@ -21,6 +21,15 @@ positive:
           masterNode:
             cpu: "1"
             memory: "1Gi"
+    # decimal CPU
+    - modules:
+        resourcesRequests:
+          everyNode:
+            cpu: 1.25
+            memory: "1G"
+          masterNode:
+            cpu: 1.25
+            memory: "1Gi"
     # modules.https.mode Disabled work properly
     - modules:
         https:
@@ -116,6 +125,16 @@ negative:
       resourcesRequests:
         everyNode:
           cpu: "100incorrect"
+  # incorrect resource request: cpu as memory
+  - modules:
+      resourcesRequests:
+        everyNode:
+          cpu: "1024M"
+  # incorrect resource request: cpu as memory
+  - modules:
+      resourcesRequests:
+        everyNode:
+          cpu: "1000Mi"
   # incorrect resource request: memory for every node
   - modules:
       resourcesRequests:


### PR DESCRIPTION
## Description
Add number type for `modules.resourcesRequests.everyNode.cpu` and `modules.resourcesRequests.masterNode.cpu`

## Why do we need it, and what problem does it solve?
Cannot use floats for example `1.25` for cpu objects

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: global
type: fix
description: Add number type for `modules.resourcesRequests.everyNode.cpu` and `modules.resourcesRequests.masterNode.cpu`
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
