### PR TITLE
[log-shipper] Fix vector pods absent alert

### DIFF
--- a/modules/460-log-shipper/monitoring/prometheus-rules/vector-agent.yaml
+++ b/modules/460-log-shipper/monitoring/prometheus-rules/vector-agent.yaml
@@ -1,10 +1,28 @@
 - name: vector-agent
   rules:
   - alert: D8VectorAgentNotScheduledOnNode
+    # The second part of this query counts how many nodes that allowed to not contain a daemonset pod are in the cluster.
+    # Alert will be fired if there are more nodes without vector pods than allowed.
     expr: |
-      max by (node) (kube_node_info)
-      unless
-      max by (node) (up{job="vector-agent"})
+      (
+        (
+          max by (node) (kube_node_info)
+          unless
+          max by (node) (up{job="vector-agent"})
+        )
+        *
+        scalar(
+          (
+            sum(
+              max by (node) (kube_node_info)
+              unless
+              max by (node) (up{job="vector-agent"})
+            )
+            >
+            sum(kube_node_info) - sum(kube_daemonset_status_desired_number_scheduled{daemonset="vector-agent", namespace="d8-log-shipper"})
+          ) or vector(0)
+        )
+      ) > 0
     for: 15m
     labels:
       severity_level: "7"


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
As for now, Deckhouse sends the alert if the log-shipper module is enabled without any CRs in the cluster (basically, this is true for most of the CE clusters).

This is a regression caused by https://github.com/deckhouse/deckhouse/pull/638

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: log-shipper
type: fix
description: Fire the alert only if there are more pods absent than allowed by the DaemonSet status.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
