### PR TITLE
[extended-monitoring] Bump events exporter to v0.0.2

### DIFF
--- a/ee/fe/modules/340-extended-monitoring/images/events-exporter/Dockerfile
+++ b/ee/fe/modules/340-extended-monitoring/images/events-exporter/Dockerfile
@@ -16,7 +16,7 @@ ARG GOPROXY
 
 ENV GOARCH=amd64
 RUN apk add --no-cache make git && \
-    git clone --branch v0.0.1 --depth 1 https://github.com/nabokihms/events_exporter.git . && \
+    git clone --branch v0.0.2 --depth 1 https://github.com/nabokihms/events_exporter.git . && \
     make build
 
 

--- a/ee/fe/modules/340-extended-monitoring/templates/events-exporter/deployment.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/events-exporter/deployment.yaml
@@ -52,6 +52,7 @@ spec:
         {{- if eq .Values.extendedMonitoring.events.severityLevel "OnlyWarnings" }}
         - "-kube.field-selector=type!=Normal"
         {{- end }}
+        - "-kube.omit-events-messages"
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
Reduce event metrics cardinality.

## Changelog entries

```changes
module: extended-monitoring
type: feature
description: Update events_exporter and omit the message field. 
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
