### PR TITLE
[node-manager] sort node users by name

### DIFF
--- a/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
@@ -318,6 +318,10 @@ func (cb *ContextBuilder) getNodeUserConfigurations(nodeGroup string) []*UserCon
 	users = append(users, cb.nodeUserConfigurations[wildcardBundle]...)
 	users = append(users, cb.nodeUserConfigurations[totalWildcard]...)
 
+	sort.SliceStable(users, func(i, j int) bool {
+		return users[i].Name < users[j].Name
+	})
+
 	return users
 }
 


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Sort node-users output in bashible-apiserver

## Why do we need it, and what problem does it solve?
Users are not sorted and their order could be different => we can have different checksum for bashible

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Sort node users for persistance
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
