### PR TITLE
[ci] fix: proper werf build commands with two registries

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -52,16 +52,18 @@ steps:
 {!{ end }!}
 
 {!{ define "build_template" }!}
+{!{- $ctx := index . 0 -}!}
+{!{- $buildType := index . 1 -}!}
 # <template: build_template>
 runs-on: [self-hosted, regular]
 steps:
-  {!{ tmpl.Exec "checkout_full_step" . | strings.Indent 2 }!}
-  {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 2 }!}
-  {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}
-  {!{ tmpl.Exec "login_rw_registry_step" . | strings.Indent 2 }!}
-  {!{ tmpl.Exec "login_flant_registry_step" . | strings.Indent 2 }!}
-  {!{ tmpl.Exec "werf_install_step" . | strings.Indent 2 }!}
-  {!{ tmpl.Exec "restore_images_tags_json_step" . | strings.Indent 2 }!}
+  {!{ tmpl.Exec "checkout_full_step" $ctx | strings.Indent 2 }!}
+  {!{ tmpl.Exec "login_dev_registry_step" $ctx | strings.Indent 2 }!}
+  {!{ tmpl.Exec "login_readonly_registry_step" $ctx | strings.Indent 2 }!}
+  {!{ tmpl.Exec "login_rw_registry_step" $ctx | strings.Indent 2 }!}
+  {!{ tmpl.Exec "login_flant_registry_step" $ctx | strings.Indent 2 }!}
+  {!{ tmpl.Exec "werf_install_step" $ctx | strings.Indent 2 }!}
+  {!{ tmpl.Exec "restore_images_tags_json_step" $ctx | strings.Indent 2 }!}
 
   - name: Build and push deckhouse images
     env:
@@ -73,91 +75,87 @@ steps:
       CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
     run: |
       ## Source: .gitlab/ci_templates/build.yml
-      if [[ -n "${DEV_REGISTRY_PATH}" ]]; then export WERF_REPO="${DEV_REGISTRY_PATH}"; fi
-
-      type werf && source $(werf ci-env github --verbose --as-file)
-
-      werf build
-
       # Put tags on produced images and push to dev and release repositories.
 
-      echo Pull dev image.
-      docker pull $(werf stage image dev)
-      echo Pull dev/install image.
-      docker pull $(werf stage image dev/install)
+      function pull_push() {
+        SOURCE_IMAGE_NAME=$1
+        WERF_STAGE=$2
+        DESTINATION_IMAGE=$3
+        echo "  Pull '${SOURCE_IMAGE_NAME}' image as ${WERF_STAGE}."
+        docker pull ${WERF_STAGE}
+        echo "  Tag '${SOURCE_IMAGE_NAME}' image as ${DESTINATION_IMAGE}."
+        docker image tag ${WERF_STAGE} ${DESTINATION_IMAGE};
+        echo "  Push '${SOURCE_IMAGE_NAME}' image as ${DESTINATION_IMAGE}."
+        docker image push ${DESTINATION_IMAGE}
+      }
 
+      if [[ -n "${DEV_REGISTRY_PATH}" ]]; then export WERF_REPO="${DEV_REGISTRY_PATH}"; fi
+      type werf && source $(werf ci-env github --verbose --as-file)
+
+      # This build put stages to "dev" registry.
+      # If "dev" registry is empty, stages are copied from FE cache.
       REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+      werf build --secondary-repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}
 
-      if [[ -n "${CI_COMMIT_TAG}" ]]; then
-        echo "Publish images for tag ${CI_COMMIT_TAG}"
-        # The tag may contain + sign, so use slugify for this situation.
-        # Slugify doesn't change a tag with safe-only characters.
-        CI_COMMIT_TAG_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-        if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-          echo "Build for "$(echo "${DECKHOUSE_REGISTRY_HOST}" | tr 'a-z' 'A-Z')
-          werf build --repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} --secondary-repo $WERF_REPO;
-        fi;
+      # Publish images for Git branch.
+      if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+        # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+        # Use it as image tag.
+        IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+        echo "Publish images to dev-registry for branch ${CI_COMMIT_BRANCH} using tag ${IMAGE_TAG}"
+
         if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-          DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${CI_COMMIT_TAG_SLUG};
