### PR TITLE
[deckhouse-web] Do not set external authentication by default

### DIFF
--- a/modules/810-deckhouse-web/openapi/config-values.yaml
+++ b/modules/810-deckhouse-web/openapi/config-values.yaml
@@ -14,7 +14,6 @@ properties:
     properties:
       externalAuthentication:
         type: object
-        default: {}
         description: |
           Parameters to enable external authentication (the Nginx Ingress [external-auth](https://kubernetes.github.io/ingress-nginx/examples/auth/external-auth/) mechanism is used that is based on the Nginx [auth_request](http://nginx.org/en/docs/http/ngx_http_auth_request_module.html) module).
         properties:


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Delete default value for externalAuthentication

## Why do we need it, and what problem does it solve?
It is impossible to disable external authentication with current default values. The `auth.password` field is always removed by the hook because the external authentication field always exists.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse-web
type: fix
summary: Do not set external authentication by default.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
