### PR TITLE
[node-manager] add error file when bashible context failed

### DIFF
--- a/modules/040-node-manager/images/bashible-apiserver/pkg/template/context.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/template/context.go
@@ -360,8 +360,11 @@ func (c *BashibleContext) update() {
 			_, _ = errStr.WriteString(fmt.Sprintf("\t%s: %s\n", bundle, err))
 		}
 		klog.Warningf("bundles checksums have errors:\n%s", errStr.String())
+		_ = ioutil.WriteFile("/tmp/context.error", []byte(errStr.String()), 0644)
 		return
 	}
+
+	_ = os.Remove("/tmp/context.error")
 
 	var res map[string]interface{}
 


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Add file with error on failed context building

## Why do we need it, and what problem does it solve?
We can lose errors in bashible-apiserver logs and it becomes complicated to debug some corner-case situations

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: node-manager
type: feature
description: Add file with context-building error on failure
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
