### PR TITLE
[ci] fix: use tagged dev/install image to run in e2e tests

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -24,15 +24,7 @@
   LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
 {!{- end }!}
 run: |
-  echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-  werfRunProg=$(cat <<'END_WERF_RUN'
-
-  # WERF_REPO should be set by caller.
-  type werf && source $(werf ci-env github --verbose --as-file)
-
-  echo "Execute '{!{ $script }!} {!{ $script_arg }!}' via 'werf run' ...
-  Use environment:
+  echo "Execute '{!{ $script }!} {!{ $script_arg }!}' via 'docker run', using environment:
     PREFIX=${PREFIX}
     TMPPATH=${TMPPATH}
     DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -44,10 +36,7 @@ run: |
     JOB_STATUS=${JOB_STATUS}
   "
 
-  git status
-
-  werf run dev/install --dev \
-  --docker-options=" \
+  docker run --rm \
     -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
     -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
     -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -84,12 +73,10 @@ run: |
     -v /etc/group:/etc/group:ro \
     -v /etc/passwd:/etc/passwd:ro \
     -v /etc/shadow:/etc/shadow:ro \
-    -w /deckhouse" -- \
+    -w /deckhouse \
+  ${INSTALL_IMAGE_NAME} \
   bash /deckhouse/testing/cloud_layouts/{!{ $script }!} {!{ $script_arg }!}
-  END_WERF_RUN
-  )
-  # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-  bash <<<"$werfRunProg"
+
 # </template: e2e_run_template>
 {!{- end -}!}
 

--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -124,8 +124,18 @@ run_{!{ $ctx.cri }!}_{!{ $ctx.kubernetesVersionSlug }!}:
     EVENT_LABEL: ${{ github.event.label.name }}
   runs-on: [self-hosted, {!{ $runsOnLabel }!}]
   steps:
+{!{ tmpl.Exec "checkout_from_event_ref_step" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "update_comment_on_start" (printf "%s, %s, k8s %s" $ctx.workflowName $ctx.criName $ctx.kubernetesVersion) | strings.Indent 4 }!}
+{!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "login_rw_registry_step" . | strings.Indent 4 }!}
+{!{ tmpl.Exec "werf_install_step" . | strings.Indent 4 }!}
+
     - name: Setup
       id: setup
+      env:
+        DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
       run: |
         # Random delay to sparse 'update comment' steps in time.
         delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -162,14 +172,36 @@ run_{!{ $ctx.cri }!}_{!{ $ctx.kubernetesVersionSlug }!}:
         fi
         echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
 
+        ## Deckhouse 'install' image name
+        ## Source: ci_templates/build.yml
 
-{!{ tmpl.Exec "checkout_from_event_ref_step" . | strings.Indent 4 }!}
-{!{ tmpl.Exec "update_comment_on_start" (printf "%s, %s, k8s %s" $ctx.workflowName $ctx.criName $ctx.kubernetesVersion) | strings.Indent 4 }!}
-{!{ tmpl.Exec "restore_images_tags_json_from_cache_or_fail" . | strings.Indent 4 }!}
-{!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 4 }!}
-{!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 4 }!}
-{!{ tmpl.Exec "login_rw_registry_step" . | strings.Indent 4 }!}
-{!{ tmpl.Exec "werf_install_step" . | strings.Indent 4 }!}
+        IMAGE_NAME=
+        if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+            IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+          else
+            IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+          fi
+        fi
+
+        if [[ -n $CI_COMMIT_TAG ]] ; then
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+          else
+            echo "DECKHOUSE_REGISTRY_HOST is empty."
+            exit 1
+          fi
+        fi
+
+        echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+        echo "Pull dev/install image."
+        docker pull "${IMAGE_NAME}"
 
     - name: "Run e2e test: {!{ $ctx.providerName }!}/{!{ $ctx.criName }!}/{!{ $ctx.kubernetesVersion }!}"
       env:
@@ -186,6 +218,7 @@ run_{!{ $ctx.cri }!}_{!{ $ctx.kubernetesVersionSlug }!}:
         CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         TMPPATH: ${{ steps.setup.outputs.tmppath}}
         PREFIX: ${{ steps.setup.outputs.prefix}}
+        INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
 {!{- tmpl.Exec "e2e_run_template" (slice .provider "run-test") | strings.Indent 6 }!}
 
     - name: Cleanup bootstrapped cluster
