### PR TITLE
[kube-dns] Add the cacheTTLSeconds option for stub zones

### DIFF
--- a/modules/042-kube-dns/openapi/config-values.yaml
+++ b/modules/042-kube-dns/openapi/config-values.yaml
@@ -24,12 +24,18 @@ properties:
           type: string
           pattern: '^[0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}$'
   stubZones:
+    x-examples:
+    -
+      - zone: example.com
+        upstreamNameservers: ['8.8.8.8']
+        cacheTTLSeconds: 3600
     description: |
       A list of additional zones CoreDNS should be authoritative for.
     type: array
     default: []
     items:
       type: object
+      required: ['zone', 'upstreamNameservers']
       properties:
         zone:
           description: |
@@ -38,12 +44,20 @@ properties:
           pattern: '^[0-9a-zA-Z\.-]+$'
           x-doc-example: consul.local
         upstreamNameservers:
+          mixLength: 1
           description: |
             A list of IP addresses of recursive DNS servers that CoreDNS will use to resolve domains in this zone.
           type: array
           items:
             type: string
             pattern: '^[0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}(:[0-9]{1,})?$'
+        cacheTTLSeconds:
+          type: integer
+          default: 30
+          minimum: 1
+          maximum: 3600
+          description: |
+            Max TTL in seconds for NOERROR responses.
   enableLogs:
     description: |
       Enable CoreDNS logging.

--- a/modules/042-kube-dns/openapi/doc-ru-config-values.yaml
+++ b/modules/042-kube-dns/openapi/doc-ru-config-values.yaml
@@ -18,6 +18,9 @@ properties:
         upstreamNameservers:
           description: |
             Список IP-адресов рекурсивных DNS-серверов, которые CoreDNS будет использовать для разрешения доменов в этой зоне.
+        cacheTTLSeconds:
+          description: |
+            Максимальный TTL в секундах для успешных запросов.
   enableLogs:
     description: |
       Позволяет включить логирование в CoreDNS.

--- a/modules/042-kube-dns/openapi/openapi-case-tests.yaml
+++ b/modules/042-kube-dns/openapi/openapi-case-tests.yaml
@@ -12,6 +12,11 @@ positive:
       - zone: consul.local
         upstreamNameservers:
         - 10.150.0.1
+    - stubZones:
+      - zone: consul.local
+        upstreamNameservers:
+          - 10.150.0.1
+        cacheTTLSeconds: 40
     - enableLogs: true
     - clusterDomainAliases:
       - foo.bar
@@ -37,6 +42,21 @@ negative:
     - enableLogs: 1
     - clusterDomainAliases:
       - foo?.bar
+    - stubZones:
+      - zone: consul.local:53
+        upstreamNameservers:
+        - 10.10.0.1
+        cacheTTLSeconds: 3800
+    - stubZones:
+      - zone: consul.local:53
+        upstreamNameservers:
+          - 10.10.0.1
+        cacheTTLSeconds: "abc"
+    - stubZones:
+      - zone: consul.local:53
+        upstreamNameservers: []
+    - stubZones:
+      - zone: consul.local:53
   values:
     - internal:
         enablePodAntiAffinity: 1

--- a/modules/042-kube-dns/templates/configmap.yaml
+++ b/modules/042-kube-dns/templates/configmap.yaml
@@ -41,7 +41,7 @@ data:
     {{- end }}
     {{ $zone.zone }} {
         errors
-        cache 30
+        cache {{ $zone.cacheSeconds | default "30" }}
         loop
         reload
         loadbalance


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Add ability to tune cache TTL for stub zones.

## Why do we need it, and what problem does it solve?
Some nameservers demand more caching time, and some of them require less.

Closes https://github.com/deckhouse/deckhouse/issues/811

## Changelog entries

```changes
module: kube-dns
type: feature
description: Add ability to tune cache TTL for stub zones.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
