### PR TITLE
[docs] Update supported Kubernetes and OS versions page

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -61,7 +61,7 @@ bashible: &bashible
           desiredVersion: "5.4.0-1029-gcp"
           allowedPattern: ""
   debian:
-    '9':
+    '9': &debian9
       docker:
         desiredVersion: "docker-ce=5:19.03.15~3-0~debian-stretch"
         allowedPattern: ""
@@ -135,6 +135,11 @@ bashible: &bashible
         generic:
           desiredVersion: "4.18.0-305.3.1.el8.x86_64"
           allowedPattern: "4.18.0-"
+  astra:
+    '1.7':
+      <<: *debian9
+    '2.12':
+      <<: *debian9
 k8s:
   '1.19':
     status: available

--- a/docs/documentation/_data/supported_versions.yml
+++ b/docs/documentation/_data/supported_versions.yml
@@ -1,6 +1,17 @@
 osDistributions:
-  ubuntu: Ubuntu
-  centos: CentOS
+  ubuntu:
+    name: Ubuntu
+  centos:
+    name: CentOS
+  debian:
+    name: Debian
+  astra:
+    name: Astra Linux
+    versions:
+      '1.7':
+        name: Special Edition
+      '2.12':
+        name: Common Edition
 
 k8s_statuses:
   end-of-life:

--- a/docs/documentation/_includes/SUPPORTED_VERSIONS.md
+++ b/docs/documentation/_includes/SUPPORTED_VERSIONS.md
@@ -11,10 +11,11 @@ The following Linux Distributions are currently supported for nodes:
 
 {%- for osItem in osVersions %}
 {%- assign osKey = osItem[0] %}
-{%- assign osName = site.data.supported_versions.osDistributions[osKey] | default: osKey  %}
+{%- assign osName = site.data.supported_versions.osDistributions[osKey].name | default: osKey  %}
 - {{ osName }}:
 {%- for osData in osItem[1] %}
-  - {{ osData[0] }}
+{%- assign osVersion = osData[0]  %}
+  - {{ osVersion }}{% if site.data.supported_versions.osDistributions[osKey]['versions'][osVersion] %} ({{ site.data.supported_versions.osDistributions[osKey]['versions'][osVersion]['name'] }}){% endif %}
 {%- endfor %}
 {%- endfor %}
 


### PR DESCRIPTION
## Description
Add Astra Linux versions to the "Supported Kubernetes and OS versions" page

## Changelog entries
```changes
section: docs
type: fix
summary: Add Astra Linux to the "Supported Kubernetes and OS versions" page
impact_level: low
```
