### PR TITLE
[candi] Support existing subnets in Yandex.Cloud

### DIFF
--- a/candi/cloud-providers/yandex/layouts/standard/base-infrastructure/main.tf
+++ b/candi/cloud-providers/yandex/layouts/standard/base-infrastructure/main.tf
@@ -28,6 +28,7 @@ module "vpc_components" {
   prefix = local.prefix
   network_id = local.network_id
   node_network_cidr = local.node_network_cidr
+  existing_zone_to_subnet_id_map = local.existing_zone_to_subnet_id_map
   dhcp_domain_name = local.dhcp_domain_name
   dhcp_domain_name_servers = local.dhcp_domain_name_servers
   labels = local.labels

--- a/candi/cloud-providers/yandex/layouts/standard/variables.tf
+++ b/candi/cloud-providers/yandex/layouts/standard/variables.tf
@@ -42,6 +42,7 @@ locals {
   prefix = var.clusterConfiguration.cloud.prefix
   existing_network_id = lookup(var.providerClusterConfiguration, "existingNetworkID", "")
   node_network_cidr = var.providerClusterConfiguration.nodeNetworkCIDR
+  existing_zone_to_subnet_id_map = lookup(var.providerClusterConfiguration, "existingZoneToSubnetIDMap", null)
 
   dhcp_options = lookup(var.providerClusterConfiguration, "dhcpOptions", null)
   dhcp_domain_name = local.dhcp_options != null ? lookup(local.dhcp_options, "domainName", null) : null

--- a/candi/cloud-providers/yandex/layouts/standard/variables.tf
+++ b/candi/cloud-providers/yandex/layouts/standard/variables.tf
@@ -42,7 +42,7 @@ locals {
   prefix = var.clusterConfiguration.cloud.prefix
   existing_network_id = lookup(var.providerClusterConfiguration, "existingNetworkID", "")
   node_network_cidr = var.providerClusterConfiguration.nodeNetworkCIDR
-  existing_zone_to_subnet_id_map = lookup(var.providerClusterConfiguration, "existingZoneToSubnetIDMap", null)
+  existing_zone_to_subnet_id_map = lookup(var.providerClusterConfiguration, "existingZoneToSubnetIDMap", {})
 
   dhcp_options = lookup(var.providerClusterConfiguration, "dhcpOptions", null)
   dhcp_domain_name = local.dhcp_options != null ? lookup(local.dhcp_options, "domainName", null) : null

--- a/candi/cloud-providers/yandex/layouts/with-nat-instance/base-infrastructure/main.tf
+++ b/candi/cloud-providers/yandex/layouts/with-nat-instance/base-infrastructure/main.tf
@@ -29,6 +29,7 @@ module "vpc_components" {
   prefix = local.prefix
   network_id = local.network_id
   node_network_cidr = local.node_network_cidr
+  existing_zone_to_subnet_id_map = local.existing_zone_to_subnet_id_map
 
   dhcp_domain_name = local.dhcp_domain_name
   dhcp_domain_name_servers = local.dhcp_domain_name_servers

--- a/candi/cloud-providers/yandex/layouts/with-nat-instance/variables.tf
+++ b/candi/cloud-providers/yandex/layouts/with-nat-instance/variables.tf
@@ -42,6 +42,7 @@ locals {
   prefix = var.clusterConfiguration.cloud.prefix
   existing_network_id = lookup(var.providerClusterConfiguration, "existingNetworkID", "")
   node_network_cidr = var.providerClusterConfiguration.nodeNetworkCIDR
+  existing_zone_to_subnet_id_map = lookup(var.providerClusterConfiguration, "existingZoneToSubnetIDMap", null)
   nat_instance_internal_subnet_id = lookup(var.providerClusterConfiguration.withNATInstance, "internalSubnetID", null)
   nat_instance_external_subnet_id = lookup(var.providerClusterConfiguration.withNATInstance, "externalSubnetID", null)
   nat_instance_external_address = lookup(var.providerClusterConfiguration.withNATInstance, "natInstanceExternalAddress", null)

--- a/candi/cloud-providers/yandex/layouts/with-nat-instance/variables.tf
+++ b/candi/cloud-providers/yandex/layouts/with-nat-instance/variables.tf
@@ -42,7 +42,7 @@ locals {
   prefix = var.clusterConfiguration.cloud.prefix
   existing_network_id = lookup(var.providerClusterConfiguration, "existingNetworkID", "")
   node_network_cidr = var.providerClusterConfiguration.nodeNetworkCIDR
-  existing_zone_to_subnet_id_map = lookup(var.providerClusterConfiguration, "existingZoneToSubnetIDMap", null)
+  existing_zone_to_subnet_id_map = lookup(var.providerClusterConfiguration, "existingZoneToSubnetIDMap", {})
   nat_instance_internal_subnet_id = lookup(var.providerClusterConfiguration.withNATInstance, "internalSubnetID", null)
   nat_instance_external_subnet_id = lookup(var.providerClusterConfiguration.withNATInstance, "externalSubnetID", null)
   nat_instance_external_address = lookup(var.providerClusterConfiguration.withNATInstance, "natInstanceExternalAddress", null)

--- a/candi/cloud-providers/yandex/layouts/without-nat/base-infrastructure/main.tf
+++ b/candi/cloud-providers/yandex/layouts/without-nat/base-infrastructure/main.tf
@@ -26,6 +26,7 @@ module "vpc_components" {
   prefix = local.prefix
   network_id = local.network_id
   node_network_cidr = local.node_network_cidr
+  existing_zone_to_subnet_id_map = local.existing_zone_to_subnet_id_map
   dhcp_domain_name = local.dhcp_domain_name
   dhcp_domain_name_servers = local.dhcp_domain_name_servers
 

--- a/candi/cloud-providers/yandex/layouts/without-nat/variables.tf
+++ b/candi/cloud-providers/yandex/layouts/without-nat/variables.tf
@@ -42,6 +42,7 @@ locals {
   prefix = var.clusterConfiguration.cloud.prefix
   existing_network_id = lookup(var.providerClusterConfiguration, "existingNetworkID", "")
   node_network_cidr = var.providerClusterConfiguration.nodeNetworkCIDR
+  existing_zone_to_subnet_id_map = lookup(var.providerClusterConfiguration, "existingZoneToSubnetIDMap", null)
 
   dhcp_options = lookup(var.providerClusterConfiguration, "dhcpOptions", null)
   dhcp_domain_name = local.dhcp_options != null ? lookup(local.dhcp_options, "domainName", null) : null

--- a/candi/cloud-providers/yandex/layouts/without-nat/variables.tf
+++ b/candi/cloud-providers/yandex/layouts/without-nat/variables.tf
@@ -42,7 +42,7 @@ locals {
   prefix = var.clusterConfiguration.cloud.prefix
   existing_network_id = lookup(var.providerClusterConfiguration, "existingNetworkID", "")
   node_network_cidr = var.providerClusterConfiguration.nodeNetworkCIDR
-  existing_zone_to_subnet_id_map = lookup(var.providerClusterConfiguration, "existingZoneToSubnetIDMap", null)
+  existing_zone_to_subnet_id_map = lookup(var.providerClusterConfiguration, "existingZoneToSubnetIDMap", {})
 
   dhcp_options = lookup(var.providerClusterConfiguration, "dhcpOptions", null)
   dhcp_domain_name = local.dhcp_options != null ? lookup(local.dhcp_options, "domainName", null) : null

--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -209,6 +209,18 @@ apiVersions:
           This subnet will be split into **three** equal parts.
 
           They will serve as a basis for subnets in three Yandex.Cloud zones.
+      existingZoneToSubnetIDMap:
+        type: object
+        description: |
+          One or more pre-existing subnets mapped to respective zone.
+
+              ```yaml
+              ru-central1-a: e2lu8r1tbbtryhdpa9ro
+              ru-central1-b: e2lu8r1tbbtryhdpa9ro
+              ru-central1-c: e2lu8r1tbbtryhdpa9ro
+              ```
+        additionalProperties:
+          type: string
         pattern: '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$'
       labels:
         description: |

--- a/candi/cloud-providers/yandex/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/master-node/main.tf
@@ -12,24 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "yandex_vpc_subnet" "kube_a" {
-  name = "${local.prefix}-a"
-}
-
-data "yandex_vpc_subnet" "kube_b" {
-  name = "${local.prefix}-b"
-}
-
-data "yandex_vpc_subnet" "kube_c" {
-  name = "${local.prefix}-c"
-}
-
 locals {
-  zone_to_subnet = {
-    "ru-central1-a" = data.yandex_vpc_subnet.kube_a
-    "ru-central1-b" = data.yandex_vpc_subnet.kube_b
-    "ru-central1-c" = data.yandex_vpc_subnet.kube_c
-  }
+  mapping = lookup(var.providerClusterConfiguration, "existingZoneToSubnetIDMap", null)
+
+  zone_to_subnet = local.mapping == null ? {
+    "ru-central1-a" = length(data.yandex_vpc_subnet.kube_a) > 0 ? data.yandex_vpc_subnet.kube_a[0] : object({})
+    "ru-central1-b" = length(data.yandex_vpc_subnet.kube_b) > 0 ? data.yandex_vpc_subnet.kube_b[0] : object({})
+    "ru-central1-c" = length(data.yandex_vpc_subnet.kube_c) > 0 ? data.yandex_vpc_subnet.kube_c[0] : object({})
+  } : data.yandex_vpc_subnet.existing
 
   actual_zones    = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(keys(local.zone_to_subnet), var.providerClusterConfiguration.zones)) : keys(local.zone_to_subnet)
   zones           = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", null) != null ? tolist(setintersection(local.actual_zones, var.providerClusterConfiguration.masterNodeGroup["zones"])) : local.actual_zones
@@ -44,6 +34,25 @@ locals {
 
 }
 
+data "yandex_vpc_subnet" "existing" {
+  for_each = local.mapping
+  subnet_id = each.value
+}
+
+data "yandex_vpc_subnet" "kube_a" {
+  count = local.mapping == null ? 1 : 0
+  name = "${local.prefix}-a"
+}
+
+data "yandex_vpc_subnet" "kube_b" {
+  count = local.mapping == null ? 1 : 0
+  name = "${local.prefix}-b"
+}
+
+data "yandex_vpc_subnet" "kube_c" {
+  count = local.mapping == null ? 1 : 0
+  name = "${local.prefix}-c"
+}
 
 resource "yandex_vpc_address" "addr" {
   count = length(local.external_ip_addresses) > 0 ? local.external_ip_addresses[var.nodeIndex] == "Auto" ? 1 : 0 : 0

--- a/candi/cloud-providers/yandex/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/master-node/main.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 locals {
-  mapping = lookup(var.providerClusterConfiguration, "existingZoneToSubnetIDMap", null)
+  mapping = lookup(var.providerClusterConfiguration, "existingZoneToSubnetIDMap", {})
 
   zone_to_subnet = local.mapping == null ? {
     "ru-central1-a" = length(data.yandex_vpc_subnet.kube_a) > 0 ? data.yandex_vpc_subnet.kube_a[0] : object({})

--- a/candi/cloud-providers/yandex/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/master-node/main.tf
@@ -15,7 +15,7 @@
 locals {
   mapping = lookup(var.providerClusterConfiguration, "existingZoneToSubnetIDMap", {})
 
-  zone_to_subnet = local.mapping == null ? {
+  zone_to_subnet = length(local.mapping) == 0 ? {
     "ru-central1-a" = length(data.yandex_vpc_subnet.kube_a) > 0 ? data.yandex_vpc_subnet.kube_a[0] : object({})
     "ru-central1-b" = length(data.yandex_vpc_subnet.kube_b) > 0 ? data.yandex_vpc_subnet.kube_b[0] : object({})
     "ru-central1-c" = length(data.yandex_vpc_subnet.kube_c) > 0 ? data.yandex_vpc_subnet.kube_c[0] : object({})
@@ -40,17 +40,17 @@ data "yandex_vpc_subnet" "existing" {
 }
 
 data "yandex_vpc_subnet" "kube_a" {
-  count = local.mapping == null ? 1 : 0
+  count = length(local.mapping) == 0 ? 1 : 0
   name = "${local.prefix}-a"
 }
 
 data "yandex_vpc_subnet" "kube_b" {
-  count = local.mapping == null ? 1 : 0
+  count = length(local.mapping) == 0 ? 1 : 0
   name = "${local.prefix}-b"
 }
 
 data "yandex_vpc_subnet" "kube_c" {
-  count = local.mapping == null ? 1 : 0
+  count = length(local.mapping) == 0 ? 1 : 0
   name = "${local.prefix}-c"
 }
 

--- a/candi/cloud-providers/yandex/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/static-node/main.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 locals {
-  mapping = lookup(var.providerClusterConfiguration, "existingZoneToSubnetIDMap", null)
+  mapping = lookup(var.providerClusterConfiguration, "existingZoneToSubnetIDMap", {})
 
   zone_to_subnet = local.mapping == null ? {
     "ru-central1-a" = length(data.yandex_vpc_subnet.kube_a) > 0 ? data.yandex_vpc_subnet.kube_a[0] : object({})

--- a/candi/cloud-providers/yandex/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/static-node/main.tf
@@ -15,7 +15,7 @@
 locals {
   mapping = lookup(var.providerClusterConfiguration, "existingZoneToSubnetIDMap", {})
 
-  zone_to_subnet = local.mapping == null ? {
+  zone_to_subnet = length(local.mapping) == 0 ? {
     "ru-central1-a" = length(data.yandex_vpc_subnet.kube_a) > 0 ? data.yandex_vpc_subnet.kube_a[0] : object({})
     "ru-central1-b" = length(data.yandex_vpc_subnet.kube_b) > 0 ? data.yandex_vpc_subnet.kube_b[0] : object({})
     "ru-central1-c" = length(data.yandex_vpc_subnet.kube_c) > 0 ? data.yandex_vpc_subnet.kube_c[0] : object({})
@@ -39,17 +39,17 @@ data "yandex_vpc_subnet" "existing" {
 }
 
 data "yandex_vpc_subnet" "kube_a" {
-  count = local.mapping == null ? 1 : 0
+  count = length(local.mapping) == 0 ? 1 : 0
   name = "${local.prefix}-a"
 }
 
 data "yandex_vpc_subnet" "kube_b" {
-  count = local.mapping == null ? 1 : 0
+  count = length(local.mapping) == 0 ? 1 : 0
   name = "${local.prefix}-b"
 }
 
 data "yandex_vpc_subnet" "kube_c" {
-  count = local.mapping == null ? 1 : 0
+  count = length(local.mapping) == 0 ? 1 : 0
   name = "${local.prefix}-c"
 }
 

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/main.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 locals {
-  should_create_subnets = var.existing_zone_to_subnet_id_map == null ? true : false
+  should_create_subnets = length(var.existing_zone_to_subnet_id_map) == 0 ? true : false
 
   kube_a_v4_cidr_block = local.should_create_subnets ? cidrsubnet(var.node_network_cidr, ceil(log(3, 2)), 0) : null
   kube_b_v4_cidr_block = local.should_create_subnets ? cidrsubnet(var.node_network_cidr, ceil(log(3, 2)), 1) : null

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
@@ -18,7 +18,7 @@ data "yandex_compute_image" "nat_image" {
 }
 
 data "yandex_vpc_subnet" "internal_subnet" {
-  subnet_id = var.nat_instance_internal_subnet_id == null ? yandex_vpc_subnet.kube_c.id : var.nat_instance_internal_subnet_id
+  subnet_id = var.nat_instance_internal_subnet_id == null ? (local.should_create_subnets ? yandex_vpc_subnet.kube_c[0].id : data.yandex_vpc_subnet.kube_c[0].id) : var.nat_instance_internal_subnet_id
 }
 
 data "yandex_vpc_subnet" "external_subnet" {
@@ -27,7 +27,6 @@ data "yandex_vpc_subnet" "external_subnet" {
 }
 
 locals {
-
   internal_subnet_zone = data.yandex_vpc_subnet.internal_subnet.zone
   external_subnet_zone = var.nat_instance_external_subnet_id == null ? null : join("", data.yandex_vpc_subnet.external_subnet.*.zone) # https://github.com/hashicorp/terraform/issues/23222#issuecomment-547462883
   assign_external_ip_address = var.nat_instance_external_subnet_id == null ? true : false
@@ -104,6 +103,4 @@ resource "yandex_compute_instance" "nat_instance" {
   metadata = {
     user-data = local.user_data
   }
-
-  depends_on = [yandex_vpc_subnet.kube_c]
 }

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/outputs.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/outputs.tf
@@ -12,14 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+locals {
+  zone_to_subnet_id_map_a = merge({}, (length(data.yandex_vpc_subnet.kube_a) > 0 ? {(data.yandex_vpc_subnet.kube_a[0].zone): data.yandex_vpc_subnet.kube_a[0].id } : {} ))
+  zone_to_subnet_id_map_b = merge(local.zone_to_subnet_id_map_a, (length(data.yandex_vpc_subnet.kube_b) > 0 ?{(data.yandex_vpc_subnet.kube_b[0].zone): data.yandex_vpc_subnet.kube_b[0].id } : {} ))
+  zone_to_subnet_id_map_c_final = merge(local.zone_to_subnet_id_map_b, (length(data.yandex_vpc_subnet.kube_c) > 0 ? {(data.yandex_vpc_subnet.kube_c[0].zone): data.yandex_vpc_subnet.kube_c[0].id } : {} ))
+}
+
 output "route_table_id" {
   value = yandex_vpc_route_table.kube.id
 }
 
 output "zone_to_subnet_id_map" {
-    value = {
-      (yandex_vpc_subnet.kube_a.zone): yandex_vpc_subnet.kube_a.id
-      (yandex_vpc_subnet.kube_b.zone): yandex_vpc_subnet.kube_b.id
-      (yandex_vpc_subnet.kube_c.zone): yandex_vpc_subnet.kube_c.id
-    }
+    value = local.should_create_subnets ? {
+      (yandex_vpc_subnet.kube_a[0].zone): yandex_vpc_subnet.kube_a[0].id
+      (yandex_vpc_subnet.kube_b[0].zone): yandex_vpc_subnet.kube_b[0].id
+      (yandex_vpc_subnet.kube_c[0].zone): yandex_vpc_subnet.kube_c[0].id
+    } : local.zone_to_subnet_id_map_c_final
 }

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/variables.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/variables.tf
@@ -37,7 +37,7 @@ variable "node_network_cidr" {
 
 variable "existing_zone_to_subnet_id_map" {
   type = map
-  default = null
+  default = {}
 }
 
 variable "should_create_nat_instance" {

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/variables.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/variables.tf
@@ -32,6 +32,12 @@ variable "network_id" {
 
 variable "node_network_cidr" {
   type = string
+  default = null
+}
+
+variable "existing_zone_to_subnet_id_map" {
+  type = map
+  default = null
 }
 
 variable "should_create_nat_instance" {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Support existing subnets in Yandex.Cloud.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Sometimes, a user creates subnets before installing a cluster. Interconnect is the main example, which requires pre-created subnets.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-yandex
type: feature
summary: Support existing subnets in Yandex.Cloud
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
