### PR TITLE
[ci] feat: build CE and EE editions for dev branches

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -85,7 +85,7 @@ steps:
         # Use it as image tag.
         IMAGE_TAG=${CI_COMMIT_REF_SLUG}
 
-        echo "⚓️ [$(date -u)] Publish images to dev-registry for branch ${CI_COMMIT_BRANCH} using tag ${IMAGE_TAG}".
+        echo "⚓️ [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 
         if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
           DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${IMAGE_TAG}

--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -96,6 +96,7 @@ pull_request_info:
   runs-on: ubuntu-latest
   outputs:
     ref: ${{ steps.ref.outputs.ref }}
+    edition: ${{ steps.check.outputs.edition }}
   # Skip if PR from deckhouse-BOaTswain, e.g. changelog PRs.
   if: ${{ ! startsWith(github.event_name, 'pull_request') || github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
   steps:
@@ -131,6 +132,8 @@ pull_request_info:
             return core.setFailed(`No pull_request found. event_name=${context.eventName} action=${context.action} ref=${context.ref}`);
           }
 
+          core.info(`Labels: ${JSON.stringify(response.data[0].labels)}`);
+
           const prRepo = context.payload.pull_request.head.repo.full_name;
           const targetRepo = context.payload.repository.full_name;
           const isInternal = prRepo === targetRepo;
@@ -154,6 +157,12 @@ pull_request_info:
               return core.setFailed(`PR#${context.payload.pull_request.number} without label 'status/ok-to-test' is ignored.`);
             }
           }
+
+          const isEE = response.data[0].labels.some((l) => l.name === 'edition/ee');
+          const isCE = response.data[0].labels.some((l) => l.name === 'edition/ce');
+          const edition = isCE ? 'CE' : (isEE ? 'EE' : process.env.WERF_ENV);
+          core.info(`PR has 'edition/*'?   ${isCE || isEE} (${edition})`);
+          core.setOutput('edition', edition);
 
     # Checkhout the head commit of the PR branch.
     - name: Checkout PR head commit

--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -23,6 +23,10 @@ const labels = {
   'deploy-web': [
     'deploy/web/test',
     'deploy/web/stage'
+  ],
+  'edition': [
+    'edition/ce',
+    'edition/ee'
   ]
 };
 module.exports.knownLabels = labels;

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -26,6 +26,36 @@ jobs:
 {!{ tmpl.Exec "pull_request_info_job" $ctx | strings.Indent 2 }!}
 {!{ tmpl.Exec "git_info_job" $ctx | strings.Indent 2 }!}
 
+  enable_fe:
+    if: ${{ needs.pull_request_info.outputs.edition == 'FE' }}
+    name: Enable FE
+    needs:
+      - pull_request_info
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo Enable ${{ needs.pull_request_info.outputs.edition }}
+
+  enable_ee:
+    if: ${{ needs.pull_request_info.outputs.edition == 'EE' }}
+    name: Enable EE
+    needs:
+      - pull_request_info
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo Enable ${{ needs.pull_request_info.outputs.edition }}
+
+  enable_ce:
+    if: ${{ needs.pull_request_info.outputs.edition == 'CE' }}
+    name: Enable CE
+    needs:
+      - pull_request_info
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo Enable ${{ needs.pull_request_info.outputs.edition }}
+
   go_generate:
     name: Go Generate
     needs:
@@ -33,12 +63,14 @@ jobs:
       - pull_request_info
 {!{ tmpl.Exec "go_generate_template" $ctx | strings.Indent 4 }!}
 
-  build_fe:
-    name: Build FE
+  build_deckhouse:
+    name: Build Deckhouse
     needs:
       - git_info
       - pull_request_info
       - go_generate
+    env:
+      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 {!{ tmpl.Exec "build_template" (slice $ctx "dev") | strings.Indent 4 }!}
 
   doc_web_build:
@@ -62,7 +94,7 @@ jobs:
     needs:
       - git_info
       - pull_request_info
-      - build_fe
+      - build_deckhouse
 {!{ tmpl.Exec "tests_template" (slice $ctx "unit") | strings.Indent 4 }!}
 
   matrix_tests:
@@ -70,7 +102,7 @@ jobs:
     needs:
       - git_info
       - pull_request_info
-      - build_fe
+      - build_deckhouse
 {!{ tmpl.Exec "tests_template" (slice $ctx "matrix") | strings.Indent 4 }!}
 
   dhctl_tests:
@@ -78,7 +110,7 @@ jobs:
     needs:
       - git_info
       - pull_request_info
-      - build_fe
+      - build_deckhouse
 {!{ tmpl.Exec "tests_template" (slice $ctx "dhctl") | strings.Indent 4 }!}
 
   golangci_lint:
@@ -86,7 +118,7 @@ jobs:
     needs:
       - git_info
       - pull_request_info
