### PR TITLE
[monitoring-kubernetes] Add POD labels to containerd pause container metrics

### DIFF
--- a/modules/340-monitoring-kubernetes/templates/kubelet/service-monitor.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kubelet/service-monitor.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   jobLabel: k8s-app
   endpoints:
+  # API metrics
   - port: https-metrics
     scheme: https
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -23,6 +24,7 @@ spec:
       replacement: kubelet
     - targetLabel: tier
       replacement: cluster
+  # CRI metrics
   - port: https-metrics
     scheme: https
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -40,6 +42,13 @@ spec:
     - targetLabel: tier
       replacement: cluster
     metricRelabelings:
+    # For Containerd metrics, the `container` label is empty for pause containers, but Docker sets the POD value.
+    # This relabeling rule is required to keep both CRI metrics in sync.
+    - sourceLabels: [image, name, container]
+      regex: '(.+);(.+);'
+      action: replace
+      targetLabel: container
+      replacement: "POD"
     - sourceLabels: [namespace]
       regex: '^$'
       action: drop
@@ -51,6 +60,7 @@ spec:
       action: drop
     - regex: container_name|pod_name|id|image|name
       action: labeldrop
+  # Probes metrics
   - port: https-metrics
     scheme: https
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Add the `container="POD"` label to all advisor metrics for pause containers. There will be more metrics in Prometheus for installations with the Contained CRI.

## Why do we need it, and what problem does it solve?
Fixes https://github.com/deckhouse/deckhouse/issues/822

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring-kubernetes
type: fix
summary: 'Add the container="POD" label to all advisor metrics for pause containers.'
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
