### PR TITLE
[docs] Make K8s 1.19 available for installation

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -137,7 +137,7 @@ bashible: &bashible
           allowedPattern: "4.18.0-"
 k8s:
   '1.19':
-    status: end-of-life
+    status: available
     patch: 16
     cniVersion: 0.8.7
     bashible: &bashible_k8s_ge_1_19


### PR DESCRIPTION
## Description
Kubernetes 1.19 was marked (#394) as EOL by mistake. Show on the site that Kubernetes 1.19 is fully supported by Deckhouse.

## Changelog entries
```changes
module: docs
type: fix
description: Mark K8s v1.19 as fully supported by Deckhouse.
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
