### PR TITLE
[candi] Support astra 1.7

### DIFF
--- a/dhctl/README.md
+++ b/dhctl/README.md
@@ -27,7 +27,7 @@ Basic features:
 
 ### Preparations
 The first step is setting up a host.
-Only `ubuntu-16.04`, `ubuntu-18.04`, `ubuntu-20.04`, `centos-7`, `rhel-7`, `centos-8`, `rhel-8`, `debian-9`, `debian-10`, `debian-11`, `astralinux-2.12(Deckhouse EE edition)` OS are supported.
+Only `ubuntu-16.04`, `ubuntu-18.04`, `ubuntu-20.04`, `centos-7`, `rhel-7`, `centos-8`, `rhel-8`, `debian-9`, `debian-10`, `debian-11`, `astralinux-2.12(Deckhouse EE edition)`, `astralinux-1.7(Deckhouse EE edition)` OS are supported.
 
 * **Bare metal** - provide SSH access to the host and sudo access.
 * **Cloud provider** - ensure that Deckhouse supports your cloud.

--- a/ee/candi/bashible/bundles/astra/all/000_install_ca_certificates.sh.tpl
+++ b/ee/candi/bashible/bundles/astra/all/000_install_ca_certificates.sh.tpl
@@ -4,7 +4,7 @@
 bb-apt-install --force ca-certificates
 
 # Hack for Astra 2.12
-if bb-is-astra-version? 2.12.+ ; then
+if bb-is-astra-version? 2.12.+ || bb-is-astra-version? 1.7.+ ; then
   if grep -q "^mozilla\/DST_Root_CA_X3.crt$" /etc/ca-certificates.conf; then
     sed -i "/mozilla\/DST_Root_CA_X3.crt/d" /etc/ca-certificates.conf
     update-ca-certificates --fresh

--- a/ee/candi/bashible/bundles/astra/all/001_install_mandatory_packages.sh.tpl
+++ b/ee/candi/bashible/bundles/astra/all/001_install_mandatory_packages.sh.tpl
@@ -8,6 +8,6 @@ bb-apt-install ${SYSTEM_PACKAGES} ${KUBERNETES_DEPENDENCIES}
 
 bb-rp-install "jq:{{ .images.registrypackages.jq16 }}" "curl:{{ .images.registrypackages.d8Curl7800 }}"
 
-if bb-is-astra-version? 2.12.+; then
+if bb-is-astra-version? 2.12.+ || bb-is-astra-version? 1.7.+; then
   bb-rp-install "virt-what:{{ .images.registrypackages.virtWhatAstra1151Deb9u1 }}" "conntrack:{{ .images.registrypackages.conntrackAstra1462 }}"
 fi

--- a/ee/candi/bashible/bundles/astra/node-group/031_install_containerd.sh.tpl
+++ b/ee/candi/bashible/bundles/astra/node-group/031_install_containerd.sh.tpl
@@ -38,7 +38,7 @@ if bb-apt-package? docker-ce || bb-apt-package? docker.io; then
   bb-flag-set reboot
 fi
 
-if bb-is-astra-version? 2.12.+; then
+if bb-is-astra-version? 2.12.+ || bb-is-astra-version? 1.7.+; then
   desired_version={{ index .k8s .kubernetesVersion "bashible" "debian" "9" "containerd" "desiredVersion" | quote }}
   allowed_versions_pattern={{ index .k8s .kubernetesVersion "bashible" "debian" "9" "containerd" "allowedPattern" | quote }}
 fi
@@ -66,7 +66,7 @@ if [[ "$should_install_containerd" == true ]]; then
 
   bb-deckhouse-get-disruptive-update-approval
 
-  if bb-is-astra-version? 2.12.+ ; then
+  if bb-is-astra-version? 2.12.+ || bb-is-astra-version? 1.7.+ ; then
     containerd_tag="{{- index $.images.registrypackages (printf "containerdDebian%sStretch" (index .k8s .kubernetesVersion "bashible" "debian" "9" "containerd" "desiredVersion" | replace "containerd.io=" "" | replace "." "" | replace "-" "")) }}"
   fi
 

--- a/ee/candi/bashible/bundles/astra/node-group/031_install_docker.sh.tpl
+++ b/ee/candi/bashible/bundles/astra/node-group/031_install_docker.sh.tpl
@@ -49,7 +49,7 @@ if bb-apt-package? containerd.io && ! bb-apt-package? docker-ce ; then
   bb-flag-set reboot
 fi
 
