### PR TITLE
[ingress-nginx] max surge and manual rollout

### DIFF
--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -35,7 +35,7 @@ apiServer:
 {{- end }}
     anonymous-auth: "false"
 {{- if semverCompare ">= 1.21" .clusterConfiguration.kubernetesVersion }}
-    feature-gates: "EndpointSliceTerminatingCondition=true"
+    feature-gates: "EndpointSliceTerminatingCondition=true,DaemonSetUpdateSurge=true"
 {{- end }}
 {{- if semverCompare "< 1.21" .clusterConfiguration.kubernetesVersion }}
     feature-gates: "TTLAfterFinished=true"
@@ -105,7 +105,7 @@ controllerManager:
     profiling: "false"
     terminated-pod-gc-threshold: "12500"
 {{- if semverCompare ">= 1.21" .clusterConfiguration.kubernetesVersion }}
-    feature-gates: "EndpointSliceTerminatingCondition=true"
+    feature-gates: "EndpointSliceTerminatingCondition=true,DaemonSetUpdateSurge=true"
 {{- end }}
 {{- if semverCompare "< 1.21" .clusterConfiguration.kubernetesVersion }}
     feature-gates: "TTLAfterFinished=true"
@@ -138,7 +138,7 @@ scheduler:
 {{- end }}
     profiling: "false"
 {{- if semverCompare ">= 1.21" .clusterConfiguration.kubernetesVersion }}
-    feature-gates: "EndpointSliceTerminatingCondition=true"
+    feature-gates: "EndpointSliceTerminatingCondition=true,DaemonSetUpdateSurge=true"
 {{- end }}
 {{- if semverCompare "< 1.20" .clusterConfiguration.kubernetesVersion }}
     feature-gates: "DefaultPodTopologySpread=true"

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 )
 
 replace github.com/deckhouse/deckhouse/dhctl => ./dhctl
+
 // Remove 'in body' from errors, fix for Go 1.16 (https://github.com/go-openapi/validate/pull/138).
 replace github.com/go-openapi/validate => github.com/flant/go-openapi-validate v0.19.12-flant.0
 
@@ -63,4 +64,5 @@ replace github.com/go-openapi/validate => github.com/flant/go-openapi-validate v
 replace k8s.io/client-go => k8s.io/client-go v0.19.11
 
 replace k8s.io/api => k8s.io/api v0.19.11
+
 //

--- a/modules/021-kube-proxy/templates/configmap.yaml
+++ b/modules/021-kube-proxy/templates/configmap.yaml
@@ -8,6 +8,7 @@ config.conf: |
   featureGates:
     EndpointSliceTerminatingCondition: true
     ProxyTerminatingEndpoints: true
+    DaemonSetUpdateSurge: true
   {{- end }}
   nodePortAddresses: ["__node_address__"]
   clientConnection:

--- a/modules/402-ingress-nginx/hooks/manual_daemonset_update.go
+++ b/modules/402-ingress-nginx/hooks/manual_daemonset_update.go
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// This is temporary hook, because daemonset controller sometime makes some trash with deleting pods
+// It could be removed, when all clusters will be upgraded to 1.21 version
+
 package hooks
 
 import (
@@ -118,10 +121,8 @@ func manualControllerUpdate(input *go_hook.HookInput) error {
 			}
 		}
 
-		if allPodsReady {
-			if podNameForDeletion != "" {
-				input.PatchCollector.Delete("v1", "Pod", "d8-ingress-nginx", podNameForDeletion)
-			}
+		if allPodsReady && podNameForDeletion != "" {
+			input.PatchCollector.Delete("v1", "Pod", "d8-ingress-nginx", podNameForDeletion)
 		}
 	}
 

