### PR TITLE
Changelog: fix PR URL

### DIFF
--- a/.github/scripts/js/changelog-find-pulls.js
+++ b/.github/scripts/js/changelog-find-pulls.js
@@ -11,7 +11,7 @@ module.exports = async function ({ github, context }, { milestone }) {
 
   // Make JSON compact to pass it further as string
   return pulls.map((p) => ({
-    url: p.url,
+    url: p.html_url,
     number: p.number,
     title: p.title,
     body: p.body,


### PR DESCRIPTION
## Description

URL to PRs are now correct

## Why do we need it, and what problem does it solve?

Now URLs point to github JSON API

## Changelog entries

```changes
section: ci
type: fix 
summary: Fixed PR URL in changelog
impact_level: low 
```
