### PR TITLE
[log-shipper] Fire an event if a config file was created/updated

### DIFF
--- a/modules/460-log-shipper/hooks/generate_config.go
+++ b/modules/460-log-shipper/hooks/generate_config.go
@@ -26,7 +26,6 @@ import (
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -254,26 +253,25 @@ func handleClusterLogs(input *go_hook.HookInput) error {
 
 	input.PatchCollector.Create(secret, object_patch.UpdateIfExists())
 
-	event := &eventsv1.Event{
+	event := &corev1.Event{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Event",
 			APIVersion: "events.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:    "d8-log-shipper",
-			GenerateName: "d8-log-shipper-config-",
+			Namespace:    secret.Namespace,
+			GenerateName: secret.Name + "-",
 		},
-		Regarding: corev1.ObjectReference{
+		InvolvedObject: corev1.ObjectReference{
 			Kind:       secret.Kind,
 			Name:       secret.Name,
 			Namespace:  secret.Namespace,
 			APIVersion: secret.APIVersion,
 		},
 		Reason:              "LogShipperConfigCreateUpdate",
-		Note:                "Config file has been created or updated.",
+		Message:             "Config file has been created or updated.",
 		Type:                corev1.EventTypeNormal,
 		EventTime:           metav1.MicroTime{Time: time.Now()},
-		Action:              "Binding",
 		ReportingInstance:   "deckhouse",
 		ReportingController: "deckhouse",
 	}

--- a/modules/460-log-shipper/hooks/generate_config.go
+++ b/modules/460-log-shipper/hooks/generate_config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -253,7 +254,7 @@ func handleClusterLogs(input *go_hook.HookInput) error {
 
 	input.PatchCollector.Create(secret, object_patch.UpdateIfExists())
 
-	event := &corev1.Event{
+	event := &eventsv1.Event{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Event",
 			APIVersion: "events.k8s.io/v1",
@@ -262,14 +263,15 @@ func handleClusterLogs(input *go_hook.HookInput) error {
 			Namespace:    secret.Namespace,
 			GenerateName: secret.Name + "-",
 		},
-		InvolvedObject: corev1.ObjectReference{
+		Regarding: corev1.ObjectReference{
 			Kind:       secret.Kind,
 			Name:       secret.Name,
 			Namespace:  secret.Namespace,
 			APIVersion: secret.APIVersion,
 		},
 		Reason:              "LogShipperConfigCreateUpdate",
-		Message:             "Config file has been created or updated.",
+		Note:                "Config file has been created or updated.",
+		Action:              "Create/Update",
 		Type:                corev1.EventTypeNormal,
 		EventTime:           metav1.MicroTime{Time: time.Now()},
 		ReportingInstance:   "deckhouse",

--- a/modules/460-log-shipper/hooks/generate_config.go
+++ b/modules/460-log-shipper/hooks/generate_config.go
@@ -18,13 +18,15 @@ package hooks
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube/object_patch"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	"github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -233,8 +235,8 @@ func handleClusterLogs(input *go_hook.HookInput) error {
 	input.Values.Set("logShipper.internal.activated", true)
 
 	// create secret with configuration
-	secret := &v1.Secret{
-		Type: v1.SecretTypeOpaque,
+	secret := &corev1.Secret{
+		Type: corev1.SecretTypeOpaque,
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",
@@ -251,6 +253,26 @@ func handleClusterLogs(input *go_hook.HookInput) error {
 	}
 
 	input.PatchCollector.Create(secret, object_patch.UpdateIfExists())
+
+	event := &eventsv1.Event{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Event",
+			APIVersion: "events.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    "d8-log-shipper",
+			GenerateName: "d8-log-shipper-config-",
+		},
+		Reason:              "LogShipperConfigCreateUpdate",
+		Note:                "Config file has been created or updated.",
+		Type:                corev1.EventTypeNormal,
+		EventTime:           metav1.MicroTime{Time: time.Now()},
+		Action:              "Binding",
+		ReportingInstance:   "deckhouse",
+		ReportingController: "deckhouse",
+	}
+
+	input.PatchCollector.Create(event)
 	return nil
 }
 

--- a/modules/460-log-shipper/hooks/generate_config.go
+++ b/modules/460-log-shipper/hooks/generate_config.go
@@ -263,6 +263,12 @@ func handleClusterLogs(input *go_hook.HookInput) error {
 			Namespace:    "d8-log-shipper",
 			GenerateName: "d8-log-shipper-config-",
 		},
+		Regarding: corev1.ObjectReference{
+			Kind:       secret.Kind,
+			Name:       secret.Name,
+			Namespace:  secret.Namespace,
+			APIVersion: secret.APIVersion,
+		},
 		Reason:              "LogShipperConfigCreateUpdate",
 		Note:                "Config file has been created or updated.",
 		Type:                corev1.EventTypeNormal,


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
It is hard to say whether the config was updated or not.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: log-shipper
type: feature
summary: Fire an event if a config file was created/updated.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
