### PR TITLE
[docs] Add warning about viewing an unreleased version

### DIFF
--- a/docs/documentation/_data/i18n.yml
+++ b/docs/documentation/_data/i18n.yml
@@ -98,6 +98,9 @@ common:
   or:
     en: or
     ru: или
+  notice-latest:
+    ru: Вы просматриваете документацию еще не вышедшей версии Deckhouse. Вы можете выбрать необходимый канал обновлений в меню версий или <a href="/ru/documentation/v1/">перейти к последней стабильной версии Deckhouse</a>.
+    en: You are viewing the documentation for an unreleased version of Deckhouse. You may choose the appropriate release channel from the versions menu or <a href="/en/documentation/v1/">go to the latest stable Deckhouse version</a>.
 features:
   experimental:
     ru: Эти возможности доступны только в Enterprise Edition. Их функциональность может существенно измениться. В настоящий момент не рекомендуется для самостоятельного использования.

--- a/docs/documentation/_includes/warning-latest.html
+++ b/docs/documentation/_includes/warning-latest.html
@@ -1,0 +1,3 @@
+<div id="notice-latest-doc-version-block" class="docs__information warning">
+{{ site.data.i18n.common.notice-latest[page.lang] }}
+</div>

--- a/docs/documentation/_layouts/page.html
+++ b/docs/documentation/_layouts/page.html
@@ -2,6 +2,7 @@
 layout: sidebar
 ---
 <div class="docs">
+    {%- include warning-latest.html %}
     {%- if page.comparable and site.mode != 'local' %}
     <div class="btn-group compare">
         <a href='{{ page.url | prepend: "compare" | true_relative_url }}' class="btn btn_o" target="_blank">
@@ -12,6 +13,11 @@ layout: sidebar
         $(document).ready(function(){
             if (window.location.hostname.match(/flant.com|localhost/)) {
                 $('.compare').addClass('active');
+            }
+            // Shows warning the viewing documentation about unreleased version
+            if (window.location.pathname.indexOf('/latest/') !== -1) {
+              console.log("Latest");
+              $('#notice-latest-doc-version-block').addClass('active');
             }
         });
     </script>

--- a/docs/site/css/docs.scss
+++ b/docs/site/css/docs.scss
@@ -661,6 +661,10 @@
     background-color: #fff3cd;
 }
 
+.docs__information.warning a {
+    color: blue ;
+}
+
 .docs__information.active {
     display: block;
 }

--- a/docs/site/css/docs.scss
+++ b/docs/site/css/docs.scss
@@ -662,7 +662,7 @@
 }
 
 .docs__information.warning a {
-    color: blue ;
+    color: #0066FF ;
 }
 
 .docs__information.active {


### PR DESCRIPTION
## Description
Added warning about viewing the latest documentation version - an unreleased version.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.
  Find examples and documentation below.
-->

```changes
module: docs
type: feature
description: Warning about viewing documentation of an unreleased Deckhouse version
impact_level: low
```

<!---
ABOUT CHANGES BLOCK

"Changes" block contains a list of YAML documents. It describes a changelog
entry that is collected to a release changelog.

Fields:

module
    Required. Affected module in kebab case, e.g. "node-manager".
type
    Required. The change type: only "fix" and "feature" supported.
description
    Optional. The changelog entry. Omit to use pull request title.
note
    Optional. Any notable detail, e.g. expected restarts, downtime, config changes, migrations, etc.

Since the syntax is YAML, `note` may contain multi-line text.

There can be multiple docs in single `changes` block, and multiple `changes`
blocks in the PR body.

Example:

```changes
module: node-manager
type: fix
description: "Nodes with outdated manifests are no longer provisioned on *InstanceClass update."
note: |
  Expect nodes of "Cloud" type to restart.

  Node checksum calculation is fixes as well as a race condition during
  the machines (MCM) rendering which caused outdated nodes to spawn.
---
module: cloud-provider-aws
type: feature
description: "Node restarts can be avoided by pinning a checksum to a node group in config values."
note: Recommended to use as a last resort.
```

-->
