### PR TITLE
[ci] fix: save logs for failed e2e tests

### DIFF
--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -189,7 +189,7 @@ run_{!{ $ctx.cri }!}_{!{ $ctx.kubernetesVersionSlug }!}:
 {!{- tmpl.Exec "e2e_run_template" (slice .provider "run-test") | strings.Indent 6 }!}
 
     - name: Cleanup bootstrapped cluster
-      if: ${{ always() }}
+      if: always()
       env:
         JOB_STATUS: ${{ job.status }}
         PROVIDER: {!{ $ctx.providerName }!}
@@ -208,9 +208,10 @@ run_{!{ $ctx.cri }!}_{!{ $ctx.kubernetesVersionSlug }!}:
 {!{- tmpl.Exec "e2e_run_template" (slice .provider "cleanup") | strings.Indent 6 }!}
 
     - name: Save test results
+      if: always()
       uses: {!{ index (ds "actions") "actions/upload-artifact" }!}
       with:
-        name: test_output
+        name: test_output_{!{ printf "%s_%s_%s" $ctx.provider $ctx.cri $ctx.kubernetesVersionSlug }!}
         path: |
           modules/images_tags_${{env.WERF_ENV}}.json
           testing/cloud_layouts/

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -403,7 +403,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
@@ -474,9 +474,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_aws_docker_1_19
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -751,7 +752,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
@@ -822,9 +823,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_aws_docker_1_20
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1099,7 +1101,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
@@ -1170,9 +1172,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_aws_docker_1_21
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1447,7 +1450,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
@@ -1518,9 +1521,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_aws_docker_1_22
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1795,7 +1799,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
@@ -1866,9 +1870,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_aws_containerd_1_19
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2143,7 +2148,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
@@ -2214,9 +2219,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_aws_containerd_1_20
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2491,7 +2497,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
@@ -2562,9 +2568,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_aws_containerd_1_21
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2839,7 +2846,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
@@ -2910,9 +2917,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_aws_containerd_1_22
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -407,7 +407,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
@@ -482,9 +482,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_azure_docker_1_19
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -763,7 +764,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
@@ -838,9 +839,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_azure_docker_1_20
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1119,7 +1121,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
@@ -1194,9 +1196,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_azure_docker_1_21
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1475,7 +1478,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
@@ -1550,9 +1553,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_azure_docker_1_22
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1831,7 +1835,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
@@ -1906,9 +1910,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_azure_containerd_1_19
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2187,7 +2192,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
@@ -2262,9 +2267,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_azure_containerd_1_20
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2543,7 +2549,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
@@ -2618,9 +2624,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_azure_containerd_1_21
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2899,7 +2906,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
@@ -2974,9 +2981,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_azure_containerd_1_22
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -401,7 +401,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
@@ -470,9 +470,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_gcp_docker_1_19
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -745,7 +746,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
@@ -814,9 +815,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_gcp_docker_1_20
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1089,7 +1091,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
@@ -1158,9 +1160,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_gcp_docker_1_21
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1433,7 +1436,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
@@ -1502,9 +1505,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_gcp_docker_1_22
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1777,7 +1781,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
@@ -1846,9 +1850,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_gcp_containerd_1_19
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2121,7 +2126,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
@@ -2190,9 +2195,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_gcp_containerd_1_20
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2465,7 +2471,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
@@ -2534,9 +2540,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_gcp_containerd_1_21
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2809,7 +2816,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
@@ -2878,9 +2885,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_gcp_containerd_1_22
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -401,7 +401,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
@@ -470,9 +470,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_openstack_docker_1_19
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -745,7 +746,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
@@ -814,9 +815,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_openstack_docker_1_20
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1089,7 +1091,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
@@ -1158,9 +1160,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_openstack_docker_1_21
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1433,7 +1436,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
@@ -1502,9 +1505,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_openstack_docker_1_22
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1777,7 +1781,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
@@ -1846,9 +1850,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_openstack_containerd_1_19
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2121,7 +2126,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
@@ -2190,9 +2195,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_openstack_containerd_1_20
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2465,7 +2471,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
@@ -2534,9 +2540,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_openstack_containerd_1_21
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2809,7 +2816,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
@@ -2878,9 +2885,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_openstack_containerd_1_22
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -401,7 +401,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
@@ -470,9 +470,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_static_docker_1_19
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -745,7 +746,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
@@ -814,9 +815,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_static_docker_1_20
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1089,7 +1091,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
@@ -1158,9 +1160,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_static_docker_1_21
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1433,7 +1436,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
@@ -1502,9 +1505,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_static_docker_1_22
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1777,7 +1781,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
@@ -1846,9 +1850,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_static_containerd_1_19
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2121,7 +2126,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
@@ -2190,9 +2195,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_static_containerd_1_20
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2465,7 +2471,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
@@ -2534,9 +2540,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_static_containerd_1_21
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2809,7 +2816,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
@@ -2878,9 +2885,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_static_containerd_1_22
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -403,7 +403,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
@@ -474,9 +474,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_vsphere_docker_1_19
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -751,7 +752,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
@@ -822,9 +823,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_vsphere_docker_1_20
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1099,7 +1101,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
@@ -1170,9 +1172,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_vsphere_docker_1_21
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1447,7 +1450,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
@@ -1518,9 +1521,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_vsphere_docker_1_22
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1795,7 +1799,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
@@ -1866,9 +1870,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_vsphere_containerd_1_19
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2143,7 +2148,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
@@ -2214,9 +2219,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_vsphere_containerd_1_20
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2491,7 +2497,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
@@ -2562,9 +2568,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_vsphere_containerd_1_21
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2839,7 +2846,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
@@ -2910,9 +2917,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_vsphere_containerd_1_22
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -405,7 +405,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
@@ -478,9 +478,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_yandex-cloud_docker_1_19
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -757,7 +758,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
@@ -830,9 +831,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_yandex-cloud_docker_1_20
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1109,7 +1111,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
@@ -1182,9 +1184,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_yandex-cloud_docker_1_21
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1461,7 +1464,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
@@ -1534,9 +1537,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_yandex-cloud_docker_1_22
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -1813,7 +1817,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
@@ -1886,9 +1890,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_yandex-cloud_containerd_1_19
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2165,7 +2170,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
@@ -2238,9 +2243,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_yandex-cloud_containerd_1_20
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2517,7 +2523,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
@@ -2590,9 +2596,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_yandex-cloud_containerd_1_21
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/
@@ -2869,7 +2876,7 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
-        if: ${{ always() }}
+        if: always()
         env:
           JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
@@ -2942,9 +2949,10 @@ jobs:
         # </template: e2e_run_template>
 
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test_output
+          name: test_output_yandex-cloud_containerd_1_22
           path: |
             modules/images_tags_${{env.WERF_ENV}}.json
             testing/cloud_layouts/


### PR DESCRIPTION
## Description

- Save bootstrap.log and templates for failed e2e tests.
- Use unique names for artifacts to save logs for each job.

<img width="573" alt="Screenshot 2022-02-04 at 10 11 20" src="https://user-images.githubusercontent.com/1055474/152487512-f68b6994-f25d-4474-a63f-faaeb59e984b.png">


## Why do we need it, and what problem does it solve?

Logs and templates are useful to reproduce e2e tests later.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: ci
type: fix | feature
description: save e2e logs for failed tests
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