-if bb-is-astra-version? 2.12.+; then
+if bb-is-astra-version? 2.12.+ || bb-is-astra-version? 1.7.+; then
   desired_version_docker={{ index .k8s .kubernetesVersion "bashible" "debian" "9" "docker" "desiredVersion" | quote }}
   allowed_versions_docker_pattern={{ index .k8s .kubernetesVersion "bashible" "debian" "9" "docker" "allowedPattern" | quote }}
   desired_version_containerd={{ index .k8s .kubernetesVersion "bashible" "debian" "9" "docker" "containerd" "desiredVersion" | quote }}
@@ -79,7 +79,7 @@ if [[ "$should_install_containerd" == true ]]; then
 
   bb-deckhouse-get-disruptive-update-approval
 
-  if bb-is-astra-version? 2.12.+; then
+  if bb-is-astra-version? 2.12.+ || bb-is-astra-version? 1.7.+; then
     containerd_tag="{{- index $.images.registrypackages (printf "containerdDebian%sStretch" (index .k8s .kubernetesVersion "bashible" "debian" "9" "docker" "containerd" "desiredVersion" | replace "containerd.io=" "" | replace "." "" | replace "-" "")) }}"
   fi
 
@@ -105,7 +105,7 @@ if [[ "$should_install_docker" == true ]]; then
 
   bb-flag-set new-docker-installed
 
-  if bb-is-astra-version? 2.12.+; then
+  if bb-is-astra-version? 2.12.+ || bb-is-astra-version? 1.7.+; then
     docker_tag="{{- index $.images.registrypackages (printf "dockerDebian%s" (index .k8s .kubernetesVersion "bashible" "debian" "9" "docker" "desiredVersion" | replace "docker-ce=" "" | replace "." "_" | replace ":" "_" | replace "~" "_" | camelcase)) }}"
   fi
 

--- a/ee/candi/bashible/bundles/astra/node-group/032_install_linux_kernel.sh.tpl
+++ b/ee/candi/bashible/bundles/astra/node-group/032_install_linux_kernel.sh.tpl
@@ -24,7 +24,7 @@ if [ -n "$metapackages" ]; then
   bb-apt-remove $metapackages
 fi
 
-if bb-is-astra-version? 2.12.+; then
+if bb-is-astra-version? 2.12.+ || bb-is-astra-version? 1.7.+; then
   desired_version={{ index .k8s .kubernetesVersion "bashible" "debian" "9" "kernel" "astra" "desiredVersion" | quote }}
   allowed_versions_pattern={{ index .k8s .kubernetesVersion "bashible" "debian" "9" "kernel" "astra" "allowedPattern" | quote }}
 fi

--- a/ee/candi/bashible/bundles/astra/node-group/051_install_kubernetes_api_proxy.sh.tpl
+++ b/ee/candi/bashible/bundles/astra/node-group/051_install_kubernetes_api_proxy.sh.tpl
@@ -1,6 +1,6 @@
 # Copyright 2021 Flant JSC
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 
-if bb-is-astra-version? 2.12.+ ; then
+if bb-is-astra-version? 2.12.+ || bb-is-astra-version? 1.7.+ ; then
   bb-rp-install "nginx:{{ .images.registrypackages.nginxDebian1180Stretch }}"
 fi

--- a/ee/candi/bashible/detect_bundle.sh
+++ b/ee/candi/bashible/detect_bundle.sh
@@ -19,7 +19,7 @@ if [ -e /etc/os-release ]; then
       echo "debian"
       exit 0
     ;;
-    astra-2.12.*|astra-1.7.*)
+    astra-2.12.*|astra-1.7*)
       echo "astra"
       exit 0
     ;;

--- a/ee/candi/bashible/detect_bundle.sh
+++ b/ee/candi/bashible/detect_bundle.sh
@@ -19,7 +19,7 @@ if [ -e /etc/os-release ]; then
       echo "debian"
       exit 0
     ;;
-    astra-2.12.*)
+    astra-2.12.*|astra-1.7.*)
       echo "astra"
       exit 0
     ;;


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
All Astra Linux editions are now available in one image with version 1.7. Previously only 2.12 orel was supported.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Extended Astra Linux support.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: candi
type: fix
description: Support Astra Linux 1.7
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
