### PR TITLE
[user-authz] Webhook probe

### DIFF
--- a/ee/modules/140-user-authz/images/webhook/web/hook/handler.go
+++ b/ee/modules/140-user-authz/images/webhook/web/hook/handler.go
@@ -42,10 +42,10 @@ type Handler struct {
 	directory map[string]map[string]DirectoryEntry
 }
 
-func NewHandler(logger *log.Logger) *Handler {
+func NewHandler(logger *log.Logger, discoveryCache cache.Cache) *Handler {
 	return &Handler{
 		logger: logger,
-		cache:  cache.NewNamespacedDiscoveryCache(logger),
+		cache:  discoveryCache,
 	}
 }
 

--- a/ee/modules/140-user-authz/images/webhook/web/hook/handler_test.go
+++ b/ee/modules/140-user-authz/images/webhook/web/hook/handler_test.go
@@ -325,6 +325,10 @@ func (d *dummyCache) GetPreferredVersion(group string) (string, error) {
 	return "", fmt.Errorf("not found")
 }
 
+func (d *dummyCache) Check() error {
+	return nil
+}
+
 func TestWrapRegexpTest(t *testing.T) {
 	tc := []struct {
 		Name   string

--- a/ee/modules/140-user-authz/templates/webhook/daemonset.yaml
+++ b/ee/modules/140-user-authz/templates/webhook/daemonset.yaml
@@ -74,6 +74,11 @@ spec:
             - --key
             - /etc/ssl/user-authz-webhook/webhook-server.key
             - https://127.0.0.1:40443/healthz
+          # Wait for one minute before restarting the container to avoid crashloopbackoofs in case if apiserver restarts
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 6
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}

--- a/ee/modules/140-user-authz/templates/webhook/rbac-for-us.yaml
+++ b/ee/modules/140-user-authz/templates/webhook/rbac-for-us.yaml
@@ -13,7 +13,7 @@ metadata:
   name: d8:user-authz:webhook
   {{- include "helm_lib_module_labels" (list . (dict "app" "webhook")) | nindent 2 }}
 rules:
-- nonResourceURLs: ["/api/v1", "/apis/*"]
+- nonResourceURLs: ["/version", "/api/v1", "/apis/*"]
   verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
* Implement the check method
* Add it to liveness probe
* Increase liveness probe thresholds

## Why do we need it, and what problem does it solve?
This will help us restart a pod if the API becomes unavailable for it (we faced a problem once).

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: user-authz
type: fix
summary: Add proper liveness probe which checks that webhook can access Kubernetes API
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
