### PR TITLE
[deckhouse] small updater improvements

### DIFF
--- a/modules/020-deckhouse/crds/deckhouse-release.yaml
+++ b/modules/020-deckhouse/crds/deckhouse-release.yaml
@@ -81,10 +81,6 @@ spec:
           jsonPath: .status.phase
           type: string
           description: 'Current release status.'
-        - name: applyAfter
-          jsonPath: .spec.applyAfter
-          type: string
-          description: 'This release will be applied after this time.'
         - name: transitionTime
           jsonPath: .status.transitionTime
           type: date

--- a/modules/020-deckhouse/crds/doc-ru-deckhouse-release.yaml
+++ b/modules/020-deckhouse/crds/doc-ru-deckhouse-release.yaml
@@ -41,10 +41,6 @@ spec:
           jsonPath: .status.phase
           type: string
           description: 'Показывает текущий статус релиза.'
-        - name: applyAfter
-          jsonPath: .spec.applyAfter
-          type: string
-          description: 'Релиз отложен до указанного времени.'
         - name: transitionTime
           jsonPath: .status.transitionTime
           type: date


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Remove field from AdditionalPrintColumns and add a couple of status messages

## Why do we need it, and what problem does it solve?
Print column `applyAfter` is not very useful but k8s default format of time makes it annoyable to read

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: deckhouse
type: fix
description: Remove additional print column `applyAfter`
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