@@ -205,6 +238,7 @@ run_{!{ $ctx.cri }!}_{!{ $ctx.kubernetesVersionSlug }!}:
         CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         TMPPATH: ${{ steps.setup.outputs.tmppath}}
         PREFIX: ${{ steps.setup.outputs.prefix}}
+        INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
 {!{- tmpl.Exec "e2e_run_template" (slice .provider "cleanup") | strings.Indent 6 }!}
 
     - name: Save test results

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -221,45 +221,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -281,20 +242,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -333,6 +280,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: AWS/Docker/1.19"
         env:
           PROVIDER: AWS
@@ -348,19 +367,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -372,10 +384,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -394,12 +403,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -419,19 +426,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -443,10 +443,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -465,12 +462,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -570,45 +565,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -630,20 +586,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -682,6 +624,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: AWS/Docker/1.20"
         env:
           PROVIDER: AWS
@@ -697,19 +711,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -721,10 +728,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -743,12 +747,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -768,19 +770,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -792,10 +787,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -814,12 +806,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -919,45 +909,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -979,20 +930,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1031,6 +968,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: AWS/Docker/1.21"
         env:
           PROVIDER: AWS
@@ -1046,19 +1055,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1070,10 +1072,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1092,12 +1091,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1117,19 +1114,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1141,10 +1131,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1163,12 +1150,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1268,45 +1253,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1328,20 +1274,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1380,6 +1312,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: AWS/Docker/1.22"
         env:
           PROVIDER: AWS
@@ -1395,19 +1399,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1419,10 +1416,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1441,12 +1435,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1466,19 +1458,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1490,10 +1475,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1512,12 +1494,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1617,45 +1597,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1677,20 +1618,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1729,6 +1656,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: AWS/Containerd/1.19"
         env:
           PROVIDER: AWS
@@ -1744,19 +1743,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1768,10 +1760,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1790,12 +1779,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1815,19 +1802,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1839,10 +1819,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1861,12 +1838,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1966,45 +1941,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2026,20 +1962,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2078,6 +2000,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: AWS/Containerd/1.20"
         env:
           PROVIDER: AWS
@@ -2093,19 +2087,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2117,10 +2104,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2139,12 +2123,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2164,19 +2146,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2188,10 +2163,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2210,12 +2182,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -2315,45 +2285,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2375,20 +2306,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2427,6 +2344,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: AWS/Containerd/1.21"
         env:
           PROVIDER: AWS
@@ -2442,19 +2431,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2466,10 +2448,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2488,12 +2467,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2513,19 +2490,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2537,10 +2507,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2559,12 +2526,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -2664,45 +2629,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2724,20 +2650,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2776,6 +2688,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: AWS/Containerd/1.22"
         env:
           PROVIDER: AWS
@@ -2791,19 +2775,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2815,10 +2792,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2837,12 +2811,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2862,19 +2834,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2886,10 +2851,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2908,12 +2870,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -221,45 +221,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -281,20 +242,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -333,6 +280,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Azure/Docker/1.19"
         env:
           PROVIDER: Azure
@@ -348,21 +367,14 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -374,10 +386,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -398,12 +407,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -423,21 +430,14 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -449,10 +449,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -473,12 +470,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -578,45 +573,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -638,20 +594,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -690,6 +632,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Azure/Docker/1.20"
         env:
           PROVIDER: Azure
@@ -705,21 +719,14 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -731,10 +738,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -755,12 +759,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -780,21 +782,14 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -806,10 +801,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -830,12 +822,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -935,45 +925,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -995,20 +946,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1047,6 +984,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Azure/Docker/1.21"
         env:
           PROVIDER: Azure
@@ -1062,21 +1071,14 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1088,10 +1090,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1112,12 +1111,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1137,21 +1134,14 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1163,10 +1153,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1187,12 +1174,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1292,45 +1277,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1352,20 +1298,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1404,6 +1336,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Azure/Docker/1.22"
         env:
           PROVIDER: Azure
@@ -1419,21 +1423,14 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1445,10 +1442,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1469,12 +1463,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1494,21 +1486,14 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1520,10 +1505,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1544,12 +1526,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1649,45 +1629,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1709,20 +1650,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1761,6 +1688,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Azure/Containerd/1.19"
         env:
           PROVIDER: Azure
