### PR TITLE
[cloud-provider-aws][cloud-provider-azure][cloud-provider-gcp][cloud-provider-yandex][cloud-provider-openstack][cloud-provider-vsphere] Fix failing csi-provisioner

### DIFF
--- a/helm_lib/templates/_csi_controller.tpl
+++ b/helm_lib/templates/_csi_controller.tpl
@@ -126,6 +126,11 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         - name: NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
## Description

Add POD_NAME variable to csi-provisioner pod

## Why do we need it, and what problem does it solve?

CSI-provisioner is failing when CSIStorageCapacity enabeled:

```
I0216 20:15:55.102354       1 csi-provisioner.go:275] CSI driver supports PUBLISH_UNPUBLISH_VOLUME, watching VolumeAttachments
F0216 20:15:55.102554       1 csi-provisioner.go:409] need POD_NAME env variable to determine CSIStorageCapacity owner
goroutine 1 [running]:
k8s.io/klog/v2.stacks(0x1)
	/workspace/vendor/k8s.io/klog/v2/klog.go:1038 +0x8a
k8s.io/klog/v2.(*loggingT).output(0x299b6c0, 0x3, 0x0, 0xc000289ce0, 0x1, {0x203e298, 0x10}, 0xc000100000, 0x0)
	/workspace/vendor/k8s.io/klog/v2/klog.go:987 +0x5fd
k8s.io/klog/v2.(*loggingT).printDepth(0x19bf26e, 0x8, 0x0, {0x0, 0x0}, 0xc0002a9a40, {0xc00014e310, 0x1, 0x1})
	/workspace/vendor/k8s.io/klog/v2/klog.go:735 +0x1ae
k8s.io/klog/v2.(*loggingT).print(...)
	/workspace/vendor/k8s.io/klog/v2/klog.go:717
k8s.io/klog/v2.Fatal(...)
	/workspace/vendor/k8s.io/klog/v2/klog.go:1512
main.main()
	/workspace/cmd/csi-provisioner/csi-provisioner.go:409 +0x23c8
```

## Changelog entries





 
<!---
Let's skip changelog because it is a fix for the feature which has not been released yet.
```
---
section: cloud-provider-aws
type: fix
summary: Fix failing csi-provisioner
---
section: cloud-provider-azure
type: fix
summary: Fix failing csi-provisioner
---
section: cloud-provider-gcp
type: fix
summary: Fix failing csi-provisioner
---
section: cloud-provider-yandex
type: fix
summary: Fix failing csi-provisioner
---
section: cloud-provider-openstack
type: fix
summary: Fix failing csi-provisioner
---
section: cloud-provider-vsphere
type: fix
summary: Fix failing csi-provisioner
```
--->