### PR TITLE
[control-plane-manager] Kubernetes version certificate validation fix

### DIFF
--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -261,8 +261,11 @@ func k8sVersions(input *go_hook.HookInput) error {
 		if versionHTTPClient != nil {
 			return
 		}
+		contentCA, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+
 		versionHTTPClient = d8http.NewClient(
 			d8http.WithTLSServerName("kubernetes.default.svc"),
+			d8http.WithAdditionalCACerts([][]byte{contentCA}),
 		)
 	})
 

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"sync"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -30,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
 
-	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	d8http "github.com/deckhouse/deckhouse/go_lib/dependency/http"
 	"github.com/deckhouse/deckhouse/go_lib/module"
 )
@@ -44,6 +44,12 @@ const (
 const kubeVersionFileName = "/tmp/kubectl_version"
 
 const apiServerNs = "kube-system"
+
+// versionHTTPClient is used to validate that tls certificate DNS name contains kubernetes service cluster ip
+var (
+	versionHTTPClient d8http.Client
+	once              sync.Once
+)
 
 func apiServerK8sAppLabels() map[string]string {
 	return map[string]string{
@@ -106,7 +112,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			FilterFunc: applyEndpointsAPIServerFilter,
 		},
 	},
-}, dependency.WithExternalDependencies(k8sVersions))
+}, k8sVersions)
 
 func applyAPIServerPodFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	// creationTimestamp needs for run hook on restart pod (name of apiserver not contains generated part)
@@ -236,7 +242,7 @@ func apiServerEndpoints(input *go_hook.HookInput) ([]string, error) {
 	return endpoints, nil
 }
 
-func k8sVersions(input *go_hook.HookInput, dc dependency.Container) error {
+func k8sVersions(input *go_hook.HookInput) error {
 	input.LogEntry.Infoln("k8s version. Start discovery")
 	endpoints, err := apiServerEndpoints(input)
 	if err != nil {
@@ -246,13 +252,25 @@ func k8sVersions(input *go_hook.HookInput, dc dependency.Container) error {
 		return nil
 	}
 
-	cl := dc.GetHTTPClient()
+	// Dedicated client for version discovery is required because cloud providers tend to issue certificates only for
+	// cluster IP, yet Deckhouse requests each endpoint separately. Certificate check will fail in this case.
+	//
+	// ServerName option allows Deckhouse to check, that certificate is issued for the kubernetes service dns name
+	// even if it requests apiserver endpoint.
+	once.Do(func() {
+		if versionHTTPClient != nil {
+			return
+		}
+		versionHTTPClient = d8http.NewClient(
+			d8http.WithTLSServerName("kubernetes.default.svc"),
+		)
+	})
 
 	versions := make([]string, 0)
 	var minVer *semver.Version
 
 	for _, endpoint := range endpoints {
-		ver, err := getKubeVersionForServer(endpoint, cl)
+		ver, err := getKubeVersionForServer(endpoint, versionHTTPClient)
 		if err != nil {
 			return err
 		}

--- a/global-hooks/discovery/kubernetes_version_test.go
+++ b/global-hooks/discovery/kubernetes_version_test.go
@@ -32,7 +32,8 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = Describe("Global hooks :: kubernetes_version ::", func() {
+var _ = FDescribe("Global hooks :: kubernetes_version ::", func() {
+	versionHTTPClient = dependency.TestDC.GetHTTPClient()
 	const (
 		initValuesString           = `{"global": {"enabledModules": ["control-plane-manager"],"modulesImages": {}, "discovery":{}}}`
 		globalValuesWithoutCPMYaml = `

--- a/global-hooks/discovery/kubernetes_version_test.go
+++ b/global-hooks/discovery/kubernetes_version_test.go
@@ -32,7 +32,7 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = FDescribe("Global hooks :: kubernetes_version ::", func() {
+var _ = Describe("Global hooks :: kubernetes_version ::", func() {
 	versionHTTPClient = dependency.TestDC.GetHTTPClient()
 	const (
 		initValuesString           = `{"global": {"enabledModules": ["control-plane-manager"],"modulesImages": {}, "discovery":{}}}`

--- a/go_lib/dependency/http/http.go
+++ b/go_lib/dependency/http/http.go
@@ -64,6 +64,10 @@ func NewClient(options ...Option) Client {
 		tlsConf.RootCAs = caPool
 	}
 
+	if opts.tlsServerName != "" {
+		tlsConf.ServerName = opts.tlsServerName
+	}
+
 	tr := &http.Transport{
 		TLSClientConfig:       tlsConf,
 		IdleConnTimeout:       5 * time.Minute,
@@ -83,6 +87,7 @@ type httpOptions struct {
 	timeout         time.Duration
 	insecure        bool
 	additionalTLSCA [][]byte
+	tlsServerName   string
 }
 
 type Option func(options *httpOptions)
@@ -104,6 +109,12 @@ func WithInsecureSkipVerify() Option {
 func WithAdditionalCACerts(certs [][]byte) Option {
 	return func(options *httpOptions) {
 		options.additionalTLSCA = append(options.additionalTLSCA, certs...)
+	}
+}
+
+func WithTLSServerName(name string) Option {
+	return func(options *httpOptions) {
+		options.tlsServerName = name
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Use dedicated HTTP client to check Kubernetes API servers versions.

## Why do we need it, and what problem does it solve?
It helps us declare which server name should be allowed for the TLS certificate. In some managed Kubernetes services, e.g., DigitalOcean Kubernetes, Azure Kubernetes Service, certificates for kube-apiservers are permitted only to be accessed by cluster IP and some common domains. The `kubernetes.default.svc` is a cluster domain-independent choice, which should always be present in the certificate allowed DNS names list.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: control-plane-manager
type: fix
summary: Validate that the Kubernetes API endpoints certificate is signed for the kubernetes.default.svc domain.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
