### PR TITLE
[control-plane-manager] Encryption at rest

### DIFF
--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -90,6 +90,9 @@ apiServer:
     audit-log-path: "-"
     {{- end }}
   {{- end }}
+  {{- if .apiserver.secretEncryptionKey }}
+    encryption-provider-config: /etc/kubernetes/deckhouse/extra-files/secret-encryption-config.yaml
+  {{- end }}
     profiling: "false"
     request-timeout: "300s"
     tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"

--- a/modules/040-control-plane-manager/hooks/ensure_secret_encryption_key.go
+++ b/modules/040-control-plane-manager/hooks/ensure_secret_encryption_key.go
@@ -38,7 +38,7 @@ const (
 	secretEncryptionKeySecretName          = "d8-secret-encryption-key"
 	secretEncryptionKeySecretKey           = "secretEncryptionKey"
 	secretEncryptionKeyValuePath           = "controlPlaneManager.internal.secretEncryptionKey"
-	secretEncryptionEnabledConfigValuePath = "controlPlaneManager.apiserver.encryptingAtRestEnabled"
+	secretEncryptionEnabledConfigValuePath = "controlPlaneManager.apiserver.encryptionEnabled"
 	kubeSystemNS                           = "kube-system"
 )
 

--- a/modules/040-control-plane-manager/hooks/ensure_secret_encryption_key.go
+++ b/modules/040-control-plane-manager/hooks/ensure_secret_encryption_key.go
@@ -35,10 +35,11 @@ import (
 type SecretEncryptionKey []byte
 
 const (
-	secretEncryptionKeySecretName = "d8-secret-encryption-key"
-	secretEncryptionKeySecretKey  = "secretEncryptionKey"
-	secretEncryptionKeyValuePath  = "controlPlaneManager.internal.secretEncryptionKey"
-	kubeSystemNS                  = "kube-system"
+	secretEncryptionKeySecretName          = "d8-secret-encryption-key"
+	secretEncryptionKeySecretKey           = "secretEncryptionKey"
+	secretEncryptionKeyValuePath           = "controlPlaneManager.internal.secretEncryptionKey"
+	secretEncryptionEnabledConfigValuePath = "controlPlaneManager.apiserver.encryptingAtRestEnabled"
+	kubeSystemNS                           = "kube-system"
 )
 
 var (
@@ -92,6 +93,10 @@ func ensureEncryptionSecretKey(input *go_hook.HookInput) error {
 	}
 
 	if len(secretKey) == 0 {
+		if !input.Values.Get(secretEncryptionEnabledConfigValuePath).Bool() {
+			return nil
+		}
+
 		key, err := generateSecretEncryptionKey()
 		if err != nil {
 			return err

--- a/modules/040-control-plane-manager/hooks/ensure_secret_encryption_key.go
+++ b/modules/040-control-plane-manager/hooks/ensure_secret_encryption_key.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+type SecretEncryptionKey []byte
+
+const (
+	secretEncryptionKeySecretName = "d8-secret-encryption-key"
+	secretEncryptionKeySecretKey  = "secretEncryptionKey"
+	secretEncryptionKeyValuePath  = "controlPlaneManager.internal.secretEncryptionKey"
+	kubeSystemNS                  = "kube-system"
+)
+
+var (
+	secretLabels = map[string]string{
+		"heritage": "deckhouse",
+		"module":   "control-plane-manager",
+		"name":     "d8-secret-encryption-key",
+	}
+)
+
+func extractEncryptionSecret(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	secret := &v1.Secret{}
+	err := sdk.FromUnstructured(obj, secret)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert incoming object to Secret: %v", err)
+	}
+
+	return secret.Data[secretEncryptionKeySecretKey], nil
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+	Queue:        "/modules/control-plane-manager",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "secret_encryption_key",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{kubeSystemNS},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{secretEncryptionKeySecretName},
+			},
+			FilterFunc: extractEncryptionSecret,
+		},
+	},
+}, ensureEncryptionSecretKey)
+
+func ensureEncryptionSecretKey(input *go_hook.HookInput) error {
+	keys, ok := input.Snapshots["secret_encryption_key"]
+
+	var secretKey []byte
+	if ok && len(keys) > 0 {
+		secretKey, ok = keys[0].([]byte)
+		if !ok {
+			return fmt.Errorf("cannot convert Kubernetes Secret to SecretEncryptionKey")
+		}
+	}
+
+	if len(secretKey) == 0 {
+		key, err := generateSecretEncryptionKey()
+		if err != nil {
+			return err
+		}
+		secretKey = key
+
+		newCM := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretEncryptionKeySecretName,
+				Namespace: kubeSystemNS,
+				Labels:    secretLabels,
+			},
+			Data: map[string][]byte{secretEncryptionKeySecretKey: key},
+		}
+
+		gvks, _, err := scheme.Scheme.ObjectKinds(newCM)
+		if err != nil {
+			return fmt.Errorf("missing apiVersion or kind and cannot assign it; %w", err)
+		}
+
+		for _, gvk := range gvks {
+			if len(gvk.Kind) == 0 {
+				continue
+			}
+			if len(gvk.Version) == 0 || gvk.Version == runtime.APIVersionInternal {
+				continue
+			}
+			newCM.SetGroupVersionKind(gvk)
+			break
+		}
+
+		input.PatchCollector.Create(newCM, object_patch.UpdateIfExists())
+	}
+
+	input.Values.Set(secretEncryptionKeyValuePath, base64.StdEncoding.EncodeToString(secretKey))
+
+	return nil
+}
+
+func generateSecretEncryptionKey() ([]byte, error) {
+	secret := make([]byte, 32)
+	_, err := rand.Read(secret)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return secret, nil
+}

