### PR TITLE
[go_lib][copy_custom_certificate] Do nothing if there is <module>.htt…

### DIFF
--- a/go_lib/hooks/copy_custom_certificate/hook.go
+++ b/go_lib/hooks/copy_custom_certificate/hook.go
@@ -75,7 +75,6 @@ func RegisterHook(moduleName string) bool {
 }
 
 func copyCustomCertificatesHandler(moduleName string) func(input *go_hook.HookInput) error {
-
 	return func(input *go_hook.HookInput) error {
 		snapshots, ok := input.Snapshots["custom_certificates"]
 		if !ok {
@@ -91,7 +90,7 @@ func copyCustomCertificatesHandler(moduleName string) func(input *go_hook.HookIn
 
 		httpsMode := module.GetHTTPSMode(moduleName, input)
 
-		if httpsMode != "CustomCertificate" && input.Values.Exists(fmt.Sprintf("%s.internal.customCertificateData", moduleName)) {
+		if httpsMode != "CustomCertificate" {
 			input.Values.Remove(fmt.Sprintf("%s.internal.customCertificateData", moduleName))
 			return nil
 		}

--- a/modules/810-deckhouse-web/openapi/config-values.yaml
+++ b/modules/810-deckhouse-web/openapi/config-values.yaml
@@ -102,7 +102,6 @@ properties:
             description: |
               The name of the secret in the `d8-system` namespace to use with the documentation web UI.
               This secret must have the [kubernetes.io/tls](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#tls-secrets) format.
-            default: "false"
   nodeSelector:
     type: object
     additionalProperties:


### PR DESCRIPTION

## Description
Deckhouse-web module openapi fix and `copy_custom_certificate` hook fix — do nothing if the `https.mode` isn't `CustomCertificate`, but there is `<module>.https.customCertificate.secretName` configured.

## Why do we need it, and what problem does it solve?
The openapi was obviously wrong and the hook didn't provide this case.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: deckhouse-web
type: fix
description: openapi fix and `copy_custom_certificate` hook fix — do nothing if the `https.mode` isn't `CustomCertificate`, but there is `<module>.https.customCertificate.secretName` configured.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