-          DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/install:${CI_COMMIT_TAG_SLUG};
+          DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/dev:${IMAGE_TAG};
+          DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG};
         else
-          DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG_SLUG};
-          DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG_SLUG};
+          DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}/dev:${IMAGE_TAG};
+          DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG};
         fi;
+
+        echo "Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
+        pull_push 'dev' $(werf stage image dev) ${DESTINATION_IMAGE}
+
+        echo "Publish 'dev/install' image to dev-registry using tag ${IMAGE_TAG}".
+        pull_push 'dev/install' $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE}
+
+        echo Remove local tags.
+        docker image rmi ${DESTINATION_IMAGE} || true;
+        docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
+      fi
+
+{!{ if eq $buildType "release" }!}
+      # Publish images for Git tag.
+      if [[ -n "${CI_COMMIT_TAG}" ]]; then
         if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-          DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG_SLUG};
-          DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG_SLUG};
-          DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG_SLUG};
-          echo Tag dev image.
-          docker image tag $(werf stage image dev) ${DECKHOUSE_DESTINATION_IMAGE};
-          echo Tag dev/install image.
-          docker image tag $(werf stage image dev/install) ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
-          echo Pull and tag release-channel-version image.
-          docker pull $(werf stage image release-channel-version)
-          docker image tag $(werf stage image release-channel-version) ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
-          echo Push dev image.
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE};
-          echo Push dev/install image.
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
-          echo Push release-channel-version image.
-          docker image push ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
+          # The Git tag may contain a '+' sign, so use slugify for this situation.
+          # Slugify doesn't change a tag with safe-only characters.
+          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+
+          echo "Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
+          # Copy stages to deckhouse registry from dev registry.
+          werf build --repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} --secondary-repo $WERF_REPO;
+
+          echo "Publish 'dev' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+          DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${IMAGE_TAG};
+          pull_push 'dev' $(werf stage image dev) ${DECKHOUSE_DESTINATION_IMAGE}
+
+          echo "Publish 'dev/install' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+          DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG};
+          pull_push 'dev/install' $(werf stage image dev/install) ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
+
+          echo "Publish 'release-channel-version' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+          DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${IMAGE_TAG};
+          pull_push 'release-channel-version' $(werf stage image release-channel-version) ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE}
+
           echo Remove local tags.
           docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
           docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
           docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true;
-        fi;
-        echo Tag dev image.
-        docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
-        echo Tag dev/install image.
-        docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
-        echo Push dev image.
-        docker image push ${DESTINATION_IMAGE};
-        echo Push dev/install image.
-        docker image push ${DESTINATION_INSTALL_IMAGE};
-        echo Remove local tags.
-        docker image rmi ${DESTINATION_IMAGE} || true;
-        docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
-      fi
-      if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-        echo "Publish images for branch ${CI_COMMIT_BRANCH} with tag ${CI_COMMIT_REF_SLUG}"
-        if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-          DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/dev:${CI_COMMIT_REF_SLUG};
-          DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/dev/install:${CI_COMMIT_REF_SLUG};
         else
-          DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}/dev:${CI_COMMIT_REF_SLUG};
-          DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/dev/install:${CI_COMMIT_REF_SLUG};
+          echo "DECKHOUSE_REGISTRY_HOST is empty. No publishing."
         fi;
-        echo Tag dev image.
-        docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
-        echo Tag dev/install image.
-        docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
-        echo Push dev image.
-        docker image push ${DESTINATION_IMAGE};
-        echo Push dev/install image.
-        docker image push ${DESTINATION_INSTALL_IMAGE};
-        echo Remove local tags.
-        docker image rmi ${DESTINATION_IMAGE} || true;
-        docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
       fi
+{!{- end }!}
 # </template: build_template>
 {!{ end }!}

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -47,7 +47,7 @@ jobs:
       - pull_request_info
       - build_modules_images_fe
       - go_generate
