### PR TITLE
[candi] Configurable kubelet log rotation

### DIFF
--- a/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
@@ -231,7 +231,7 @@ healthzBindAddress: 127.0.0.1
 healthzPort: 10248
 protectKernelDefaults: true
 {{- if eq .cri "Containerd" }}
-containerLogMaxSize: 50Mi
-containerLogMaxFiles: 4
+containerLogMaxSize: {{ .nodeGroup.kubelet.containerLogMaxSize | default "50Mi" }}
+containerLogMaxFiles: {{ .nodeGroup.kubelet.containerLogMaxFiles | default 4 }}
 {{- end }}
 EOF

--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -501,6 +501,15 @@ spec:
                       type: string
                       x-doc-default: '/var/lib/kubelet'
                       description: Directory path for managing kubelet files (volume mounts,etc).
+                    containerLogMaxSize:
+                      type: string
+                      default: 50Mi
+                      description: Maximum log file size before it is rotated.
+                    containerLogMaxFiles:
+                      type: integer
+                      minimum: 1
+                      default: 4
+                      description: How many rotated log files to store before deleting them.
     - name: v1alpha2
       served: true
       storage: true

--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -504,12 +504,18 @@ spec:
                     containerLogMaxSize:
                       type: string
                       default: 50Mi
-                      description: Maximum log file size before it is rotated.
+                      pattern: '\d+[Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|k|m]'
+                      description: |
+                        Maximum log file size before it is rotated.
+                        WARNING! This parameter does nothing if CRI type == Docker.
                     containerLogMaxFiles:
                       type: integer
                       minimum: 1
+                      maximum: 20
                       default: 4
-                      description: How many rotated log files to store before deleting them.
+                      description: |
+                        How many rotated log files to store before deleting them.
+                        WARNING! This parameter does nothing if CRI type == Docker.
     - name: v1alpha2
       served: true
       storage: true


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Allow users to configure kubelet log rotation.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Based on a choice of a log collector and volume of logging it is desirable to configure kubelet log rotation.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: node-manager
type: feature
description: Allows changing kubelet log rotation via new NodeGroup parameters: `containerLogMaxSize` and `containerLogMaxFiles`.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