--- a/modules/040-control-plane-manager/hooks/ensure_secret_encryption_key_test.go
+++ b/modules/040-control-plane-manager/hooks/ensure_secret_encryption_key_test.go
@@ -24,9 +24,9 @@ import (
 )
 
 var _ = Describe("Modules :: controlPlaneManager :: hooks :: ensure_secret_encryption_key ::", func() {
-	f := HookExecutionConfigInit(`{"controlPlaneManager":{"apiserver":{"encryptingAtRestEnabled":true}, "internal":{}}}`, ``)
+	f := HookExecutionConfigInit(`{"controlPlaneManager":{"apiserver":{"encryptionEnabled":true}, "internal":{}}}`, ``)
 
-	Context("Empty cluster, encryptingAtRestEnabled = true", func() {
+	Context("Empty cluster, encryptionEnabled = true", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(``))
 			f.RunHook()
@@ -47,7 +47,7 @@ var _ = Describe("Modules :: controlPlaneManager :: hooks :: ensure_secret_encry
 
 	g := HookExecutionConfigInit(`{"controlPlaneManager":{"internal":{}}}`, ``)
 
-	Context("Empty cluster, encryptingAtRestEnabled = false", func() {
+	Context("Empty cluster, encryptionEnabled = false", func() {
 		BeforeEach(func() {
 			g.BindingContexts.Set(g.KubeStateSet(``))
 			g.RunHook()

--- a/modules/040-control-plane-manager/hooks/ensure_secret_encryption_key_test.go
+++ b/modules/040-control-plane-manager/hooks/ensure_secret_encryption_key_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: controlPlaneManager :: hooks :: ensure_secret_encryption_key ::", func() {
+	f := HookExecutionConfigInit(`{"controlPlaneManager":{"internal":{}}}`, ``)
+
+	FContext("Empty cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Must be executed successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("Must create a ConfigMap with hash and set a value", func() {
+			secret := f.KubernetesResource("Secret", kubeSystemNS, secretEncryptionKeySecretName)
+			Expect(secret.Exists()).To(BeTrue())
+
+			Expect(f.ValuesGet(secretEncryptionKeyValuePath).Exists()).To(BeTrue())
+			Expect(f.ValuesGet(secretEncryptionKeyValuePath).String()).To(HaveLen(44))
+		})
+	})
+})

--- a/modules/040-control-plane-manager/hooks/ensure_secret_encryption_key_test.go
+++ b/modules/040-control-plane-manager/hooks/ensure_secret_encryption_key_test.go
@@ -26,7 +26,7 @@ import (
 var _ = Describe("Modules :: controlPlaneManager :: hooks :: ensure_secret_encryption_key ::", func() {
 	f := HookExecutionConfigInit(`{"controlPlaneManager":{"internal":{}}}`, ``)
 
-	FContext("Empty cluster", func() {
+	Context("Empty cluster", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(``))
 			f.RunHook()

--- a/modules/040-control-plane-manager/images/control-plane-manager/control-plane-manager
+++ b/modules/040-control-plane-manager/images/control-plane-manager/control-plane-manager
@@ -25,7 +25,7 @@ CLUSTER_PKI_DIR=/pki
 CONFIG_DIR=/config
 ROOTFS_DIR=
 MAX_RETRIES=42
-secret_encryption_config_file_name="secret-encryption-config.yaml"
+secret_encryption_config_file_name="extra-file-secret-encryption-config.yaml"
 secret_encryption_config_file_path="$ROOTFS_DIR/etc/kubernetes/deckhouse/$secret_encryption_config_file_name"
 
 >&2 echo "Setting control-plane-manger.deckhouse.io/waiting-for-approval= annotation on our Node..."

--- a/modules/040-control-plane-manager/images/control-plane-manager/control-plane-manager
+++ b/modules/040-control-plane-manager/images/control-plane-manager/control-plane-manager
@@ -25,7 +25,6 @@ CLUSTER_PKI_DIR=/pki
 CONFIG_DIR=/config
 ROOTFS_DIR=
 MAX_RETRIES=42
-secret_encryption_config_file_path="$ROOTFS_DIR/etc/kubernetes/deckhouse/secret-encryption-config.yaml"
 
 >&2 echo "Setting control-plane-manger.deckhouse.io/waiting-for-approval= annotation on our Node..."
 attempt=0
@@ -328,11 +327,7 @@ function converge_component() {
   esac
 
   if [[ "$component" != "etcd" ]] ; then
-    if [[ "$component" == "apiserver" && -f "$secret_encryption_config_file_path" ]]; then
-      kubeadm_cmd="$kubeadm_binary init phase control-plane ${component#kube-} --config $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/config.yaml ${experimental_option} $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/patches/" --apiserver-extra-args "encryption-provider-config=$secret_encryption_config_file_path"
-    else
       kubeadm_cmd="$kubeadm_binary init phase control-plane ${component#kube-} --config $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/config.yaml ${experimental_option} $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/patches/"
-    fi
   else
     kubeadm_cmd="$kubeadm_binary init phase etcd local --config $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/config.yaml ${experimental_option} $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/patches/"
     kubeadm_etcd_join_cmd="$kubeadm_binary -v=5 join phase control-plane-join etcd --config $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/config.yaml ${experimental_option} $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/patches/"

--- a/modules/040-control-plane-manager/images/control-plane-manager/control-plane-manager
+++ b/modules/040-control-plane-manager/images/control-plane-manager/control-plane-manager
@@ -25,6 +25,8 @@ CLUSTER_PKI_DIR=/pki
 CONFIG_DIR=/config
 ROOTFS_DIR=
 MAX_RETRIES=42
+secret_encryption_config_file_name="secret-encryption-config.yaml"
+secret_encryption_config_file_path="$ROOTFS_DIR/etc/kubernetes/deckhouse/$secret_encryption_config_file_name"
 
 >&2 echo "Setting control-plane-manger.deckhouse.io/waiting-for-approval= annotation on our Node..."
 attempt=0
@@ -162,6 +164,11 @@ function install_files_if_changed() {
   # install src files
   installed_files=()
   for file in "$src_prefix"* ; do
+    if [[ "$file" == "*$secret_encryption_config_file_name" && ! -e "$secret_encryption_config_file_path" ]]; then
+      cp "$file" "$secret_encryption_config_file_path"
+
+      continue
+    fi
     dst_file_name=${file#"${src_prefix}"}
     # shellcheck disable=SC2068
     $install_cmd "$file" "$dst_dir/$dst_file_name" $@
@@ -327,7 +334,11 @@ function converge_component() {
   esac
 
   if [[ "$component" != "etcd" ]] ; then
-    kubeadm_cmd="$kubeadm_binary init phase control-plane ${component#kube-} --config $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/config.yaml ${experimental_option} $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/patches/"
+    if [[ "$component" == "apiserver" && -f "$secret_encryption_config_file_path" ]]; then
+      kubeadm_cmd="$kubeadm_binary init phase control-plane ${component#kube-} --config $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/config.yaml ${experimental_option} $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/patches/" --apiserver-extra-args "encryption-provider-config=$secret_encryption_config_file_path"
+    else
+      kubeadm_cmd="$kubeadm_binary init phase control-plane ${component#kube-} --config $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/config.yaml ${experimental_option} $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/patches/"
+    fi
   else
     kubeadm_cmd="$kubeadm_binary init phase etcd local --config $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/config.yaml ${experimental_option} $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/patches/"
     kubeadm_etcd_join_cmd="$kubeadm_binary -v=5 join phase control-plane-join etcd --config $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/config.yaml ${experimental_option} $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/patches/"

--- a/modules/040-control-plane-manager/images/control-plane-manager/control-plane-manager
+++ b/modules/040-control-plane-manager/images/control-plane-manager/control-plane-manager
@@ -25,8 +25,7 @@ CLUSTER_PKI_DIR=/pki
 CONFIG_DIR=/config
 ROOTFS_DIR=
 MAX_RETRIES=42
-secret_encryption_config_file_name="extra-file-secret-encryption-config.yaml"
-secret_encryption_config_file_path="$ROOTFS_DIR/etc/kubernetes/deckhouse/$secret_encryption_config_file_name"
+secret_encryption_config_file_path="$ROOTFS_DIR/etc/kubernetes/deckhouse/secret-encryption-config.yaml"
 
 >&2 echo "Setting control-plane-manger.deckhouse.io/waiting-for-approval= annotation on our Node..."
 attempt=0
@@ -164,11 +163,6 @@ function install_files_if_changed() {
   # install src files
   installed_files=()
   for file in "$src_prefix"* ; do
-    if [[ "$file" == "*$secret_encryption_config_file_name" && ! -e "$secret_encryption_config_file_path" ]]; then
-      cp "$file" "$secret_encryption_config_file_path"
-
-      continue
-    fi
     dst_file_name=${file#"${src_prefix}"}
     # shellcheck disable=SC2068
     $install_cmd "$file" "$dst_dir/$dst_file_name" $@

--- a/modules/040-control-plane-manager/images/control-plane-manager/control-plane-manager
+++ b/modules/040-control-plane-manager/images/control-plane-manager/control-plane-manager
@@ -327,7 +327,7 @@ function converge_component() {
   esac
 
   if [[ "$component" != "etcd" ]] ; then
-      kubeadm_cmd="$kubeadm_binary init phase control-plane ${component#kube-} --config $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/config.yaml ${experimental_option} $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/patches/"
+    kubeadm_cmd="$kubeadm_binary init phase control-plane ${component#kube-} --config $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/config.yaml ${experimental_option} $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/patches/"
   else
     kubeadm_cmd="$kubeadm_binary init phase etcd local --config $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/config.yaml ${experimental_option} $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/patches/"
     kubeadm_etcd_join_cmd="$kubeadm_binary -v=5 join phase control-plane-join etcd --config $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/config.yaml ${experimental_option} $ROOTFS_DIR/etc/kubernetes/deckhouse/kubeadm/patches/"

--- a/modules/040-control-plane-manager/openapi/config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/config-values.yaml
@@ -171,7 +171,7 @@ properties:
             # Avoid trailing slash
             pattern: ^[a-zA-Z0-9_/.-]+[a-zA-Z0-9_.-]$
             default: /var/log/kube-audit
-      encryptingAtRestEnabled:
+      encryptionEnabled:
         type: boolean
         default: false
         description: |

--- a/modules/040-control-plane-manager/openapi/config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/config-values.yaml
@@ -171,7 +171,13 @@ properties:
             # Avoid trailing slash
             pattern: ^[a-zA-Z0-9_/.-]+[a-zA-Z0-9_.-]$
             default: /var/log/kube-audit
-
+      encryptingAtRestEnabled:
+        type: boolean
+        default: false
+        description: |
+          Enables [encrypting secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
+          Generates secret `kube-system/d8-secret-encryption-key` with encryption key.
+          > **Note!** This mode cannot be disabled !!!
   etcd:
     type: object
     description: |

--- a/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
@@ -99,7 +99,7 @@ properties:
             description: Вывод логов.
           path:
             description: Путь к директории. Действует только в случае `output=file`.
-      encryptingAtRestEnabled:
+      encryptionEnabled:
         description: |
           Включает режим [encrypting secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
           Генерирует secret `kube-system/d8-secret-encryption-key`, содержащий ключ шифрации.

--- a/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
@@ -99,6 +99,12 @@ properties:
             description: Вывод логов.
           path:
             description: Путь к директории. Действует только в случае `output=file`.
+      encryptingAtRestEnabled:
+        description: |
+          Включает режим [encrypting secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
+          Генерирует secret `kube-system/d8-secret-encryption-key`, содержащий ключ шифрации.
+          > **Важно!**  Этот режим нельзя отключить!!!
+
   etcd:
     description: |
       Параметры `etcd`.

--- a/modules/040-control-plane-manager/openapi/values.yaml
+++ b/modules/040-control-plane-manager/openapi/values.yaml
@@ -25,6 +25,10 @@ properties:
         type: integer
       auditPolicy:
         type: string
+      secretEncryptionKey:
+        type: string
+        minLength: 44
+        maxLength: 44
       arguments:
         type: object
         properties:
@@ -38,4 +42,3 @@ properties:
             type: [integer, string]
           nodeStatusUpdateFrequency:
             type: [integer, string]
-

--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Module :: control-plane-manager :: helm template :: arguments 
 
 			s := f.KubernetesResource("Secret", "kube-system", "d8-control-plane-manager-config")
 			Expect(s.Exists()).To(BeTrue())
-			data, err := base64.StdEncoding.DecodeString(s.Field("data.secret-encryption-config\\.yaml").String())
+			data, err := base64.StdEncoding.DecodeString(s.Field("data.extra-file-secret-encryption-config\\.yaml").String())
 			Expect(err).To(BeNil())
 			Expect(data).To(MatchYAML(`
 apiVersion: apiserver.config.k8s.io/v1

--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package template_tests
 
 import (
+	"encoding/base64"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -95,4 +97,34 @@ var _ = Describe("Module :: control-plane-manager :: helm template :: arguments 
 			Expect(s.Field("data.arguments\\.json").String()).To(Equal("eyJkZWZhdWx0VW5yZWFjaGFibGVUb2xlcmF0aW9uU2Vjb25kcyI6MTUsIm5vZGVNb25pdG9yR3JhY2VQZXJpb2QiOiIxNXMiLCJub2RlTW9uaXRvclBlcmlvZCI6IjJzIiwibm9kZVN0YXR1c1VwZGF0ZUZyZXF1ZW5jeSI6IjRzIiwicG9kRXZpY3Rpb25UaW1lb3V0IjoiMTVzIn0="))
 		})
 	})
+
+	Context("With secretEncryptionKey", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("controlPlaneManager.internal.secretEncryptionKey", `ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCD`)
+			f.HelmRender()
+		})
+
+		It("should render correctly", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			s := f.KubernetesResource("Secret", "kube-system", "d8-control-plane-manager-config")
+			Expect(s.Exists()).To(BeTrue())
+			data, err := base64.StdEncoding.DecodeString(s.Field("data.secret-encryption-config\\.yaml").String())
+			Expect(err).To(BeNil())
+			Expect(data).To(MatchYAML(`
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources:
+    - secrets
+    providers:
+    - aescbc:
+        keys:
+        - name: secretbox
+          secret: ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCD
+    - identity: {}
+`))
+		})
+	})
+
 })

--- a/modules/040-control-plane-manager/templates/_encryption_config.tpl
+++ b/modules/040-control-plane-manager/templates/_encryption_config.tpl
@@ -1,0 +1,13 @@
+{{- define "encryptionConfigTemplate" }}
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources:
+    - secrets
+    providers:
+    - aescbc:
+        keys:
+        - name: secretbox
+          secret: {{ .secretEncryptionKey | quote }}
+    - identity: {}
+{{- end }}

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -101,7 +101,7 @@ extra-file-audit-policy.yaml: {{ $tpl_context.apiserver.auditPolicy }}
   {{- end }}
 
   {{- if $tpl_context.apiserver.secretEncryptionKey }}
-secret-encryption-config.yaml: {{ include "encryptionConfigTemplate" (dict "secretEncryptionKey" $tpl_context.apiserver.secretEncryptionKey) | b64enc }}
+extra-file-secret-encryption-config.yaml: {{ include "encryptionConfigTemplate" (dict "secretEncryptionKey" $tpl_context.apiserver.secretEncryptionKey) | b64enc }}
   {{- end }}
 
 extra-file-scheduler-config.yaml: {{ include "schedulerConfig" $tpl_context | b64enc }}

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -100,7 +100,7 @@ extra-file-authn-webhook-config.yaml: {{ include "authnWebhookTemplate" (dict "w
 extra-file-audit-policy.yaml: {{ $tpl_context.apiserver.auditPolicy }}
   {{- end }}
 
-  {{- if $tpl_context.apiserver.secretEncryptionKey }}
+  {{- if $tpl_context.secretEncryptionKey }}
 secret-encryption-config.yaml: {{ include "encryptionConfigTemplate" (dict "secretEncryptionKey" $tpl_context.apiserver.secretEncryptionKey) }}
   {{- end }}
 

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -74,7 +74,7 @@
 {{- $_ := set $tpl_context "arguments" .Values.controlPlaneManager.internal.arguments }}
 {{- end }}
 {{- if hasKey .Values.controlPlaneManager.internal "secretEncryptionKey" }}
-{{- $_ := set $tpl_context "secretEncryptionKey" .Values.controlPlaneManager.internal.secretEncryptionKey }}
+{{- $_ := set $tpl_context.apiserver "secretEncryptionKey" .Values.controlPlaneManager.internal.secretEncryptionKey }}
 {{- end }}
 {{- $_ := set $tpl_context "Template" $.Template }}
 
@@ -100,8 +100,8 @@ extra-file-authn-webhook-config.yaml: {{ include "authnWebhookTemplate" (dict "w
 extra-file-audit-policy.yaml: {{ $tpl_context.apiserver.auditPolicy }}
   {{- end }}
 
-  {{- if $tpl_context.secretEncryptionKey }}
-secret-encryption-config.yaml: {{ include "encryptionConfigTemplate" (dict "secretEncryptionKey" $tpl_context.secretEncryptionKey) }}
+  {{- if $tpl_context.apiserver.secretEncryptionKey }}
+secret-encryption-config.yaml: {{ include "encryptionConfigTemplate" (dict "secretEncryptionKey" $tpl_context.apiserver.secretEncryptionKey) }}
   {{- end }}
 
 extra-file-scheduler-config.yaml: {{ include "schedulerConfig" $tpl_context | b64enc }}

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -101,7 +101,7 @@ extra-file-audit-policy.yaml: {{ $tpl_context.apiserver.auditPolicy }}
   {{- end }}
 
   {{- if $tpl_context.apiserver.secretEncryptionKey }}
-extra-file-audit-policy.yaml: {{ include "encryptionConfigTemplate" (dict "secretEncryptionKey" $tpl_context.apiserver.secretEncryptionKey) }}
+secret-encryption-config.yaml: {{ include "encryptionConfigTemplate" (dict "secretEncryptionKey" $tpl_context.apiserver.secretEncryptionKey) }}
   {{- end }}
 
 extra-file-scheduler-config.yaml: {{ include "schedulerConfig" $tpl_context | b64enc }}

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -101,7 +101,7 @@ extra-file-audit-policy.yaml: {{ $tpl_context.apiserver.auditPolicy }}
   {{- end }}
 
   {{- if $tpl_context.secretEncryptionKey }}
-secret-encryption-config.yaml: {{ include "encryptionConfigTemplate" (dict "secretEncryptionKey" $tpl_context.apiserver.secretEncryptionKey) }}
+secret-encryption-config.yaml: {{ include "encryptionConfigTemplate" (dict "secretEncryptionKey" $tpl_context.secretEncryptionKey) }}
   {{- end }}
 
 extra-file-scheduler-config.yaml: {{ include "schedulerConfig" $tpl_context | b64enc }}

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -73,6 +73,9 @@
 {{- if hasKey .Values.controlPlaneManager.internal "arguments" }}
 {{- $_ := set $tpl_context "arguments" .Values.controlPlaneManager.internal.arguments }}
 {{- end }}
+{{- if hasKey .Values.controlPlaneManager.internal "secretEncryptionKey" }}
+{{- $_ := set $tpl_context "secretEncryptionKey" .Values.controlPlaneManager.internal.secretEncryptionKey }}
+{{- end }}
 {{- $_ := set $tpl_context "Template" $.Template }}
 
 {{- define "control_plane_config" }}
@@ -95,6 +98,10 @@ extra-file-authn-webhook-config.yaml: {{ include "authnWebhookTemplate" (dict "w
 
   {{- if $tpl_context.apiserver.auditPolicy }}
 extra-file-audit-policy.yaml: {{ $tpl_context.apiserver.auditPolicy }}
+  {{- end }}
+
+  {{- if $tpl_context.apiserver.secretEncryptionKey }}
+extra-file-audit-policy.yaml: {{ include "encryptionConfigTemplate" (dict "secretEncryptionKey" $tpl_context.apiserver.secretEncryptionKey) }}
   {{- end }}
 
 extra-file-scheduler-config.yaml: {{ include "schedulerConfig" $tpl_context | b64enc }}

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -101,7 +101,7 @@ extra-file-audit-policy.yaml: {{ $tpl_context.apiserver.auditPolicy }}
   {{- end }}
 
   {{- if $tpl_context.apiserver.secretEncryptionKey }}
-secret-encryption-config.yaml: {{ include "encryptionConfigTemplate" (dict "secretEncryptionKey" $tpl_context.apiserver.secretEncryptionKey) }}
+secret-encryption-config.yaml: {{ include "encryptionConfigTemplate" (dict "secretEncryptionKey" $tpl_context.apiserver.secretEncryptionKey) | b64enc }}
   {{- end }}
 
 extra-file-scheduler-config.yaml: {{ include "schedulerConfig" $tpl_context | b64enc }}

--- a/modules/040-control-plane-manager/webhooks/validating/d8-secret-encryption-key-configuration
+++ b/modules/040-control-plane-manager/webhooks/validating/d8-secret-encryption-key-configuration
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /shell_lib.sh
+
+function __config__(){
+  cat <<EOF
+configVersion: v1
+kubernetesValidating:
+- name: d8-secret-encryption-key-secret.deckhouse.io
+  group: main
+  labelSelector:
+    matchLabels:
+      name: d8-secret-encryption-key
+  rules:
+  - apiGroups:   [""]
+    apiVersions: ["v1"]
+    operations:  ["*"]
+    resources:   ["secrets"]
+    scope:       "Namespaced"
+EOF
+}
+
+function __main__() {
+  # Secret kube-system/d8-secret-encryption-key cannot be deleted
+  if context::jq -e -r '.review.request.operation != "CREATE"' >/dev/null 2>&1; then
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"it is forbidden to modify secret d8-secret-encryption-key"}
+EOF
+
+    return 0
+  fi
+
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":true}
+EOF
+
+  return 0
+}
+
+hook::run "$@"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Enables use of encryption at rest mode for apiserver (https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Encryption at rest solves problem with unencrypted secrets in etcd storage.
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: control-plane-manager
type: feature
summary: Encryption at rest.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