@@ -1776,21 +1775,14 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1802,10 +1794,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1826,12 +1815,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1851,21 +1838,14 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1877,10 +1857,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1901,12 +1878,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -2006,45 +1981,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2066,20 +2002,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2118,6 +2040,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Azure/Containerd/1.20"
         env:
           PROVIDER: Azure
@@ -2133,21 +2127,14 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2159,10 +2146,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2183,12 +2167,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2208,21 +2190,14 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2234,10 +2209,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2258,12 +2230,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -2363,45 +2333,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2423,20 +2354,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2475,6 +2392,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Azure/Containerd/1.21"
         env:
           PROVIDER: Azure
@@ -2490,21 +2479,14 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2516,10 +2498,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2540,12 +2519,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2565,21 +2542,14 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2591,10 +2561,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2615,12 +2582,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -2720,45 +2685,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2780,20 +2706,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2832,6 +2744,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Azure/Containerd/1.22"
         env:
           PROVIDER: Azure
@@ -2847,21 +2831,14 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2873,10 +2850,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2897,12 +2871,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2922,21 +2894,14 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
           LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2948,10 +2913,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2972,12 +2934,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -221,45 +221,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -281,20 +242,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -333,6 +280,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: GCP/Docker/1.19"
         env:
           PROVIDER: GCP
@@ -348,18 +367,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -371,10 +383,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -392,12 +401,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -417,18 +424,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -440,10 +440,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -461,12 +458,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -566,45 +561,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -626,20 +582,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -678,6 +620,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: GCP/Docker/1.20"
         env:
           PROVIDER: GCP
@@ -693,18 +707,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -716,10 +723,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -737,12 +741,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -762,18 +764,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -785,10 +780,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -806,12 +798,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -911,45 +901,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -971,20 +922,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1023,6 +960,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: GCP/Docker/1.21"
         env:
           PROVIDER: GCP
@@ -1038,18 +1047,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1061,10 +1063,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1082,12 +1081,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1107,18 +1104,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1130,10 +1120,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1151,12 +1138,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1256,45 +1241,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1316,20 +1262,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1368,6 +1300,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: GCP/Docker/1.22"
         env:
           PROVIDER: GCP
@@ -1383,18 +1387,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1406,10 +1403,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1427,12 +1421,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1452,18 +1444,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1475,10 +1460,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1496,12 +1478,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1601,45 +1581,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1661,20 +1602,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1713,6 +1640,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: GCP/Containerd/1.19"
         env:
           PROVIDER: GCP
@@ -1728,18 +1727,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1751,10 +1743,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1772,12 +1761,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1797,18 +1784,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1820,10 +1800,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1841,12 +1818,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1946,45 +1921,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2006,20 +1942,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2058,6 +1980,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: GCP/Containerd/1.20"
         env:
           PROVIDER: GCP
@@ -2073,18 +2067,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2096,10 +2083,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2117,12 +2101,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2142,18 +2124,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2165,10 +2140,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2186,12 +2158,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -2291,45 +2261,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2351,20 +2282,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2403,6 +2320,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: GCP/Containerd/1.21"
         env:
           PROVIDER: GCP
@@ -2418,18 +2407,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2441,10 +2423,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2462,12 +2441,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2487,18 +2464,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2510,10 +2480,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2531,12 +2498,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -2636,45 +2601,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2696,20 +2622,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2748,6 +2660,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: GCP/Containerd/1.22"
         env:
           PROVIDER: GCP
@@ -2763,18 +2747,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2786,10 +2763,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2807,12 +2781,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2832,18 +2804,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2855,10 +2820,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2876,12 +2838,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -221,45 +221,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -281,20 +242,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -333,6 +280,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: OpenStack/Docker/1.19"
         env:
           PROVIDER: OpenStack
@@ -348,18 +367,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -371,10 +383,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -392,12 +401,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -417,18 +424,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -440,10 +440,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -461,12 +458,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -566,45 +561,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -626,20 +582,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -678,6 +620,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: OpenStack/Docker/1.20"
         env:
           PROVIDER: OpenStack
@@ -693,18 +707,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -716,10 +723,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -737,12 +741,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -762,18 +764,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -785,10 +780,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -806,12 +798,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -911,45 +901,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -971,20 +922,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1023,6 +960,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: OpenStack/Docker/1.21"
         env:
           PROVIDER: OpenStack
