### PR TITLE
Changelog: fix self-trigger

### DIFF
--- a/.github/actions/milestone-changelog/action.yml
+++ b/.github/actions/milestone-changelog/action.yml
@@ -17,29 +17,22 @@ runs:
         echo "::set-output name=milestone_title::${{ fromJSON(inputs.milestone).title }}"
         echo "::set-output name=milestone_number::${{ fromJSON(inputs.milestone).number }}"
 
-    # The gh utility has a shortcut to filter merged PRs by milestone, while it would require
-    # multiple calls in JS rest client
-    - name: Find Merged Pull Requsts
+    # Fetch merged PRs in milestone
+    - name: Find Merged Pull Requests
       id: merged_milestone
-      shell: bash
+      uses: actions/github-script@v5
+      with:
+        result-encoding: json
+        script: |
+          const fetch = require('./.github/scripts/js/changelog-find-pulls.js')
+          const prs = await fetch({ github, context }, { milestone: process.env.MILESTONE })
+          core.setOutput("prs", prs)
       env:
-        GITHUB_TOKEN: ${{ inputs.token }}
-      # Pick at most 1000 PRs with possible changes blocks;
-      # skip auto-generated PRs
-      run: |
-        prs="$(jq -c '[.[] | select(all( .labels[]; .name != "auto" )) | del(.labels) ]' <<< "$(
-          gh pr list \
-            --repo '${{ github.repository }}' \
-            --search 'milestone:${{ steps.args.outputs.milestone_title }}' \
-            --state merged \
-            --limit 1000 \
-            --json number,url,title,body,state,milestone,labels
-          )")"
-        echo "::set-output name=prs::${prs}"
+        MILESTONE: ${{ steps.args.outputs.milestone_title }}
 
     - name: Collect Changelog
       id: changelog
-      uses: deckhouse/changelog-action@main
+      uses: deckhouse/changelog-action@v1
       with:
         token: ${{ inputs.token }}
         pull_requests: ${{ steps.merged_milestone.outputs.prs }}

--- a/.github/scripts/js/changelog-find-pulls.js
+++ b/.github/scripts/js/changelog-find-pulls.js
@@ -1,0 +1,25 @@
+//@ts-check
+
+// Search all merged PRs in passed milestone.
+//
+// Uses search API to find merged PRs in current milestone and excluding "auto" label.
+module.exports = async function ({ github, context }, { milestone }) {
+  const repo = `${context.repo.owner}/${context.repo.repo}`;
+  const q = `repo:${repo} is:pr is:merged milestone:${milestone} -label:auto`;
+
+  const pulls = await github.paginate(github.rest.search.issuesAndPullRequests, { q });
+
+  // Make JSON compact to pass it further as string
+  return pulls.map((p) => ({
+    url: p.url,
+    number: p.number,
+    title: p.title,
+    body: p.body,
+    state: p.state,
+    milestone: {
+      number: p.milestone.number,
+      title: p.milestone.title,
+      state: p.milestone.state
+    }
+  }));
+};

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -28,14 +28,16 @@ jobs:
     if: |
       (
         github.event.pull_request &&
-        github.event.pull_request.state == 'closed' &&
-        github.event.pull_request.merged &&
-        github.event.pull_request.milestone.state == 'open' &&
-        !contains(github.event.issue.labels.*.name, 'changelog')
-      ) || (
-        (github.event.action == 'milestoned' || github.event.action == 'demilestoned') &&
-        github.event.issue.pull_request &&
-        !contains(github.event.issue.labels.*.name, 'changelog')
+        !contains(github.event.pull_request.labels.*.name, 'changelog')
+      ) && (
+        (
+          github.event.pull_request.state == 'closed'         &&
+          github.event.pull_request.merged                    &&
+          github.event.pull_request.milestone.state == 'open'
+        ) || (
+          github.event.action == 'milestoned' ||
+          github.event.action == 'demilestoned'
+        )
       )
     steps:
       - name: Check PR


### PR DESCRIPTION
## Description

Fix triggering changelog workflow by merging the changelog PR

## Why do we need it, and what problem does it solve?

This change leaves us without useless workflows and useless PRs

## Changelog entries

```changes
section: ci
type: fix
summary: Fixed self-trigger of changelog PR
impact_level: low
```
