### PR TITLE
[candi] proper work with astra bundle in EE/FE

### DIFF
--- a/candi/bashible/detect_bundle.sh
+++ b/candi/bashible/detect_bundle.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-{{- /*
 # Copyright 2021 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-*/}}
 if [ -e /etc/os-release ]; then
   . /etc/os-release
   bundleName="${ID}-${VERSION_ID}"

--- a/ee/candi/bashible/detect_bundle.sh
+++ b/ee/candi/bashible/detect_bundle.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
-{{- /*
-Copyright 2021 Flant JSC
-Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
-*/}}
+# Copyright 2021 Flant JSC
+# Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 if [ -e /etc/os-release ]; then
   . /etc/os-release
   bundleName="${ID}-${VERSION_ID}"

--- a/ee/modules/040-node-manager/.build.yaml
+++ b/ee/modules/040-node-manager/.build.yaml
@@ -1,1 +1,2 @@
 cloud-providers/*
+openapi/*

--- a/ee/modules/040-node-manager/openapi/config-values.yaml
+++ b/ee/modules/040-node-manager/openapi/config-values.yaml
@@ -30,11 +30,12 @@ properties:
       - "ubuntu-lts"
       - "centos"
       - "debian"
+      - "astra"
     x-examples:
       - ["ubuntu-lts"]
     items:
       type: string
-      enum: [ubuntu-lts, centos, debian]
+      enum: [ubuntu-lts, centos, debian, astra]
     description: |
       Names of available bashible OS bundles to reduce helm release size.
 

--- a/ee/modules/040-node-manager/openapi/openapi-case-tests.yaml
+++ b/ee/modules/040-node-manager/openapi/openapi-case-tests.yaml
@@ -1,0 +1,42 @@
+defaults:
+  internal: &internalDefault
+    clusterMasterAddresses: ["10.0.0.1:6443", "10.0.0.2:6443", "10.0.0.3:6443"]
+    kubernetesCA: myclusterca
+    bashibleApiServerCA: myapiserverca
+    bashibleApiServerCrt: myapiservercrt
+    bashibleApiServerKey: myapiserverprivkey
+
+positive:
+  configValues:
+    - {}
+    - allowedKubernetesVersions: ["1.19"]
+    - allowedBundles: ["ubuntu-lts"]
+    - allowedBundles: []
+      allowedKubernetesVersions: ["1.19"]
+    - allowedBundles: ["ubuntu-lts"]
+      allowedKubernetesVersions: ["1.19"]
+  values:
+    - { internal: {} }
+    - internal:
+        <<: *internalDefault
+        standbyNodeGroups:
+          - name: worker
+            reserveCPU: 12m
+            reserveMemory: 30%
+        cloudProvider:
+          type: aws
+          machineClassKind: AWSInstanceClass
+          aws:
+            providerAccessKeyId: myprovaccesskeyid
+            providerSecretAccessKey: myprovsecretaccesskey
+            region: myregion
+            loadBalancerSecurityGroupID: mylbsecuritygroupid
+            keyName: mykeyname
+            instances:
+              iamProfileName: myiamprofilename
+            internal:
+              zoneToSubnetIdMap:
+                zonea: mysubnetida
+                zoneb: mysubnetidb
+            tags:
+              aaa: aaa

--- a/ee/modules/040-node-manager/openapi/values.yaml
+++ b/ee/modules/040-node-manager/openapi/values.yaml
@@ -1,0 +1,266 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties:
+  internal:
+    type: object
+    default: {}
+    properties:
+      machineControllerManagerEnabled:
+        type: boolean
+
+      clusterMasterAddresses:
+        type: array
+        description: |
+          Array of API servers addresses.
+        x-examples:
+          - ["10.0.0.1:6443", "10.0.0.2:6443", "10.0.0.3:6443"]
+        items:
+          type: string
+          pattern: '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:[1-9][0-9]{0,4}$'
+
+      kubernetesCA:
+        type: string
+        x-examples:
+          - LS0tQ0VSVC0tLSBhYWFxcXEgLS1FTkQgQ0VSVC0tLQo=
+        description: |
+          kubernetes.ca content
+
+      standbyNodeGroups:
+        type: array
+        description: |
+          Settings for standby Pods.
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+            standby:
+              type: number
+            reserveCPU:
+              type: [integer, string]
+            reserveMemory:
+              type: [integer, string]
+            taints:
+              type: array
+              description: |
+                Similar to the `.spec.taints` field of the [Node](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#taint-v1-core) object.
+
+                **Caution!** Only `effect`, `key`, `value` fields are available.
+              items:
+                type: object
+                properties:
+                  effect:
+                    type: string
+                    enum:
+                    - NoSchedule
+                    - PreferNoSchedule
+                    - NoExecute
+                  key:
+                    type: string
+                  value:
+                    type: string
+
+      bashibleApiServerCA:
+        type: string
+        x-examples:
+          - LS0tQ0VSVC0tLSBhYWFxcXEgLS1FTkQgQ0VSVC0tLQo=
+        description: |
+          CA certificate for API server used by bashible.
+      bashibleApiServerCrt:
+        type: string
+        x-examples:
+          - LS0tQ0VSVC0tLSBhYWFxcXEgLS1FTkQgQ0VSVC0tLQo=
+        description: |
+          Certificate for API server used by bashible.
+      bashibleApiServerKey:
+        type: string
+        x-examples:
+          - LS0tcHJpdmtleS0tLSBhYWFxcXEgLS1lbmQgcHJpdmtleS0tLQo=
+        description: |
+          Private key for API server used by bashible.
+
+      nodeStatusUpdateFrequency:
+        type: [integer, string]
+        description: |
+          Seconds for nodeStatusUpdateFrequency field in kubelet config. The frequency that kubelet computes node status.
+        x-examples:
+          - "10"
+
+      bootstrapTokens:
+        type: object
+        # This is a dictionary nodeGroup name -> bootstrap token.
+        additionalProperties:
+          type: string
+        description: |
+          Bootstrap tokens for node groups.
+        x-examples:
+          - worker: mytoken
+
+      instancePrefix:
+        type: string
+        x-examples:
+          - "myprefix"
+        description: |
+          Prefix for instance name.
+
+      machineDeployments:
+        type: object
+        description: |
+          Checksums of all EXISTING MachineClasses in the map "{MachineDeployment name}": "{name, nodeGroup, Checksum}"
+        x-examples:
+          - worker:
+              name: "myprefix-worker-02320933"
+              nodeGroup: "workers"
+              checksum: "62090f2241986a8361242e47cf541657099fdccc0c08e34cd694922bdcf31893"
+        additionalProperties:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Name of the MachineDeployment.
+            nodeGroup:
+              type: string
+              description: Name of the NodeGroup.
+            checksum:
+              type: string
+              description: Checksum of the MachineClass, to be reused in MachineDeployment templates at right moments.
+
+      static:
+        type: object
+        default: {}
+        description: |
+          Settings for Static nodes.
+        properties:
+          internalNetworkCIDRs:
+            type: array
+            default: []
+            items:
+              type: string
+              pattern: '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[1-9][0-9]?$'
+
+      cloudProvider:
+        type: object
+        additionalProperties: true
+        description: |
+          Settings specific for cloud provider: access, zones, regions, etc.
+        properties:
+          type:
+            type: string
+          zones:
+            type: array
+            items:
+              type: string
+          instanceClassKind:
+            type: string
+          machineClassKind:
+            type: string
+        x-examples:
+          - type: aws
+            machineClassKind: AWSInstanceClass
+            aws:
+              providerAccessKeyId: myprovaccesskeyid
+              providerSecretAccessKey: myprovsecretaccesskey
+              region: myregion
+              loadBalancerSecurityGroupID: mylbsecuritygroupid
+              keyName: mykeyname
+              instances:
+                iamProfileName: myiamprofilename
+                additionalSecurityGroups:
+                  - ["mysecgroupid1", "mysecgroupid2"]
+              internal:
+                zoneToSubnetIdMap:
+                  zonea: mysubnetida
+                  zoneb: mysubnetidb
+              tags:
+                aaa: aaa
+
+      nodeGroups:
+        type: array
+        description: |
+          Array of available NodeGroups.
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              description: |
+                A name of the NodeGroup.
+            manualRolloutID:
+              type: string
+              description: |
+                Value of NodeGroup's annotation "manual-rollout-id".
+            static:
+              type: object
+              description: |
+                Settings for Static nodes.
+              properties:
+                internalNetworkCIDRs:
+                  type: array
+                  items:
+                    type: string
+                    pattern: '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[1-9][0-9]?$'
+            instanceClass:
+              type: [object, "null"]
+              description: |
+                Copy of the 'spec' section from WhateverInstanceClass resource. Fields are specific to used cloud provider.
+              additionalProperties: true
+            kubernetesVersion:
+              type: string
+              description: |
+                Major.Minor of the Kubernetes version used in cluster.
+              x-examples:
+                - "1.19"
+            updateEpoch:
+              type: [integer, string]
+              x-examples:
+                - "1624550403"
+            nodeType:
+              # See NodeGroup in candi/openapi/node_group.yaml
+              type: string
+              enum: ["CloudEphemeral", "CloudPermanent", "CloudStatic", "Static"]
+            cri:
+              # This is a copy from NodeGroup object. We trust that hook will not change it.
+              type: object
+              additionalProperties: true
+            cloudInstances:
+              # This is a copy from NodeGroup object. We trust that hook will not change it.
+              type: object
+              additionalProperties: true
+            nodeTemplate:
+              # This is a copy from NodeGroup object. We trust that hook will not change it.
+              type: object
+              additionalProperties: true
+            chaos:
+              # This is a copy from NodeGroup object. We trust that hook will not change it.
+              type: object
+              additionalProperties: true
+            operatingSystem:
+              # This is a copy from NodeGroup object. We trust that hook will not change it.
+              type: object
+              additionalProperties: true
+            disruptions:
+              # This is a copy from NodeGroup object. We trust that hook will not change it.
+              type: object
+              additionalProperties: true
+            kubelet:
+              # This is a copy from NodeGroup object. We trust that hook will not change it.
+              type: object
+              additionalProperties: true
+        x-examples:
+          - - name: worker
+              instanceClass: # minimum
+                ami: myami
+                instanceType: t2.medium
+              nodeType: CloudEphemeral
+              kubernetesVersion: "1.19"
+              cri:
+                type: "Docker"
+              cloudInstances:
+                classReference:
+                  kind: AWSInstanceClass
+                  name: worker
+                maxPerZone: 1
+                minPerZone: 1
+                zones:
+                  - zonea

--- a/tools/build_includes/modules-EE.yaml
+++ b/tools/build_includes/modules-EE.yaml
@@ -11,6 +11,8 @@
   to: /deckhouse/modules/040-node-manager/cloud-providers/vsphere
 - add: /ee/modules/040-node-manager/openapi/config-values.yaml
   to: /deckhouse/modules/040-node-manager/openapi/config-values.yaml
+- add: /ee/modules/040-node-manager/openapi/openapi-case-tests.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/openapi-case-tests.yaml
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
 - add: /ee/modules/140-user-authz/templates/webhook

--- a/tools/build_includes/modules-EE.yaml
+++ b/tools/build_includes/modules-EE.yaml
@@ -9,6 +9,8 @@
   to: /deckhouse/modules/040-node-manager/cloud-providers/openstack
 - add: /ee/modules/040-node-manager/cloud-providers/vsphere
   to: /deckhouse/modules/040-node-manager/cloud-providers/vsphere
+- add: /ee/modules/040-node-manager/openapi/config-values.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/config-values.yaml
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
 - add: /ee/modules/140-user-authz/templates/webhook

--- a/tools/build_includes/modules-EE.yaml
+++ b/tools/build_includes/modules-EE.yaml
@@ -13,6 +13,8 @@
   to: /deckhouse/modules/040-node-manager/openapi/config-values.yaml
 - add: /ee/modules/040-node-manager/openapi/openapi-case-tests.yaml
   to: /deckhouse/modules/040-node-manager/openapi/openapi-case-tests.yaml
+- add: /ee/modules/040-node-manager/openapi/values.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/values.yaml
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
 - add: /ee/modules/140-user-authz/templates/webhook

--- a/tools/build_includes/modules-FE.yaml
+++ b/tools/build_includes/modules-FE.yaml
@@ -27,6 +27,8 @@
   to: /deckhouse/modules/040-node-manager/cloud-providers/openstack
 - add: /ee/modules/040-node-manager/cloud-providers/vsphere
   to: /deckhouse/modules/040-node-manager/cloud-providers/vsphere
+- add: /ee/modules/040-node-manager/openapi/config-values.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/config-values.yaml
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
 - add: /ee/modules/140-user-authz/templates/webhook

--- a/tools/build_includes/modules-FE.yaml
+++ b/tools/build_includes/modules-FE.yaml
@@ -31,6 +31,8 @@
   to: /deckhouse/modules/040-node-manager/openapi/config-values.yaml
 - add: /ee/modules/040-node-manager/openapi/openapi-case-tests.yaml
   to: /deckhouse/modules/040-node-manager/openapi/openapi-case-tests.yaml
+- add: /ee/modules/040-node-manager/openapi/values.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/values.yaml
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
 - add: /ee/modules/140-user-authz/templates/webhook

--- a/tools/build_includes/modules-FE.yaml
+++ b/tools/build_includes/modules-FE.yaml
@@ -29,6 +29,8 @@
   to: /deckhouse/modules/040-node-manager/cloud-providers/vsphere
 - add: /ee/modules/040-node-manager/openapi/config-values.yaml
   to: /deckhouse/modules/040-node-manager/openapi/config-values.yaml
+- add: /ee/modules/040-node-manager/openapi/openapi-case-tests.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/openapi-case-tests.yaml
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
 - add: /ee/modules/140-user-authz/templates/webhook

--- a/tools/build_includes/modules-with-dependencies-EE.yaml
+++ b/tools/build_includes/modules-with-dependencies-EE.yaml
@@ -34,6 +34,11 @@
   stageDependencies:
     setup:
         - '**/*.go'
