### PR TITLE
[ingress-nginx] Temporary remove 1.0 version from CRD

### DIFF
--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -58,7 +58,7 @@ spec:
                     One of the supported NGINX Ingress Controller versions.
 
                     **By default**: the version in the module settings is used.
-                  enum: ['0.25', '0.26', '0.33', '0.46', '0.48', '0.49', '1.0']
+                  enum: ['0.25', '0.26', '0.33', '0.46', '0.48', '0.49']
                 enableIstioSidecar:
                   type: boolean
                   description: |

--- a/modules/402-ingress-nginx/openapi/config-values.yaml
+++ b/modules/402-ingress-nginx/openapi/config-values.yaml
@@ -4,6 +4,6 @@ properties:
     default: "0.33"
     oneOf:
       - type: string
-        enum: ["0.25", "0.26", "0.33", "0.46", "0.48", "0.49", "1.0"]
+        enum: ["0.25", "0.26", "0.33", "0.46", "0.48", "0.49"]
     description: |
       The version of the ingress-nginx controller that is used for all controllers by default if the `controllerVersion` parameter is omitted in the IngressNginxController CR.


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Temporary disable 1.0 version from NginxIngressController CRD

## Why do we need it, and what problem does it solve?
1.0 ingress-controller is not ready - it's not working properly. We have to fix it before using

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: ingress-nginx
type: fix
description: temporary remove support of 1.0 controller
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
