### PR TITLE
[docs] Update getting started for bare metal cluster

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA.liquid
@@ -48,7 +48,8 @@ You will need:
    - at least 40 GB of disk space for the cluster and etcd data;
    - OS: Ubuntu Linux 16.04/18.04/20.04 LTS or CentOS 7;
    - HTTPS access to the `registry.deckhouse.io` container registry (it is also possible to use a [third-party registry](/{{ page.lang }}/documentation/v1/deckhouse-faq.html#how-do-i-configure-deckhouse-to-use-a-third-party-registry));
-   - SSH key access from the **personal computer** (section 1).
+   - SSH key access from the **personal computer** (section 1);
+   - container runtime packages, such as containerd or docker, should not be installed on the node.
 
 1. Additional nodes (not required).
 {% if page.platform_type == 'cloud' %}

--- a/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/STEP_INSTALL_SCHEMA_RU.liquid
@@ -48,7 +48,8 @@
    - не менее 40 ГБ дискового пространства;
    - ОС: Ubuntu Linux 16.04/18.04/20.04 LTS или CentOS 7;
    - HTTPS-доступ до container registry `registry.deckhouse.io` (установка также возможна и в [закрытом контуре](/{{ page.lang }}/documentation/v1/deckhouse-faq.html#как-установить-deckhouse-из-стороннего-registry));
-   - SSH-доступ от **персонального компьютера** (см. п.1) по ключу.
+   - SSH-доступ от **персонального компьютера** (см. п.1) по ключу;
+   - на узле не должно быть установлено пакетов container runtime, например containerd или docker.
 
 1. Дополнительные узлы (не обязательно).
 {% if page.platform_type == 'cloud' %}


### PR DESCRIPTION
## Description
Add requirement to the getting started on bare metal that master node shouldn't have container runtime packages.

## Changelog entries
```changes
section: docs
type: fix
summary: Add requirement to the getting started on bare metal that master node shouldn't have container runtime packages.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
