### PR TITLE
[ingress-nginx] background remove of a pod

### DIFF
--- a/modules/402-ingress-nginx/hooks/manual_daemonset_update.go
+++ b/modules/402-ingress-nginx/hooks/manual_daemonset_update.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -133,7 +134,7 @@ func manualControllerUpdate(input *go_hook.HookInput) error {
 		}
 
 		if podsReadyForUpdate && podNameForDeletion != "" {
-			input.PatchCollector.Delete("v1", "Pod", "d8-ingress-nginx", podNameForDeletion)
+			input.PatchCollector.Delete("v1", "Pod", "d8-ingress-nginx", podNameForDeletion, object_patch.InBackground())
 		}
 	}
 

--- a/modules/402-ingress-nginx/hooks/manual_daemonset_update_test.go
+++ b/modules/402-ingress-nginx/hooks/manual_daemonset_update_test.go
@@ -63,6 +63,16 @@ status:
   currentNumberScheduled: 1
   desiredNumberScheduled: 1
 ---
+apiVersion: apps/v1
+kind: ControllerRevision
+metadata:
+  labels:
+    app: controller
+    name: main
+  name: controller-main-f45878d89
+  namespace: d8-ingress-nginx
+revision: 1
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -170,6 +180,26 @@ spec:
 status:
   currentNumberScheduled: 3
   desiredNumberScheduled: 3
+---
+apiVersion: apps/v1
+kind: ControllerRevision
+metadata:
+  labels:
+    app: controller
+    name: main
+  name: controller-main-f45878d88
+  namespace: d8-ingress-nginx
+revision: 1
+---
+apiVersion: apps/v1
+kind: ControllerRevision
+metadata:
+  labels:
+    app: controller
+    name: main
+  name: controller-main-f45878d89
+  namespace: d8-ingress-nginx
+revision: 2
 ---
 apiVersion: v1
 kind: Pod
@@ -279,6 +309,16 @@ status:
   currentNumberScheduled: 3
   desiredNumberScheduled: 3
 ---
+apiVersion: apps/v1
+kind: ControllerRevision
+metadata:
+  labels:
+    app: controller
+    name: main
+  name: controller-main-f45878d89
+  namespace: d8-ingress-nginx
+revision: 2
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -385,6 +425,16 @@ spec:
 status:
   currentNumberScheduled: 3
   desiredNumberScheduled: 3
+---
+apiVersion: apps/v1
+kind: ControllerRevision
+metadata:
+  labels:
+    app: controller
+    name: main
+  name: controller-main-f45878d89
+  namespace: d8-ingress-nginx
+revision: 2
 ---
 apiVersion: v1
 kind: Pod
@@ -493,6 +543,16 @@ spec:
 status:
   currentNumberScheduled: 1
   desiredNumberScheduled: 3
+---
+apiVersion: apps/v1
+kind: ControllerRevision
+metadata:
+  labels:
+    app: controller
+    name: main
+  name: controller-main-f45878d89
+  namespace: d8-ingress-nginx
+revision: 2
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Remove pod in background. Also use ControllerRevision as point of truth about controller generation

## Why do we need it, and what problem does it solve?
Ingress pod can be in a terminating state for some time and hook fails with timeout error
Also DS can write a wrong generation

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ingress-nginx
type: fix
summary: remove pod in a background
impact_level: low 
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
