### PR TITLE
Changelog schema template and link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 ## Why do we need it, and what problem does it solve?
 <!---
   This is the most important paragraph.
-  You have to describe the main goal of your feature.
+  You must describe the main goal of your feature.
 
   If it fixes an issue, place a link to the issue here.
 
@@ -19,54 +19,31 @@
 ## Changelog entries
 <!---
   Describe the changes so they will be included in a release changelog.
-  Find examples and documentation below.
+
+  Find examples and documentation below, or visit the instruction page on the repo wiki
+  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
 -->
 
 ```changes
-module: <kebab-case>
+section: <kebab-case of a modules/*> | <1st level dir in the repo>
 type: fix | feature
-description: <what effectively changes>
-note: <what to expect>
+summary: <what effectively changes in a single line>
+impact_level: low | high*
+impact: <what to expect, possibly multi-line>, required if impact_level is high
 ```
 
 <!---
-ABOUT CHANGES BLOCK
+Tip for the section field:
 
-"Changes" block contains a list of YAML documents. It describes a changelog
-entry that is collected to a release changelog.
-
-Fields:
-
-module
-    Required. Affected module in kebab case, e.g. "node-manager".
-type
-    Required. The change type: only "fix" and "feature" supported.
-description
-    Optional. The changelog entry. Omit to use pull request title.
-note
-    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.
-
-Since the syntax is YAML, `note` may contain multi-line text.
-
-There can be multiple docs in single `changes` block, and multiple `changes`
-blocks in the PR body.
-
-Example:
-
-```changes
-module: node-manager
-type: fix
-description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
-note: |
-  Expect nodes of "Cloud" type to restart.
-
-  Node checksum calculation is fixes as well as a race condition during
-  the machines (MCM) rendering which caused outdated nodes to spawn.
----
-module: cloud-provider-aws
-type: feature
-description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
-note: Recommended to use as a last resort.
-```
+  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
+  - "dhctl"
+  - "candi"
+  - "deckhouse-controller"
+  - *_lib
+  - "docs", includes website changes, should always have low impact
+  - "tests", should always have low impact
+  - "tools", should always have low impact
+  - "ci", should always have low impact
+  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes
 
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,21 @@
+# Contributing
+
 Deckhouse is an Open Source project, and third-party contributions are warmly welcome.
 
-# Guidelines
+## Guidelines
 
 Please read our [development guidelines](https://github.com/deckhouse/deckhouse/blob/main/docs/documentation/pages/internal/DEVELOPMENT.md) to learn about building, testing, releasing, and troubleshooting Deckhouse, as well as our naming convention for code itself, modules names, Helm values, etc.
 
-# What to do
+## What to do
 
-* Contact us via [Telegram chat](https://t.me/deckhouse) for any questions on developing Deckhouse & contributing to this repo. *There's a dedicated [Telegram chat in Russian](https://t.me/deckhouse_ru) as well.*
-* Open your [issues](https://github.com/deckhouse/deckhouse/issues) and [discussions](https://github.com/deckhouse/deckhouse/discussions) in this repo.
-* If you believe no preliminary discussion is required, submit your [PRs](https://github.com/deckhouse/deckhouse/pulls) with your code changes straight away.
+- Contact us via [Telegram chat](https://t.me/deckhouse) for any questions on developing Deckhouse & contributing to this repo. _There's a dedicated [Telegram chat in Russian](https://t.me/deckhouse_ru) as well._
+- Open your [issues](https://github.com/deckhouse/deckhouse/issues) and [discussions](https://github.com/deckhouse/deckhouse/discussions) in this repo.
+- If you believe no preliminary discussion is required, submit your [PRs](https://github.com/deckhouse/deckhouse/pulls) with your code changes straight away.
 
 P.S. The [maintainers list](https://github.com/deckhouse/deckhouse/blob/main/MAINTAINERS.md) might also be helpful to reach our core developers.
+
+## Making a PR
+
+When creating a PR, please fill in the template that you meet in the text body including the changes
+block. This will make your work mentioned in the release message. Please refer to a [change block
+explanation](https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog).


### PR DESCRIPTION
## Description

Add PR template to explain modern changes block

## Why do we need it, and what problem does it solve?

Helps describe PRs our way

## Changelog entries

```changes
section: repo
type: feature
summary: Updated PR template and the contribution guide
impact_level: low
```