--- a/modules/402-ingress-nginx/hooks/manual_daemonset_update.go
+++ b/modules/402-ingress-nginx/hooks/manual_daemonset_update.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue:       "/modules/ingress-nginx/manual_daemonset_update",
+	OnAfterHelm: &go_hook.OrderedConfig{Order: 10},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                         "controllers",
+			ApiVersion:                   "apps/v1",
+			Kind:                         "DaemonSet",
+			ExecuteHookOnSynchronization: pointer.BoolPtr(false),
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-ingress-nginx"},
+				},
+			},
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"ingress-nginx-manual-update": "true",
+					"app":                         "controller",
+				},
+			},
+			FilterFunc: filterManualDS,
+		},
+		{
+			Name:                         "pods",
+			ApiVersion:                   "v1",
+			Kind:                         "Pod",
+			ExecuteHookOnSynchronization: pointer.BoolPtr(false),
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-ingress-nginx"},
+				},
+			},
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"ingress-nginx-manual-update": "true",
+					"app":                         "controller",
+				},
+			},
+			FilterFunc: filterManualPod,
+		},
+	},
+}, manualControllerUpdate)
+
+type manualDSController struct {
+	Name       string
+	Generation int64
+}
+
+type manualRolloutPod struct {
+	Name       string
+	Generation int64
+
+	DSControllerName string
+
+	Ready bool
+}
+
+func manualControllerUpdate(input *go_hook.HookInput) error {
+	var controllers []manualDSController
+	snap := input.Snapshots["controllers"]
+	for _, sn := range snap {
+		controller := sn.(manualDSController)
+		controllers = append(controllers, controller)
+	}
+
+	// by ds controller name
+	podsMap := make(map[string][]manualRolloutPod)
+	snap = input.Snapshots["pods"]
+	for _, sn := range snap {
+		pod := sn.(manualRolloutPod)
+		podsMap[pod.DSControllerName] = append(podsMap[pod.DSControllerName], pod)
+	}
+
+	for _, controller := range controllers {
+		allPodsReady := true
+		var podNameForDeletion string
+		for _, pod := range podsMap[controller.Name] {
+			if !pod.Ready {
+				allPodsReady = false
+				break
+			}
+
+			if pod.Generation != controller.Generation {
+				podNameForDeletion = pod.Name
+			}
+		}
+
+		if allPodsReady {
+			if podNameForDeletion != "" {
+				input.PatchCollector.Delete("v1", "Pod", "d8-ingress-nginx", podNameForDeletion)
+			}
+		}
+	}
+
+	return nil
+}
+
+func filterManualDS(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return manualDSController{
+		Name:       obj.GetName(),
+		Generation: obj.GetGeneration(),
+	}, nil
+}
+
+func filterManualPod(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var pod v1.Pod
+
+	err := sdk.FromUnstructured(obj, &pod)
+	if err != nil {
+		return nil, err
+	}
+
+	genLabel := pod.Labels["pod-template-generation"]
+	if len(genLabel) == 0 {
+		return nil, errors.New("pod-template-generation label missed")
+	}
+	gen, err := strconv.ParseInt(genLabel, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	var podReady bool
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == v1.PodReady && cond.Status == v1.ConditionTrue {
+			podReady = true
+			break
+		}
+	}
+
+	return manualRolloutPod{
+		Name:             pod.Name,
+		Generation:       gen,
+		DSControllerName: pod.Labels["name"],
+		Ready:            podReady,
+	}, nil
+}

--- a/modules/402-ingress-nginx/hooks/manual_daemonset_update.go
+++ b/modules/402-ingress-nginx/hooks/manual_daemonset_update.go
@@ -63,8 +63,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			},
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"ingress-nginx-manual-update": "true",
-					"app":                         "controller",
+					"app": "controller",
 				},
 			},
 			FilterFunc: filterManualPod,
