### PR TITLE
[control-plane-manager] Support bound service account tokens and TokenRequest API

### DIFF
--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -28,6 +28,10 @@ apiServer:
   {{- end }}
 {{- end }}
   extraArgs:
+    api-audiences: https://kubernetes.default.svc{{ if .apiserver.saTokenAPIAudiences }},{{ .apiserver.saTokenAPIAudiences | join "," }}{{ end }}
+    service-account-issuer: https://kubernetes.default.svc
+    service-account-key-file: /etc/kubernetes/pki/sa.pub
+    service-account-signing-key-file: /etc/kubernetes/pki/sa.key
 {{- if ne .runType "ClusterBootstrap" }}
     enable-admission-plugins: "EventRateLimit,ExtendedResourceToleration{{ if .apiserver.admissionPlugins }},{{ .apiserver.admissionPlugins | join "," }}{{ end }}"
     admission-control-config-file: "/etc/kubernetes/deckhouse/extra-files/admission-control-config.yaml"

--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -29,8 +29,8 @@ apiServer:
 {{- end }}
   extraArgs:
 {{- if .apiserver.serviceAccount }}
-    api-audiences: https://kubernetes.default.svc{{ with .apiserver.serviceAccount.additionalAPIAudiences }},{{ . | join "," }}{{ end }}
-    service-account-issuer: https://kubernetes.default.svc
+    api-audiences: https://kubernetes.default.svc.{{ .clusterConfiguration.clusterDomain }}{{ with .apiserver.serviceAccount.additionalAPIAudiences }},{{ . | join "," }}{{ end }}
+    service-account-issuer: https://kubernetes.default.svc.{{ .clusterConfiguration.clusterDomain }}
     service-account-key-file: /etc/kubernetes/pki/sa.pub
     service-account-signing-key-file: /etc/kubernetes/pki/sa.key
 {{- end }}

--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -28,10 +28,12 @@ apiServer:
   {{- end }}
 {{- end }}
   extraArgs:
-    api-audiences: https://kubernetes.default.svc{{ if .apiserver.saTokenAPIAudiences }},{{ .apiserver.saTokenAPIAudiences | join "," }}{{ end }}
+{{- if .apiserver.serviceAccount }}
+    api-audiences: https://kubernetes.default.svc{{ with .apiserver.serviceAccount.additionalAPIAudiences }},{{ . | join "," }}{{ end }}
     service-account-issuer: https://kubernetes.default.svc
     service-account-key-file: /etc/kubernetes/pki/sa.pub
     service-account-signing-key-file: /etc/kubernetes/pki/sa.key
+{{- end }}
 {{- if ne .runType "ClusterBootstrap" }}
     enable-admission-plugins: "EventRateLimit,ExtendedResourceToleration{{ if .apiserver.admissionPlugins }},{{ .apiserver.admissionPlugins | join "," }}{{ end }}"
     admission-control-config-file: "/etc/kubernetes/deckhouse/extra-files/admission-control-config.yaml"

--- a/modules/040-control-plane-manager/openapi/config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/config-values.yaml
@@ -11,11 +11,11 @@ properties:
         default: {}
         x-examples:
           - {}
-          - additionalTokenAPIAudiences: [ "istio-ca" ]
+          - additionalAPIAudiences: [ "istio-ca" ]
         description: |
           ServiceAccount issuing settings.
         properties:
-          additionalTokenAPIAudiences:
+          additionalAPIAudiences:
             type: array
             description: |
               A list of API audiences to add when provisioning ServiceAccount tokens.

--- a/modules/040-control-plane-manager/openapi/config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/config-values.yaml
@@ -6,6 +6,14 @@ properties:
     description: |
       `kube-apiserver` parameters.
     properties:
+      saTokenAPIAudiences:
+        type: array
+        description: |
+          A list of api audiences to use when provisioning ServiceAccount Tokens
+        x-examples:
+          - [ "foo", "istio-ca" ]
+        items:
+          type: string
       admissionPlugins:
         type: array
         description: |

--- a/modules/040-control-plane-manager/openapi/config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/config-values.yaml
@@ -6,14 +6,21 @@ properties:
     description: |
       `kube-apiserver` parameters.
     properties:
-      saTokenAPIAudiences:
-        type: array
-        description: |
-          A list of api audiences to use when provisioning ServiceAccount Tokens
+      serviceAccount:
+        type: object
+        default: {}
         x-examples:
-          - [ "foo", "istio-ca" ]
-        items:
-          type: string
+          - {}
+          - additionalTokenAPIAudiences: [ "istio-ca" ]
+        description: |
+          ServiceAccount issuing settings.
+        properties:
+          additionalTokenAPIAudiences:
+            type: array
+            description: |
+              A list of API audiences to add when provisioning ServiceAccount tokens.
+            items:
+              type: string
       admissionPlugins:
         type: array
         description: |

