### PR TITLE
[monitoring-kubernetes] Enable systemd collector in the node-exporter

### DIFF
--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -65,6 +65,7 @@ spec:
         - '--collector.ntp.server-is-local'
         - '--collector.processes'
         - '--collector.interrupts'
+        - '--collector.systemd'
         - '--collector.filesystem.ignored-mount-points'
         - '(^/(dev|proc|sys|run|var/lib/kubelet)($|/))|(^/var/lib/docker/)'
         - '--collector.filesystem.ignored-fs-types'


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Enable systemd collector in the node-exporter.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

One of our clients requested this. It is also beneficial to monitor (in the future) various systems services that are created by the bashible.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: monitoring-kubernetes
type: feature
description: Enable systemd collector in the node-exporter
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
