### PR TITLE
[candi] speed up reboot master node on cluster bootstrap

### DIFF
--- a/candi/bashible/common-steps/all/099_reboot.sh.tpl
+++ b/candi/bashible/common-steps/all/099_reboot.sh.tpl
@@ -98,7 +98,6 @@ bb-flag-unset disruption
 bb-flag-unset reboot
   {{- if eq .cri "Containerd" }}
 systemctl stop kubelet
-systemctl stop containerd
 # to speed up reboot process, we manually stop containers and kill appropriate containerd-shim processes with SIGKILL
 # https://github.com/containerd/containerd/issues/386
 crictl stop $(crictl ps -q)

--- a/candi/bashible/common-steps/all/099_reboot.sh.tpl
+++ b/candi/bashible/common-steps/all/099_reboot.sh.tpl
@@ -103,5 +103,4 @@ systemctl stop kubelet
 crictl stop $(crictl ps -q)
 kill -KILL $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}')
   {{- end }}
-
 {{- end }}

--- a/candi/bashible/common-steps/all/099_reboot.sh.tpl
+++ b/candi/bashible/common-steps/all/099_reboot.sh.tpl
@@ -20,7 +20,6 @@ if bb-flag? reboot; then
 
   {{- if eq .runType "Normal" }}
   systemctl stop kubelet
-
   # Wait till kubelet stopped
   attempt=0
   until ! pidof kubelet > /dev/null; do
@@ -97,4 +96,13 @@ fi
 bb-flag-unset disruption
 # to prevent extra reboot during first "Normal" run.
 bb-flag-unset reboot
+  {{- if eq .cri "Containerd" }}
+systemctl stop kubelet
+systemctl stop containerd
+# to speed up reboot process, we manually stop containers and kill appropriate containerd-shim processes with SIGKILL
+# https://github.com/containerd/containerd/issues/386
+crictl stop $(crictl ps -q)
+kill -KILL $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}')
+  {{- end }}
+
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Speed up reboot master node on cluster bootstrap.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When master node reboots after bootstrap, reboot takes long time due to reboot process waits containerd-shim processes stops. This is known containerd isue https://github.com/containerd/containerd/issues/386
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: candi
type: fix
description: "Speed up reboot master node on cluster bootstrap."
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
