### PR TITLE
[dhctl] Terraform runner tests

### DIFF
--- a/dhctl/pkg/terraform/executor.go
+++ b/dhctl/pkg/terraform/executor.go
@@ -1,0 +1,136 @@
+package terraform
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+)
+
+type Executor interface {
+	Output(...string) ([]byte, error)
+	Exec(...string) (int, error)
+	Stop()
+}
+
+func terraformCmd(args ...string) *exec.Cmd {
+	cmd := exec.Command("terraform", args...)
+	cmd.Env = append(
+		cmd.Env,
+		"TF_IN_AUTOMATION=yes", "TF_DATA_DIR="+filepath.Join(app.TmpDirName, "tf_dhctl"),
+	)
+	if app.IsDebug {
+		// Debug mode is deprecated, however trace produces more useless information
+		cmd.Env = append(cmd.Env, "TF_LOG=DEBUG")
+	}
+	return cmd
+}
+
+// CMDExecutor straightforward cmd executor which provides convenient output and handles quit signal.
+type CMDExecutor struct {
+	cmd *exec.Cmd
+}
+
+func (c *CMDExecutor) Output(args ...string) ([]byte, error) {
+	return terraformCmd(args...).Output()
+}
+
+func (c *CMDExecutor) Exec(args ...string) (int, error) {
+	c.cmd = terraformCmd(args...)
+
+	// Start terraform as a leader of the new process group to prevent
+	// os.Interrupt (SIGINT) signal from the shell when Ctrl-C is pressed.
+	c.cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+
+	stdout, err := c.cmd.StdoutPipe()
+	if err != nil {
+		return 1, fmt.Errorf("stdout pipe: %v", err)
+	}
+
+	stderr, err := c.cmd.StderrPipe()
+	if err != nil {
+		return 1, fmt.Errorf("stderr pipe: %v", err)
+	}
+
+	log.DebugLn(c.cmd.String())
+	err = c.cmd.Start()
+	if err != nil {
+		log.ErrorLn(err)
+		return c.cmd.ProcessState.ExitCode(), err
+	}
+
+	var errBuf bytes.Buffer
+	waitCh := make(chan error)
+	go func() {
+		e := bufio.NewScanner(stderr)
+		for e.Scan() {
+			if app.IsDebug {
+				log.DebugLn(e.Text())
+			} else {
+				errBuf.WriteString(e.Text() + "\n")
+			}
+		}
+
+		waitCh <- c.cmd.Wait()
+	}()
+
+	s := bufio.NewScanner(stdout)
+	for s.Scan() {
+		log.InfoLn(s.Text())
+	}
+
+	err = <-waitCh
+
+	exitCode := c.cmd.ProcessState.ExitCode() // 2 = exit code, if terraform plan has diff
+	if err != nil && exitCode != terraformHasChangesExitCode {
+		log.ErrorLn(err)
+		err = fmt.Errorf(errBuf.String())
+		if app.IsDebug {
+			err = fmt.Errorf("terraform has failed in DEBUG mode, search in the output above for an error")
+		}
+	}
+
+	if exitCode == 0 {
+		err = nil
+	}
+	return exitCode, err
+}
+
+func (c *CMDExecutor) Stop() {
+	log.DebugF("Interrupt terraform process by pid: %d\n", c.cmd.Process.Pid)
+
+	// 1. Terraform exits immediately on SIGTERM, so SIGINT is used here
+	//    to interrupt it gracefully even when main process caught the SIGTERM.
+	// 2. Negative pid is used to send signal to the process group
+	//    started by "Setpgid: true" to prevent double signaling
+	//    from shell and from us.
+	//    See also pkg/system/ssh/cmd/ssh.go
+	_ = syscall.Kill(-c.cmd.Process.Pid, syscall.SIGINT)
+}
+
+// fakeResponse returns data by the first terraform command line argument.
+type fakeResponse struct {
+	err  error
+	code int
+	resp []byte
+}
+type fakeExecutor struct {
+	data map[string]fakeResponse
+}
+
+func (f *fakeExecutor) Output(parts ...string) ([]byte, error) {
+	result := f.data[parts[0]]
+	return result.resp, result.err
+}
+func (f *fakeExecutor) Exec(parts ...string) (int, error) {
+	result := f.data[parts[0]]
+	return result.code, result.err
+}
+func (f *fakeExecutor) Stop() {}

--- a/dhctl/pkg/terraform/mocks/checkplan/destructively_changed.json
+++ b/dhctl/pkg/terraform/mocks/checkplan/destructively_changed.json
@@ -1,0 +1,232 @@
+{
+  "format_version": "0.1",
+  "terraform_version": "0.13.4",
+  "resource_changes": [
+    {
+      "address": "yandex_compute_disk.kubernetes_data",
+      "mode": "managed",
+      "type": "yandex_compute_disk",
+      "name": "kubernetes_data",
+      "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "created_at": "2021-02-26T09:41:40Z",
+          "description": "volume for etcd and kubernetes certs",
+          "folder_id": "test",
+          "id": "test",
+          "image_id": "",
+          "labels": {},
+          "name": "kubernetes-data",
+          "product_ids": [],
+          "size": 10,
+          "snapshot_id": "",
+          "status": "ready",
+          "timeouts": null,
+          "type": "network-ssd",
+          "zone": "ru-central1-c"
+        },
+        "after": {
+          "created_at": "2021-02-26T09:41:40Z",
+          "description": "volume for etcd and kubernetes certs",
+          "folder_id": "test",
+          "id": "test",
+          "image_id": "",
+          "labels": {},
+          "name": "kubernetes-data",
+          "product_ids": [],
+          "size": 10,
+          "snapshot_id": "",
+          "status": "ready",
+          "timeouts": null,
+          "type": "network-ssd",
+          "zone": "ru-central1-c"
+        },
+        "after_unknown": {}
+      }
+    },
+    {
+      "address": "yandex_compute_instance.master",
+      "mode": "managed",
+      "type": "yandex_compute_instance",
+      "name": "master",
+      "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+      "change": {
+        "actions": [
+          "delete",
+          "create"
+        ],
+        "before": {
+          "allow_stopping_for_update": true,
+          "boot_disk": [
+            {
+              "auto_delete": true,
+              "device_name": "test",
+              "disk_id": "test",
+              "initialize_params": [
+                {
+                  "description": "",
+                  "image_id": "tests",
+                  "name": "kubernetes-data-root",
+                  "size": 35,
+                  "snapshot_id": "",
+                  "type": "network-ssd"
+                }
+              ],
+              "mode": "READ_WRITE"
+            }
+          ],
+          "created_at": "2021-02-26T09:41:42Z",
+          "description": "",
+          "folder_id": "test",
+          "fqdn": "kube-master",
+          "hostname": "kube-master",
+          "id": "test",
+          "labels": {},
+          "metadata": {
+            "ssh-keys": "",
+            "user-data": ""
+          },
+          "name": "kube-master",
+          "network_acceleration_type": "standard",
+          "network_interface": [
+            {
+              "index": 0,
+              "ip_address": "10.233.2.21",
+              "ipv4": true,
+              "ipv6": false,
+              "ipv6_address": "",
+              "mac_address": "test",
+              "nat": false,
+              "nat_ip_address": "",
+              "nat_ip_version": "",
+              "security_group_ids": [],
+              "subnet_id": "test"
+            }
+          ],
+          "platform_id": "standard-v2",
+          "resources": [
+            {
+              "core_fraction": 100,
+              "cores": 4,
+              "gpus": 0,
+              "memory": 8
+            }
+          ],
+          "scheduling_policy": [
+            {
+              "preemptible": false
+            }
+          ],
+          "secondary_disk": [
+            {
+              "auto_delete": false,
+              "device_name": "kubernetes-data",
+              "disk_id": "test",
+              "mode": "READ_WRITE"
+            }
+          ],
+          "service_account_id": "",
+          "status": "running",
+          "timeouts": null,
+          "zone": "ru-central1-c"
+        },
+        "after": {
+          "allow_stopping_for_update": true,
+          "boot_disk": [
+            {
+              "auto_delete": true,
+              "initialize_params": [
+                {
+                  "image_id": "test",
+                  "size": 45,
+                  "type": "network-ssd"
+                }
+              ]
+            }
+          ],
+          "description": null,
+          "hostname": "kube-master",
+          "labels": null,
+          "metadata": {
+            "node-network-cidr": "10.233.0.0/22",
+            "ssh-keys": "test",
+            "user-data": ""
+          },
+          "name": "kube-master",
+          "network_acceleration_type": "standard",
+          "network_interface": [
+            {
+              "ipv4": true,
+              "nat": false,
+              "subnet_id": "test"
+            }
+          ],
+          "platform_id": "standard-v2",
+          "resources": [
+            {
+              "core_fraction": 100,
+              "cores": 4,
+              "gpus": null,
+              "memory": 8
+            }
+          ],
+          "secondary_disk": [
+            {
+              "auto_delete": false,
+              "device_name": "kubernetes-data",
+              "disk_id": "test",
+              "mode": "READ_WRITE"
+            }
+          ],
+          "timeouts": null,
+          "zone": "ru-central1-c"
+        },
+        "after_unknown": {
+          "boot_disk": [
+            {
+              "device_name": true,
+              "disk_id": true,
+              "initialize_params": [
+                {
+                  "description": true,
+                  "name": true,
+                  "snapshot_id": true
+                }
+              ],
+              "mode": true
+            }
+          ],
+          "created_at": true,
+          "folder_id": true,
+          "fqdn": true,
+          "id": true,
+          "metadata": {},
+          "network_interface": [
+            {
+              "index": true,
+              "ip_address": true,
+              "ipv6": true,
+              "ipv6_address": true,
+              "mac_address": true,
+              "nat_ip_address": true,
+              "nat_ip_version": true,
+              "security_group_ids": true
+            }
+          ],
+          "resources": [
+            {}
+          ],
+          "scheduling_policy": true,
+          "secondary_disk": [
+            {}
+          ],
+          "service_account_id": true,
+          "status": true
+        }
+      }
+    }
+  ]
+}

--- a/dhctl/pkg/terraform/mocks/checkplan/empty.json
+++ b/dhctl/pkg/terraform/mocks/checkplan/empty.json
@@ -1,0 +1,5 @@
+{
+  "format_version": "0.1",
+  "terraform_version": "0.13.4",
+  "resource_changes": []
+}