--- a/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
@@ -3,6 +3,9 @@ properties:
     description: |
       Параметры `kube-apiserver`.
     properties:
+      saTokenAPIAudiences:
+        description: |
+          Список api audiences, которые следует использовать при создании ServiceAccount Tokens
       admissionPlugins:
         description: |
           Включить дополнительные [admission plugin'ы](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers).

--- a/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
@@ -3,9 +3,13 @@ properties:
     description: |
       Параметры `kube-apiserver`.
     properties:
-      saTokenAPIAudiences:
+      serviceAccount:
         description: |
-          Список api audiences, которые следует использовать при создании ServiceAccount Tokens
+          Настройки выпуска ServiceAccounts.
+        properties:
+          additionalAPIAudiences:
+            description: |
+              Список API audiences, которые следует добавить при создании токенов ServiceAccount.
       admissionPlugins:
         description: |
           Включить дополнительные [admission plugin'ы](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers).

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -99,10 +99,6 @@ extra-file-authn-webhook-config.yaml: {{ include "authnWebhookTemplate" (dict "w
   {{- if $tpl_context.apiserver.auditPolicy }}
 extra-file-audit-policy.yaml: {{ $tpl_context.apiserver.auditPolicy }}
   {{- end }}
-
-extra-file-scheduler-config.yaml: {{ include "schedulerConfig" $tpl_context | b64enc }}
-extra-file-admission-control-config.yaml: {{ include "admissionControlConfig" $tpl_context | b64enc }}
-extra-file-event-rate-limit-config.yaml: {{ include "eventRateLimitAdmissionConfig" $tpl_context | b64enc }}
 {{- end }}
 ---
 apiVersion: v1

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -66,8 +66,8 @@
   {{- if hasKey .Values.controlPlaneManager.apiserver "auditLog" }}
     {{ $_ := set $tpl_context.apiserver "auditLog" .Values.controlPlaneManager.apiserver.auditLog }}
   {{- end }}
-  {{- if hasKey .Values.controlPlaneManager.apiserver "saTokenAPIAudiences" }}
-    {{ $_ := set $tpl_context.apiserver "saTokenAPIAudiences" .Values.controlPlaneManager.apiserver.saTokenAPIAudiences }}
+  {{- if hasKey .Values.controlPlaneManager.apiserver "serviceAccount" }}
+    {{ $_ := set $tpl_context.apiserver "serviceAccount" .Values.controlPlaneManager.apiserver.serviceAccount }}
   {{- end }}
 {{- end }}
 {{- if hasKey .Values.controlPlaneManager.internal "auditPolicy" }}
@@ -99,6 +99,10 @@ extra-file-authn-webhook-config.yaml: {{ include "authnWebhookTemplate" (dict "w
   {{- if $tpl_context.apiserver.auditPolicy }}
 extra-file-audit-policy.yaml: {{ $tpl_context.apiserver.auditPolicy }}
   {{- end }}
+
+extra-file-scheduler-config.yaml: {{ include "schedulerConfig" $tpl_context | b64enc }}
+extra-file-admission-control-config.yaml: {{ include "admissionControlConfig" $tpl_context | b64enc }}
+extra-file-event-rate-limit-config.yaml: {{ include "eventRateLimitAdmissionConfig" $tpl_context | b64enc }}
 {{- end }}
 ---
 apiVersion: v1

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -66,6 +66,9 @@
   {{- if hasKey .Values.controlPlaneManager.apiserver "auditLog" }}
     {{ $_ := set $tpl_context.apiserver "auditLog" .Values.controlPlaneManager.apiserver.auditLog }}
   {{- end }}
+  {{- if hasKey .Values.controlPlaneManager.apiserver "saTokenAPIAudiences" }}
+    {{ $_ := set $tpl_context.apiserver "saTokenAPIAudiences" .Values.controlPlaneManager.apiserver.saTokenAPIAudiences }}
+  {{- end }}
 {{- end }}
 {{- if hasKey .Values.controlPlaneManager.internal "auditPolicy" }}
   {{- $_ := set $tpl_context.apiserver "auditPolicy" .Values.controlPlaneManager.internal.auditPolicy }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

1. Support bound service account tokens in Kubernetes >=1.21
2. Support TokenRequest API in all support Kubernetes versions

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Currently, we do not support the aforementioned API nor [Bound Service Account Tokens](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/1205-bound-service-account-tokens/README.md).

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: control-plane-manager
type: feature
description: |
  1. Support bound service account tokens in Kubernetes >=1.21
  2. Support TokenRequest API in all supported Kubernetes versions
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