+- add: /ee/modules/040-node-manager/openapi/values.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/values.yaml
+  stageDependencies:
+    setup:
+        - '**/*.go'
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
   stageDependencies:

--- a/tools/build_includes/modules-with-dependencies-EE.yaml
+++ b/tools/build_includes/modules-with-dependencies-EE.yaml
@@ -29,6 +29,11 @@
   stageDependencies:
     setup:
         - '**/*.go'
+- add: /ee/modules/040-node-manager/openapi/openapi-case-tests.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/openapi-case-tests.yaml
+  stageDependencies:
+    setup:
+        - '**/*.go'
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
   stageDependencies:

--- a/tools/build_includes/modules-with-dependencies-EE.yaml
+++ b/tools/build_includes/modules-with-dependencies-EE.yaml
@@ -24,6 +24,11 @@
   stageDependencies:
     setup:
         - '**/*.go'
+- add: /ee/modules/040-node-manager/openapi/config-values.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/config-values.yaml
+  stageDependencies:
+    setup:
+        - '**/*.go'
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
   stageDependencies:

--- a/tools/build_includes/modules-with-dependencies-FE.yaml
+++ b/tools/build_includes/modules-with-dependencies-FE.yaml
@@ -69,6 +69,11 @@
   stageDependencies:
     setup:
         - '**/*.go'
