### PR TITLE
[global] Update addon-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.9.0
-	github.com/flant/addon-operator v1.0.4-0.20220121072209-d27b5b3473ac
+	github.com/flant/addon-operator v1.0.4-0.20220208071927-1b4e2c72f3db
 	github.com/flant/kube-client v0.0.6
 	github.com/flant/shell-operator v1.0.8-0.20220121071428-6b7bd04272e5
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwo
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/flant/addon-operator v1.0.4-0.20220121072209-d27b5b3473ac h1:uJmQdyQtPN7NzPFefD+pg8/X77+SYQ9x4cxhKm2Kyf8=
-github.com/flant/addon-operator v1.0.4-0.20220121072209-d27b5b3473ac/go.mod h1:jrqkO7KN1/teI3uVXg5W5CmyLTwPCQrpr/UTDhe5xDw=
+github.com/flant/addon-operator v1.0.4-0.20220208071927-1b4e2c72f3db h1:kcXkD8PAWcAKoYOFVQB63lZi3v64CvZcQyjcL1RUmgQ=
+github.com/flant/addon-operator v1.0.4-0.20220208071927-1b4e2c72f3db/go.mod h1:jrqkO7KN1/teI3uVXg5W5CmyLTwPCQrpr/UTDhe5xDw=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v0.0.6 h1:cHFMf7xGtJOgg+KBuPcA+7q+M7IJRSgf2pHVStv2aj0=


### PR DESCRIPTION
## Description
Update addon-operator for deckhouse. 

## Why do we need it, and what problem does it solve?
We need to add new improvements to deckhouse.
In new version, cronjobs hooks will be started after first converge.

## Changelog entries

```changes
section: global
type: feature
summary: 
impact_level: high
impact: Now, cronjobs hooks will be started after first converge.
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