-{!{ tmpl.Exec "build_template" $ctx | strings.Indent 4 }!}
+{!{ tmpl.Exec "build_template" (slice $ctx "dev") | strings.Indent 4 }!}
 
   doc_web_build:
     name: Doc web build

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -84,7 +84,7 @@ jobs:
       - go_generate
     env:
       WERF_ENV: "FE"
-{!{ tmpl.Exec "build_template" $ctx | strings.Indent 4 }!}
+{!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Build FE") | strings.Indent 6 }!}
 
   build_ee:
@@ -96,7 +96,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "EE"
-{!{ tmpl.Exec "build_template" $ctx | strings.Indent 4 }!}
+{!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Build EE") | strings.Indent 6 }!}
 
   build_ce:
@@ -108,7 +108,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "CE"
-{!{ tmpl.Exec "build_template" $ctx | strings.Indent 4 }!}
+{!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,inline" "Build CE") | strings.Indent 6 }!}
 
   doc_web_build:

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -407,7 +407,6 @@ jobs:
       - pull_request_info
       - build_modules_images_fe
       - go_generate
-
     # <template: build_template>
     runs-on: [self-hosted, regular]
     steps:
@@ -485,92 +484,56 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
           ## Source: .gitlab/ci_templates/build.yml
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then export WERF_REPO="${DEV_REGISTRY_PATH}"; fi
-
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          werf build
-
           # Put tags on produced images and push to dev and release repositories.
 
-          echo Pull dev image.
-          docker pull $(werf stage image dev)
-          echo Pull dev/install image.
-          docker pull $(werf stage image dev/install)
+          function pull_push() {
+            SOURCE_IMAGE_NAME=$1
+            WERF_STAGE=$2
+            DESTINATION_IMAGE=$3
+            echo "  Pull '${SOURCE_IMAGE_NAME}' image as ${WERF_STAGE}."
+            docker pull ${WERF_STAGE}
+            echo "  Tag '${SOURCE_IMAGE_NAME}' image as ${DESTINATION_IMAGE}."
+            docker image tag ${WERF_STAGE} ${DESTINATION_IMAGE};
+            echo "  Push '${SOURCE_IMAGE_NAME}' image as ${DESTINATION_IMAGE}."
+            docker image push ${DESTINATION_IMAGE}
+          }
 
+          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then export WERF_REPO="${DEV_REGISTRY_PATH}"; fi
+          type werf && source $(werf ci-env github --verbose --as-file)
+
+          # This build put stages to "dev" registry.
+          # If "dev" registry is empty, stages are copied from FE cache.
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+          werf build --secondary-repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}
 
-          if [[ -n "${CI_COMMIT_TAG}" ]]; then
-            echo "Publish images for tag ${CI_COMMIT_TAG}"
-            # The tag may contain + sign, so use slugify for this situation.
-            # Slugify doesn't change a tag with safe-only characters.
-            CI_COMMIT_TAG_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              echo "Build for "$(echo "${DECKHOUSE_REGISTRY_HOST}" | tr 'a-z' 'A-Z')
-              werf build --repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} --secondary-repo $WERF_REPO;
-            fi;
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${CI_COMMIT_TAG_SLUG};
-              DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/install:${CI_COMMIT_TAG_SLUG};
-            else
-              DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG_SLUG};
-              DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG_SLUG};
-            fi;
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG_SLUG};
-              DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG_SLUG};
-              DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG_SLUG};
-              echo Tag dev image.
-              docker image tag $(werf stage image dev) ${DECKHOUSE_DESTINATION_IMAGE};
-              echo Tag dev/install image.
-              docker image tag $(werf stage image dev/install) ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
-              echo Pull and tag release-channel-version image.
-              docker pull $(werf stage image release-channel-version)
-              docker image tag $(werf stage image release-channel-version) ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
-              echo Push dev image.
-              docker image push ${DECKHOUSE_DESTINATION_IMAGE};
-              echo Push dev/install image.
-              docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
-              echo Push release-channel-version image.
-              docker image push ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
-              echo Remove local tags.
-              docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-              docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-              docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true;
-            fi;
-            echo Tag dev image.
-            docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
-            echo Tag dev/install image.
-            docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
-            echo Push dev image.
-            docker image push ${DESTINATION_IMAGE};
-            echo Push dev/install image.
-            docker image push ${DESTINATION_INSTALL_IMAGE};
-            echo Remove local tags.
-            docker image rmi ${DESTINATION_IMAGE} || true;
-            docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
-          fi
+          # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            echo "Publish images for branch ${CI_COMMIT_BRANCH} with tag ${CI_COMMIT_REF_SLUG}"
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            echo "Publish images to dev-registry for branch ${CI_COMMIT_BRANCH} using tag ${IMAGE_TAG}"
+
             if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/dev:${CI_COMMIT_REF_SLUG};
