### PR TITLE
[dhctl] Add parameterization for bootstrapped kube-resources

### DIFF
--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -31,6 +31,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/cache"
 	terrastate "github.com/deckhouse/deckhouse/dhctl/pkg/state/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terraform"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
@@ -131,9 +132,9 @@ func DefineCreateResourcesCommand(parent *kingpin.CmdClause) *kingpin.CmdClause 
 	app.DefineKubeFlags(cmd)
 
 	runFunc := func() error {
-		var resourcesToCreate *config.Resources
+		var resourcesToCreate *template.Resources
 		if app.ResourcesPath != "" {
-			parsedResources, err := config.ParseResources(app.ResourcesPath)
+			parsedResources, err := template.ParseResources(app.ResourcesPath, nil)
 			if err != nil {
 				return err
 			}

--- a/dhctl/pkg/app/bootstrap.go
+++ b/dhctl/pkg/app/bootstrap.go
@@ -54,7 +54,9 @@ func DefineDeckhouseFlags(cmd *kingpin.CmdClause) {
 }
 
 func DefineResourcesFlags(cmd *kingpin.CmdClause, isRequired bool) {
-	cmd.Flag("resources", "Path to a file with declared Kubernetes resources in YAML format.").
+	cmd.Flag("resources", `Path to a file with declared Kubernetes resources in YAML format. It can be go-template file. Passed data contains next keys:
+  cloudDiscovery - the data discovered by applying Terrfarorm and getting its output. It depends on the cloud provider.
+`).
 		Envar(configEnvName("RESOURCES")).
 		StringVar(&ResourcesPath)
 	cmd.Flag("resources-timeout", "Timeout to create resources. Experimental. This feature may be deleted in the future.").

--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -26,14 +26,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
-func CreateResources(kubeCl *client.KubernetesClient, resources *config.Resources) error {
+func CreateResources(kubeCl *client.KubernetesClient, resources *template.Resources) error {
 	for gvk := range resources.Items {
 		var resourcesList *metav1.APIResourceList
 		var err error
@@ -93,7 +93,7 @@ func isNamespaced(kubeCl *client.KubernetesClient, gvk schema.GroupVersionKind, 
 	return namespaced, nil
 }
 
-func createSingleResource(kubeCl *client.KubernetesClient, resources *config.Resources, gvk schema.GroupVersionKind) error {
+func createSingleResource(kubeCl *client.KubernetesClient, resources *template.Resources, gvk schema.GroupVersionKind) error {
 	return retry.NewLoop(fmt.Sprintf("Create %s resources", gvk.String()), 25, 5*time.Second).Run(func() error {
 		gvr, err := kubeCl.GroupVersionResource(gvk.ToAPIVersionAndKind())
 		if err != nil {
@@ -142,7 +142,7 @@ func createSingleResource(kubeCl *client.KubernetesClient, resources *config.Res
 	})
 }
 
-func CreateResourcesLoop(kubeCl *client.KubernetesClient, resources *config.Resources) error {
+func CreateResourcesLoop(kubeCl *client.KubernetesClient, resources *template.Resources) error {
 	timeout, err := time.ParseDuration(app.ResourcesTimeout)
 	if err != nil {
 		return fmt.Errorf("cannot parse timeout to create resources: %v", err)

--- a/dhctl/pkg/template/resources_test.go
+++ b/dhctl/pkg/template/resources_test.go
@@ -1,0 +1,110 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package template
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	nsKind = schema.GroupVersionKind{Version: "v1", Kind: "Namespace"}
+	cmKind = schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
+)
+
+func fromUnstructured(unstructuredObj unstructured.Unstructured, obj interface{}) {
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), obj)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestResourcesWithoutTemplateData(t *testing.T) {
+	t.Run("parse resources from multidocument without template data", func(t *testing.T) {
+		resources, err := ParseResources("testdata/resources/without_tmp.yaml", nil)
+		require.NoError(t, err)
+
+		require.Contains(t, resources.Items, nsKind)
+		require.Len(t, resources.Items[nsKind].Items, 2)
+
+		ns := v1.Namespace{}
+		fromUnstructured(resources.Items[nsKind].Items[0], &ns)
+
+		require.Equal(t, ns.Name, "test-ns")
+
+		fromUnstructured(resources.Items[nsKind].Items[1], &ns)
+		require.Equal(t, ns.Name, "another-ns")
+
+		require.Contains(t, resources.Items, cmKind)
+		require.Len(t, resources.Items[cmKind].Items, 1)
+
+		cm := v1.ConfigMap{}
+		fromUnstructured(resources.Items[cmKind].Items[0], &cm)
+
+		require.Equal(t, cm.Namespace, "test-ns")
+		require.Equal(t, cm.Name, "some-cm")
+
+		require.Contains(t, cm.Data["key"], "value")
+	})
+}
+
+func TestResourcesWithTemplateData(t *testing.T) {
+	const expectedValueFromCloudData = "id1"
+	t.Run("parses template resources and put data in manifests", func(t *testing.T) {
+		resources, err := ParseResources("testdata/resources/with_tmp.yaml", map[string]interface{}{
+			"cloudDiscovery": map[string]interface{}{
+				"networkId": map[string]interface{}{
+					"ru-central1-a": expectedValueFromCloudData,
+					"ru-central1-b": expectedValueFromCloudData + "1",
+					"ru-central1-c": expectedValueFromCloudData + "2",
+				},
+
+				"anotherKey": "anotherValue",
+			},
+		})
+		require.NoError(t, err)
+
+		require.Contains(t, resources.Items, cmKind)
+		require.Len(t, resources.Items[cmKind].Items, 1)
+
+		cm := v1.ConfigMap{}
+		fromUnstructured(resources.Items[cmKind].Items[0], &cm)
+
+		require.Equal(t, cm.Namespace, "test-ns")
+		require.Equal(t, cm.Name, "some-cm")
+
+		require.Equal(t, cm.Data["key"], "value")
+		require.Equal(t, cm.Data["fromCloudDiscovery"], expectedValueFromCloudData)
+		require.Equal(t, cm.Data["sprigFuncAvailable"], "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b")
+	})
+}
+
+func TestResourcesNotExistsTemplateDataReturnError(t *testing.T) {
+	t.Run("returns error if value not found in data", func(t *testing.T) {
+		resources, err := ParseResources("testdata/resources/with_tmp.yaml", map[string]interface{}{
+			"cloudDiscovery": map[string]interface{}{
+				"anotherKey": "anotherValue",
+			},
+		})
+
+		require.Error(t, err)
+		require.Nil(t, resources)
+	})
+}

--- a/dhctl/pkg/template/testdata/resources/with_tmp.yaml
+++ b/dhctl/pkg/template/testdata/resources/with_tmp.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  key: value
+  fromCloudDiscovery: {{ index .cloudDiscovery.networkId "ru-central1-a" }}
+  sprigFuncAvailable: {{ sha256sum "1" }}
+kind: ConfigMap
+metadata:
+  name: some-cm
+  namespace: test-ns

--- a/dhctl/pkg/template/testdata/resources/without_tmp.yaml
+++ b/dhctl/pkg/template/testdata/resources/without_tmp.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns
+
+---
+apiVersion: v1
+data:
+  key: value
+kind: ConfigMap
+metadata:
+  name: some-cm
+  namespace: test-ns
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: another-ns
+
+---


### PR DESCRIPTION
## Description
Add parameterization for bootstrapped resources.
Now, we can template resources for bootstrap with cloud discovery data.

## Why do we need it, and what problem does it solve?
We can add YandexInstanceClass for ephemeral nodes by providing the resources.yaml file for executing dhctl.

On executing terraform to create initial resources, we discover subnets ids for all zones.  It would be convenient if we could use these subnets in YandexInstanceClass to connect instances to subnets created on a previous step.

## Changelog entries

```changes
module: dhctl
type: feature
description: Add a templating feature for Kubernetes resources сreated by dhctl.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
