### PR TITLE
[okmeter] Make okagent data persistent

### DIFF
--- a/ee/fe/modules/500-okmeter/templates/daemonset.yaml
+++ b/ee/fe/modules/500-okmeter/templates/daemonset.yaml
@@ -90,4 +90,6 @@ spec:
         hostPath:
           path: /proc
       - name: okagentdir
-        emptyDir: {}
+        hostPath:
+          path: /usr/local/okagent
+          type: DirectoryOrCreate


### PR DESCRIPTION
## Description
<!---
  This PR makes all the data okagent relies on persistent.

  Due to the okagent DaemonSet manifest change, all Okmeter agents will be restarted.
-->

## Why do we need it, and what problem does it solve?
<!---
  Previously okagent directory was not persisted during pod evictions, DaemonSet rollout, etc.
  There are several issues regarding to this, in no particular order:
  - Original container image contains only the supervisor binary, which downloads the up-to-date agent version. In the case of pod restart, agent binary is lost and downloaded again, causing pauses in metrics delivery and excessive traffic.
  - Supervisor can roll back the agent to a previously cached version if it exists on disk. Persisting this cache between restarts is a must.
  - Okmeter agent can buffer the collected metrics on disk when the metrics collector is inaccessible. In case of pod restart, these buffered metrics will be lost

-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: okmeter
type: fix
summary: Make all the data okagent relies on persistent
impact_level: low
impact: Expect okmeter DaemonSet rollout restart
```