+- add: /ee/modules/040-node-manager/openapi/config-values.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/config-values.yaml
+  stageDependencies:
+    setup:
+        - '**/*.go'
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
   stageDependencies:

--- a/tools/build_includes/modules-with-dependencies-FE.yaml
+++ b/tools/build_includes/modules-with-dependencies-FE.yaml
@@ -79,6 +79,11 @@
   stageDependencies:
     setup:
         - '**/*.go'
+- add: /ee/modules/040-node-manager/openapi/values.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/values.yaml
+  stageDependencies:
+    setup:
+        - '**/*.go'
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
   stageDependencies:

--- a/tools/build_includes/modules-with-dependencies-FE.yaml
+++ b/tools/build_includes/modules-with-dependencies-FE.yaml
@@ -74,6 +74,11 @@
   stageDependencies:
     setup:
         - '**/*.go'
+- add: /ee/modules/040-node-manager/openapi/openapi-case-tests.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/openapi-case-tests.yaml
+  stageDependencies:
+    setup:
+        - '**/*.go'
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
   stageDependencies:

--- a/tools/build_includes/modules-with-exclude-EE.yaml
+++ b/tools/build_includes/modules-with-exclude-EE.yaml
@@ -65,6 +65,17 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+- add: /ee/modules/040-node-manager/openapi/openapi-case-tests.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/openapi-case-tests.yaml
+  excludePaths:
+    - docs
+    - README.md
+    - images
+    - hooks/**/*.go
+    - template_tests
+    - .namespace
+    - values_matrix_test.yaml
+    - .build.yaml
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
   excludePaths:

--- a/tools/build_includes/modules-with-exclude-EE.yaml
+++ b/tools/build_includes/modules-with-exclude-EE.yaml
@@ -76,6 +76,17 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+- add: /ee/modules/040-node-manager/openapi/values.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/values.yaml
+  excludePaths:
+    - docs
+    - README.md
+    - images
+    - hooks/**/*.go
+    - template_tests
+    - .namespace
+    - values_matrix_test.yaml
+    - .build.yaml
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
   excludePaths:

--- a/tools/build_includes/modules-with-exclude-EE.yaml
+++ b/tools/build_includes/modules-with-exclude-EE.yaml
@@ -54,6 +54,17 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+- add: /ee/modules/040-node-manager/openapi/config-values.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/config-values.yaml
+  excludePaths:
+    - docs
+    - README.md
+    - images
+    - hooks/**/*.go
+    - template_tests
+    - .namespace
+    - values_matrix_test.yaml
+    - .build.yaml
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
   excludePaths:

--- a/tools/build_includes/modules-with-exclude-FE.yaml
+++ b/tools/build_includes/modules-with-exclude-FE.yaml
@@ -164,6 +164,17 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+- add: /ee/modules/040-node-manager/openapi/openapi-case-tests.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/openapi-case-tests.yaml
+  excludePaths:
+    - docs
+    - README.md
+    - images
+    - hooks/**/*.go
+    - template_tests
+    - .namespace
+    - values_matrix_test.yaml
+    - .build.yaml
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
   excludePaths:

--- a/tools/build_includes/modules-with-exclude-FE.yaml
+++ b/tools/build_includes/modules-with-exclude-FE.yaml
@@ -175,6 +175,17 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+- add: /ee/modules/040-node-manager/openapi/values.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/values.yaml
+  excludePaths:
+    - docs
+    - README.md
+    - images
+    - hooks/**/*.go
+    - template_tests
+    - .namespace
+    - values_matrix_test.yaml
+    - .build.yaml
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
   excludePaths:

--- a/tools/build_includes/modules-with-exclude-FE.yaml
+++ b/tools/build_includes/modules-with-exclude-FE.yaml
@@ -153,6 +153,17 @@
     - .namespace
     - values_matrix_test.yaml
     - .build.yaml
+- add: /ee/modules/040-node-manager/openapi/config-values.yaml
+  to: /deckhouse/modules/040-node-manager/openapi/config-values.yaml
+  excludePaths:
+    - docs
+    - README.md
+    - images
+    - hooks/**/*.go
+    - template_tests
+    - .namespace
+    - values_matrix_test.yaml
+    - .build.yaml
 - add: /ee/modules/110-istio
   to: /deckhouse/modules/110-istio
   excludePaths:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
[candi] Proper work with astra bundle in EE/FE.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You have to describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Because Astra Linux bundle exists only in EE/FE edition, we remove `astra` from allowedBundles.
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: candi
type: fix
description: "Proper work with astra bundle in EE/FE."
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