-              DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/dev/install:${CI_COMMIT_REF_SLUG};
+              DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/dev:${IMAGE_TAG};
+              DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG};
             else
-              DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}/dev:${CI_COMMIT_REF_SLUG};
-              DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/dev/install:${CI_COMMIT_REF_SLUG};
+              DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}/dev:${IMAGE_TAG};
+              DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG};
             fi;
-            echo Tag dev image.
-            docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
-            echo Tag dev/install image.
-            docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
-            echo Push dev image.
-            docker image push ${DESTINATION_IMAGE};
-            echo Push dev/install image.
-            docker image push ${DESTINATION_INSTALL_IMAGE};
+
+            echo "Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
+            pull_push 'dev' $(werf stage image dev) ${DESTINATION_IMAGE}
+
+            echo "Publish 'dev/install' image to dev-registry using tag ${IMAGE_TAG}".
+            pull_push 'dev/install' $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE}
+
             echo Remove local tags.
             docker image rmi ${DESTINATION_IMAGE} || true;
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
+
+
     # </template: build_template>
 
 

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -602,7 +602,6 @@ jobs:
       - go_generate
     env:
       WERF_ENV: "FE"
-
     # <template: build_template>
     runs-on: [self-hosted, regular]
     steps:
@@ -679,91 +678,86 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
           ## Source: .gitlab/ci_templates/build.yml
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then export WERF_REPO="${DEV_REGISTRY_PATH}"; fi
-
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          werf build
-
           # Put tags on produced images and push to dev and release repositories.
 
-          echo Pull dev image.
-          docker pull $(werf stage image dev)
-          echo Pull dev/install image.
-          docker pull $(werf stage image dev/install)
+          function pull_push() {
+            SOURCE_IMAGE_NAME=$1
+            WERF_STAGE=$2
+            DESTINATION_IMAGE=$3
+            echo "  Pull '${SOURCE_IMAGE_NAME}' image as ${WERF_STAGE}."
+            docker pull ${WERF_STAGE}
+            echo "  Tag '${SOURCE_IMAGE_NAME}' image as ${DESTINATION_IMAGE}."
+            docker image tag ${WERF_STAGE} ${DESTINATION_IMAGE};
+            echo "  Push '${SOURCE_IMAGE_NAME}' image as ${DESTINATION_IMAGE}."
+            docker image push ${DESTINATION_IMAGE}
+          }
 
+          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then export WERF_REPO="${DEV_REGISTRY_PATH}"; fi
+          type werf && source $(werf ci-env github --verbose --as-file)
+
+          # This build put stages to "dev" registry.
+          # If "dev" registry is empty, stages are copied from FE cache.
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+          werf build --secondary-repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}
 
-          if [[ -n "${CI_COMMIT_TAG}" ]]; then
-            echo "Publish images for tag ${CI_COMMIT_TAG}"
-            # The tag may contain + sign, so use slugify for this situation.
-            # Slugify doesn't change a tag with safe-only characters.
-            CI_COMMIT_TAG_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              echo "Build for "$(echo "${DECKHOUSE_REGISTRY_HOST}" | tr 'a-z' 'A-Z')
-              werf build --repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} --secondary-repo $WERF_REPO;
-            fi;
+          # Publish images for Git branch.
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            echo "Publish images to dev-registry for branch ${CI_COMMIT_BRANCH} using tag ${IMAGE_TAG}"
+
             if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${CI_COMMIT_TAG_SLUG};
