### PR TITLE
[dhctl] Create additional kube resources in order

### DIFF
--- a/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
@@ -293,7 +293,7 @@ func DefineBootstrapCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 		// next parse and check resources
 		// do it after bootstrap cloud because resources can be template
 		// and we want to fail immediately if template has errors
-		var resourcesToCreate *template.Resources
+		var resourcesToCreate template.Resources
 		if app.ResourcesPath != "" {
 			parsedResources, err := template.ParseResources(app.ResourcesPath, resourcesTemplateData)
 			if err != nil {

--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -132,7 +132,7 @@ func DefineCreateResourcesCommand(parent *kingpin.CmdClause) *kingpin.CmdClause 
 	app.DefineKubeFlags(cmd)
 
 	runFunc := func() error {
-		var resourcesToCreate *template.Resources
+		var resourcesToCreate template.Resources
 		if app.ResourcesPath != "" {
 			parsedResources, err := template.ParseResources(app.ResourcesPath, nil)
 			if err != nil {
@@ -142,7 +142,7 @@ func DefineCreateResourcesCommand(parent *kingpin.CmdClause) *kingpin.CmdClause 
 			resourcesToCreate = parsedResources
 		}
 
-		if resourcesToCreate == nil || len(resourcesToCreate.Items) == 0 {
+		if resourcesToCreate == nil || len(resourcesToCreate) == 0 {
 			log.WarnLn("Resources to create were not found.")
 			return nil
 		}

--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -80,10 +80,10 @@ type Creator struct {
 	resources []*template.Resource
 }
 
-func NewCreator(kubeCl *client.KubernetesClient, resources *template.Resources) *Creator {
+func NewCreator(kubeCl *client.KubernetesClient, resources template.Resources) *Creator {
 	return &Creator{
 		kubeCl:    kubeCl,
-		resources: resources.Items,
+		resources: resources,
 	}
 }
 
@@ -217,7 +217,7 @@ func (c *Creator) createSingleResource(resource *template.Resource) error {
 	})
 }
 
-func CreateResourcesLoop(kubeCl *client.KubernetesClient, resources *template.Resources) error {
+func CreateResourcesLoop(kubeCl *client.KubernetesClient, resources template.Resources) error {
 	timeout, err := time.ParseDuration(app.ResourcesTimeout)
 	if err != nil {
 		return fmt.Errorf("cannot parse timeout to create resources: %v", err)

--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -16,6 +16,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -33,46 +34,122 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
-func CreateResources(kubeCl *client.KubernetesClient, resources *template.Resources) error {
-	for gvk := range resources.Items {
-		var resourcesList *metav1.APIResourceList
-		var err error
-		err = retry.NewSilentLoop("Get resources list", 25, 5*time.Second).Run(func() error {
-			resourcesList, err = kubeCl.Discovery().ServerResourcesForGroupVersion(gvk.GroupVersion().String())
-			if err != nil {
-				return fmt.Errorf("can't get preferred resources: %w", err)
+var ErrNotAllResourcesCreated = fmt.Errorf("Not all resources were creatated")
+
+// apiResourceListGetter discovery and cache APIResources list for group version kind
+type apiResourceListGetter struct {
+	kubeCl             *client.KubernetesClient
+	gvkToResourcesList map[string]*metav1.APIResourceList
+}
+
+func newAPIResourceListGetter(kubeCl *client.KubernetesClient) *apiResourceListGetter {
+	return &apiResourceListGetter{
+		kubeCl:             kubeCl,
+		gvkToResourcesList: make(map[string]*metav1.APIResourceList),
+	}
+}
+
+func (g *apiResourceListGetter) Get(gvk *schema.GroupVersionKind) (*metav1.APIResourceList, error) {
+	key := gvk.GroupVersion().String()
+	if resourcesList, ok := g.gvkToResourcesList[key]; ok {
+		return resourcesList, nil
+	}
+
+	var resourcesList *metav1.APIResourceList
+	var err error
+	err = retry.NewSilentLoop("Get resources list", 25, 5*time.Second).Run(func() error {
+		// ServerResourcesForGroupVersion does not return error if API returned NotFound (404) or Forbidden (403)
+		// https://github.com/kubernetes/client-go/blob/51a4fd4aee686931f6a53148b3f4c9094f80d512/discovery/discovery_client.go#L204
+		// and if CRD was not deployed method will return empty APIResources list
+		resourcesList, err = g.kubeCl.Discovery().ServerResourcesForGroupVersion(gvk.GroupVersion().String())
+		if err != nil {
+			return fmt.Errorf("can't get preferred resources: %w", err)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resourcesList, nil
+}
+
+type Creator struct {
+	kubeCl    *client.KubernetesClient
+	resources []*template.Resource
+}
+
+func NewCreator(kubeCl *client.KubernetesClient, resources *template.Resources) *Creator {
+	return &Creator{
+		kubeCl:    kubeCl,
+		resources: resources.Items,
+	}
+}
+
+func (c *Creator) createAll() error {
+	apiResourceGetter := newAPIResourceListGetter(c.kubeCl)
+	addedResourcesIndexes := make(map[int]struct{})
+
+	defer func() {
+		remainResources := make([]*template.Resource, 0)
+
+		for i, resource := range c.resources {
+			if _, ok := addedResourcesIndexes[i]; !ok {
+				remainResources = append(remainResources, resource)
 			}
-			return nil
-		})
+		}
+
+		c.resources = remainResources
+	}()
+
+	for indx, resource := range c.resources {
+		resourcesList, err := apiResourceGetter.Get(&resource.GVK)
 		if err != nil {
 			return err
 		}
 
 		for _, discoveredResource := range resourcesList.APIResources {
-			if discoveredResource.Kind != gvk.Kind {
+			if discoveredResource.Kind != resource.GVK.Kind {
 				continue
 			}
-			if err := createSingleResource(kubeCl, resources, gvk); err != nil {
+			if err := c.createSingleResource(resource); err != nil {
 				return err
 			}
-			delete(resources.Items, gvk)
+
+			addedResourcesIndexes[indx] = struct{}{}
 			break
 		}
 	}
 
-	resourcesToCreate := make([]string, 0, len(resources.Items))
-	for key := range resources.Items {
-		resourcesToCreate = append(resourcesToCreate, key.String())
-	}
-
-	if len(resourcesToCreate) > 0 {
-		log.InfoF("\rResources to create: \n\t%s\n\n", strings.Join(resourcesToCreate, "\n\t"))
-	}
 	return nil
 }
 
-func isNamespaced(kubeCl *client.KubernetesClient, gvk schema.GroupVersionKind, name string) (bool, error) {
-	lists, err := kubeCl.APIResourceList(gvk.GroupVersion().String())
+func (c *Creator) TryToCreate() error {
+	if err := c.createAll(); err != nil {
+		return err
+	}
+
+	gvks := make(map[string]struct{})
+	resourcesToCreate := make([]string, 0, len(c.resources))
+	for _, resource := range c.resources {
+		key := resource.GVK.String()
+		if _, ok := gvks[key]; !ok {
+			gvks[key] = struct{}{}
+			resourcesToCreate = append(resourcesToCreate, key)
+		}
+	}
+
+	if len(c.resources) > 0 {
+		log.InfoF("\rResources to create: \n\t%s\n\n", strings.Join(resourcesToCreate, "\n\t"))
+		return ErrNotAllResourcesCreated
+	}
+
+	return nil
+}
+
+func (c *Creator) isNamespaced(gvk schema.GroupVersionKind, name string) (bool, error) {
+	lists, err := c.kubeCl.APIResourceList(gvk.GroupVersion().String())
 	if err != nil && len(lists) == 0 {
 		// apiVersion is defined and there is a ServerResourcesForGroupVersion error
 		return false, err
@@ -93,52 +170,50 @@ func isNamespaced(kubeCl *client.KubernetesClient, gvk schema.GroupVersionKind, 
 	return namespaced, nil
 }
 
-func createSingleResource(kubeCl *client.KubernetesClient, resources *template.Resources, gvk schema.GroupVersionKind) error {
+func (c *Creator) createSingleResource(resource *template.Resource) error {
+	doc := resource.Object
+	gvk := resource.GVK
+
 	return retry.NewLoop(fmt.Sprintf("Create %s resources", gvk.String()), 25, 5*time.Second).Run(func() error {
-		gvr, err := kubeCl.GroupVersionResource(gvk.ToAPIVersionAndKind())
+		gvr, err := c.kubeCl.GroupVersionResource(gvk.ToAPIVersionAndKind())
 		if err != nil {
 			return fmt.Errorf("can't get resource by kind and apiVersion: %w", err)
 		}
 
-		namespaced, err := isNamespaced(kubeCl, gvk, gvr.Resource)
+		namespaced, err := c.isNamespaced(gvk, gvr.Resource)
 		if err != nil {
 			return fmt.Errorf("can't determine whether a resource is namespaced or not: %v", err)
 		}
 
-		item := resources.Items[gvk]
-		for _, doc := range item.Items {
-			docCopy := doc.DeepCopy()
-			namespace := docCopy.GetNamespace()
-			if namespace == metav1.NamespaceNone && namespaced {
-				namespace = metav1.NamespaceDefault
-			}
-
-			manifestTask := actions.ManifestTask{
-				Name:     getUnstructuredName(docCopy),
-				Manifest: func() interface{} { return nil },
-				CreateFunc: func(manifest interface{}) error {
-					_, err := kubeCl.Dynamic().Resource(gvr).
-						Namespace(namespace).
-						Create(context.TODO(), docCopy, metav1.CreateOptions{})
-					return err
-				},
-				UpdateFunc: func(manifest interface{}) error {
-					content, err := docCopy.MarshalJSON()
-					if err != nil {
-						return err
-					}
-					// using patch here because of https://github.com/kubernetes/kubernetes/issues/70674
-					_, err = kubeCl.Dynamic().Resource(gvr).
-						Namespace(namespace).
-						Patch(context.TODO(), docCopy.GetName(), types.MergePatchType, content, metav1.PatchOptions{})
-					return err
-				},
-			}
-			if err := manifestTask.CreateOrUpdate(); err != nil {
-				return err
-			}
+		docCopy := doc.DeepCopy()
+		namespace := docCopy.GetNamespace()
+		if namespace == metav1.NamespaceNone && namespaced {
+			namespace = metav1.NamespaceDefault
 		}
-		return nil
+
+		manifestTask := actions.ManifestTask{
+			Name:     getUnstructuredName(docCopy),
+			Manifest: func() interface{} { return nil },
+			CreateFunc: func(manifest interface{}) error {
+				_, err := c.kubeCl.Dynamic().Resource(gvr).
+					Namespace(namespace).
+					Create(context.TODO(), docCopy, metav1.CreateOptions{})
+				return err
+			},
+			UpdateFunc: func(manifest interface{}) error {
+				content, err := docCopy.MarshalJSON()
+				if err != nil {
+					return err
+				}
+				// using patch here because of https://github.com/kubernetes/kubernetes/issues/70674
+				_, err = c.kubeCl.Dynamic().Resource(gvr).
+					Namespace(namespace).
+					Patch(context.TODO(), docCopy.GetName(), types.MergePatchType, content, metav1.PatchOptions{})
+				return err
+			},
+		}
+
+		return manifestTask.CreateOrUpdate()
 	})
 }
 
@@ -152,13 +227,15 @@ func CreateResourcesLoop(kubeCl *client.KubernetesClient, resources *template.Re
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
 
+	resourceCreator := NewCreator(kubeCl, resources)
+
 	for {
-		err := CreateResources(kubeCl, resources)
-		if err != nil {
+		err := resourceCreator.TryToCreate()
+		if err != nil && !errors.Is(err, ErrNotAllResourcesCreated) {
 			return err
 		}
 
-		if len(resources.Items) == 0 {
+		if err == nil {
 			return nil
 		}
 

--- a/dhctl/pkg/template/resources.go
+++ b/dhctl/pkg/template/resources.go
@@ -140,6 +140,8 @@ func ParseResources(path string, data map[string]interface{}) (Resources, error)
 
 	docs := BigFileSplit(content)
 
+	// false-positive for `Consider preallocating `resources` (prealloc)`
+	//nolint:prealloc
 	var resources Resources = make([]*Resource, 0, len(docs))
 	for _, doc := range docs {
 		doc = strings.TrimSpace(doc)

--- a/dhctl/pkg/template/resources_test.go
+++ b/dhctl/pkg/template/resources_test.go
@@ -35,31 +35,56 @@ func fromUnstructured(unstructuredObj unstructured.Unstructured, obj interface{}
 	}
 }
 
-func TestResourcesWithoutTemplateData(t *testing.T) {
-	assertNs := func(t *testing.T, resources *Resources, indx int, name string) {
+func TestResourcesOrder(t *testing.T) {
+	unknownAdditionalOrder := []string{
+		"ClusterAuthorizationRule",
+		"YandexInstanceClass",
+		"NodeGroup",
+	}
+	expectedLen := len(unknownAdditionalOrder) + len(bootstrapKindsOrder)
+
+	resources, err := ParseResources("testdata/resources/order.yaml", nil)
+	require.NoError(t, err)
+
+	require.Len(t, resources, expectedLen)
+
+	t.Run("known resources should be located in begin and in order", func(t *testing.T) {
+		for i, kind := range bootstrapKindsOrder {
+			require.Equal(t, kind, resources[i].Object.GetKind())
+		}
+	})
+
+	t.Run("unknown resources should be located after known resources in order same in yaml", func(t *testing.T) {
+		for i, kind := range unknownAdditionalOrder {
+			indx := i + len(bootstrapKindsOrder)
+			require.Equal(t, kind, resources[indx].Object.GetKind())
+		}
+	})
+}
+
+func TestResourcesOrderWithSameKind(t *testing.T) {
+	assertNs := func(t *testing.T, resources Resources, indx int, name string) {
 		ns := v1.Namespace{}
 
-		fromUnstructured(resources.Items[indx].Object, &ns)
+		fromUnstructured(resources[indx].Object, &ns)
 		require.Equal(t, ns.Name, name)
-		require.Equal(t, resources.Items[indx].GVK, schema.GroupVersionKind{Version: "v1", Kind: "Namespace"})
+		require.Equal(t, resources[indx].GVK, schema.GroupVersionKind{Version: "v1", Kind: "Namespace"})
 	}
 
-	t.Run("parse resources from multidocument without template data in order", func(t *testing.T) {
-		resources, err := ParseResources("testdata/resources/without_tmp.yaml", nil)
-		require.NoError(t, err)
+	resources, err := ParseResources("testdata/resources/same_kind_order.yaml", nil)
+	require.NoError(t, err)
 
-		require.Len(t, resources.Items, 3)
+	require.Len(t, resources, 5)
 
-		assertNs(t, resources, 0, "test-ns")
-
-		cm := v1.ConfigMap{}
-		fromUnstructured(resources.Items[1].Object, &cm)
-		require.Equal(t, cm.Namespace, "test-ns")
-		require.Equal(t, cm.Name, "some-cm")
-		require.Contains(t, cm.Data["key"], "value")
-		require.Equal(t, resources.Items[1].GVK, cmKind)
-
-		assertNs(t, resources, 2, "another-ns")
+	t.Run("resources with same kind should sort on name alphanumeric order", func(t *testing.T) {
+		namesInOrder := []string{
+			"another",
+			"r-test",
+			"test-ns",
+		}
+		for i, name := range namesInOrder {
+			assertNs(t, resources, i, name)
+		}
 	})
 }
 
@@ -79,10 +104,10 @@ func TestResourcesWithTemplateData(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		require.Len(t, resources.Items, 1)
+		require.Len(t, resources, 1)
 
 		cm := v1.ConfigMap{}
-		fromUnstructured(resources.Items[0].Object, &cm)
+		fromUnstructured(resources[0].Object, &cm)
 
 		require.Equal(t, cm.Namespace, "test-ns")
 		require.Equal(t, cm.Name, "some-cm")
@@ -91,7 +116,7 @@ func TestResourcesWithTemplateData(t *testing.T) {
 		require.Equal(t, cm.Data["fromCloudDiscovery"], expectedValueFromCloudData)
 		require.Equal(t, cm.Data["sprigFuncAvailable"], "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b")
 
-		require.Equal(t, resources.Items[0].GVK, cmKind)
+		require.Equal(t, resources[0].GVK, cmKind)
 	})
 }
 

--- a/dhctl/pkg/template/testdata/resources/order.yaml
+++ b/dhctl/pkg/template/testdata/resources/order.yaml
@@ -1,0 +1,492 @@
+apiVersion: deckhouse.io/v1
+kind: ClusterAuthorizationRule
+metadata:
+  name: admin
+spec:
+  subjects:
+    - kind: User
+      name: admin@example.com
+  accessLevel: SuperAdmin
+  portForwarding: true
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: test-a
+data:
+  key: value
+---
+apiVersion: deckhouse.io/v1
+kind: YandexInstanceClass
+metadata:
+  name: system
+spec:
+  cores: 4
+  memory: 8192
+  diskSizeGb: 30
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: system
+spec:
+  cloudInstances:
+    classReference:
+      kind: YandexInstanceClass
+      name: system
+    maxPerZone: 1
+    minPerZone: 1
+    zones:
+      - zones
+  disruptions:
+    approvalMode: Automatic
+  nodeTemplate:
+    labels:
+      node-role.deckhouse.io/system: ""
+    taints:
+      - effect: NoExecute
+        key: dedicated.deckhouse.io
+        value: system
+  nodeType: CloudEphemeral
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.wardle.example.com
+spec:
+  insecureSkipTLSVerify: true
+  group: wardle.example.com
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: api
+    namespace: wardle
+  version: v1alpha1
+---
+apiVersion: v1
+data:
+  key: value
+kind: ConfigMap
+metadata:
+  name: some-cm
+  namespace: test-ns
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: another-ns
+
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: example
+spec:
+  privileged: false  # Don't allow privileged pods!
+  # The rest fills in some required fields.
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+    - '*'
+---
+apiVersion: "v1"
+kind: "LimitRange"
+metadata:
+  name: "resource-limits"
+spec:
+  limits:
+    -
+      type: "Pod"
+      max:
+        cpu: "2"
+        memory: "1Gi"
+      min:
+        cpu: "200m"
+        memory: "6Mi"
+    -
+      type: "Container"
+      max:
+        cpu: "2"
+        memory: "1Gi"
+      min:
+        cpu: "100m"
+        memory: "4Mi"
+      default:
+        cpu: "300m"
+        memory: "200Mi"
+      defaultRequest:
+        cpu: "200m"
+        memory: "100Mi"
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: standard
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+mountOptions:
+  - debug
+volumeBindingMode: Immediate
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-static
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: gp2
+  awsElasticBlockStore:
+    fsType: ext4
+    volumeID: vol-0928650905a2491e2
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: test-a
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-static
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  volumeName: pv-static
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: crontabs.stable.example.com
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: stable.example.com
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: crontabs
+    # singular name to be used as an alias on the CLI and for display
+    singular: crontab
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CronTab
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+      - ct
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: test-a
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: test-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: test-b
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: test-b
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: role
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: test-b
+  name: test-b
+spec:
+  ports:
+    - name: 80-80
+      port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: test-b
+  type: NodePort
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+    - name: nginx
+      image: nginx:1.14.2
+      ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: nginx
+spec:
+  replicas: 3
+  selector:
+    app: nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx
+          ports:
+            - containerPort: 80
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: guestbook
+    tier: frontend
+spec:
+  # modify replicas according to your case
+  replicas: 3
+  selector:
+    matchLabels:
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        tier: frontend
+    spec:
+      containers:
+        - name: php-redis
+          image: gcr.io/google_samples/gb-frontend:v3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  serviceName: "nginx"
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: k8s.gcr.io/nginx-slim:0.8
+          ports:
+            - containerPort: 80
+              name: web
+          volumeMounts:
+            - name: www
+              mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+    - metadata:
+        name: www
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 1Gi
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  creationTimestamp: null
+  name: test
+spec: {}
+status: {}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: hello
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: hello
+              image: busybox
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minimal-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx-example
+  rules:
+    - http:
+        paths:
+          - path: /testpath
+            pathType: Prefix
+            backend:
+              service:
+                name: test
+                port:
+                  number: 80
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pi
+spec:
+  template:
+    spec:
+      containers:
+        - name: pi
+          image: perl
+          command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+      restartPolicy: Never
+  backoffLimit: 4
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd-elasticsearch
+  namespace: kube-system
+  labels:
+    k8s-app: fluentd-logging
+spec:
+  selector:
+    matchLabels:
+      name: fluentd-elasticsearch
+  template:
+    metadata:
+      labels:
+        name: fluentd-elasticsearch
+    spec:
+      tolerations:
+        # this toleration is to have the daemonset runnable on master nodes
+        # remove it if your masters can't run pods
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: fluentd-elasticsearch
+          image: quay.io/fluentd_elasticsearch/fluentd:v2.5.2
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers

--- a/dhctl/pkg/template/testdata/resources/same_kind_order.yaml
+++ b/dhctl/pkg/template/testdata/resources/same_kind_order.yaml
@@ -1,4 +1,12 @@
 apiVersion: v1
+data:
+  key: value
+kind: ConfigMap
+metadata:
+  name: second
+  namespace: test-ns
+---
+apiVersion: v1
 kind: Namespace
 metadata:
   name: test-ns
@@ -9,12 +17,18 @@ data:
   key: value
 kind: ConfigMap
 metadata:
-  name: some-cm
+  name: another
   namespace: test-ns
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: another-ns
+  name: another
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: r-test
 
 ---

--- a/dhctl/pkg/util/fs/create_test.go
+++ b/dhctl/pkg/util/fs/create_test.go
@@ -15,29 +15,12 @@
 package fs
 
 import (
-	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"os"
-	"path/filepath"
-	"strconv"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
-
-func getFileName() string {
-	// we silent gosec linter here
-	// because we do not need security random number
-	s := rand.NewSource(time.Now().UnixNano())
-	r := rand.New(s) //nolint:gosec
-
-	rndSuf := strconv.FormatUint(r.Uint64(), 10)
-	fileName := fmt.Sprintf("dhctl-tst-touch-%s", rndSuf)
-
-	return filepath.Join(os.TempDir(), fileName)
-}
 
 func assertFileExistsWithContent(t *testing.T, fileName, expectContent string) {
 	_, err := os.Stat(fileName)
@@ -51,7 +34,7 @@ func assertFileExistsWithContent(t *testing.T, fileName, expectContent string) {
 
 func TestTouchFile(t *testing.T) {
 	t.Run("Creates file if it not exists with empty content", func(t *testing.T) {
-		fileName := getFileName()
+		fileName := RandomFileName()
 		_, err := os.Stat(fileName)
 		if err != nil && !os.IsNotExist(err) {
 			t.Fail()
@@ -71,7 +54,7 @@ func TestTouchFile(t *testing.T) {
 	})
 
 	t.Run("Does not rewrite file content if exists", func(t *testing.T) {
-		fileName := getFileName()
+		fileName := RandomFileName()
 
 		const content = "test content"
 		err := ioutil.WriteFile(fileName, []byte(content), 0o600)

--- a/dhctl/pkg/util/fs/random.go
+++ b/dhctl/pkg/util/fs/random.go
@@ -1,0 +1,36 @@
+// Copyright 2022 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+func RandomFileName() string {
+	// we silent gosec linter here
+	// because we do not need security random number
+	s := rand.NewSource(time.Now().UnixNano())
+	r := rand.New(s) //nolint:gosec
+
+	rndSuf := strconv.FormatUint(r.Uint64(), 10)
+	fileName := fmt.Sprintf("dhctl-tst-touch-%s", rndSuf)
+
+	return filepath.Join(os.TempDir(), fileName)
+}


### PR DESCRIPTION
## Description
Create additional kube resurces in order instead create group by GVK

## Why do we need it, and what problem does it solve?
If you need to create namespace and resource in this namespace, you can get error because dhctl can create resource before namespace. It happens because we group resources by GVK into map and maps in go are unordered.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: dhctl
type: feature
description: Create additional kube resources in order
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