--- a/dhctl/pkg/terraform/mocks/pipeline/base_infra_ok_plan.json
+++ b/dhctl/pkg/terraform/mocks/pipeline/base_infra_ok_plan.json
@@ -1,0 +1,1465 @@
+{
+  "format_version": "0.1",
+  "terraform_version": "0.13.4",
+  "variables": {
+    "cloudConfig": {
+      "value": ""
+    },
+    "clusterConfiguration": {
+      "value": {
+        "apiVersion": "deckhouse.io/v1alpha1",
+        "cloud": {
+          "prefix": "kube",
+          "provider": "Yandex"
+        },
+        "clusterDomain": "cluster.local",
+        "clusterType": "Cloud",
+        "defaultCRI": "Docker",
+        "kind": "ClusterConfiguration",
+        "kubernetesVersion": "1.19",
+        "podSubnetCIDR": "0.0.0.0/16",
+        "podSubnetNodeCIDRPrefix": "24",
+        "serviceSubnetCIDR": "0.0.0.0/16"
+      }
+    },
+    "clusterUUID": {
+      "value": "000000-ed62-4723-9814-a686e1cd6ece"
+    },
+    "nodeIndex": {
+      "value": 0
+    },
+    "providerClusterConfiguration": {
+      "value": {
+        "apiVersion": "deckhouse.io/v1alpha1",
+        "existingNetworkID": "enp3rgpigukmn45l2chc",
+        "kind": "YandexClusterConfiguration",
+        "layout": "WithNATInstance",
+        "masterNodeGroup": {
+          "instanceClass": {
+            "cores": 4,
+            "diskSizeGB": 45,
+            "imageID": "test",
+            "memory": 8192
+          },
+          "replicas": 3
+        },
+        "nodeNetworkCIDR": "0.0.0.0/22",
+        "provider": {
+          "cloudID": "test",
+          "folderID": "test",
+          "serviceAccountJSON": ""
+        },
+        "sshPublicKey": "",
+        "withNATInstance": {
+          "internalSubnetID": "test",
+          "natInstanceExternalAddress": "0.0.0.0",
+          "natInstanceInternalAddress": "0.0.0.0"
+        }
+      }
+    }
+  },
+  "planned_values": {
+    "outputs": {
+      "cloud_discovery_data": {
+        "sensitive": false,
+        "value": {
+          "apiVersion": "deckhouse.io/v1",
+          "defaultLbTargetGroupNetworkId": "test",
+          "internalNetworkIDs": [
+            "test"
+          ],
+          "kind": "YandexCloudDiscoveryData",
+          "region": "ru-central1",
+          "routeTableID": "test",
+          "shouldAssignPublicIPAddress": false,
+          "zoneToSubnetIdMap": {
+            "ru-central1-a": "test",
+            "ru-central1-b": "test",
+            "ru-central1-c": "test"
+          },
+          "zones": [
+            "ru-central1-a",
+            "ru-central1-b",
+            "ru-central1-c"
+          ]
+        }
+      }
+    },
+    "root_module": {
+      "child_modules": [
+        {
+          "resources": [
+            {
+              "address": "module.vpc_components.yandex_compute_instance.nat_instance[0]",
+              "mode": "managed",
+              "type": "yandex_compute_instance",
+              "name": "nat_instance",
+              "index": 0,
+              "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+              "schema_version": 1,
+              "values": {
+                "allow_stopping_for_update": null,
+                "boot_disk": [
+                  {
+                    "auto_delete": true,
+                    "device_name": "test",
+                    "disk_id": "test",
+                    "initialize_params": [
+                      {
+                        "description": "",
+                        "image_id": "test",
+                        "name": "",
+                        "size": 20,
+                        "snapshot_id": "",
+                        "type": "network-hdd"
+                      }
+                    ],
+                    "mode": "READ_WRITE"
+                  }
+                ],
+                "created_at": "2020-06-29T09:17:25Z",
+                "description": "",
+                "folder_id": "test",
+                "fqdn": "nat-instance-a.ru-central1.internal",
+                "hostname": "nat-instance-a",
+                "id": "test",
+                "labels": {},
+                "metadata": {
+                  "serial-port-enable": "0",
+                  "ssh-keys": "",
+                  "user-data": ""
+                },
+                "name": "kube-nat",
+                "network_acceleration_type": "standard",
+                "network_interface": [
+                  {
+                    "index": 0,
+                    "ip_address": "0.0.0.0",
+                    "ipv4": true,
+                    "ipv6": false,
+                    "ipv6_address": "",
+                    "mac_address": "00:00:00:00:00:00",
+                    "nat": true,
+                    "nat_ip_address": "0.0.0.0",
+                    "nat_ip_version": "IPV4",
+                    "security_group_ids": [],
+                    "subnet_id": "test"
+                  }
+                ],
+                "platform_id": "standard-v2",
+                "resources": [
+                  {
+                    "core_fraction": 100,
+                    "cores": 2,
+                    "gpus": 0,
+                    "memory": 2
+                  }
+                ],
+                "scheduling_policy": [
+                  {
+                    "preemptible": false
+                  }
+                ],
+                "secondary_disk": [],
+                "service_account_id": "",
+                "status": "running",
+                "timeouts": {
+                  "create": null,
+                  "delete": null,
+                  "update": null
+                },
+                "zone": "ru-central1-a"
+              }
+            },
+            {
+              "address": "module.vpc_components.yandex_vpc_route_table.kube",
+              "mode": "managed",
+              "type": "yandex_vpc_route_table",
+              "name": "kube",
+              "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+              "schema_version": 0,
+              "values": {
+                "created_at": "2020-01-15T11:47:00Z",
+                "description": "",
+                "folder_id": "test",
+                "id": "test",
+                "labels": {},
+                "name": "kube",
+                "network_id": "test",
+                "static_route": [
+                  {
+                    "destination_prefix": "0.0.0.0/0",
+                    "next_hop_address": "0.0.0.0"
+                  }
+                ],
+                "timeouts": {
+                  "create": null,
+                  "delete": null,
+                  "update": null
+                }
+              }
+            },
+            {
+              "address": "module.vpc_components.yandex_vpc_subnet.kube_a",
+              "mode": "managed",
+              "type": "yandex_vpc_subnet",
+              "name": "kube_a",
+              "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+              "schema_version": 0,
+              "values": {
+                "created_at": "2020-09-04T16:19:53Z",
+                "description": "",
+                "dhcp_options": [],
+                "folder_id": "test",
+                "id": "test",
+                "labels": {},
+                "name": "kube-a",
+                "network_id": "test",
+                "route_table_id": "test",
+                "timeouts": null,
+                "v4_cidr_blocks": [
+                  "0.0.0.0/24"
+                ],
+                "v6_cidr_blocks": [],
+                "zone": "ru-central1-a"
+              }
+            },
+            {
+              "address": "module.vpc_components.yandex_vpc_subnet.kube_b",
+              "mode": "managed",
+              "type": "yandex_vpc_subnet",
+              "name": "kube_b",
+              "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+              "schema_version": 0,
+              "values": {
+                "created_at": "2020-09-04T16:20:01Z",
+                "description": "",
+                "dhcp_options": [],
+                "folder_id": "test",
+                "id": "test",
+                "labels": {},
+                "name": "kube-b",
+                "network_id": "test",
+                "route_table_id": "test",
+                "timeouts": null,
+                "v4_cidr_blocks": [
+                  "0.0.0.0/24"
+                ],
+                "v6_cidr_blocks": [],
+                "zone": "ru-central1-b"
+              }
+            },
+            {
+              "address": "module.vpc_components.yandex_vpc_subnet.kube_c",
+              "mode": "managed",
+              "type": "yandex_vpc_subnet",
+              "name": "kube_c",
+              "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+              "schema_version": 0,
+              "values": {
+                "created_at": "2020-09-04T16:19:56Z",
+                "description": "",
+                "dhcp_options": [],
+                "folder_id": "test",
+                "id": "test",
+                "labels": {},
+                "name": "kube-c",
+                "network_id": "test",
+                "route_table_id": "test",
+                "timeouts": null,
+                "v4_cidr_blocks": [
+                  "0.0.0.0/24"
+                ],
+                "v6_cidr_blocks": [],
+                "zone": "ru-central1-c"
+              }
+            }
+          ],
+          "address": "module.vpc_components"
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "module.vpc_components.yandex_compute_instance.nat_instance[0]",
+      "module_address": "module.vpc_components",
+      "mode": "managed",
+      "type": "yandex_compute_instance",
+      "name": "nat_instance",
+      "index": 0,
+      "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "allow_stopping_for_update": null,
+          "boot_disk": [
+            {
+              "auto_delete": true,
+              "device_name": "test",
+              "disk_id": "test",
+              "initialize_params": [
+                {
+                  "description": "",
+                  "image_id": "test",
+                  "name": "",
+                  "size": 20,
+                  "snapshot_id": "",
+                  "type": "network-hdd"
+                }
+              ],
+              "mode": "READ_WRITE"
+            }
+          ],
+          "created_at": "2020-06-29T09:17:25Z",
+          "description": "",
+          "folder_id": "test",
+          "fqdn": "nat-instance-a.ru-central1.internal",
+          "hostname": "nat-instance-a",
+          "id": "test",
+          "labels": {},
+          "metadata": {
+            "serial-port-enable": "0",
+            "ssh-keys": "",
+            "user-data": ""
+          },
+          "name": "kube-nat",
+          "network_acceleration_type": "standard",
+          "network_interface": [
+            {
+              "index": 0,
+              "ip_address": "0.0.0.0",
+              "ipv4": true,
+              "ipv6": false,
+              "ipv6_address": "",
+              "mac_address": "00:00:00:00:00:00",
+              "nat": true,
+              "nat_ip_address": "0.0.0.0",
+              "nat_ip_version": "IPV4",
+              "security_group_ids": [],
+              "subnet_id": "test"
+            }
+          ],
+          "platform_id": "standard-v2",
+          "resources": [
+            {
+              "core_fraction": 100,
+              "cores": 2,
+              "gpus": 0,
+              "memory": 2
+            }
+          ],
+          "scheduling_policy": [
+            {
+              "preemptible": false
+            }
+          ],
+          "secondary_disk": [],
+          "service_account_id": "",
+          "status": "running",
+          "timeouts": {
+            "create": null,
+            "delete": null,
+            "update": null
+          },
+          "zone": "ru-central1-a"
+        },
+        "after": {
+          "allow_stopping_for_update": null,
+          "boot_disk": [
+            {
+              "auto_delete": true,
+              "device_name": "test",
+              "disk_id": "test",
+              "initialize_params": [
+                {
+                  "description": "",
+                  "image_id": "test",
+                  "name": "",
+                  "size": 20,
+                  "snapshot_id": "",
+                  "type": "network-hdd"
+                }
+              ],
+              "mode": "READ_WRITE"
+            }
+          ],
+          "created_at": "2020-06-29T09:17:25Z",
+          "description": "",
+          "folder_id": "test",
+          "fqdn": "nat-instance-a.ru-central1.internal",
+          "hostname": "nat-instance-a",
+          "id": "test",
+          "labels": {},
+          "metadata": {
+            "serial-port-enable": "0",
+            "ssh-keys": "",
+            "user-data": ""
+          },
+          "name": "kube-nat",
+          "network_acceleration_type": "standard",
+          "network_interface": [
+            {
+              "index": 0,
+              "ip_address": "0.0.0.0",
+              "ipv4": true,
+              "ipv6": false,
+              "ipv6_address": "",
+              "mac_address": "00:00:0:0:0:0",
+              "nat": true,
+              "nat_ip_address": "0.0.0.0",
+              "nat_ip_version": "IPV4",
+              "security_group_ids": [],
+              "subnet_id": "test"
+            }
+          ],
+          "platform_id": "standard-v2",
+          "resources": [
+            {
+              "core_fraction": 100,
+              "cores": 2,
+              "gpus": 0,
+              "memory": 2
+            }
+          ],
+          "scheduling_policy": [
+            {
+              "preemptible": false
+            }
+          ],
+          "secondary_disk": [],
+          "service_account_id": "",
+          "status": "running",
+          "timeouts": {
+            "create": null,
+            "delete": null,
+            "update": null
+          },
+          "zone": "ru-central1-a"
+        },
+        "after_unknown": {}
+      }
+    },
+    {
+      "address": "module.vpc_components.yandex_vpc_route_table.kube",
+      "module_address": "module.vpc_components",
+      "mode": "managed",
+      "type": "yandex_vpc_route_table",
+      "name": "kube",
+      "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "created_at": "2020-01-15T11:47:00Z",
+          "description": "",
+          "folder_id": "test",
+          "id": "test",
+          "labels": {},
+          "name": "kube",
+          "network_id": "test",
+          "static_route": [
+            {
+              "destination_prefix": "0.0.0.0/0",
+              "next_hop_address": "0.0.0.0"
+            }
+          ],
+          "timeouts": {
+            "create": null,
+            "delete": null,
+            "update": null
+          }
+        },
+        "after": {
+          "created_at": "2020-01-15T11:47:00Z",
+          "description": "",
+          "folder_id": "test",
+          "id": "test",
+          "labels": {},
+          "name": "kube",
+          "network_id": "test",
+          "static_route": [
+            {
+              "destination_prefix": "0.0.0.0/0",
+              "next_hop_address": "0.0.0.0"
+            }
+          ],
+          "timeouts": {
+            "create": null,
+            "delete": null,
+            "update": null
+          }
+        },
+        "after_unknown": {}
+      }
+    },
+    {
+      "address": "module.vpc_components.yandex_vpc_subnet.kube_a",
+      "module_address": "module.vpc_components",
+      "mode": "managed",
+      "type": "yandex_vpc_subnet",
+      "name": "kube_a",
+      "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "created_at": "2020-09-04T16:19:53Z",
+          "description": "",
+          "dhcp_options": [],
+          "folder_id": "test",
+          "id": "test",
+          "labels": {},
+          "name": "kube-a",
+          "network_id": "test",
+          "route_table_id": "test",
+          "timeouts": null,
+          "v4_cidr_blocks": [
+            "0.0.0.0/24"
+          ],
+          "v6_cidr_blocks": [],
+          "zone": "ru-central1-a"
+        },
+        "after": {
+          "created_at": "2020-09-04T16:19:53Z",
+          "description": "",
+          "dhcp_options": [],
+          "folder_id": "test",
+          "id": "test",
+          "labels": {},
+          "name": "kube-a",
+          "network_id": "test",
+          "route_table_id": "test",
+          "timeouts": null,
+          "v4_cidr_blocks": [
+            "0.0.0.0/24"
+          ],
+          "v6_cidr_blocks": [],
+          "zone": "ru-central1-a"
+        },
+        "after_unknown": {}
+      }
+    },
+    {
+      "address": "module.vpc_components.yandex_vpc_subnet.kube_b",
+      "module_address": "module.vpc_components",
+      "mode": "managed",
+      "type": "yandex_vpc_subnet",
+      "name": "kube_b",
+      "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "created_at": "2020-09-04T16:20:01Z",
+          "description": "",
+          "dhcp_options": [],
+          "folder_id": "test",
+          "id": "test",
+          "labels": {},
+          "name": "kube-b",
+          "network_id": "test",
+          "route_table_id": "test",
+          "timeouts": null,
+          "v4_cidr_blocks": [
+            "0.0.0.0/24"
+          ],
+          "v6_cidr_blocks": [],
+          "zone": "ru-central1-b"
+        },
+        "after": {
+          "created_at": "2020-09-04T16:20:01Z",
+          "description": "",
+          "dhcp_options": [],
+          "folder_id": "test",
+          "id": "test",
+          "labels": {},
+          "name": "kube-b",
+          "network_id": "test",
+          "route_table_id": "test",
+          "timeouts": null,
+          "v4_cidr_blocks": [
+            "0.0.0.0/24"
+          ],
+          "v6_cidr_blocks": [],
+          "zone": "ru-central1-b"
+        },
+        "after_unknown": {}
+      }
+    },
+    {
+      "address": "module.vpc_components.yandex_vpc_subnet.kube_c",
+      "module_address": "module.vpc_components",
+      "mode": "managed",
+      "type": "yandex_vpc_subnet",
+      "name": "kube_c",
+      "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "created_at": "2020-09-04T16:19:56Z",
+          "description": "",
+          "dhcp_options": [],
+          "folder_id": "test",
+          "id": "test",
+          "labels": {},
+          "name": "kube-c",
+          "network_id": "test",
+          "route_table_id": "test",
+          "timeouts": null,
+          "v4_cidr_blocks": [
+            "0.0.0.0/24"
+          ],
+          "v6_cidr_blocks": [],
+          "zone": "ru-central1-c"
+        },
+        "after": {
+          "created_at": "2020-09-04T16:19:56Z",
+          "description": "",
+          "dhcp_options": [],
+          "folder_id": "test",
+          "id": "test",
+          "labels": {},
+          "name": "kube-c",
+          "network_id": "test",
+          "route_table_id": "test",
+          "timeouts": null,
+          "v4_cidr_blocks": [
+            "0.0.0.0/24"
+          ],
+          "v6_cidr_blocks": [],
+          "zone": "ru-central1-c"
+        },
+        "after_unknown": {}
+      }
+    }
+  ],
+  "output_changes": {
+    "cloud_discovery_data": {
+      "actions": [
+        "create"
+      ],
+      "before": null,
+      "after": {
+        "apiVersion": "deckhouse.io/v1",
+        "defaultLbTargetGroupNetworkId": "test",
+        "internalNetworkIDs": [
+          "test"
+        ],
+        "kind": "YandexCloudDiscoveryData",
+        "region": "ru-central1",
+        "routeTableID": "test",
+        "shouldAssignPublicIPAddress": false,
+        "zoneToSubnetIdMap": {
+          "ru-central1-a": "test",
+          "ru-central1-b": "test",
+          "ru-central1-c": "test"
+        },
+        "zones": [
+          "ru-central1-a",
+          "ru-central1-b",
+          "ru-central1-c"
+        ]
+      },
+      "after_unknown": false
+    }
+  },
+  "prior_state": {
+    "format_version": "0.1",
+    "terraform_version": "0.13.4",
+    "values": {
+      "outputs": {
+        "cloud_discovery_data": {
+          "sensitive": false,
+          "value": {
+            "apiVersion": "deckhouse.io/v1",
+            "defaultLbTargetGroupNetworkId": "test",
+            "internalNetworkIDs": [
+              "test"
+            ],
+            "kind": "YandexCloudDiscoveryData",
+            "region": "ru-central1",
+            "routeTableID": "test",
+            "shouldAssignPublicIPAddress": false,
+            "zoneToSubnetIdMap": {
+              "ru-central1-a": "test",
+              "ru-central1-b": "test",
+              "ru-central1-c": "test"
+            },
+            "zones": [
+              "ru-central1-a",
+              "ru-central1-b",
+              "ru-central1-c"
+            ]
+          }
+        }
+      },
+      "root_module": {
+        "child_modules": [
+          {
+            "resources": [
+              {
+                "address": "module.vpc_components.data.yandex_compute_image.nat_image[0]",
+                "mode": "data",
+                "type": "yandex_compute_image",
+                "name": "nat_image",
+                "index": 0,
+                "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+                "schema_version": 0,
+                "values": {
+                  "created_at": "2021-02-08T21:22:42Z",
+                  "description": "Image with pre-configured routing and IP address translation rules.",
+                  "family": "nat-instance-ubuntu",
+                  "folder_id": "standard-images",
+                  "id": "test",
+                  "image_id": "test",
+                  "labels": {},
+                  "min_disk_size": 3,
+                  "name": "nat-instance-ubuntu-1612818947",
+                  "os_type": "linux",
+                  "product_ids": [
+                    "test"
+                  ],
+                  "size": 2,
+                  "status": "ready"
+                }
+              },
+              {
+                "address": "module.vpc_components.data.yandex_vpc_subnet.internal_subnet",
+                "mode": "data",
+                "type": "yandex_vpc_subnet",
+                "name": "internal_subnet",
+                "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+                "schema_version": 0,
+                "values": {
+                  "created_at": "2020-06-29T09:10:21Z",
+                  "description": "",
+                  "dhcp_options": [],
+                  "folder_id": "test",
+                  "id": "test",
+                  "labels": {},
+                  "name": "k8s-public-network-central-1a",
+                  "network_id": "test",
+                  "route_table_id": "",
+                  "subnet_id": "test",
+                  "v4_cidr_blocks": [
+                    "0.0.0.0/24"
+                  ],
+                  "v6_cidr_blocks": [],
+                  "zone": "ru-central1-a"
+                }
+              },
+              {
+                "address": "module.vpc_components.yandex_compute_instance.nat_instance[0]",
+                "mode": "managed",
+                "type": "yandex_compute_instance",
+                "name": "nat_instance",
+                "index": 0,
+                "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+                "schema_version": 1,
+                "values": {
+                  "allow_stopping_for_update": null,
+                  "boot_disk": [
+                    {
+                      "auto_delete": true,
+                      "device_name": "test",
+                      "disk_id": "test",
+                      "initialize_params": [
+                        {
+                          "description": "",
+                          "image_id": "test",
+                          "name": "",
+                          "size": 20,
+                          "snapshot_id": "",
+                          "type": "network-hdd"
+                        }
+                      ],
+                      "mode": "READ_WRITE"
+                    }
+                  ],
+                  "created_at": "2020-06-29T09:17:25Z",
+                  "description": "",
+                  "folder_id": "test",
+                  "fqdn": "nat-instance-a.ru-central1.internal",
+                  "hostname": "nat-instance-a",
+                  "id": "test",
+                  "labels": {},
+                  "metadata": {
+                    "serial-port-enable": "0",
+                    "ssh-keys": "",
+                    "user-data": ""
+                  },
+                  "name": "kube-nat",
+                  "network_acceleration_type": "standard",
+                  "network_interface": [
+                    {
+                      "index": 0,
+                      "ip_address": "0.0.0.0",
+                      "ipv4": true,
+                      "ipv6": false,
+                      "ipv6_address": "",
+                      "mac_address": "00:00:00:00:00:00",
+                      "nat": true,
+                      "nat_ip_address": "0.0.0.0",
+                      "nat_ip_version": "IPV4",
+                      "security_group_ids": [],
+                      "subnet_id": "test"
+                    }
+                  ],
+                  "platform_id": "standard-v2",
+                  "resources": [
+                    {
+                      "core_fraction": 100,
+                      "cores": 2,
+                      "gpus": 0,
+                      "memory": 2
+                    }
+                  ],
+                  "scheduling_policy": [
+                    {
+                      "preemptible": false
+                    }
+                  ],
+                  "secondary_disk": [],
+                  "service_account_id": "",
+                  "status": "running",
+                  "timeouts": {
+                    "create": null,
+                    "delete": null,
+                    "update": null
+                  },
+                  "zone": "ru-central1-a"
+                },
+                "depends_on": [
+                  "module.vpc_components.data.yandex_compute_image.nat_image",
+                  "module.vpc_components.data.yandex_vpc_subnet.external_subnet",
+                  "module.vpc_components.data.yandex_vpc_subnet.internal_subnet",
+                  "module.vpc_components.yandex_vpc_route_table.kube",
+                  "module.vpc_components.yandex_vpc_subnet.kube_c",
+                  "yandex_vpc_network.kube"
+                ]
+              },
+              {
+                "address": "module.vpc_components.yandex_vpc_route_table.kube",
+                "mode": "managed",
+                "type": "yandex_vpc_route_table",
+                "name": "kube",
+                "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+                "schema_version": 0,
+                "values": {
+                  "created_at": "2020-01-15T11:47:00Z",
+                  "description": "",
+                  "folder_id": "test",
+                  "id": "test",
+                  "labels": {},
+                  "name": "kube",
+                  "network_id": "test",
+                  "static_route": [
+                    {
+                      "destination_prefix": "0.0.0.0/0",
+                      "next_hop_address": "0.0.0.0"
+                    }
+                  ],
+                  "timeouts": {
+                    "create": null,
+                    "delete": null,
+                    "update": null
+                  }
+                },
+                "depends_on": [
+                  "yandex_vpc_network.kube"
+                ]
+              },
+              {
+                "address": "module.vpc_components.yandex_vpc_subnet.kube_a",
+                "mode": "managed",
+                "type": "yandex_vpc_subnet",
+                "name": "kube_a",
+                "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+                "schema_version": 0,
+                "values": {
+                  "created_at": "2020-09-04T16:19:53Z",
+                  "description": "",
+                  "dhcp_options": [],
+                  "folder_id": "test",
+                  "id": "test",
+                  "labels": {},
+                  "name": "kube-a",
+                  "network_id": "test",
+                  "route_table_id": "test",
+                  "timeouts": null,
+                  "v4_cidr_blocks": [
+                    "0.0.0.0/24"
+                  ],
+                  "v6_cidr_blocks": [],
+                  "zone": "ru-central1-a"
+                },
+                "depends_on": [
+                  "module.vpc_components.yandex_vpc_route_table.kube",
+                  "yandex_vpc_network.kube"
+                ]
+              },
+              {
+                "address": "module.vpc_components.yandex_vpc_subnet.kube_b",
+                "mode": "managed",
+                "type": "yandex_vpc_subnet",
+                "name": "kube_b",
+                "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+                "schema_version": 0,
+                "values": {
+                  "created_at": "2020-09-04T16:20:01Z",
+                  "description": "",
+                  "dhcp_options": [],
+                  "folder_id": "test",
+                  "id": "test",
+                  "labels": {},
+                  "name": "kube-b",
+                  "network_id": "test",
+                  "route_table_id": "test",
+                  "timeouts": null,
+                  "v4_cidr_blocks": [
+                    "0.0.0.0/24"
+                  ],
+                  "v6_cidr_blocks": [],
+                  "zone": "ru-central1-b"
+                },
+                "depends_on": [
+                  "module.vpc_components.yandex_vpc_route_table.kube",
+                  "yandex_vpc_network.kube"
+                ]
+              },
+              {
+                "address": "module.vpc_components.yandex_vpc_subnet.kube_c",
+                "mode": "managed",
+                "type": "yandex_vpc_subnet",
+                "name": "kube_c",
+                "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+                "schema_version": 0,
+                "values": {
+                  "created_at": "2020-09-04T16:19:56Z",
+                  "description": "",
+                  "dhcp_options": [],
+                  "folder_id": "test",
+                  "id": "test",
+                  "labels": {},
+                  "name": "kube-c",
+                  "network_id": "test",
+                  "route_table_id": "test",
+                  "timeouts": null,
+                  "v4_cidr_blocks": [
+                    "0.0.0.0/24"
+                  ],
+                  "v6_cidr_blocks": [],
+                  "zone": "ru-central1-c"
+                },
+                "depends_on": [
+                  "module.vpc_components.yandex_vpc_route_table.kube",
+                  "yandex_vpc_network.kube"
+                ]
+              }
+            ],
+            "address": "module.vpc_components"
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "yandex": {
+        "name": "yandex",
+        "expressions": {
+          "cloud_id": {
+            "references": [
+              "var.providerClusterConfiguration"
+            ]
+          },
+          "folder_id": {
+            "references": [
+              "var.providerClusterConfiguration"
+            ]
+          },
+          "service_account_key_file": {
+            "references": [
+              "var.providerClusterConfiguration"
+            ]
+          }
+        }
+      }
+    },
+    "root_module": {
+      "outputs": {
+        "cloud_discovery_data": {
+          "expression": {
+            "references": [
+              "module.vpc_components.route_table_id",
+              "local.network_id",
+              "local.network_id",
+              "var.providerClusterConfiguration",
+              "module.vpc_components.zone_to_subnet_id_map",
+              "var.providerClusterConfiguration",
+              "module.vpc_components.zone_to_subnet_id_map",
+              "module.vpc_components.zone_to_subnet_id_map"
+            ]
+          }
+        }
+      },
+      "resources": [
+        {
+          "address": "yandex_vpc_network.kube",
+          "mode": "managed",
+          "type": "yandex_vpc_network",
+          "name": "kube",
+          "provider_config_key": "yandex",
+          "expressions": {
+            "labels": {
+              "references": [
+                "local.labels"
+              ]
+            },
+            "name": {
+              "references": [
+                "local.prefix"
+              ]
+            }
+          },
+          "schema_version": 0,
+          "count_expression": {
+            "references": [
+              "local.existing_network_id"
+            ]
+          }
+        }
+      ],
+      "module_calls": {
+        "vpc_components": {
+          "source": "../../../terraform-modules/vpc-components",
+          "expressions": {
+            "dhcp_domain_name": {
+              "references": [
+                "local.dhcp_domain_name"
+              ]
+            },
+            "dhcp_domain_name_servers": {
+              "references": [
+                "local.dhcp_domain_name_servers"
+              ]
+            },
+            "labels": {
+              "references": [
+                "local.labels"
+              ]
+            },
+            "nat_instance_external_address": {
+              "references": [
+                "local.nat_instance_external_address"
+              ]
+            },
+            "nat_instance_external_subnet_id": {
+              "references": [
+                "local.nat_instance_external_subnet_id"
+              ]
+            },
+            "nat_instance_internal_address": {
+              "references": [
+                "local.nat_instance_internal_address"
+              ]
+            },
+            "nat_instance_internal_subnet_id": {
+              "references": [
+                "local.nat_instance_internal_subnet_id"
+              ]
+            },
+            "nat_instance_ssh_key": {
+              "references": [
+                "var.providerClusterConfiguration"
+              ]
+            },
+            "network_id": {
+              "references": [
+                "local.network_id"
+              ]
+            },
+            "node_network_cidr": {
+              "references": [
+                "local.node_network_cidr"
+              ]
+            },
+            "prefix": {
+              "references": [
+                "local.prefix"
+              ]
+            },
+            "should_create_nat_instance": {
+              "constant_value": true
+            }
+          },
+          "module": {
+            "outputs": {
+              "route_table_id": {
+                "expression": {
+                  "references": [
+                    "yandex_vpc_route_table.kube"
+                  ]
+                }
+              },
+              "zone_to_subnet_id_map": {
+                "expression": {
+                  "references": [
+                    "yandex_vpc_subnet.kube_a",
+                    "yandex_vpc_subnet.kube_a",
+                    "yandex_vpc_subnet.kube_b",
+                    "yandex_vpc_subnet.kube_b",
+                    "yandex_vpc_subnet.kube_c",
+                    "yandex_vpc_subnet.kube_c"
+                  ]
+                }
+              }
+            },
+            "resources": [
+              {
+                "address": "yandex_compute_instance.nat_instance",
+                "mode": "managed",
+                "type": "yandex_compute_instance",
+                "name": "nat_instance",
+                "provider_config_key": "vpc_components:yandex",
+                "expressions": {
+                  "boot_disk": [
+                    {
+                      "initialize_params": [
+                        {
+                          "image_id": {
+                            "references": [
+                              "data.yandex_compute_image.nat_image[0]"
+                            ]
+                          },
+                          "size": {
+                            "constant_value": 13
+                          },
+                          "type": {
+                            "constant_value": "network-hdd"
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "hostname": {
+                    "references": [
+                      "var.prefix"
+                    ]
+                  },
+                  "metadata": {
+                    "references": [
+                      "local.user_data"
+                    ]
+                  },
+                  "name": {
+                    "references": [
+                      "var.prefix"
+                    ]
+                  },
+                  "network_interface": [
+                    {
+                      "ip_address": {
+                        "references": [
+                          "local.nat_instance_internal_address_calculated"
+                        ]
+                      },
+                      "nat": {
+                        "references": [
+                          "local.assign_external_ip_address"
+                        ]
+                      },
+                      "nat_ip_address": {
+                        "references": [
+                          "local.assign_external_ip_address",
+                          "var.nat_instance_external_address"
+                        ]
+                      },
+                      "subnet_id": {
+                        "references": [
+                          "data.yandex_vpc_subnet.internal_subnet"
+                        ]
+                      }
+                    }
+                  ],
+                  "platform_id": {
+                    "constant_value": "standard-v2"
+                  },
+                  "resources": [
+                    {
+                      "cores": {
+                        "constant_value": 2
+                      },
+                      "memory": {
+                        "constant_value": 2
+                      }
+                    }
+                  ],
+                  "zone": {
+                    "references": [
+                      "var.nat_instance_external_subnet_id",
+                      "local.internal_subnet_zone",
+                      "local.external_subnet_zone"
+                    ]
+                  }
+                },
+                "schema_version": 1,
+                "count_expression": {
+                  "references": [
+                    "var.should_create_nat_instance"
+                  ]
+                },
+                "depends_on": [
+                  "yandex_vpc_subnet.kube_c"
+                ]
+              },
+              {
+                "address": "yandex_vpc_route_table.kube",
+                "mode": "managed",
+                "type": "yandex_vpc_route_table",
+                "name": "kube",
+                "provider_config_key": "vpc_components:yandex",
+                "expressions": {
+                  "labels": {
+                    "references": [
+                      "var.labels"
+                    ]
+                  },
+                  "name": {
+                    "references": [
+                      "var.prefix"
+                    ]
+                  },
+                  "network_id": {
+                    "references": [
+                      "var.network_id"
+                    ]
+                  }
+                },
+                "schema_version": 0
+              },
+              {
+                "address": "yandex_vpc_subnet.kube_a",
+                "mode": "managed",
+                "type": "yandex_vpc_subnet",
+                "name": "kube_a",
+                "provider_config_key": "vpc_components:yandex",
+                "expressions": {
+                  "labels": {
+                    "references": [
+                      "var.labels"
+                    ]
+                  },
+                  "name": {
+                    "references": [
+                      "var.prefix"
+                    ]
+                  },
+                  "network_id": {
+                    "references": [
+                      "var.network_id"
+                    ]
+                  },
+                  "route_table_id": {
+                    "references": [
+                      "yandex_vpc_route_table.kube"
+                    ]
+                  },
+                  "v4_cidr_blocks": {
+                    "references": [
+                      "local.kube_a_v4_cidr_block"
+                    ]
+                  },
+                  "zone": {
+                    "constant_value": "ru-central1-a"
+                  }
+                },
+                "schema_version": 0
+              },
+              {
+                "address": "yandex_vpc_subnet.kube_b",
+                "mode": "managed",
+                "type": "yandex_vpc_subnet",
+                "name": "kube_b",
+                "provider_config_key": "vpc_components:yandex",
+                "expressions": {
+                  "labels": {
+                    "references": [
+                      "var.labels"
+                    ]
+                  },
+                  "name": {
+                    "references": [
+                      "var.prefix"
+                    ]
+                  },
+                  "network_id": {
+                    "references": [
+                      "var.network_id"
+                    ]
+                  },
+                  "route_table_id": {
+                    "references": [
+                      "yandex_vpc_route_table.kube"
+                    ]
+                  },
+                  "v4_cidr_blocks": {
+                    "references": [
+                      "local.kube_b_v4_cidr_block"
+                    ]
+                  },
+                  "zone": {
+                    "constant_value": "ru-central1-b"
+                  }
+                },
+                "schema_version": 0
+              },
+              {
+                "address": "yandex_vpc_subnet.kube_c",
+                "mode": "managed",
+                "type": "yandex_vpc_subnet",
+                "name": "kube_c",
+                "provider_config_key": "vpc_components:yandex",
+                "expressions": {
+                  "labels": {
+                    "references": [
+                      "var.labels"
+                    ]
+                  },
+                  "name": {
+                    "references": [
+                      "var.prefix"
+                    ]
+                  },
+                  "network_id": {
+                    "references": [
+                      "var.network_id"
+                    ]
+                  },
+                  "route_table_id": {
+                    "references": [
+                      "yandex_vpc_route_table.kube"
+                    ]
+                  },
+                  "v4_cidr_blocks": {
+                    "references": [
+                      "local.kube_c_v4_cidr_block"
+                    ]
+                  },
+                  "zone": {
+                    "constant_value": "ru-central1-c"
+                  }
+                },
+                "schema_version": 0
+              },
+              {
+                "address": "data.yandex_compute_image.nat_image",
+                "mode": "data",
+                "type": "yandex_compute_image",
+                "name": "nat_image",
+                "provider_config_key": "vpc_components:yandex",
+                "expressions": {
+                  "family": {
+                    "constant_value": "nat-instance-ubuntu"
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "var.should_create_nat_instance"
+                  ]
+                }
+              },
+              {
+                "address": "data.yandex_vpc_subnet.external_subnet",
+                "mode": "data",
+                "type": "yandex_vpc_subnet",
+                "name": "external_subnet",
+                "provider_config_key": "vpc_components:yandex",
+                "expressions": {
+                  "subnet_id": {
+                    "references": [
+                      "var.nat_instance_external_subnet_id"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "var.nat_instance_external_subnet_id"
+                  ]
+                }
+              },
+              {
+                "address": "data.yandex_vpc_subnet.internal_subnet",
+                "mode": "data",
+                "type": "yandex_vpc_subnet",
+                "name": "internal_subnet",
+                "provider_config_key": "vpc_components:yandex",
+                "expressions": {
+                  "subnet_id": {
+                    "references": [
+                      "var.nat_instance_internal_subnet_id",
+                      "yandex_vpc_subnet.kube_c",
+                      "var.nat_instance_internal_subnet_id"
+                    ]
+                  }
+                },
+                "schema_version": 0
+              }
+            ],
+            "variables": {
+              "dhcp_domain_name": {
+                "default": null
+              },
+              "dhcp_domain_name_servers": {
+                "default": null
+              },
+              "labels": {},
+              "nat_instance_external_address": {
+                "default": null
+              },
+              "nat_instance_external_subnet_id": {
+                "default": null
+              },
+              "nat_instance_internal_address": {
+                "default": null
+              },
+              "nat_instance_internal_subnet_id": {
+                "default": null
+              },
+              "nat_instance_ssh_key": {
+                "default": ""
+              },
+              "network_id": {},
+              "node_network_cidr": {},
+              "prefix": {},
+              "should_create_nat_instance": {
+                "default": false
+              }
+            }
+          }
+        }
+      },
+      "variables": {
+        "cloudConfig": {
+          "default": ""
+        },
+        "clusterConfiguration": {},
+        "clusterUUID": {},
+        "nodeIndex": {
+          "default": 0
+        },
+        "providerClusterConfiguration": {}
+      }
+    }
+  }
+}

--- a/dhctl/pkg/terraform/mocks/pipeline/cloud_discovery_data.json
+++ b/dhctl/pkg/terraform/mocks/pipeline/cloud_discovery_data.json
@@ -1,0 +1,21 @@
+{
+  "apiVersion": "deckhouse.io/v1",
+  "defaultLbTargetGroupNetworkId": "test",
+  "internalNetworkIDs": [
+    "test"
+  ],
+  "kind": "YandexCloudDiscoveryData",
+  "region": "ru-central1",
+  "routeTableID": "test",
+  "shouldAssignPublicIPAddress": false,
+  "zoneToSubnetIdMap": {
+    "ru-central1-a": "test",
+    "ru-central1-b": "test",
+    "ru-central1-c": "test"
+  },
+  "zones": [
+    "ru-central1-a",
+    "ru-central1-b",
+    "ru-central1-c"
+  ]
+}

--- a/dhctl/pkg/terraform/mocks/pipeline/cloud_discovery_data_changed_zones.json
+++ b/dhctl/pkg/terraform/mocks/pipeline/cloud_discovery_data_changed_zones.json
@@ -1,0 +1,22 @@
+{
+  "apiVersion": "deckhouse.io/v1",
+  "defaultLbTargetGroupNetworkId": "test",
+  "internalNetworkIDs": [
+    "test"
+  ],
+  "kind": "YandexCloudDiscoveryData",
+  "region": "ru-central1",
+  "routeTableID": "test",
+  "shouldAssignPublicIPAddress": false,
+  "zoneToSubnetIdMap": {
+    "ru-central1-a": "test",
+    "ru-central1-b": "test",
+    "ru-central1-c": "test"
+  },
+  "zones": [
+    "ru-central1-a",
+    "ru-central1-b",
+    "ru-central1-c",
+    "ru-novosibirsk"
+  ]
+}

--- a/dhctl/pkg/terraform/mocks/pipeline/empty_state.json
+++ b/dhctl/pkg/terraform/mocks/pipeline/empty_state.json
@@ -1,0 +1,6 @@
+{
+  "format_version": "0.1",
+  "terraform_version": "0.13.4",
+  "resource_changes": [],
+  "resources": []
+}

--- a/dhctl/pkg/terraform/mocks/pipeline/master_node_destructively_changed_plan.json
+++ b/dhctl/pkg/terraform/mocks/pipeline/master_node_destructively_changed_plan.json
@@ -1,0 +1,940 @@
+{
+  "format_version": "0.1",
+  "terraform_version": "0.13.4",
+  "variables": {
+    "cloudConfig": {
+      "value": ""
+    },
+    "clusterConfiguration": {
+      "value": {
+        "apiVersion": "deckhouse.io/v1alpha1",
+        "cloud": {
+          "prefix": "kube",
+          "provider": "Yandex"
+        },
+        "clusterDomain": "cluster.local",
+        "clusterType": "Cloud",
+        "defaultCRI": "Docker",
+        "kind": "ClusterConfiguration",
+        "kubernetesVersion": "1.19",
+        "podSubnetCIDR": "10.244.0.0/16",
+        "podSubnetNodeCIDRPrefix": "24",
+        "serviceSubnetCIDR": "192.168.0.0/16"
+      }
+    },
+    "clusterUUID": {
+      "value": "00000000-ed62-4723-9814-a686e1cd6ece"
+    },
+    "network_types": {
+      "value": {
+        "SoftwareAccelerated": "software_accelerated",
+        "Standard": "standard"
+      }
+    },
+    "nodeIndex": {
+      "value": 0
+    },
+    "providerClusterConfiguration": {
+      "value": {
+        "apiVersion": "deckhouse.io/v1alpha1",
+        "existingNetworkID": "test",
+        "kind": "YandexClusterConfiguration",
+        "layout": "WithNATInstance",
+        "masterNodeGroup": {
+          "instanceClass": {
+            "cores": 4,
+            "diskSizeGB": 45,
+            "imageID": "test",
+            "memory": 8192
+          },
+          "replicas": 3
+        },
+        "nodeNetworkCIDR": "10.233.0.0/22",
+        "provider": {
+          "cloudID": "test",
+          "folderID": "test",
+          "serviceAccountJSON": ""
+        },
+        "sshPublicKey": "",
+        "withNATInstance": {
+          "internalSubnetID": "test",
+          "natInstanceExternalAddress": "130.193.51.24",
+          "natInstanceInternalAddress": "10.133.1.34"
+        }
+      }
+    }
+  },
+  "planned_values": {
+    "outputs": {
+      "kubernetes_data_device_path": {
+        "sensitive": false,
+        "value": "/dev/disk/by-id/virtio-kubernetes-data"
+      },
+      "master_ip_address_for_ssh": {
+        "sensitive": false
+      },
+      "node_internal_ip_address": {
+        "sensitive": false
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "yandex_compute_disk.kubernetes_data",
+          "mode": "managed",
+          "type": "yandex_compute_disk",
+          "name": "kubernetes_data",
+          "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+          "schema_version": 0,
+          "values": {
+            "created_at": "2021-02-26T09:40:42Z",
+            "description": "volume for etcd and kubernetes certs",
+            "folder_id": "test",
+            "id": "test",
+            "image_id": "",
+            "labels": {},
+            "name": "kube-kubernetes-data-0",
+            "product_ids": [],
+            "size": 10,
+            "snapshot_id": "",
+            "status": "ready",
+            "timeouts": null,
+            "type": "network-ssd",
+            "zone": "ru-central1-a"
+          }
+        },
+        {
+          "address": "yandex_compute_instance.master",
+          "mode": "managed",
+          "type": "yandex_compute_instance",
+          "name": "master",
+          "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+          "schema_version": 1,
+          "values": {
+            "allow_stopping_for_update": true,
+            "boot_disk": [
+              {
+                "auto_delete": true,
+                "initialize_params": [
+                  {
+                    "image_id": "test",
+                    "size": 45,
+                    "type": "network-ssd"
+                  }
+                ]
+              }
+            ],
+            "description": null,
+            "hostname": "kube-master-0",
+            "labels": null,
+            "metadata": {
+              "node-network-cidr": "10.233.0.0/22",
+              "ssh-keys": "",
+              "user-data": ""
+            },
+            "name": "kube-master-0",
+            "network_acceleration_type": "standard",
+            "network_interface": [
+              {
+                "ipv4": true,
+                "nat": false,
+                "subnet_id": "test"
+              }
+            ],
+            "platform_id": "standard-v2",
+            "resources": [
+              {
+                "core_fraction": 100,
+                "cores": 4,
+                "gpus": null,
+                "memory": 8
+              }
+            ],
+            "secondary_disk": [
+              {
+                "auto_delete": false,
+                "device_name": "kubernetes-data",
+                "disk_id": "test",
+                "mode": "READ_WRITE"
+              }
+            ],
+            "timeouts": null,
+            "zone": "ru-central1-a"
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "yandex_compute_disk.kubernetes_data",
+      "mode": "managed",
+      "type": "yandex_compute_disk",
+      "name": "kubernetes_data",
+      "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "created_at": "2021-02-26T09:40:42Z",
+          "description": "volume for etcd and kubernetes certs",
+          "folder_id": "test",
+          "id": "test",
+          "image_id": "",
+          "labels": {},
+          "name": "kube-kubernetes-data-0",
+          "product_ids": [],
+          "size": 10,
+          "snapshot_id": "",
+          "status": "ready",
+          "timeouts": null,
+          "type": "network-ssd",
+          "zone": "ru-central1-a"
+        },
+        "after": {
+          "created_at": "2021-02-26T09:40:42Z",
+          "description": "volume for etcd and kubernetes certs",
+          "folder_id": "test",
+          "id": "test",
+          "image_id": "",
+          "labels": {},
+          "name": "kube-kubernetes-data-0",
+          "product_ids": [],
+          "size": 10,
+          "snapshot_id": "",
+          "status": "ready",
+          "timeouts": null,
+          "type": "network-ssd",
+          "zone": "ru-central1-a"
+        },
+        "after_unknown": {}
+      }
+    },
+    {
+      "address": "yandex_compute_instance.master",
+      "mode": "managed",
+      "type": "yandex_compute_instance",
+      "name": "master",
+      "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+      "change": {
+        "actions": [
+          "delete",
+          "create"
+        ],
+        "before": {
+          "allow_stopping_for_update": true,
+          "boot_disk": [
+            {
+              "auto_delete": true,
+              "device_name": "test",
+              "disk_id": "test",
+              "initialize_params": [
+                {
+                  "description": "",
+                  "image_id": "test",
+                  "name": "test",
+                  "size": 35,
+                  "snapshot_id": "",
+                  "type": "network-ssd"
+                }
+              ],
+              "mode": "READ_WRITE"
+            }
+          ],
+          "created_at": "2021-02-26T09:40:46Z",
+          "description": "",
+          "folder_id": "test",
+          "fqdn": "kube-master-0.ru-central1.internal",
+          "hostname": "kube-master-0",
+          "id": "test",
+          "labels": {},
+          "metadata": {
+            "ssh-keys": "",
+            "user-data": ""
+          },
+          "name": "kube-master-0",
+          "network_acceleration_type": "standard",
+          "network_interface": [
+            {
+              "index": 0,
+              "ip_address": "10.233.0.18",
+              "ipv4": true,
+              "ipv6": false,
+              "ipv6_address": "",
+              "mac_address": "00:00:00:00:00:00",
+              "nat": false,
+              "nat_ip_address": "",
+              "nat_ip_version": "",
+              "security_group_ids": [],
+              "subnet_id": "test"
+            }
+          ],
+          "platform_id": "standard-v2",
+          "resources": [
+            {
+              "core_fraction": 100,
+              "cores": 4,
+              "gpus": 0,
+              "memory": 8
+            }
+          ],
+          "scheduling_policy": [
+            {
+              "preemptible": false
+            }
+          ],
+          "secondary_disk": [
+            {
+              "auto_delete": false,
+              "device_name": "kubernetes-data",
+              "disk_id": "test",
+              "mode": "READ_WRITE"
+            }
+          ],
+          "service_account_id": "",
+          "status": "running",
+          "timeouts": null,
+          "zone": "ru-central1-a"
+        },
+        "after": {
+          "allow_stopping_for_update": true,
+          "boot_disk": [
+            {
+              "auto_delete": true,
+              "initialize_params": [
+                {
+                  "image_id": "test",
+                  "size": 45,
+                  "type": "network-ssd"
+                }
+              ]
+            }
+          ],
+          "description": null,
+          "hostname": "kube-master-0",
+          "labels": null,
+          "metadata": {
+            "node-network-cidr": "10.233.0.0/22",
+            "ssh-keys": "",
+            "user-data": ""
+          },
+          "name": "kube-master-0",
+          "network_acceleration_type": "standard",
+          "network_interface": [
+            {
+              "ipv4": true,
+              "nat": false,
+              "subnet_id": "test"
+            }
+          ],
+          "platform_id": "standard-v2",
+          "resources": [
+            {
+              "core_fraction": 100,
+              "cores": 4,
+              "gpus": null,
+              "memory": 8
+            }
+          ],
+          "secondary_disk": [
+            {
+              "auto_delete": false,
+              "device_name": "kubernetes-data",
+              "disk_id": "test",
+              "mode": "READ_WRITE"
+            }
+          ],
+          "timeouts": null,
+          "zone": "ru-central1-a"
+        },
+        "after_unknown": {
+          "boot_disk": [
+            {
+              "device_name": true,
+              "disk_id": true,
+              "initialize_params": [
+                {
+                  "description": true,
+                  "name": true,
+                  "snapshot_id": true
+                }
+              ],
+              "mode": true
+            }
+          ],
+          "created_at": true,
+          "folder_id": true,
+          "fqdn": true,
+          "id": true,
+          "metadata": {},
+          "network_interface": [
+            {
+              "index": true,
+              "ip_address": true,
+              "ipv6": true,
+              "ipv6_address": true,
+              "mac_address": true,
+              "nat_ip_address": true,
+              "nat_ip_version": true,
+              "security_group_ids": true
+            }
+          ],
+          "resources": [
+            {}
+          ],
+          "scheduling_policy": true,
+          "secondary_disk": [
+            {}
+          ],
+          "service_account_id": true,
+          "status": true
+        }
+      }
+    }
+  ],
+  "output_changes": {
+    "kubernetes_data_device_path": {
+      "actions": [
+        "create"
+      ],
+      "before": null,
+      "after": "/dev/disk/by-id/virtio-kubernetes-data",
+      "after_unknown": false
+    },
+    "master_ip_address_for_ssh": {
+      "actions": [
+        "create"
+      ],
+      "before": null,
+      "after_unknown": true
+    },
+    "node_internal_ip_address": {
+      "actions": [
+        "create"
+      ],
+      "before": null,
+      "after_unknown": true
+    }
+  },
+  "prior_state": {
+    "format_version": "0.1",
+    "terraform_version": "0.13.4",
+    "values": {
+      "outputs": {
+        "kubernetes_data_device_path": {
+          "sensitive": false,
+          "value": "/dev/disk/by-id/virtio-kubernetes-data"
+        },
+        "master_ip_address_for_ssh": {
+          "sensitive": false,
+          "value": "10.233.0.18"
+        },
+        "node_internal_ip_address": {
+          "sensitive": false,
+          "value": "10.233.0.18"
+        }
+      },
+      "root_module": {
+        "resources": [
+          {
+            "address": "data.yandex_vpc_subnet.kube_a",
+            "mode": "data",
+            "type": "yandex_vpc_subnet",
+            "name": "kube_a",
+            "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+            "schema_version": 0,
+            "values": {
+              "created_at": "2020-09-04T16:19:53Z",
+              "description": "",
+              "dhcp_options": [],
+              "folder_id": "test",
+              "id": "test",
+              "labels": {},
+              "name": "kube-a",
+              "network_id": "test",
+              "route_table_id": "test",
+              "subnet_id": "test",
+              "v4_cidr_blocks": [
+                "10.233.0.0/24"
+              ],
+              "v6_cidr_blocks": [],
+              "zone": "ru-central1-a"
+            }
+          },
+          {
+            "address": "data.yandex_vpc_subnet.kube_b",
+            "mode": "data",
+            "type": "yandex_vpc_subnet",
+            "name": "kube_b",
+            "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+            "schema_version": 0,
+            "values": {
+              "created_at": "2020-09-04T16:20:01Z",
+              "description": "",
+              "dhcp_options": [],
+              "folder_id": "test",
+              "id": "test",
+              "labels": {},
+              "name": "kube-b",
+              "network_id": "test",
+              "route_table_id": "test",
+              "subnet_id": "test",
+              "v4_cidr_blocks": [
+                "10.233.1.0/24"
+              ],
+              "v6_cidr_blocks": [],
+              "zone": "ru-central1-b"
+            }
+          },
+          {
+            "address": "data.yandex_vpc_subnet.kube_c",
+            "mode": "data",
+            "type": "yandex_vpc_subnet",
+            "name": "kube_c",
+            "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+            "schema_version": 0,
+            "values": {
+              "created_at": "2020-09-04T16:19:56Z",
+              "description": "",
+              "dhcp_options": [],
+              "folder_id": "test",
+              "id": "test",
+              "labels": {},
+              "name": "kube-c",
+              "network_id": "test",
+              "route_table_id": "test",
+              "subnet_id": "test",
+              "v4_cidr_blocks": [
+                "10.233.2.0/24"
+              ],
+              "v6_cidr_blocks": [],
+              "zone": "ru-central1-c"
+            }
+          },
+          {
+            "address": "yandex_compute_disk.kubernetes_data",
+            "mode": "managed",
+            "type": "yandex_compute_disk",
+            "name": "kubernetes_data",
+            "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+            "schema_version": 0,
+            "values": {
+              "created_at": "2021-02-26T09:40:42Z",
+              "description": "volume for etcd and kubernetes certs",
+              "folder_id": "test",
+              "id": "fhm1bgsm68j8t65v6kdo",
+              "image_id": "",
+              "labels": {},
+              "name": "kube-kubernetes-data-0",
+              "product_ids": [],
+              "size": 10,
+              "snapshot_id": "",
+              "status": "ready",
+              "timeouts": null,
+              "type": "network-ssd",
+              "zone": "ru-central1-a"
+            },
+            "depends_on": [
+              "data.yandex_vpc_subnet.kube_a",
+              "data.yandex_vpc_subnet.kube_b",
+              "data.yandex_vpc_subnet.kube_c"
+            ]
+          },
+          {
+            "address": "yandex_compute_instance.master",
+            "mode": "managed",
+            "type": "yandex_compute_instance",
+            "name": "master",
+            "provider_name": "registry.terraform.io/yandex-cloud/yandex",
+            "schema_version": 1,
+            "values": {
+              "allow_stopping_for_update": true,
+              "boot_disk": [
+                {
+                  "auto_delete": true,
+                  "device_name": "test",
+                  "disk_id": "test",
+                  "initialize_params": [
+                    {
+                      "description": "",
+                      "image_id": "test",
+                      "name": "test",
+                      "size": 35,
+                      "snapshot_id": "",
+                      "type": "network-ssd"
+                    }
+                  ],
+                  "mode": "READ_WRITE"
+                }
+              ],
+              "created_at": "2021-02-26T09:40:46Z",
+              "description": "",
+              "folder_id": "test",
+              "fqdn": "kube-master-0.ru-central1.internal",
+              "hostname": "kube-master-0",
+              "id": "test",
+              "labels": {},
+              "metadata": {
+                "ssh-keys": "",
+                "user-data": ""
+              },
+              "name": "kube-master-0",
+              "network_acceleration_type": "standard",
+              "network_interface": [
+                {
+                  "index": 0,
+                  "ip_address": "10.233.0.18",
+                  "ipv4": true,
+                  "ipv6": false,
+                  "ipv6_address": "",
+                  "mac_address": "00:00:00:00:00:00",
+                  "nat": false,
+                  "nat_ip_address": "",
+                  "nat_ip_version": "",
+                  "security_group_ids": [],
+                  "subnet_id": "test"
+                }
+              ],
+              "platform_id": "standard-v2",
+              "resources": [
+                {
+                  "core_fraction": 100,
+                  "cores": 4,
+                  "gpus": 0,
+                  "memory": 8
+                }
+              ],
+              "scheduling_policy": [
+                {
+                  "preemptible": false
+                }
+              ],
+              "secondary_disk": [
+                {
+                  "auto_delete": false,
+                  "device_name": "kubernetes-data",
+                  "disk_id": "test",
+                  "mode": "READ_WRITE"
+                }
+              ],
+              "service_account_id": "",
+              "status": "running",
+              "timeouts": null,
+              "zone": "ru-central1-a"
+            },
+            "depends_on": [
+              "data.yandex_vpc_subnet.kube_a",
+              "data.yandex_vpc_subnet.kube_b",
+              "data.yandex_vpc_subnet.kube_c",
+              "yandex_compute_disk.kubernetes_data"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "yandex": {
+        "name": "yandex",
+        "expressions": {
+          "cloud_id": {
+            "references": [
+              "var.providerClusterConfiguration"
+            ]
+          },
+          "folder_id": {
+            "references": [
+              "var.providerClusterConfiguration"
+            ]
+          },
+          "service_account_key_file": {
+            "references": [
+              "var.providerClusterConfiguration"
+            ]
+          }
+        }
+      }
+    },
+    "root_module": {
+      "outputs": {
+        "kubernetes_data_device_path": {
+          "expression": {
+            "constant_value": "/dev/disk/by-id/virtio-kubernetes-data"
+          }
+        },
+        "master_ip_address_for_ssh": {
+          "expression": {
+            "references": [
+              "yandex_compute_instance.master",
+              "yandex_compute_instance.master",
+              "yandex_compute_instance.master"
+            ]
+          }
+        },
+        "node_internal_ip_address": {
+          "expression": {
+            "references": [
+              "yandex_compute_instance.master",
+              "local.master_internal_ip_iface_index"
+            ]
+          }
+        }
+      },
+      "resources": [
+        {
+          "address": "yandex_compute_disk.kubernetes_data",
+          "mode": "managed",
+          "type": "yandex_compute_disk",
+          "name": "kubernetes_data",
+          "provider_config_key": "yandex",
+          "expressions": {
+            "description": {
+              "constant_value": "volume for etcd and kubernetes certs"
+            },
+            "labels": {
+              "references": [
+                "local.additional_labels"
+              ]
+            },
+            "name": {
+              "references": [
+                "local.prefix",
+                "var.nodeIndex"
+              ]
+            },
+            "size": {
+              "constant_value": 10
+            },
+            "type": {
+              "constant_value": "network-ssd"
+            },
+            "zone": {
+              "references": [
+                "local.internal_subnet"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "yandex_compute_instance.master",
+          "mode": "managed",
+          "type": "yandex_compute_instance",
+          "name": "master",
+          "provider_config_key": "yandex",
+          "expressions": {
+            "allow_stopping_for_update": {
+              "constant_value": true
+            },
+            "boot_disk": [
+              {
+                "initialize_params": [
+                  {
+                    "image_id": {
+                      "references": [
+                        "local.image_id"
+                      ]
+                    },
+                    "size": {
+                      "references": [
+                        "local.disk_size_gb"
+                      ]
+                    },
+                    "type": {
+                      "constant_value": "network-ssd"
+                    }
+                  }
+                ]
+              }
+            ],
+            "hostname": {
+              "references": [
+                "local.prefix",
+                "var.nodeIndex"
+              ]
+            },
+            "labels": {
+              "references": [
+                "local.additional_labels"
+              ]
+            },
+            "metadata": {
+              "references": [
+                "local.ssh_public_key",
+                "var.cloudConfig",
+                "local.node_network_cidr"
+              ]
+            },
+            "name": {
+              "references": [
+                "local.prefix",
+                "var.nodeIndex"
+              ]
+            },
+            "network_acceleration_type": {
+              "references": [
+                "local.network_type"
+              ]
+            },
+            "network_interface": [
+              {
+                "nat": {
+                  "references": [
+                    "local.assign_external_ip_address"
+                  ]
+                },
+                "nat_ip_address": {
+                  "references": [
+                    "local.assign_external_ip_address",
+                    "local.external_ip_address"
+                  ]
+                },
+                "subnet_id": {
+                  "references": [
+                    "local.internal_subnet"
+                  ]
+                }
+              }
+            ],
+            "platform_id": {
+              "references": [
+                "local.platform"
+              ]
+            },
+            "resources": [
+              {
+                "cores": {
+                  "references": [
+                    "local.cores"
+                  ]
+                },
+                "memory": {
+                  "references": [
+                    "local.memory"
+                  ]
+                }
+              }
+            ],
+            "secondary_disk": [
+              {
+                "auto_delete": {
+                  "constant_value": "false"
+                },
+                "device_name": {
+                  "constant_value": "kubernetes-data"
+                },
+                "disk_id": {
+                  "references": [
+                    "yandex_compute_disk.kubernetes_data"
+                  ]
+                }
+              }
+            ],
+            "zone": {
+              "references": [
+                "local.internal_subnet"
+              ]
+            }
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "yandex_vpc_address.addr",
+          "mode": "managed",
+          "type": "yandex_vpc_address",
+          "name": "addr",
+          "provider_config_key": "yandex",
+          "expressions": {
+            "external_ipv4_address": [
+              {
+                "zone_id": {
+                  "references": [
+                    "local.internal_subnet"
+                  ]
+                }
+              }
+            ],
+            "name": {
+              "references": [
+                "local.prefix",
+                "var.nodeIndex"
+              ]
+            }
+          },
+          "schema_version": 0,
+          "count_expression": {
+            "references": [
+              "local.external_ip_addresses",
+              "local.external_ip_addresses",
+              "var.nodeIndex"
+            ]
+          }
+        },
+        {
+          "address": "data.yandex_vpc_subnet.kube_a",
+          "mode": "data",
+          "type": "yandex_vpc_subnet",
+          "name": "kube_a",
+          "provider_config_key": "yandex",
+          "expressions": {
+            "name": {
+              "references": [
+                "local.prefix"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "data.yandex_vpc_subnet.kube_b",
+          "mode": "data",
+          "type": "yandex_vpc_subnet",
+          "name": "kube_b",
+          "provider_config_key": "yandex",
+          "expressions": {
+            "name": {
+              "references": [
+                "local.prefix"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "data.yandex_vpc_subnet.kube_c",
+          "mode": "data",
+          "type": "yandex_vpc_subnet",
+          "name": "kube_c",
+          "provider_config_key": "yandex",
+          "expressions": {
+            "name": {
+              "references": [
+                "local.prefix"
+              ]
+            }
+          },
+          "schema_version": 0
+        }
+      ],
+      "variables": {
+        "cloudConfig": {
+          "default": ""
+        },
+        "clusterConfiguration": {},
+        "clusterUUID": {},
+        "network_types": {
+          "default": {
+            "SoftwareAccelerated": "software_accelerated",
+            "Standard": "standard"
+          }
+        },
+        "nodeIndex": {
+          "default": 0
+        },
+        "providerClusterConfiguration": {}
+      }
+    }
+  }
+}

--- a/dhctl/pkg/terraform/mocks/pipeline/master_output.json
+++ b/dhctl/pkg/terraform/mocks/pipeline/master_output.json
@@ -1,0 +1,17 @@
+{
+  "kubernetes_data_device_path": {
+    "sensitive": false,
+    "type": "string",
+    "value": "/dev/disk/by-id/virtio-kubernetes-data"
+  },
+  "master_ip_address_for_ssh": {
+    "sensitive": false,
+    "type": "string",
+    "value": "10.233.2.21"
+  },
+  "node_internal_ip_address": {
+    "sensitive": false,
+    "type": "string",
+    "value": "10.233.2.21"
+  }
+}

--- a/dhctl/pkg/terraform/mocks/pipeline/not_empty_state.json
+++ b/dhctl/pkg/terraform/mocks/pipeline/not_empty_state.json
@@ -1,0 +1,6 @@
+{
+  "format_version": "0.1",
+  "terraform_version": "0.13.4",
+  "resource_changes": [],
+  "resources": [{"test":  "test"}]
+}

--- a/dhctl/pkg/terraform/pipeline.go
+++ b/dhctl/pkg/terraform/pipeline.go
@@ -140,7 +140,7 @@ func CheckBaseInfrastructurePipeline(r *Runner, name string) (int, error) {
 			} `json:"output_changes"`
 		}
 
-		result, err := terraformCmd("show", "-json", r.planPath).Output()
+		result, err := r.terraformExecutor.Output("show", "-json", r.planPath)
 		if err != nil {
 			var ee *exec.ExitError
 			if ok := errors.As(err, &ee); ok {

--- a/dhctl/pkg/terraform/pipeline_test.go
+++ b/dhctl/pkg/terraform/pipeline_test.go
@@ -1,0 +1,201 @@
+package terraform
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
+)
+
+func TestGetMasterNodeResult(t *testing.T) {
+	state, err := os.ReadFile("./mocks/pipeline/empty_state.json")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		outputResp  fakeResponse
+		expectedRes *PipelineOutputs
+		expectedErr error
+	}{
+		{
+			name:       "Return values for master int",
+			outputResp: fakeResponse{code: 0, resp: []byte(`1`)},
+			expectedRes: &PipelineOutputs{
+				TerraformState:     state,
+				MasterIPForSSH:     "1",
+				NodeInternalIP:     "1",
+				KubeDataDevicePath: "1",
+			},
+			expectedErr: nil,
+		},
+		{
+			name:       "Return values for master string",
+			outputResp: fakeResponse{code: 0, resp: []byte(`"test-data"`)},
+			expectedRes: &PipelineOutputs{
+				TerraformState:     state,
+				MasterIPForSSH:     "test-data",
+				NodeInternalIP:     "test-data",
+				KubeDataDevicePath: "test-data",
+			},
+			expectedErr: nil,
+		},
+		{
+			name:        "With output error return err",
+			outputResp:  fakeResponse{code: 1, err: fmt.Errorf("failed")},
+			expectedRes: nil,
+			expectedErr: fmt.Errorf("can't get terraform output for \"master_ip_address_for_ssh\"\nfailed"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			executor := &fakeExecutor{data: map[string]fakeResponse{
+				"output": tc.outputResp,
+			}}
+
+			runner := newTestRunner().
+				WithName("test").
+				WithStatePath("./mocks/pipeline/empty_state.json").
+				withTerraformExecutor(executor)
+
+			res, err := GetMasterNodeResult(runner)
+			if tc.expectedErr != nil {
+				require.EqualError(t, err, tc.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.expectedRes, res)
+		})
+	}
+}
+
+func TestCheckBaseInfrastructurePipeline(t *testing.T) {
+	app.TmpDirName = "/tmp"
+
+	okPlan, err := os.ReadFile("./mocks/pipeline/base_infra_ok_plan.json")
+	require.NoError(t, err)
+
+	discoveryData, err := os.ReadFile("./mocks/pipeline/cloud_discovery_data.json")
+	require.NoError(t, err)
+
+	discoveryDataWithNewZones, err := os.ReadFile("./mocks/pipeline/cloud_discovery_data_changed_zones.json")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		showResp    fakeResponse
+		planResp    fakeResponse
+		outputResp  fakeResponse
+		expectedRes int
+		expectedErr error
+	}{
+		{
+			name:        "No changes",
+			showResp:    fakeResponse{resp: okPlan},
+			outputResp:  fakeResponse{resp: discoveryData},
+			expectedRes: PlanHasNoChanges,
+			expectedErr: nil,
+		},
+		{
+			name:        "Changes exit code",
+			planResp:    fakeResponse{code: terraformHasChangesExitCode},
+			showResp:    fakeResponse{resp: okPlan},
+			outputResp:  fakeResponse{resp: discoveryData},
+			expectedRes: PlanHasChanges,
+			expectedErr: nil,
+		},
+		{
+			name:        "Changes exit code and changed zones",
+			planResp:    fakeResponse{code: terraformHasChangesExitCode},
+			showResp:    fakeResponse{resp: discoveryDataWithNewZones},
+			expectedRes: PlanHasDestructiveChanges,
+			expectedErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			executor := &fakeExecutor{data: map[string]fakeResponse{
+				"show":   tc.showResp,
+				"plan":   tc.planResp,
+				"output": {resp: discoveryData},
+			}}
+
+			runner := newTestRunner().
+				WithName("test").
+				WithStatePath("./mocks/pipeline/empty_state.json").
+				withTerraformExecutor(executor)
+
+			res, err := CheckBaseInfrastructurePipeline(runner, "test")
+			if tc.expectedErr != nil {
+				require.EqualError(t, err, tc.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.expectedRes, res)
+		})
+	}
+}
+
+func TestDestroyPipeline(t *testing.T) {
+	tests := []struct {
+		name        string
+		stateFile   string
+		destroyResp fakeResponse
+		expectedErr error
+	}{
+		{
+			name:        "Empty state runner ok is ok",
+			stateFile:   "./mocks/pipeline/empty_state.json",
+			destroyResp: fakeResponse{},
+			expectedErr: nil,
+		},
+		{
+			name:        "Empty state runner failed still ok",
+			stateFile:   "./mocks/pipeline/empty_state.json",
+			destroyResp: fakeResponse{err: fmt.Errorf("failed")},
+			expectedErr: nil,
+		},
+		{
+			name:        "Not empty state failed destroy returns error",
+			stateFile:   "./mocks/pipeline/not_empty_state.json",
+			destroyResp: fakeResponse{code: 1, err: fmt.Errorf("failed")},
+			expectedErr: fmt.Errorf("failed"),
+		},
+		{
+			name:        "Not empty state runner ok destroy is ok",
+			stateFile:   "./mocks/pipeline/not_empty_state.json",
+			destroyResp: fakeResponse{},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			executor := &fakeExecutor{data: map[string]fakeResponse{
+				"destroy": tc.destroyResp,
+			}}
+
+			runner := newTestRunner().
+				WithName("test").
+				WithConfirm(func() *input.Confirmation {
+					return input.NewConfirmation().WithYesByDefault()
+				}).
+				WithStatePath(tc.stateFile).
+				withTerraformExecutor(executor)
+
+			err := DestroyPipeline(runner, "test")
+			if tc.expectedErr != nil {
+				require.EqualError(t, err, tc.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/dhctl/pkg/terraform/runner.go
+++ b/dhctl/pkg/terraform/runner.go
@@ -15,15 +15,13 @@
 package terraform
 
 import (
-	"bufio"
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"os/exec"
 	"path/filepath"
-	"syscall"
+	"sync/atomic"
 	"time"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
@@ -85,20 +83,26 @@ type Runner struct {
 
 	stateSaver *StateSaver
 
-	cmd     *exec.Cmd
 	confirm func() *input.Confirmation
 	stopped bool
+
+	// Atomic flag to check weather terraform is running. Do not manually change its values.
+	// Odd number - terraform is running
+	// Even number - runner is in standby mode
+	terraformRunningCounter int32
+	terraformExecutor       Executor
 }
 
 func NewRunner(provider, prefix, layout, step string, stateCache state.Cache) *Runner {
 	r := &Runner{
-		prefix:         prefix,
-		step:           step,
-		name:           step,
-		workingDir:     buildTerraformPath(provider, layout, step),
-		confirm:        input.NewConfirmation,
-		stateCache:     stateCache,
-		changeSettings: ChangeActionSettings{},
+		prefix:            prefix,
+		step:              step,
+		name:              step,
+		workingDir:        buildTerraformPath(provider, layout, step),
+		confirm:           input.NewConfirmation,
+		stateCache:        stateCache,
+		changeSettings:    ChangeActionSettings{},
+		terraformExecutor: &CMDExecutor{},
 	}
 
 	var destinations []SaverDestination
@@ -198,6 +202,19 @@ func (r *Runner) WithSkipChangesOnDeny(flag bool) *Runner {
 func (r *Runner) WithAdditionalStateSaverDestination(destinations ...SaverDestination) *Runner {
 	r.stateSaver.addDestinations(destinations...)
 	return r
+}
+
+func (r *Runner) withTerraformExecutor(t Executor) *Runner {
+	r.terraformExecutor = t
+	return r
+}
+
+func (r *Runner) switchTerraformIsRunning() {
+	atomic.AddInt32(&r.terraformRunningCounter, 1)
+}
+
+func (r *Runner) checkTerraformIsRunning() bool {
+	return (r.terraformRunningCounter % 2) > 0
 }
 
 func (r *Runner) Init() error {
@@ -369,7 +386,7 @@ func (r *Runner) Plan() error {
 		exitCode, err := r.execTerraform(args...)
 		if exitCode == terraformHasChangesExitCode {
 			r.changesInPlan = PlanHasChanges
-			hasDestructiveChanges, err := checkPlanDestructiveChanges(tmpFile.Name())
+			hasDestructiveChanges, err := r.checkPlanDestructiveChanges(tmpFile.Name())
 			if err != nil {
 				return err
 			}
@@ -401,7 +418,7 @@ func (r *Runner) GetTerraformOutput(output string) ([]byte, error) {
 	}
 	args = append(args, output)
 
-	result, err := terraformCmd(args...).Output()
+	result, err := r.terraformExecutor.Output(args...)
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
 			err = fmt.Errorf("%s\n%v", string(ee.Stderr), err)
@@ -432,8 +449,6 @@ func (r *Runner) Destroy() error {
 		}
 	}
 
-	// TODO: why is this line here?
-	// r.stopped = true
 	return log.Process("default", "terraform destroy ...", func() error {
 		err := r.stateSaver.Start(r)
 		if err != nil {
@@ -488,19 +503,13 @@ func (r *Runner) getState() ([]byte, error) {
 // Stop interrupts the current runner command and sets
 // a flag to prevent executions of next runner commands.
 func (r *Runner) Stop() {
-	if r.cmd != nil && !r.stopped {
-		log.DebugF("Runner Stop is called for %s. Interrupt terraform process by pid: %d\n", r.name, r.cmd.Process.Pid)
-		// 1. Terraform exits immediately on SIGTERM, so SIGINT is used here
-		//    to interrupt it gracefully even when main process caught the SIGTERM.
-		// 2. Negative pid is used to send signal to the process group
-		//    started by "Setpgid: true" to prevent double signaling
-		//    from shell and from us.
-		//    See also pkg/system/ssh/cmd/ssh.go
-		_ = syscall.Kill(-r.cmd.Process.Pid, syscall.SIGINT)
+	if r.checkTerraformIsRunning() && !r.stopped {
+		log.DebugF("Runner Stop is called for %s.\n", r.name)
+		r.terraformExecutor.Stop()
 	}
 	r.stopped = true
 	// Wait until the running terraform command stops.
-	for r.cmd != nil {
+	for r.checkTerraformIsRunning() {
 		time.Sleep(50 * time.Millisecond)
 	}
 	// Wait until the StateSaver saves the Secret for Apply and Destroy commands.
@@ -510,94 +519,27 @@ func (r *Runner) Stop() {
 }
 
 func (r *Runner) execTerraform(args ...string) (int, error) {
-	r.cmd = terraformCmd(args...)
-	// Start terraform as a leader of the new process group to prevent
-	// os.Interrupt (SIGINT) signal from the shell when Ctrl-C is pressed.
-	r.cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true,
+	if r.checkTerraformIsRunning() {
+		return 0, fmt.Errorf("Terraform have been already executed.")
 	}
 
-	stdout, err := r.cmd.StdoutPipe()
-	if err != nil {
-		return 1, fmt.Errorf("stdout pipe: %v", err)
-	}
+	r.switchTerraformIsRunning()
+	defer r.switchTerraformIsRunning()
 
-	stderr, err := r.cmd.StderrPipe()
-	if err != nil {
-		return 1, fmt.Errorf("stderr pipe: %v", err)
-	}
-
-	log.DebugLn(r.cmd.String())
-	err = r.cmd.Start()
-	if err != nil {
-		log.ErrorLn(err)
-		return r.cmd.ProcessState.ExitCode(), err
-	}
-
-	var errBuf bytes.Buffer
-	waitCh := make(chan error)
-	go func() {
-		e := bufio.NewScanner(stderr)
-		for e.Scan() {
-			if app.IsDebug {
-				log.DebugLn(e.Text())
-			} else {
-				errBuf.WriteString(e.Text() + "\n")
-			}
-		}
-
-		waitCh <- r.cmd.Wait()
-	}()
-
-	s := bufio.NewScanner(stdout)
-	for s.Scan() {
-		log.InfoLn(s.Text())
-	}
-
-	err = <-waitCh
+	exitCode, err := r.terraformExecutor.Exec(args...)
 	log.InfoF("Terraform runner %q process exited.\n", r.step)
 
-	exitCode := r.cmd.ProcessState.ExitCode() // 2 = exit code, if terraform plan has diff
-	if err != nil && exitCode != terraformHasChangesExitCode {
-		log.ErrorLn(err)
-		err = fmt.Errorf(errBuf.String())
-		if app.IsDebug {
-			err = fmt.Errorf("terraform has failed in DEBUG mode, search in the output above for an error")
-		}
-	}
-	r.cmd = nil
-
-	if exitCode == 0 {
-		err = nil
-	}
 	return exitCode, err
 }
 
-func buildTerraformPath(provider, layout, step string) string {
-	return filepath.Join(cloudProvidersDir, provider, "layouts", layout, step)
-}
-
-func terraformCmd(args ...string) *exec.Cmd {
-	cmd := exec.Command("terraform", args...)
-	cmd.Env = append(
-		cmd.Env,
-		"TF_IN_AUTOMATION=yes", "TF_DATA_DIR="+filepath.Join(app.TmpDirName, "tf_dhctl"),
-	)
-	if app.IsDebug {
-		// Debug mode is deprecated, however trace produces more useless information
-		cmd.Env = append(cmd.Env, "TF_LOG=DEBUG")
-	}
-	return cmd
-}
-
-func checkPlanDestructiveChanges(planFile string) (bool, error) {
+func (r *Runner) checkPlanDestructiveChanges(planFile string) (bool, error) {
 	args := []string{
 		"show",
 		"-json",
 		planFile,
 	}
 
-	result, err := terraformCmd(args...).Output()
+	result, err := r.terraformExecutor.Output(args...)
 	if err != nil {
 		var ee *exec.ExitError
 		if ok := errors.As(err, &ee); ok {
@@ -628,4 +570,8 @@ func checkPlanDestructiveChanges(planFile string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func buildTerraformPath(provider, layout, step string) string {
+	return filepath.Join(cloudProvidersDir, provider, "layouts", layout, step)
 }


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Add test for terraform runners and terraform pipelines

## Why do we need it, and what problem does it solve?
There are approximately 1k lines of the code, yet no unit tests. Entrenching runners' behavior will help developers improve the development process's stability and durability of the code and, last but not least, improve the pace.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: dhctl
type: feature
description: Add unit tests for Terraform runners.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
