### PR TITLE
[bashible-apiserver] sort NodeUsers by name

### DIFF
--- a/modules/040-node-manager/images/bashible-apiserver/pkg/template/context.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/template/context.go
@@ -547,6 +547,9 @@ func (c *BashibleContext) AddNodeUserConfiguration(nu *NodeUser) {
 	for _, ngBundlePair := range ngBundlePairs {
 		if m, ok := c.contextBuilder.nodeUserConfigurations[ngBundlePair]; ok {
 			m = append(m, &nuc)
+			sort.Slice(m, func(i, j int) bool {
+				return m[i].Name < m[j].Name
+			})
 			c.contextBuilder.nodeUserConfigurations[ngBundlePair] = m
 		} else {
 			c.contextBuilder.nodeUserConfigurations[ngBundlePair] = []*UserConfiguration{&nuc}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Sort NodeUsers by name in bashible-apiserver.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In HA configuration, each bashible-apiserver gets NodeUser objects from api in random order. So checksum of bundles in each bashible-apiserver differs from another bashible-apiservers.  When node asks apiserver for bundle,  result differs on each request and bashible on node runs full reconcile.
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Sort NodeUsers by name in bashible-apiserver.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