-              DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/install:${CI_COMMIT_TAG_SLUG};
+              DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/dev:${IMAGE_TAG};
+              DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG};
             else
-              DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG_SLUG};
-              DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG_SLUG};
+              DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}/dev:${IMAGE_TAG};
+              DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG};
             fi;
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG_SLUG};
-              DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG_SLUG};
-              DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG_SLUG};
-              echo Tag dev image.
-              docker image tag $(werf stage image dev) ${DECKHOUSE_DESTINATION_IMAGE};
-              echo Tag dev/install image.
-              docker image tag $(werf stage image dev/install) ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
-              echo Pull and tag release-channel-version image.
-              docker pull $(werf stage image release-channel-version)
-              docker image tag $(werf stage image release-channel-version) ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
-              echo Push dev image.
-              docker image push ${DECKHOUSE_DESTINATION_IMAGE};
-              echo Push dev/install image.
-              docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
-              echo Push release-channel-version image.
-              docker image push ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
-              echo Remove local tags.
-              docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-              docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-              docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true;
-            fi;
-            echo Tag dev image.
-            docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
-            echo Tag dev/install image.
-            docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
-            echo Push dev image.
-            docker image push ${DESTINATION_IMAGE};
-            echo Push dev/install image.
-            docker image push ${DESTINATION_INSTALL_IMAGE};
+
+            echo "Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
+            pull_push 'dev' $(werf stage image dev) ${DESTINATION_IMAGE}
+
+            echo "Publish 'dev/install' image to dev-registry using tag ${IMAGE_TAG}".
+            pull_push 'dev/install' $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE}
+
             echo Remove local tags.
             docker image rmi ${DESTINATION_IMAGE} || true;
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            echo "Publish images for branch ${CI_COMMIT_BRANCH} with tag ${CI_COMMIT_REF_SLUG}"
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/dev:${CI_COMMIT_REF_SLUG};
-              DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/dev/install:${CI_COMMIT_REF_SLUG};
+
+
+          # Publish images for Git tag.
+          if [[ -n "${CI_COMMIT_TAG}" ]]; then
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              # The Git tag may contain a '+' sign, so use slugify for this situation.
+              # Slugify doesn't change a tag with safe-only characters.
+              IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+
+              echo "Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
+              # Copy stages to deckhouse registry from dev registry.
+              werf build --repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} --secondary-repo $WERF_REPO;
+
+              echo "Publish 'dev' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+              DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${IMAGE_TAG};
+              pull_push 'dev' $(werf stage image dev) ${DECKHOUSE_DESTINATION_IMAGE}
+
+              echo "Publish 'dev/install' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+              DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG};
+              pull_push 'dev/install' $(werf stage image dev/install) ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
+
+              echo "Publish 'release-channel-version' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+              DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${IMAGE_TAG};
+              pull_push 'release-channel-version' $(werf stage image release-channel-version) ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE}
+
+              echo Remove local tags.
+              docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
+              docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
+              docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true;
             else
-              DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}/dev:${CI_COMMIT_REF_SLUG};
-              DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/dev/install:${CI_COMMIT_REF_SLUG};
+              echo "DECKHOUSE_REGISTRY_HOST is empty. No publishing."
             fi;
-            echo Tag dev image.
-            docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
-            echo Tag dev/install image.
-            docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
-            echo Push dev image.
-            docker image push ${DESTINATION_IMAGE};
-            echo Push dev/install image.
-            docker image push ${DESTINATION_INSTALL_IMAGE};
-            echo Remove local tags.
-            docker image rmi ${DESTINATION_IMAGE} || true;
-            docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
     # </template: build_template>
 
@@ -799,7 +793,6 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "EE"
-
     # <template: build_template>
     runs-on: [self-hosted, regular]
     steps:
