### PR TITLE
[cloud-provider-openstack] Fix certificates ordering for balancers with PROXY PROTOCOL enabled

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/secret.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/secret.yaml
@@ -39,6 +39,9 @@ subnet-id = {{ .Values.cloudProviderOpenstack.internal.loadBalancer.subnetID | q
 floating-network-id = {{ .Values.cloudProviderOpenstack.internal.loadBalancer.floatingNetworkID | quote }}
     {{- end }}
   {{- end }}
+  {{- if semverCompare ">=1.21" .Values.global.discovery.kubernetesVersion -}}
+enable-ingress-hostname = true
+  {{- end }}
 [BlockStorage]
 rescan-on-resize = true
 {{- end }}


### PR DESCRIPTION
## Why do we need it, and what problem does it solve?
Related issue https://github.com/deckhouse/deckhouse/issues/841

## Changelog entries


```changes
section: cloud-provider-openstack
type: fix
summary: Fix LE certificates ordering for balancers with PROXY PROTOCOL enabled
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
