### PR TITLE
[global] Make dashboards immutable

### DIFF
--- a/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/elasticsearch/elasticsearch.json
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/elasticsearch/elasticsearch.json
@@ -27,7 +27,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,

--- a/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/etcd3/etcd3.json
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/etcd3/etcd3.json
@@ -40,7 +40,7 @@
     ]
   },
   "description": "",
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,

--- a/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/memcached/memcached.json
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/memcached/memcached.json
@@ -34,7 +34,7 @@
     ]
   },
   "description": "Monitors Kubernetes Memcached Pods. Shows memory usage, hit rate, evicts and reclaims rate, items in cache, network stats, commands rate. Requires Memcached Exporter for Prometheus.",
-  "editable": true,
+  "editable": false,
   "gnetId": 37,
   "graphTooltip": 0,
   "id": null,

--- a/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/mongodb/mongodb.json
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/mongodb/mongodb.json
@@ -34,7 +34,7 @@
     ]
   },
   "description": "MongoDB Prometheus Exporter Dashboard. \r\nWorks well with https://github.com/percona/mongodb_exporter\r\n\r\nIf you have the node_exporter running on the mongo instance, you will also get some useful alert panels related to disk io and cpu.",
-  "editable": true,
+  "editable": false,
   "gnetId": 2583,
   "graphTooltip": 1,
   "id": null,

--- a/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/nats/nats-legacy.json
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/nats/nats-legacy.json
@@ -28,7 +28,7 @@
     ]
   },
   "description": "NATS Server Dashboard",
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,

--- a/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/nats/nats.json
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/nats/nats.json
@@ -13,7 +13,7 @@
     ]
   },
   "description": "NATS Server Dashboard",
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "id": 35,

--- a/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/php-fpm/php-fpm.json
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/php-fpm/php-fpm.json
@@ -33,7 +33,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,

--- a/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/prometheus/prometheus.json
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/prometheus/prometheus.json
@@ -64,7 +64,7 @@
     ]
   },
   "description": "",
-  "editable": true,
+  "editable": false,
   "gnetId": 3662,
   "graphTooltip": 0,
   "id": null,

--- a/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/rabbitmq/rabbitmq-legacy.json
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/rabbitmq/rabbitmq-legacy.json
@@ -34,7 +34,7 @@
     ]
   },
   "description": "Basic rabbitmq host stats: Node Stats, Exchanges, Channels, Consumers,  Connections, Queues, Messages, Messages per Queue, Memory, File Descriptors, Sockets.",
-  "editable": true,
+  "editable": false,
   "gnetId": 2121,
   "graphTooltip": 0,
   "id": null,

--- a/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/rabbitmq/rabbitmq.json
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/rabbitmq/rabbitmq.json
@@ -13,7 +13,7 @@
     ]
   },
   "description": "A RabbitMQ Management Overview",
-  "editable": true,
+  "editable": false,
   "gnetId": 10991,
   "graphTooltip": 1,
   "iteration": 1609156918146,

--- a/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/redis/redis.json
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/redis/redis.json
@@ -13,7 +13,7 @@
     ]
   },
   "description": "Prometheus dashboard for Redis servers (by pod and alias)",
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,

--- a/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/sidekiq/sidekiq.json
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/sidekiq/sidekiq.json
@@ -33,7 +33,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,

--- a/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/uwsgi/uwsgi.json
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/grafana-dashboards/applications/uwsgi/uwsgi.json
@@ -27,7 +27,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/ntp.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/ntp.json
@@ -13,7 +13,7 @@
     ]
   },
   "description": "Dashboard for chrony or OpenNTPD.",
-  "editable": true,
+  "editable": false,
   "gnetId": 7496,
   "graphTooltip": 0,
   "iteration": 1557844573805,

--- a/modules/500-upmeter/monitoring_test/grafana-dashboards/kubernetes-cluster/upmeter/dns_5m.json
+++ b/modules/500-upmeter/monitoring_test/grafana-dashboards/kubernetes-cluster/upmeter/dns_5m.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "id": 24,

--- a/modules/500-upmeter/monitoring_test/grafana-dashboards/kubernetes-cluster/upmeter/hpa_5m.json
+++ b/modules/500-upmeter/monitoring_test/grafana-dashboards/kubernetes-cluster/upmeter/hpa_5m.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "id": 24,

--- a/modules/500-upmeter/monitoring_test/grafana-dashboards/kubernetes-cluster/upmeter/trickster_5m.json
+++ b/modules/500-upmeter/monitoring_test/grafana-dashboards/kubernetes-cluster/upmeter/trickster_5m.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "id": 24,


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
Deckhouse provides stateless Grafana, which is configured by custom resources. This is fiction, that you can change anything using GUI.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: global
type: fix
description: Make dashboards immutable (that weren't already).
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
