### PR TITLE
[candi] fix nodeUser password set error

### DIFF
--- a/candi/bashible/common-steps/node-group/090_node_users.sh.tpl
+++ b/candi/bashible/common-steps/node-group/090_node_users.sh.tpl
@@ -14,11 +14,9 @@
 
 {{- if eq .runType "Normal" }}
 
+
   {{- if .nodeUsers }}
-node_users_json="$(cat <<-END
-{{ .nodeUsers | toJson}}
-END
-)"
+node_users_json='{{ .nodeUsers | toJson}}'
   {{- end }}
 
 # if reboot flag set due to disruption update (for example, in case of CRI change) we pass this step.

--- a/candi/bashible/common-steps/node-group/090_node_users.sh.tpl
+++ b/candi/bashible/common-steps/node-group/090_node_users.sh.tpl
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 {{- if eq .runType "Normal" }}
-
-
   {{- if .nodeUsers }}
 node_users_json='{{ .nodeUsers | toJson}}'
   {{- end }}

--- a/candi/bashible/common-steps/node-group/090_node_users.sh.tpl
+++ b/candi/bashible/common-steps/node-group/090_node_users.sh.tpl
@@ -31,7 +31,7 @@ function modify_user() {
   local extra_groups="$2"
   local password_hash="$3"
 
-  usermod -G "$extra_group" "$user_name"
+  usermod -G "$extra_groups" "$user_name"
 
   if ! grep -q -F "$password_hash" /etc/shadow; then
       usermod -p "$password_hash" "$user_name"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix nodeUser password set error.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary:  Fix nodeUser password set error.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