@@ -89,6 +88,9 @@ type manualRolloutPod struct {
 func manualControllerUpdate(input *go_hook.HookInput) error {
 	var controllers []manualDSController
 	snap := input.Snapshots["controllers"]
+	if len(snap) == 0 {
+		return nil
+	}
 	for _, sn := range snap {
 		controller := sn.(manualDSController)
 		controllers = append(controllers, controller)

--- a/modules/402-ingress-nginx/hooks/manual_daemonset_update_test.go
+++ b/modules/402-ingress-nginx/hooks/manual_daemonset_update_test.go
@@ -1,0 +1,526 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("ingress-nginx :: hooks :: manual_daemonset_update ::", func() {
+	f := HookExecutionConfigInit(`{"ingressNginx":{"defaultControllerVersion": "0.33", "internal": {}}}`, "")
+	f.RegisterCRD("deckhouse.io", "v1", "IngressNginxController", true)
+
+	Context("DS has same generation as pods", func() {
+		BeforeEach(func() {
+			dspods := `
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  generation: 1
+  labels:
+    app: controller
+    ingress-nginx-manual-update: "true"
+    name: main
+  name: controller-main
+  namespace: d8-ingress-nginx
+spec:
+  selector:
+    matchLabels:
+      app: controller
+      name: main
+  template:
+    metadata:
+      labels:
+        app: controller
+        name: main
+    spec:
+      containers:
+      - args:
+        - /nginx-ingress-controller
+      image: registry.deckhouse.io/image:nginx
+      imagePullPolicy: IfNotPresent
+  updateStrategy:
+    type: OnDelete
+status:
+  currentNumberScheduled: 1
+  desiredNumberScheduled: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: controller
+    name: main
+    pod-template-generation: "1"
+  name: controller-main-1
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - args:
+    - /nginx-ingress-controller
+    image: registry.deckhouse.io/image:nginx
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: controller
+    name: main
+    pod-template-generation: "1"
+  name: controller-main-2
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - args:
+    - /nginx-ingress-controller
+    image: registry.deckhouse.io/image:nginx
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: controller
+    name: main
+    pod-template-generation: "1"
+  name: controller-main-3
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - args:
+    - /nginx-ingress-controller
+    image: registry.deckhouse.io/image:nginx
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  phase: Running
+`
+			f.KubeStateSet(dspods)
+			f.BindingContexts.Set(f.GenerateAfterHelmContext())
+			f.RunHook()
+		})
+
+		It("Pods should not be recreated", func() {
+			Expect(f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-main-1").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-main-2").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-main-3").Exists()).To(BeTrue())
+		})
+	})
+
+	Context("DS has new generation", func() {
+		BeforeEach(func() {
+			dspods := `
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  generation: 2
+  labels:
+    app: controller
+    ingress-nginx-manual-update: "true"
+    name: main
+  name: controller-main
+  namespace: d8-ingress-nginx
+spec:
+  selector:
+    matchLabels:
+      app: controller
+      name: main
+  template:
+    metadata:
+      labels:
+        app: controller
+        name: main
+    spec:
+      containers:
+      - args:
+        - /nginx-ingress-controller
+      image: registry.deckhouse.io/image:nginx
+      imagePullPolicy: IfNotPresent
+  updateStrategy:
+    type: OnDelete
+status:
+  currentNumberScheduled: 3
+  desiredNumberScheduled: 3
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: controller
+    name: main
+    pod-template-generation: "1"
+  name: controller-main-1
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - args:
+    - /nginx-ingress-controller
+    image: registry.deckhouse.io/image:nginx
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: controller
+    name: main
+    pod-template-generation: "1"
+  name: controller-main-2
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - args:
+    - /nginx-ingress-controller
+    image: registry.deckhouse.io/image:nginx
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: controller
+    name: main
+    pod-template-generation: "1"
+  name: controller-main-3
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - args:
+    - /nginx-ingress-controller
+    image: registry.deckhouse.io/image:nginx
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  phase: Running
+`
+			f.KubeStateSet(dspods)
+			f.BindingContexts.Set(f.GenerateAfterHelmContext())
+			f.RunHook()
+		})
+
+		It("One pod should be deleted", func() {
+			Expect(f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-main-3").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-main-2").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-main-1").Exists()).To(BeTrue())
+		})
+
+		Context("second run", func() {
+			BeforeEach(func() {
+				delete(f.BindingContextController.Controller.CurrentState, "d8-ingress-nginx/Pod/controller-main-3")
+				ff := f.KubeStateSet(`
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  generation: 2
+  labels:
+    app: controller
+    ingress-nginx-manual-update: "true"
+    name: main
+  name: controller-main
+  namespace: d8-ingress-nginx
+spec:
+  selector:
+    matchLabels:
+      app: controller
+      name: main
+  template:
+    metadata:
+      labels:
+        app: controller
+        name: main
+    spec:
+      containers:
+      - args:
+        - /nginx-ingress-controller
+      image: registry.deckhouse.io/image:nginx
+      imagePullPolicy: IfNotPresent
+  updateStrategy:
+    type: OnDelete
+status:
+  currentNumberScheduled: 3
+  desiredNumberScheduled: 3
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: controller
+    name: main
+    pod-template-generation: "1"
+  name: controller-main-1
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - args:
+    - /nginx-ingress-controller
+    image: registry.deckhouse.io/image:nginx
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: controller
+    name: main
+    pod-template-generation: "1"
+  name: controller-main-2
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - args:
+    - /nginx-ingress-controller
+    image: registry.deckhouse.io/image:nginx
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: controller
+    name: main
+    pod-template-generation: "2"
+  name: controller-main-4
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - args:
+    - /nginx-ingress-controller
+    image: registry.deckhouse.io/image:nginx
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  phase: Running
+`)
+				f.BindingContexts.Set(ff)
+				f.RunHook()
+			})
+			It("Second pod should be deleted", func() {
+				Expect(f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-main-1").Exists()).To(BeTrue())
+				Expect(f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-main-2").Exists()).To(BeFalse())
+				Expect(f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-main-4").Exists()).To(BeTrue())
+			})
+		})
+	})
+
+	Context("Pods are not ready", func() {
+		BeforeEach(func() {
+			dspods := `
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  generation: 2
+  labels:
+    app: controller
+    ingress-nginx-manual-update: "true"
+    name: main
+  name: controller-main
+  namespace: d8-ingress-nginx
+spec:
+  selector:
+    matchLabels:
+      app: controller
+      name: main
+  template:
+    metadata:
+      labels:
+        app: controller
+        name: main
+    spec:
+      containers:
+      - args:
+        - /nginx-ingress-controller
+      image: registry.deckhouse.io/image:nginx
+      imagePullPolicy: IfNotPresent
+  updateStrategy:
+    type: OnDelete
+status:
+  currentNumberScheduled: 3
+  desiredNumberScheduled: 3
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: controller
+    name: main
+    pod-template-generation: "1"
+  name: controller-main-1
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - args:
+    - /nginx-ingress-controller
+    image: registry.deckhouse.io/image:nginx
+status:
+  conditions:
+  - status: "False"
+    type: Ready
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: controller
+    name: main
+    pod-template-generation: "1"
+  name: controller-main-2
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - args:
+    - /nginx-ingress-controller
+    image: registry.deckhouse.io/image:nginx
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: controller
+    name: main
+    pod-template-generation: "1"
+  name: controller-main-3
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - args:
+    - /nginx-ingress-controller
+    image: registry.deckhouse.io/image:nginx
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  phase: Running
+`
+			f.KubeStateSet(dspods)
+			f.BindingContexts.Set(f.GenerateAfterHelmContext())
+			f.RunHook()
+		})
+
+		It("Pods should not be deleted", func() {
+			Expect(f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-main-3").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-main-2").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-main-1").Exists()).To(BeTrue())
+		})
+	})
+
+	Context("DS has wrong count", func() {
+		BeforeEach(func() {
+			dspods := `
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  generation: 2
+  labels:
+    app: controller
+    ingress-nginx-manual-update: "true"
+    name: main
+  name: controller-main
+  namespace: d8-ingress-nginx
+spec:
+  selector:
+    matchLabels:
+      app: controller
+      name: main
+  template:
+    metadata:
+      labels:
+        app: controller
+        name: main
+    spec:
+      containers:
+      - args:
+        - /nginx-ingress-controller
+      image: registry.deckhouse.io/image:nginx
+      imagePullPolicy: IfNotPresent
+  updateStrategy:
+    type: OnDelete
+status:
+  currentNumberScheduled: 1
+  desiredNumberScheduled: 3
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: controller
+    name: main
+    pod-template-generation: "1"
+  name: controller-main-1
+  namespace: d8-ingress-nginx
+spec:
+  containers:
+  - args:
+    - /nginx-ingress-controller
+    image: registry.deckhouse.io/image:nginx
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  phase: Running
+`
+			f.KubeStateSet(dspods)
+			f.BindingContexts.Set(f.GenerateAfterHelmContext())
+			f.RunHook()
+		})
+
+		It("Pod should not be deleted", func() {
+			Expect(f.KubernetesResource("Pod", "d8-ingress-nginx", "controller-main-1").Exists()).To(BeTrue())
+		})
+	})
+})

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -21,6 +21,20 @@
 {{- $defaultSSLCertificate := $crd.spec.defaultSSLCertificate | default dict }}
 {{- $defaultSSLCertificateSecretRef := $defaultSSLCertificate.secretRef | default dict }}
 
+{{- $manualInlets := list "LoadBalancer" "LoadBalancerWithProxyProtocol" "HostPort" "HostPortWithProxyProtocol" }}
+{{- $isManualRollout := false }}
+{{- if has $crd.spec.inlet $manualInlets }}
+  {{- if semverCompare ">=1.21" $kubernetesVersion}}
+    {{- if $loadBalancer }}
+      {{- $isManualRollout = false }}
+    {{- else }}
+      {{- $isManualRollout = true }}
+    {{- end }}
+  {{- else }}
+    {{- $isManualRollout = true }}
+  {{- end}}
+{{- end }}
+
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
@@ -83,27 +97,32 @@ metadata:
     ingress-nginx-safe-update: ""
     {{- end }}
   {{- end }}
+  {{- if $isManualRollout }}
+    ingress-nginx-manual-update: "true"
+  {{- end }}
   annotations:
     ingress-nginx-controller.deckhouse.io/controller-version: {{ $crd.spec.controllerVersion | quote }}
     ingress-nginx-controller.deckhouse.io/inlet: {{ $crd.spec.inlet | quote }}
     ingress-nginx-controller.deckhouse.io/checksum: {{ $crdChecksum }}
 spec:
   updateStrategy:
-  {{- if $loadBalancer }}
+  {{- if eq $crd.spec.inlet "HostWithFailover" }}
+    {{- if not $failover }}
+    type: OnDelete
+    {{- else }}
     type: RollingUpdate
-    {{- if semverCompare ">=1.21" $kubernetesVersion}}
+    rollingUpdate:
+      maxUnavailable: 1
+    {{- end}}
+  {{- else if $isManualRollout }}
+    type: OnDelete
+  {{- else }}
+    type: RollingUpdate
+    {{- if and $loadBalancer (semverCompare ">=1.21" $kubernetesVersion) }}
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
     {{- else }}
-    rollingUpdate:
-      maxUnavailable: 1
-    {{- end }}
-  {{- else }}
-    {{- if and (eq $crd.spec.inlet "HostWithFailover") (not $failover) }}
-    type: OnDelete
-    {{- else }}
-    type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 1
     {{- end }}
@@ -117,6 +136,9 @@ spec:
       labels:
         app: controller
         name: {{ $name }}
+        {{- if $isManualRollout }}
+        ingress-nginx-manual-update: "true"
+        {{- end }}
       {{- if include "is_istio_in_use" $context }}
       annotations:
         {{- if $crd.spec.enableIstioSidecar }}

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -136,9 +136,6 @@ spec:
       labels:
         app: controller
         name: {{ $name }}
-        {{- if $isManualRollout }}
-        ingress-nginx-manual-update: "true"
-        {{- end }}
       {{- if include "is_istio_in_use" $context }}
       annotations:
         {{- if $crd.spec.enableIstioSidecar }}

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -6,6 +6,7 @@
 {{- $crdChecksum := toJson $crd | sha256sum }}
 {{- $loadBalancer := (or (eq $crd.spec.inlet "LoadBalancer") (eq $crd.spec.inlet "LoadBalancerWithProxyProtocol")) }}
 {{- $controllerVersion := $crd.spec.controllerVersion | default $context.Values.ingressNginx.defaultControllerVersion }}
+{{- $kubernetesSemVer := semver $context.Values.global.discovery.kubernetesVersion }}
 
 {{- $resourcesRequests := $crd.spec.resourcesRequests | default dict }}
 {{- $geoIP2 := $crd.spec.geoIP2 | default dict }}
@@ -90,6 +91,13 @@ spec:
   updateStrategy:
   {{- if and (eq $crd.spec.inlet "HostWithFailover") (not $failover) }}
     type: OnDelete
+  {{- else if $loadBalancer }}
+    type: RollingUpdate
+    {{- if semverCompare ">=1.21" $kubernetesSemVer }}
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+    {{- end }}
   {{- else }}
     type: RollingUpdate
   {{- end }}

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -6,7 +6,7 @@
 {{- $crdChecksum := toJson $crd | sha256sum }}
 {{- $loadBalancer := (or (eq $crd.spec.inlet "LoadBalancer") (eq $crd.spec.inlet "LoadBalancerWithProxyProtocol")) }}
 {{- $controllerVersion := $crd.spec.controllerVersion | default $context.Values.ingressNginx.defaultControllerVersion }}
-{{- $kubernetesSemVer := semver $context.Values.global.discovery.kubernetesVersion }}
+{{- $kubernetesVersion := $context.Values.global.discovery.kubernetesVersion }}
 
 {{- $resourcesRequests := $crd.spec.resourcesRequests | default dict }}
 {{- $geoIP2 := $crd.spec.geoIP2 | default dict }}
@@ -93,7 +93,7 @@ spec:
     type: OnDelete
   {{- else if $loadBalancer }}
     type: RollingUpdate
-    {{- if semverCompare ">=1.21" $kubernetesSemVer }}
+    {{- if semverCompare ">=1.21" $kubernetesVersion}}
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -89,17 +89,24 @@ metadata:
     ingress-nginx-controller.deckhouse.io/checksum: {{ $crdChecksum }}
 spec:
   updateStrategy:
-  {{- if and (eq $crd.spec.inlet "HostWithFailover") (not $failover) }}
-    type: OnDelete
-  {{- else if $loadBalancer }}
+  {{- if $loadBalancer }}
     type: RollingUpdate
     {{- if semverCompare ">=1.21" $kubernetesVersion}}
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+    {{- else }}
+    rollingUpdate:
+      maxUnavailable: 1
     {{- end }}
   {{- else }}
+    {{- if and (eq $crd.spec.inlet "HostWithFailover") (not $failover) }}
+    type: OnDelete
+    {{- else }}
     type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+    {{- end }}
   {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Add maxSurge==1 for clusters >=1.21 k8s version.
Add hook for manual Daemonset rollout for <1.21 clusters

## Why do we need it, and what problem does it solve?
Ingress controller pod terminating and only then creating a new pod during rollout. This could be a problem in some heavy-loaded clusters. Adding maxSurge changes this behavior.
Sometime native DaemonSet rollout removes two pods concurrently instead of sequential update. We can handle this situation by manual rollout control via the hook. It seems like a bug in old k8s version, guess we can disabled it after everyone will upgrade to 1.21+

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ingress-nginx
type: fix
summary: Manual update for ingress controllers
impact_level: high
impact: ingress nginx controllers will be removed manually by hook
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