@@ -1038,18 +1047,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1061,10 +1063,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1082,12 +1081,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1107,18 +1104,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1130,10 +1120,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1151,12 +1138,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1256,45 +1241,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1316,20 +1262,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1368,6 +1300,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: OpenStack/Docker/1.22"
         env:
           PROVIDER: OpenStack
@@ -1383,18 +1387,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1406,10 +1403,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1427,12 +1421,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1452,18 +1444,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1475,10 +1460,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1496,12 +1478,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1601,45 +1581,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1661,20 +1602,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1713,6 +1640,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: OpenStack/Containerd/1.19"
         env:
           PROVIDER: OpenStack
@@ -1728,18 +1727,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1751,10 +1743,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1772,12 +1761,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1797,18 +1784,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1820,10 +1800,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1841,12 +1818,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1946,45 +1921,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2006,20 +1942,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2058,6 +1980,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: OpenStack/Containerd/1.20"
         env:
           PROVIDER: OpenStack
@@ -2073,18 +2067,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2096,10 +2083,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2117,12 +2101,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2142,18 +2124,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2165,10 +2140,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2186,12 +2158,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -2291,45 +2261,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2351,20 +2282,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2403,6 +2320,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: OpenStack/Containerd/1.21"
         env:
           PROVIDER: OpenStack
@@ -2418,18 +2407,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2441,10 +2423,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2462,12 +2441,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2487,18 +2464,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2510,10 +2480,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2531,12 +2498,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -2636,45 +2601,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2696,20 +2622,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2748,6 +2660,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: OpenStack/Containerd/1.22"
         env:
           PROVIDER: OpenStack
@@ -2763,18 +2747,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2786,10 +2763,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2807,12 +2781,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2832,18 +2804,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2855,10 +2820,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2876,12 +2838,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -221,45 +221,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -281,20 +242,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -333,6 +280,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Static/Docker/1.19"
         env:
           PROVIDER: Static
@@ -348,18 +367,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -371,10 +383,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -392,12 +401,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -417,18 +424,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -440,10 +440,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -461,12 +458,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -566,45 +561,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -626,20 +582,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -678,6 +620,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Static/Docker/1.20"
         env:
           PROVIDER: Static
@@ -693,18 +707,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -716,10 +723,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -737,12 +741,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -762,18 +764,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -785,10 +780,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -806,12 +798,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -911,45 +901,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -971,20 +922,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1023,6 +960,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Static/Docker/1.21"
         env:
           PROVIDER: Static
@@ -1038,18 +1047,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1061,10 +1063,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1082,12 +1081,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1107,18 +1104,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1130,10 +1120,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1151,12 +1138,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1256,45 +1241,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1316,20 +1262,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1368,6 +1300,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Static/Docker/1.22"
         env:
           PROVIDER: Static
@@ -1383,18 +1387,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1406,10 +1403,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1427,12 +1421,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1452,18 +1444,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1475,10 +1460,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1496,12 +1478,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1601,45 +1581,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1661,20 +1602,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1713,6 +1640,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Static/Containerd/1.19"
         env:
           PROVIDER: Static
@@ -1728,18 +1727,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1751,10 +1743,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1772,12 +1761,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1797,18 +1784,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1820,10 +1800,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1841,12 +1818,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1946,45 +1921,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2006,20 +1942,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2058,6 +1980,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Static/Containerd/1.20"
         env:
           PROVIDER: Static
@@ -2073,18 +2067,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2096,10 +2083,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2117,12 +2101,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2142,18 +2124,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2165,10 +2140,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2186,12 +2158,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -2291,45 +2261,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2351,20 +2282,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2403,6 +2320,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Static/Containerd/1.21"
         env:
           PROVIDER: Static
@@ -2418,18 +2407,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2441,10 +2423,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2462,12 +2441,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2487,18 +2464,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2510,10 +2480,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2531,12 +2498,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -2636,45 +2601,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2696,20 +2622,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2748,6 +2660,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Static/Containerd/1.22"
         env:
           PROVIDER: Static
@@ -2763,18 +2747,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2786,10 +2763,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2807,12 +2781,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2832,18 +2804,11 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2855,10 +2820,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2876,12 +2838,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -221,45 +221,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -281,20 +242,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -333,6 +280,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: vSphere/Docker/1.19"
         env:
           PROVIDER: vSphere
