### PR TITLE
Changelog: skip auto-generated PRs

### DIFF
--- a/.github/actions/milestone-changelog/action.yml
+++ b/.github/actions/milestone-changelog/action.yml
@@ -24,14 +24,17 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
-      # Pick at most 1000 PRs with possible changes blocks
+      # Pick at most 1000 PRs with possible changes blocks;
+      # skip auto-generated PRs
       run: |
-        prs="$(gh pr list \
-          --repo '${{ github.repository }}' \
-          --search 'milestone:${{ steps.args.outputs.milestone_title }}' \
-          --state merged \
-          --limit 1000 \
-          --json number,url,title,body,state,milestone)"
+        prs=$(jq '[.[] | select(all( .labels[]; .name != "auto" )) | del(.labels) ]' <<< "$(
+          gh pr list \
+            --repo '${{ github.repository }}' \
+            --search 'milestone:${{ steps.args.outputs.milestone_title }}' \
+            --state merged \
+            --limit 1000 \
+            --json number,url,title,body,state,milestone,labels
+          )")
         echo "::set-output name=prs::${prs}"
 
     - name: Collect Changelog


### PR DESCRIPTION
## Description

Skip changelog PR in the list of fetched PRs for the changelog generation.

## Why do we need it, and what problem does it solve?

Reduces the risk of failing workflow due to too big argument passed to an action.
This is a just a cosmetic change addressing useless changelog generations.

## Changelog entries

```changes
module: ci
type: fix
description: Skip automatic PRs in changelog
note: At least changelog will not participate in changelog action when it is merged
```
