### PR TITLE
[node-manager] Fix constant OOM on small-sized nodes

### DIFF
--- a/modules/040-node-manager/templates/early-oom/daemonset.yaml
+++ b/modules/040-node-manager/templates/early-oom/daemonset.yaml
@@ -59,7 +59,7 @@ spec:
           - 'sh'
           - '-c'
           - |
-            MIN_MEMORY_BY_PERCENT_KiB="$(grep 'MemTotal' /proc/meminfo | awk -v percent=$MIN_MEMORY_PERCENT '{ printf("%d", $2*percent/100 }')"
+            MIN_MEMORY_BY_PERCENT_KiB="$(grep 'MemTotal' /proc/meminfo | awk -v percent=$MIN_MEMORY_PERCENT '{ printf("%d", $2*percent/100) }')"
             if [ "$MIN_MEMORY_BY_PERCENT_KiB" -lt "$MIN_MEMORY_KiB" ]; then
               MIN_MEMORY_KiB="$MIN_MEMORY_BY_PERCENT_KiB"
             fi

--- a/modules/040-node-manager/templates/early-oom/daemonset.yaml
+++ b/modules/040-node-manager/templates/early-oom/daemonset.yaml
@@ -54,12 +54,18 @@ spec:
       containers:
       - name: oom-killer
         image: "{{ .Values.global.modulesImages.registry }}:{{ .Values.global.modulesImages.tags.common.alpine }}"
+        # based on https://gist.github.com/stewartpark/14a5690afbf717be04857d2cda1d8620
         args:
           - 'sh'
           - '-c'
           - |
             while true; do
-              if [ "$(cat /proc/meminfo | grep 'MemAvailable' | awk '{ print $2 }')" -lt "$MIN_MEMORY_KB" ]; then
+              if [ "$(grep 'MemTotal' /proc/meminfo | awk '{ print $2 }')" -le "$MIN_TOTAL_MEMORY_KiB" ]; then
+                sleep 600
+                continue
+              fi
+
+              if [ "$(grep 'MemAvailable' /proc/meminfo | awk '{ print $2 }')" -lt "$MIN_MEMORY_KiB" ]; then
                 echo f > /host_proc/sysrq-trigger
                 echo "Kernel OOM killer invoked."
               fi
@@ -67,8 +73,10 @@ spec:
               sleep 10
             done
         env:
-          - name: 'MIN_MEMORY_KB'
-            value: '500000'
+          - name: 'MIN_MEMORY_KiB'
+            value: '524288'
+          - name: 'MIN_TOTAL_MEMORY_KiB'
+            value: '6291456'
         securityContext:
           privileged: true
         volumeMounts:

--- a/modules/040-node-manager/templates/early-oom/daemonset.yaml
+++ b/modules/040-node-manager/templates/early-oom/daemonset.yaml
@@ -59,12 +59,12 @@ spec:
           - 'sh'
           - '-c'
           - |
-            while true; do
-              if [ "$(grep 'MemTotal' /proc/meminfo | awk '{ print $2 }')" -le "$MIN_TOTAL_MEMORY_KiB" ]; then
-                sleep 600
-                continue
-              fi
+            MIN_TOTAL_MEMORY_BY_PERCENT_KiB="$(grep 'MemTotal' /proc/meminfo | awk -v percent=$MIN_MEMORY_PERCENT '{ printf("%d", $2*percent/100 }')"
+            if [ "$MIN_TOTAL_MEMORY_BY_PERCENT_KiB" -lt "$MIN_TOTAL_MEMORY_KiB" ]; then
+              MIN_TOTAL_MEMORY_KiB="$MIN_TOTAL_MEMORY_BY_PERCENT_KiB"
+            fi
 
+            while true; do
               if [ "$(grep 'MemAvailable' /proc/meminfo | awk '{ print $2 }')" -lt "$MIN_MEMORY_KiB" ]; then
                 echo f > /host_proc/sysrq-trigger
                 echo "Kernel OOM killer invoked."
@@ -77,6 +77,8 @@ spec:
             value: '524288'
           - name: 'MIN_TOTAL_MEMORY_KiB'
             value: '6291456'
+          - name: 'MIN_MEMORY_PERCENT'
+            value: '5'
         securityContext:
           privileged: true
         volumeMounts:

--- a/modules/040-node-manager/templates/early-oom/daemonset.yaml
+++ b/modules/040-node-manager/templates/early-oom/daemonset.yaml
@@ -59,11 +59,10 @@ spec:
           - 'sh'
           - '-c'
           - |
-            MIN_TOTAL_MEMORY_BY_PERCENT_KiB="$(grep 'MemTotal' /proc/meminfo | awk -v percent=$MIN_MEMORY_PERCENT '{ printf("%d", $2*percent/100 }')"
-            if [ "$MIN_TOTAL_MEMORY_BY_PERCENT_KiB" -lt "$MIN_TOTAL_MEMORY_KiB" ]; then
-              MIN_TOTAL_MEMORY_KiB="$MIN_TOTAL_MEMORY_BY_PERCENT_KiB"
+            MIN_MEMORY_BY_PERCENT_KiB="$(grep 'MemTotal' /proc/meminfo | awk -v percent=$MIN_MEMORY_PERCENT '{ printf("%d", $2*percent/100 }')"
+            if [ "$MIN_MEMORY_BY_PERCENT_KiB" -lt "$MIN_MEMORY_KiB" ]; then
+              MIN_MEMORY_KiB="$MIN_MEMORY_BY_PERCENT_KiB"
             fi
-
             while true; do
               if [ "$(grep 'MemAvailable' /proc/meminfo | awk '{ print $2 }')" -lt "$MIN_MEMORY_KiB" ]; then
                 echo f > /host_proc/sysrq-trigger
@@ -75,8 +74,6 @@ spec:
         env:
           - name: 'MIN_MEMORY_KiB'
             value: '524288'
-          - name: 'MIN_TOTAL_MEMORY_KiB'
-            value: '6291456'
           - name: 'MIN_MEMORY_PERCENT'
             value: '5'
         securityContext:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

The previous configuration ensured almost constant OOMs on small-sized Nodes.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The amount of available memory is calculated as a minimum of 512 MB and 5% of the total node memory. If the amount of free node memory is less than the calculated value, the oom is triggered.
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Fix constant OOM on small-sized nodes.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