@@ -348,19 +367,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -372,10 +384,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -394,12 +403,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -419,19 +426,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -443,10 +443,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -465,12 +462,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -570,45 +565,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -630,20 +586,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -682,6 +624,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: vSphere/Docker/1.20"
         env:
           PROVIDER: vSphere
@@ -697,19 +711,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -721,10 +728,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -743,12 +747,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -768,19 +770,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -792,10 +787,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -814,12 +806,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -919,45 +909,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -979,20 +930,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1031,6 +968,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: vSphere/Docker/1.21"
         env:
           PROVIDER: vSphere
@@ -1046,19 +1055,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1070,10 +1072,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1092,12 +1091,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1117,19 +1114,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1141,10 +1131,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1163,12 +1150,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1268,45 +1253,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1328,20 +1274,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1380,6 +1312,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: vSphere/Docker/1.22"
         env:
           PROVIDER: vSphere
@@ -1395,19 +1399,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1419,10 +1416,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1441,12 +1435,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1466,19 +1458,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1490,10 +1475,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1512,12 +1494,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1617,45 +1597,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1677,20 +1618,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1729,6 +1656,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: vSphere/Containerd/1.19"
         env:
           PROVIDER: vSphere
@@ -1744,19 +1743,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1768,10 +1760,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1790,12 +1779,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1815,19 +1802,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1839,10 +1819,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1861,12 +1838,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1966,45 +1941,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2026,20 +1962,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2078,6 +2000,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: vSphere/Containerd/1.20"
         env:
           PROVIDER: vSphere
@@ -2093,19 +2087,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2117,10 +2104,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2139,12 +2123,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2164,19 +2146,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2188,10 +2163,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2210,12 +2182,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -2315,45 +2285,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2375,20 +2306,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2427,6 +2344,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: vSphere/Containerd/1.21"
         env:
           PROVIDER: vSphere
@@ -2442,19 +2431,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2466,10 +2448,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2488,12 +2467,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2513,19 +2490,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2537,10 +2507,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2559,12 +2526,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -2664,45 +2629,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-vsphere]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2724,20 +2650,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2776,6 +2688,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: vSphere/Containerd/1.22"
         env:
           PROVIDER: vSphere
@@ -2791,19 +2775,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2815,10 +2792,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2837,12 +2811,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2862,19 +2834,12 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2886,10 +2851,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2908,12 +2870,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -221,45 +221,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -281,20 +242,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -333,6 +280,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Yandex.Cloud/Docker/1.19"
         env:
           PROVIDER: Yandex.Cloud
@@ -348,20 +367,13 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -373,10 +385,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -396,12 +405,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -421,20 +428,13 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -446,10 +446,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -469,12 +466,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -574,45 +569,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -634,20 +590,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -686,6 +628,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Yandex.Cloud/Docker/1.20"
         env:
           PROVIDER: Yandex.Cloud
@@ -701,20 +715,13 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -726,10 +733,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -749,12 +753,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -774,20 +776,13 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -799,10 +794,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -822,12 +814,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -927,45 +917,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -987,20 +938,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1039,6 +976,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Yandex.Cloud/Docker/1.21"
         env:
           PROVIDER: Yandex.Cloud
@@ -1054,20 +1063,13 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1079,10 +1081,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1102,12 +1101,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1127,20 +1124,13 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1152,10 +1142,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1175,12 +1162,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1280,45 +1265,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1340,20 +1286,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1392,6 +1324,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Yandex.Cloud/Docker/1.22"
         env:
           PROVIDER: Yandex.Cloud
@@ -1407,20 +1411,13 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1432,10 +1429,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1455,12 +1449,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1480,20 +1472,13 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1505,10 +1490,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1528,12 +1510,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1633,45 +1613,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -1693,20 +1634,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -1745,6 +1672,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.19"
         env:
           PROVIDER: Yandex.Cloud
@@ -1760,20 +1759,13 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1785,10 +1777,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1808,12 +1797,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -1833,20 +1820,13 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -1858,10 +1838,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -1881,12 +1858,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -1986,45 +1961,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2046,20 +1982,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2098,6 +2020,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.20"
         env:
           PROVIDER: Yandex.Cloud