@@ -876,91 +869,86 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
           ## Source: .gitlab/ci_templates/build.yml
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then export WERF_REPO="${DEV_REGISTRY_PATH}"; fi
-
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          werf build
-
           # Put tags on produced images and push to dev and release repositories.
 
-          echo Pull dev image.
-          docker pull $(werf stage image dev)
-          echo Pull dev/install image.
-          docker pull $(werf stage image dev/install)
+          function pull_push() {
+            SOURCE_IMAGE_NAME=$1
+            WERF_STAGE=$2
+            DESTINATION_IMAGE=$3
+            echo "  Pull '${SOURCE_IMAGE_NAME}' image as ${WERF_STAGE}."
+            docker pull ${WERF_STAGE}
+            echo "  Tag '${SOURCE_IMAGE_NAME}' image as ${DESTINATION_IMAGE}."
+            docker image tag ${WERF_STAGE} ${DESTINATION_IMAGE};
+            echo "  Push '${SOURCE_IMAGE_NAME}' image as ${DESTINATION_IMAGE}."
+            docker image push ${DESTINATION_IMAGE}
+          }
 
+          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then export WERF_REPO="${DEV_REGISTRY_PATH}"; fi
+          type werf && source $(werf ci-env github --verbose --as-file)
+
+          # This build put stages to "dev" registry.
+          # If "dev" registry is empty, stages are copied from FE cache.
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+          werf build --secondary-repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}
 
-          if [[ -n "${CI_COMMIT_TAG}" ]]; then
-            echo "Publish images for tag ${CI_COMMIT_TAG}"
-            # The tag may contain + sign, so use slugify for this situation.
-            # Slugify doesn't change a tag with safe-only characters.
-            CI_COMMIT_TAG_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              echo "Build for "$(echo "${DECKHOUSE_REGISTRY_HOST}" | tr 'a-z' 'A-Z')
-              werf build --repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} --secondary-repo $WERF_REPO;
-            fi;
+          # Publish images for Git branch.
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            echo "Publish images to dev-registry for branch ${CI_COMMIT_BRANCH} using tag ${IMAGE_TAG}"
+
             if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${CI_COMMIT_TAG_SLUG};
-              DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/install:${CI_COMMIT_TAG_SLUG};
+              DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/dev:${IMAGE_TAG};
+              DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG};
             else
-              DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG_SLUG};
-              DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG_SLUG};
+              DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}/dev:${IMAGE_TAG};
+              DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG};
             fi;
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG_SLUG};
-              DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG_SLUG};
-              DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG_SLUG};
-              echo Tag dev image.
-              docker image tag $(werf stage image dev) ${DECKHOUSE_DESTINATION_IMAGE};
-              echo Tag dev/install image.
-              docker image tag $(werf stage image dev/install) ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
-              echo Pull and tag release-channel-version image.
-              docker pull $(werf stage image release-channel-version)
-              docker image tag $(werf stage image release-channel-version) ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
-              echo Push dev image.
-              docker image push ${DECKHOUSE_DESTINATION_IMAGE};
-              echo Push dev/install image.
-              docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
-              echo Push release-channel-version image.
-              docker image push ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
-              echo Remove local tags.
-              docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-              docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-              docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true;
-            fi;
-            echo Tag dev image.
-            docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
-            echo Tag dev/install image.
-            docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
-            echo Push dev image.
-            docker image push ${DESTINATION_IMAGE};
-            echo Push dev/install image.
-            docker image push ${DESTINATION_INSTALL_IMAGE};
+
+            echo "Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
+            pull_push 'dev' $(werf stage image dev) ${DESTINATION_IMAGE}
+
+            echo "Publish 'dev/install' image to dev-registry using tag ${IMAGE_TAG}".
+            pull_push 'dev/install' $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE}
+
             echo Remove local tags.
             docker image rmi ${DESTINATION_IMAGE} || true;
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            echo "Publish images for branch ${CI_COMMIT_BRANCH} with tag ${CI_COMMIT_REF_SLUG}"
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/dev:${CI_COMMIT_REF_SLUG};
-              DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/dev/install:${CI_COMMIT_REF_SLUG};
+
+
+          # Publish images for Git tag.
+          if [[ -n "${CI_COMMIT_TAG}" ]]; then
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              # The Git tag may contain a '+' sign, so use slugify for this situation.
+              # Slugify doesn't change a tag with safe-only characters.
+              IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+
+              echo "Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
+              # Copy stages to deckhouse registry from dev registry.
+              werf build --repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} --secondary-repo $WERF_REPO;
+
+              echo "Publish 'dev' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+              DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${IMAGE_TAG};
+              pull_push 'dev' $(werf stage image dev) ${DECKHOUSE_DESTINATION_IMAGE}
+
+              echo "Publish 'dev/install' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+              DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG};
+              pull_push 'dev/install' $(werf stage image dev/install) ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
+
+              echo "Publish 'release-channel-version' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+              DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${IMAGE_TAG};
+              pull_push 'release-channel-version' $(werf stage image release-channel-version) ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE}
+
+              echo Remove local tags.
+              docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
+              docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
+              docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true;
             else
