### PR TITLE
[control-plane-manager] Allow enabling additional admission plugins as well as defaulting some of them

### DIFF
--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -27,6 +27,8 @@ apiServer:
 {{- end }}
   extraArgs:
 {{- if ne .runType "ClusterBootstrap" }}
+    enable-admission-plugins: "EventRateLimit,ExtendedResourceToleration{{ if .apiserver.admissionPlugins }},{{ .apiserver.admissionPlugins | join "," }}{{ end }}"
+    admission-control-config-file: "/etc/kubernetes/deckhouse/extra-files/admission-control-config.yaml"
 # kubelet-certificate-authority flag should be set after bootstrap of first master.
 # This flag affects logs from kubelets, for period of time between kubelet start and certificate request approve by Deckhouse hook.
     kubelet-certificate-authority: "/etc/kubernetes/pki/ca.crt"

--- a/modules/040-control-plane-manager/openapi/config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/config-values.yaml
@@ -6,6 +6,32 @@ properties:
     description: |
       `kube-apiserver` parameters.
     properties:
+      admissionPlugins:
+        type: array
+        description: |
+          Enable additional [admission plugins](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers).
+
+          Always enabled admission plugins in addition to the ones enabled by Kubernetes itself:
+          1. ExtendedResourceToleration
+          2. EventRateLimit with the following config:
+
+          apiVersion: eventratelimit.admission.k8s.io/v1alpha1
+          kind: Configuration
+          limits:
+          - type: Namespace
+            qps: 50
+            burst: 100
+            cacheSize: 2000
+        x-examples:
+          - [ "AlwaysPullImages", "NamespaceAutoProvision" ]
+        items:
+          type: string
+          enum:
+          - AlwaysPullImages
+          - NamespaceAutoProvision
+          - OwnerReferencesPermissionEnforcement
+          - PodNodeSelector
+          - PodTolerationRestriction
       bindToWildcard:
         type: boolean
         default: false

--- a/modules/040-control-plane-manager/openapi/config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/config-values.yaml
@@ -15,13 +15,17 @@ properties:
           1. ExtendedResourceToleration
           2. EventRateLimit with the following config:
 
-          apiVersion: eventratelimit.admission.k8s.io/v1alpha1
-          kind: Configuration
-          limits:
-          - type: Namespace
-            qps: 50
-            burst: 100
-            cacheSize: 2000
+              ```yaml
+              apiVersion: eventratelimit.admission.k8s.io/v1alpha1
+              kind: Configuration
+              limits:
+              - type: Namespace
+                qps: 50
+                burst: 100
+                cacheSize: 2000
+              ```
+
+          Note that `PodNodeSelector` [does not require](https://github.com/kubernetes/kubernetes/blob/f0ea54070bec90dd829b7054117d670f9f90839f/plugin/pkg/admission/podnodeselector/admission.go#L74-L97) specifiying a global configuration, it relies on annotated Namespaces.
         x-examples:
           - [ "AlwaysPullImages", "NamespaceAutoProvision" ]
         items:

--- a/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
@@ -3,6 +3,21 @@ properties:
     description: |
       Параметры `kube-apiserver`.
     properties:
+      admissionPlugins:
+        description: |
+          Включить дополнительные [admission plugin'ы](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers).
+
+          Список admission plugin'ов, включенных всегда вдобавок к включенным в Kubernetes по умолчанию:
+          1. ExtendedResourceToleration
+          2. EventRateLimit с конфигурацией:
+
+          apiVersion: eventratelimit.admission.k8s.io/v1alpha1
+          kind: Configuration
+          limits:
+          - type: Namespace
+            qps: 50
+            burst: 100
+            cacheSize: 2000
       bindToWildcard:
         description: |
           Cлушать ли на `0.0.0.0`.

--- a/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
@@ -11,13 +11,18 @@ properties:
           1. ExtendedResourceToleration
           2. EventRateLimit с конфигурацией:
 
-          apiVersion: eventratelimit.admission.k8s.io/v1alpha1
-          kind: Configuration
-          limits:
-          - type: Namespace
-            qps: 50
-            burst: 100
-            cacheSize: 2000
+              ```yaml
+              apiVersion: eventratelimit.admission.k8s.io/v1alpha1
+              kind: Configuration
+              limits:
+              - type: Namespace
+                qps: 50
+                burst: 100
+                cacheSize: 2000
+              ```
+
+          `PodNodeSelector` [не требует](https://github.com/kubernetes/kubernetes/blob/f0ea54070bec90dd829b7054117d670f9f90839f/plugin/pkg/admission/podnodeselector/admission.go#L74-L97) указания глобальной конфигурации, он использует только аннотации на Namespaces.
+
       bindToWildcard:
         description: |
           Cлушать ли на `0.0.0.0`.

--- a/modules/040-control-plane-manager/templates/_admission_control_config.tpl
+++ b/modules/040-control-plane-manager/templates/_admission_control_config.tpl
@@ -1,0 +1,17 @@
+{{- define "admissionControlConfig" }}
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: EventRateLimit
+  path: /etc/kubernetes/deckhouse/extra-files/event-rate-limit-config.yaml
+{{- end }}
+
+{{- define "eventRateLimitAdmissionConfig" }}
+apiVersion: eventratelimit.admission.k8s.io/v1alpha1
+kind: Configuration
+limits:
+- type: Namespace
+  qps: 50
+  burst: 100
+  cacheSize: 2000
+{{- end }}

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -60,6 +60,9 @@
   {{- if hasKey .Values.controlPlaneManager.apiserver "certSANs" }}
     {{ $_ := set $tpl_context.apiserver "certSANs" .Values.controlPlaneManager.apiserver.certSANs }}
   {{- end }}
+  {{- if hasKey .Values.controlPlaneManager.apiserver "admissionPlugins" }}
+    {{ $_ := set $tpl_context.apiserver "admissionPlugins" .Values.controlPlaneManager.apiserver.admissionPlugins }}
+  {{- end }}
 {{- end }}
 {{- if hasKey .Values.controlPlaneManager.internal "auditPolicy" }}
   {{- $_ := set $tpl_context.apiserver "auditPolicy" .Values.controlPlaneManager.internal.auditPolicy }}
@@ -92,6 +95,8 @@ extra-file-audit-policy.yaml: {{ $tpl_context.apiserver.auditPolicy }}
   {{- end }}
 
 extra-file-scheduler-config.yaml: {{ include "schedulerConfig" $tpl_context | b64enc }}
+extra-file-admission-control-config.yaml: {{ include "admissionControlConfig" $tpl_context | b64enc }}
+extra-file-event-rate-limit-config.yaml: {{ include "eventRateLimitAdmissionConfig" $tpl_context | b64enc }}
 {{- end }}
 ---
 apiVersion: v1


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Allow enabling additional admission plugins as well as defaulting some of them

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

There are some useful admission controllers. Some of them are worth force-enabling.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: control-plane-manager
type: feature
description: |
  Allow changing a list of active admission plugins via `controlPlaneManager.apiserver.admissionPlugins` configuration.
  ExtendedResourceToleration and EventRateLimit are always enabled.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
