### PR TITLE
[ingress-nginx] Expose status class label values with the xx suffix

### DIFF
--- a/modules/402-ingress-nginx/images/controller-0-33/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-33/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -351,7 +351,7 @@ local function fill_buffer()
     for status in gmatch(ngx.var.upstream_status, "[%d]+") do
       -- responses (for each backend)
       n = n + 1
-      _increment("c19#" .. backend_key .. "#" .. backends[n] .. "#" .. sub(status, 1, 1), 19)
+      _increment("c19#" .. backend_key .. "#" .. backends[n] .. "#" .. sub(status, 1, 1) .. "xx", 19)
     end
 
     n = 0

--- a/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -351,7 +351,7 @@ local function fill_buffer()
     for status in gmatch(ngx.var.upstream_status, "[%d]+") do
       -- responses (for each backend)
       n = n + 1
-      _increment("c19#" .. backend_key .. "#" .. backends[n] .. "#" .. sub(status, 1, 1), 19)
+      _increment("c19#" .. backend_key .. "#" .. backends[n] .. "#" .. sub(status, 1, 1) .. "xx", 19)
     end
 
     n = 0

--- a/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -351,7 +351,7 @@ local function fill_buffer()
     for status in gmatch(ngx.var.upstream_status, "[%d]+") do
       -- responses (for each backend)
       n = n + 1
-      _increment("c19#" .. backend_key .. "#" .. backends[n] .. "#" .. sub(status, 1, 1), 19)
+      _increment("c19#" .. backend_key .. "#" .. backends[n] .. "#" .. sub(status, 1, 1) .. "xx", 19)
     end
 
     n = 0

--- a/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -351,7 +351,7 @@ local function fill_buffer()
     for status in gmatch(ngx.var.upstream_status, "[%d]+") do
       -- responses (for each backend)
       n = n + 1
-      _increment("c19#" .. backend_key .. "#" .. backends[n] .. "#" .. sub(status, 1, 1), 19)
+      _increment("c19#" .. backend_key .. "#" .. backends[n] .. "#" .. sub(status, 1, 1) .. "xx", 19)
     end
 
     n = 0

--- a/modules/402-ingress-nginx/images/controller-1-0/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-0/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -351,7 +351,7 @@ local function fill_buffer()
     for status in gmatch(ngx.var.upstream_status, "[%d]+") do
       -- responses (for each backend)
       n = n + 1
-      _increment("c19#" .. backend_key .. "#" .. backends[n] .. "#" .. sub(status, 1, 1), 19)
+      _increment("c19#" .. backend_key .. "#" .. backends[n] .. "#" .. sub(status, 1, 1) .. "xx", 19)
     end
 
     n = 0


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Add the `xx` suffix to the `status_class` label of the `ingress_nginx_detail_backend_responses_total` metric.

## Why do we need it, and what problem does it solve?
This PR fixes panels for ingress-nginx controllers in Grafana. As for now, users an only see zeros in some tables, e.g.

![image](https://user-images.githubusercontent.com/32434187/153671571-eae68f3d-1fd9-4357-8615-6b8fbf8e4f89.png)


## Changelog entries
```changes
section: ingress-nginx
type: fix
summary: "Expose status class label values with the xx suffix. Fix info about backends on dashboards."
impact_level: high
impact: |
  All ingress controllers >= 0.33 will restart.
```