-              DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}/dev:${CI_COMMIT_REF_SLUG};
-              DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/dev/install:${CI_COMMIT_REF_SLUG};
+              echo "DECKHOUSE_REGISTRY_HOST is empty. No publishing."
             fi;
-            echo Tag dev image.
-            docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
-            echo Tag dev/install image.
-            docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
-            echo Push dev image.
-            docker image push ${DESTINATION_IMAGE};
-            echo Push dev/install image.
-            docker image push ${DESTINATION_INSTALL_IMAGE};
-            echo Remove local tags.
-            docker image rmi ${DESTINATION_IMAGE} || true;
-            docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
     # </template: build_template>
 
@@ -996,7 +984,6 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "CE"
-
     # <template: build_template>
     runs-on: [self-hosted, regular]
     steps:
@@ -1073,91 +1060,86 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
           ## Source: .gitlab/ci_templates/build.yml
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then export WERF_REPO="${DEV_REGISTRY_PATH}"; fi
-
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          werf build
-
           # Put tags on produced images and push to dev and release repositories.
 
-          echo Pull dev image.
-          docker pull $(werf stage image dev)
-          echo Pull dev/install image.
-          docker pull $(werf stage image dev/install)
+          function pull_push() {
+            SOURCE_IMAGE_NAME=$1
+            WERF_STAGE=$2
+            DESTINATION_IMAGE=$3
+            echo "  Pull '${SOURCE_IMAGE_NAME}' image as ${WERF_STAGE}."
+            docker pull ${WERF_STAGE}
+            echo "  Tag '${SOURCE_IMAGE_NAME}' image as ${DESTINATION_IMAGE}."
+            docker image tag ${WERF_STAGE} ${DESTINATION_IMAGE};
+            echo "  Push '${SOURCE_IMAGE_NAME}' image as ${DESTINATION_IMAGE}."
+            docker image push ${DESTINATION_IMAGE}
+          }
 
+          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then export WERF_REPO="${DEV_REGISTRY_PATH}"; fi
+          type werf && source $(werf ci-env github --verbose --as-file)
+
+          # This build put stages to "dev" registry.
+          # If "dev" registry is empty, stages are copied from FE cache.
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+          werf build --secondary-repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}
 
-          if [[ -n "${CI_COMMIT_TAG}" ]]; then
-            echo "Publish images for tag ${CI_COMMIT_TAG}"
-            # The tag may contain + sign, so use slugify for this situation.
-            # Slugify doesn't change a tag with safe-only characters.
-            CI_COMMIT_TAG_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              echo "Build for "$(echo "${DECKHOUSE_REGISTRY_HOST}" | tr 'a-z' 'A-Z')
-              werf build --repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} --secondary-repo $WERF_REPO;
-            fi;
+          # Publish images for Git branch.
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            echo "Publish images to dev-registry for branch ${CI_COMMIT_BRANCH} using tag ${IMAGE_TAG}"
+
             if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${CI_COMMIT_TAG_SLUG};
-              DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/install:${CI_COMMIT_TAG_SLUG};
+              DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/dev:${IMAGE_TAG};
+              DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG};
             else
