### PR TITLE
[node-manager] Fix alpha2_to_v1 conversion for CloudPermanent NodeGroup type

### DIFF
--- a/modules/040-node-manager/webhooks/conversion/node_group
+++ b/modules/040-node-manager/webhooks/conversion/node_group
@@ -115,7 +115,7 @@ function __on_conversion::alpha2_to_v1() {
           if . == "Cloud" then "CloudEphemeral"
             elif . == "Static" then "Static"
             elif . == "Hybrid" then
-              if ($config | .nodeGroups += [{"name": "master"}] | .nodeGroups[] | select($ngName == .name) // false) then
+              if ($config | .nodeGroups += [{"name": "master"}] | .nodeGroups[] | select($ngName == .name)) // false then
                 "CloudPermanent"
               else
                 "CloudStatic"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix jq

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
If there is more than one Hybrid NodeGroup in the cluster then conversion works only for one of NodeGroups.