-      - build_fe
+      - build_deckhouse
 {!{ tmpl.Exec "tests_template" (slice $ctx "golangci_lint") | strings.Indent 4 }!}
 
   openapi_test_cases:
@@ -94,7 +126,7 @@ jobs:
     needs:
       - git_info
       - pull_request_info
-      - build_fe
+      - build_deckhouse
 {!{ tmpl.Exec "tests_template" (slice $ctx "openapi_test_cases") | strings.Indent 4 }!}
 
   web_links_test:
@@ -112,5 +144,5 @@ jobs:
     needs:
       - git_info
       - pull_request_info
-      - build_fe
+      - build_deckhouse
 {!{ tmpl.Exec "tests_template" (slice $ctx "validators") | strings.Indent 4 }!}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -87,6 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       ref: ${{ steps.ref.outputs.ref }}
+      edition: ${{ steps.check.outputs.edition }}
     # Skip if PR from deckhouse-BOaTswain, e.g. changelog PRs.
     if: ${{ ! startsWith(github.event_name, 'pull_request') || github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
@@ -122,6 +123,8 @@ jobs:
               return core.setFailed(`No pull_request found. event_name=${context.eventName} action=${context.action} ref=${context.ref}`);
             }
 
+            core.info(`Labels: ${JSON.stringify(response.data[0].labels)}`);
+
             const prRepo = context.payload.pull_request.head.repo.full_name;
             const targetRepo = context.payload.repository.full_name;
             const isInternal = prRepo === targetRepo;
@@ -145,6 +148,12 @@ jobs:
                 return core.setFailed(`PR#${context.payload.pull_request.number} without label 'status/ok-to-test' is ignored.`);
               }
             }
+
+            const isEE = response.data[0].labels.some((l) => l.name === 'edition/ee');
+            const isCE = response.data[0].labels.some((l) => l.name === 'edition/ce');
+            const edition = isCE ? 'CE' : (isEE ? 'EE' : process.env.WERF_ENV);
+            core.info(`PR has 'edition/*'?   ${isCE || isEE} (${edition})`);
+            core.setOutput('edition', edition);
 
       # Checkhout the head commit of the PR branch.
       - name: Checkout PR head commit
@@ -269,6 +278,36 @@ jobs:
 
   # </template: git_info_job>
 
+  enable_fe:
+    if: ${{ needs.pull_request_info.outputs.edition == 'FE' }}
+    name: Enable FE
+    needs:
+      - pull_request_info
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo Enable ${{ needs.pull_request_info.outputs.edition }}
+
+  enable_ee:
+    if: ${{ needs.pull_request_info.outputs.edition == 'EE' }}
+    name: Enable EE
+    needs:
+      - pull_request_info
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo Enable ${{ needs.pull_request_info.outputs.edition }}
+
+  enable_ce:
+    if: ${{ needs.pull_request_info.outputs.edition == 'CE' }}
+    name: Enable CE
+    needs:
+      - pull_request_info
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo Enable ${{ needs.pull_request_info.outputs.edition }}
+
   go_generate:
     name: Go Generate
     needs:
@@ -315,12 +354,14 @@ jobs:
     # </template: go_generate_template>
 
 
-  build_fe:
-    name: Build FE
+  build_deckhouse:
+    name: Build Deckhouse
     needs:
       - git_info
       - pull_request_info
       - go_generate
+    env:
+      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
     # <template: build_template>
     runs-on: [self-hosted, regular]
     steps:
@@ -442,7 +483,7 @@ jobs:
             # Use it as image tag.
             IMAGE_TAG=${CI_COMMIT_REF_SLUG}
 
-            echo "⚓️ [$(date -u)] Publish images to dev-registry for branch ${CI_COMMIT_BRANCH} using tag ${IMAGE_TAG}".
+            echo "⚓️ [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 
             if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
               DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${IMAGE_TAG}
@@ -587,7 +628,7 @@ jobs:
     needs:
       - git_info
       - pull_request_info
-      - build_fe
+      - build_deckhouse
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -648,7 +689,7 @@ jobs:
     needs:
       - git_info
       - pull_request_info
-      - build_fe
+      - build_deckhouse
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -709,7 +750,7 @@ jobs:
     needs:
       - git_info
       - pull_request_info
-      - build_fe
+      - build_deckhouse
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -770,7 +811,7 @@ jobs:
     needs:
       - git_info
       - pull_request_info
-      - build_fe
+      - build_deckhouse
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -831,7 +872,7 @@ jobs:
     needs:
       - git_info
       - pull_request_info
-      - build_fe
+      - build_deckhouse
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1015,7 +1056,7 @@ jobs:
     needs:
       - git_info
       - pull_request_info
-      - build_fe
+      - build_deckhouse
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -404,7 +404,7 @@ jobs:
             # Use it as image tag.
             IMAGE_TAG=${CI_COMMIT_REF_SLUG}
 