-              DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG_SLUG};
-              DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG_SLUG};
+              DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}/dev:${IMAGE_TAG};
+              DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG};
             fi;
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG_SLUG};
-              DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG_SLUG};
-              DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG_SLUG};
-              echo Tag dev image.
-              docker image tag $(werf stage image dev) ${DECKHOUSE_DESTINATION_IMAGE};
-              echo Tag dev/install image.
-              docker image tag $(werf stage image dev/install) ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
-              echo Pull and tag release-channel-version image.
-              docker pull $(werf stage image release-channel-version)
-              docker image tag $(werf stage image release-channel-version) ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
-              echo Push dev image.
-              docker image push ${DECKHOUSE_DESTINATION_IMAGE};
-              echo Push dev/install image.
-              docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE};
-              echo Push release-channel-version image.
-              docker image push ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE};
-              echo Remove local tags.
-              docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-              docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-              docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true;
-            fi;
-            echo Tag dev image.
-            docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
-            echo Tag dev/install image.
-            docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
-            echo Push dev image.
-            docker image push ${DESTINATION_IMAGE};
-            echo Push dev/install image.
-            docker image push ${DESTINATION_INSTALL_IMAGE};
+
+            echo "Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
+            pull_push 'dev' $(werf stage image dev) ${DESTINATION_IMAGE}
+
+            echo "Publish 'dev/install' image to dev-registry using tag ${IMAGE_TAG}".
+            pull_push 'dev/install' $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE}
+
             echo Remove local tags.
             docker image rmi ${DESTINATION_IMAGE} || true;
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            echo "Publish images for branch ${CI_COMMIT_BRANCH} with tag ${CI_COMMIT_REF_SLUG}"
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/dev:${CI_COMMIT_REF_SLUG};
-              DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/dev/install:${CI_COMMIT_REF_SLUG};
+
+
+          # Publish images for Git tag.
+          if [[ -n "${CI_COMMIT_TAG}" ]]; then
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              # The Git tag may contain a '+' sign, so use slugify for this situation.
+              # Slugify doesn't change a tag with safe-only characters.
+              IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+
+              echo "Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
+              # Copy stages to deckhouse registry from dev registry.
+              werf build --repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} --secondary-repo $WERF_REPO;
+
+              echo "Publish 'dev' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+              DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${IMAGE_TAG};
+              pull_push 'dev' $(werf stage image dev) ${DECKHOUSE_DESTINATION_IMAGE}
+
+              echo "Publish 'dev/install' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+              DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG};
+              pull_push 'dev/install' $(werf stage image dev/install) ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
+
+              echo "Publish 'release-channel-version' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+              DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${IMAGE_TAG};
+              pull_push 'release-channel-version' $(werf stage image release-channel-version) ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE}
+
+              echo Remove local tags.
+              docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
+              docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
+              docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true;
             else
-              DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}/dev:${CI_COMMIT_REF_SLUG};
-              DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/dev/install:${CI_COMMIT_REF_SLUG};
+              echo "DECKHOUSE_REGISTRY_HOST is empty. No publishing."
             fi;
-            echo Tag dev image.
-            docker image tag $(werf stage image dev) ${DESTINATION_IMAGE};
-            echo Tag dev/install image.
-            docker image tag $(werf stage image dev/install) ${DESTINATION_INSTALL_IMAGE};
-            echo Push dev image.
-            docker image push ${DESTINATION_IMAGE};
-            echo Push dev/install image.
-            docker image push ${DESTINATION_INSTALL_IMAGE};
-            echo Remove local tags.
-            docker image rmi ${DESTINATION_IMAGE} || true;
-            docker image rmi ${DESTINATION_INSTALL_IMAGE} || true;
           fi
     # </template: build_template>
 


### PR DESCRIPTION
## Description

Use deckhouse registry as second-repo for proper stages caching. The same commands use in modules build.


## Why do we need it, and what problem does it solve?

These commands keep cache synchronized when dev-registry cleaned.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: ci
type: fix
description: proper werf build commands with two registries
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