@@ -2113,20 +2107,13 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2138,10 +2125,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2161,12 +2145,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2186,20 +2168,13 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2211,10 +2186,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2234,12 +2206,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -2339,45 +2309,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2399,20 +2330,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2451,6 +2368,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.21"
         env:
           PROVIDER: Yandex.Cloud
@@ -2466,20 +2455,13 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2491,10 +2473,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2514,12 +2493,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2539,20 +2516,13 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2564,10 +2534,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2587,12 +2554,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results
@@ -2692,45 +2657,6 @@ jobs:
       EVENT_LABEL: ${{ github.event.label.name }}
     runs-on: [self-hosted, e2e-common]
     steps:
-      - name: Setup
-        id: setup
-        run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
-          # Calculate unique prefix for e2e test.
-          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
-
-          # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
-            exit 1
-          else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
-          fi
-          echo "::set-output name=tmppath::${tmppath}"
-
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
-
 
       # <template: checkout_from_event_ref_step>
       - name: Checkout sources
@@ -2752,20 +2678,6 @@ jobs:
             return await ci.updateCommentOnStart({github, context, core, name})
 
       # </template: update_comment_on_start>
-
-      # <template: restore_images_tags_json_from_cache_or_fail>
-      - name: Restore images_tags_json from cache
-        id: images-tags-json
-        uses: actions/cache@v2.1.7
-        with:
-          path: modules/images_tags_${{env.WERF_ENV}}.json
-          key: images_tags_json-${{env.WERF_ENV}}-${{needs.git_info.outputs.github_sha}}
-      - name: Fail if not found
-        if: steps.images-tags-json.outputs.cache-hit != 'true'
-        run: |
-          echo images_tags_${WERF_ENV}.json file not found in cache: restart build modules job.
-          exit 1
-      # </template: restore_images_tags_json_from_cache_or_fail>
 
       # <template: login_dev_registry_step>
       - name: Login to dev registry
@@ -2804,6 +2716,78 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          prefix=${GITHUB_RUN_ID}-$(echo ${KUBERNETES_VERSION} | tr '.' '-')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
+          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
+
+          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
+            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
+          fi
+          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
+            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
+            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
+          fi
+          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            # Use it as image tag.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+
+            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
+              IMAGE_NAME=${DEV_REGISTRY_PATH}/dev/install:${IMAGE_TAG}
+            else
+              IMAGE_NAME=${CI_REGISTRY_IMAGE}/dev/install:${IMAGE_TAG}
+            fi
+          fi
+
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            else
+              echo "DECKHOUSE_REGISTRY_HOST is empty."
+              exit 1
+            fi
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          echo "Pull dev/install image."
+          docker pull "${IMAGE_NAME}"
+
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.22"
         env:
           PROVIDER: Yandex.Cloud
@@ -2819,20 +2803,13 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh run-test' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2844,10 +2821,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2867,12 +2841,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh run-test
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Cleanup bootstrapped cluster
@@ -2892,20 +2864,13 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
-          echo "Workflow url: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-
-          werfRunProg=$(cat <<'END_WERF_RUN'
-
-          # WERF_REPO should be set by caller.
-          type werf && source $(werf ci-env github --verbose --as-file)
-
-          echo "Execute 'script.sh cleanup' via 'werf run' ...
-          Use environment:
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
             PREFIX=${PREFIX}
             TMPPATH=${TMPPATH}
             DEV_BRANCH=${CI_COMMIT_REF_SLUG}
@@ -2917,10 +2882,7 @@ jobs:
             JOB_STATUS=${JOB_STATUS}
           "
 
-          git status
-
-          werf run dev/install --dev \
-          --docker-options=" \
+          docker run --rm \
             -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
             -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
@@ -2940,12 +2902,10 @@ jobs:
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
             -v /etc/shadow:/etc/shadow:ro \
-            -w /deckhouse" -- \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
           bash /deckhouse/testing/cloud_layouts/script.sh cleanup
-          END_WERF_RUN
-          )
-          # Run werf in a subshell to fix 'Cancel workflow'. Actually, better not press this button.
-          bash <<<"$werfRunProg"
+
         # </template: e2e_run_template>
 
       - name: Save test results


### PR DESCRIPTION
## Description

Save 'dev/install' image name and use `docker run` to start e2e tests.

## Why do we need it, and what problem does it solve?

`werf run` could rebuild some stages and it makes e2e test last more than 30 minutes.

<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: ci
type: fix
description: use docker run to start e2e tests
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