-            echo "⚓️ [$(date -u)] Publish images to dev-registry for branch ${CI_COMMIT_BRANCH} using tag ${IMAGE_TAG}".
+            echo "⚓️ [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 
             if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
               DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${IMAGE_TAG}
@@ -631,7 +631,7 @@ jobs:
             # Use it as image tag.
             IMAGE_TAG=${CI_COMMIT_REF_SLUG}
 
-            echo "⚓️ [$(date -u)] Publish images to dev-registry for branch ${CI_COMMIT_BRANCH} using tag ${IMAGE_TAG}".
+            echo "⚓️ [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 
             if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
               DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${IMAGE_TAG}
@@ -858,7 +858,7 @@ jobs:
             # Use it as image tag.
             IMAGE_TAG=${CI_COMMIT_REF_SLUG}
 
-            echo "⚓️ [$(date -u)] Publish images to dev-registry for branch ${CI_COMMIT_BRANCH} using tag ${IMAGE_TAG}".
+            echo "⚓️ [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 
             if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
               DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${IMAGE_TAG}

--- a/.github/workflows/on-pull-request-labeled.yml
+++ b/.github/workflows/on-pull-request-labeled.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       ref: ${{ steps.ref.outputs.ref }}
+      edition: ${{ steps.check.outputs.edition }}
     # Skip if PR from deckhouse-BOaTswain, e.g. changelog PRs.
     if: ${{ ! startsWith(github.event_name, 'pull_request') || github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
@@ -53,6 +54,8 @@ jobs:
               return core.setFailed(`No pull_request found. event_name=${context.eventName} action=${context.action} ref=${context.ref}`);
             }
 
+            core.info(`Labels: ${JSON.stringify(response.data[0].labels)}`);
+
             const prRepo = context.payload.pull_request.head.repo.full_name;
             const targetRepo = context.payload.repository.full_name;
             const isInternal = prRepo === targetRepo;
@@ -76,6 +79,12 @@ jobs:
                 return core.setFailed(`PR#${context.payload.pull_request.number} without label 'status/ok-to-test' is ignored.`);
               }
             }
+
+            const isEE = response.data[0].labels.some((l) => l.name === 'edition/ee');
+            const isCE = response.data[0].labels.some((l) => l.name === 'edition/ce');
+            const edition = isCE ? 'CE' : (isEE ? 'EE' : process.env.WERF_ENV);
+            core.info(`PR has 'edition/*'?   ${isCE || isEE} (${edition})`);
+            core.setOutput('edition', edition);
 
       # Checkhout the head commit of the PR branch.
       - name: Checkout PR head commit

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       ref: ${{ steps.ref.outputs.ref }}
+      edition: ${{ steps.check.outputs.edition }}
     # Skip if PR from deckhouse-BOaTswain, e.g. changelog PRs.
     if: ${{ ! startsWith(github.event_name, 'pull_request') || github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
     steps:
@@ -69,6 +70,8 @@ jobs:
               return core.setFailed(`No pull_request found. event_name=${context.eventName} action=${context.action} ref=${context.ref}`);
             }
 
+            core.info(`Labels: ${JSON.stringify(response.data[0].labels)}`);
+
             const prRepo = context.payload.pull_request.head.repo.full_name;
             const targetRepo = context.payload.repository.full_name;
             const isInternal = prRepo === targetRepo;
@@ -92,6 +95,12 @@ jobs:
                 return core.setFailed(`PR#${context.payload.pull_request.number} without label 'status/ok-to-test' is ignored.`);
               }
             }
+
+            const isEE = response.data[0].labels.some((l) => l.name === 'edition/ee');
+            const isCE = response.data[0].labels.some((l) => l.name === 'edition/ce');
+            const edition = isCE ? 'CE' : (isEE ? 'EE' : process.env.WERF_ENV);
+            core.info(`PR has 'edition/*'?   ${isCE || isEE} (${edition})`);
+            core.setOutput('edition', edition);
 
       # Checkhout the head commit of the PR branch.
       - name: Checkout PR head commit


### PR DESCRIPTION
## Description

Use 'edition/ce' and 'edition/ee' labels to set active edition for pull request. It affects build-and-test workflow and e2e tests.

### How it works?

- We use one tag 'prNUM' for deckhouse images related to PR (since #494 ).
- Default edition is FE. It is used to build images when new PR is opened.
- Add 'edition/*' label to enable CE or EE edition and build new 'prNUM' tag.
- Bot toggles 'edition/*' labels: when 'edition/ce' is added, bot removes 'edition/ee' label and vice versa.
- Remove 'edition/*' labels to build FE again.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

We need to test changes in pull requests using deckhouse images built not only for FE but also for CE or EE.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: feature
summary: Added 'edition/ce' and 'edition/ee' labels to set edition for build and tests.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
