### PR TITLE
[ci] fix: lowercase for cluster prefix

### DIFF
--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -174,7 +174,7 @@ jobs:
         # Calculate unique prefix for e2e test.
         # GITHUB_RUN_ID is a unique number for each workflow run.
         # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-        prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+        prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
         echo "::set-output name=prefix::${prefix}"
         echo "prefix=${prefix}"
 

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -317,7 +317,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -679,7 +679,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1041,7 +1041,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1403,7 +1403,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1765,7 +1765,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2127,7 +2127,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2489,7 +2489,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2851,7 +2851,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -317,7 +317,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -687,7 +687,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1057,7 +1057,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1427,7 +1427,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1797,7 +1797,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2167,7 +2167,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2537,7 +2537,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2907,7 +2907,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -317,7 +317,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -675,7 +675,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1033,7 +1033,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1391,7 +1391,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1749,7 +1749,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2107,7 +2107,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2465,7 +2465,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2823,7 +2823,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -317,7 +317,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -675,7 +675,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1033,7 +1033,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1391,7 +1391,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1749,7 +1749,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2107,7 +2107,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2465,7 +2465,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2823,7 +2823,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -317,7 +317,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -675,7 +675,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1033,7 +1033,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1391,7 +1391,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1749,7 +1749,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2107,7 +2107,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2465,7 +2465,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2823,7 +2823,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -317,7 +317,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -679,7 +679,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1041,7 +1041,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1403,7 +1403,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1765,7 +1765,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2127,7 +2127,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2489,7 +2489,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2851,7 +2851,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -317,7 +317,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -683,7 +683,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1049,7 +1049,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1415,7 +1415,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -1781,7 +1781,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2147,7 +2147,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2513,7 +2513,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 
@@ -2879,7 +2879,7 @@ jobs:
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=${GITHUB_RUN_ID}-${CRI}-$(echo "${KUBERNETES_VERSION}" | tr '.' '-')
+          prefix=$(echo "${GITHUB_RUN_ID}-${CRI}-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
           echo "::set-output name=prefix::${prefix}"
           echo "prefix=${prefix}"
 


### PR DESCRIPTION
## Description

Lower case cluster prefix for e2e to fix error:

```
1 error occurred:
	* cloud.prefix should match '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
```

## Why do we need it, and what problem does it solve?

Fix broken e2e tests.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: fix
summary: cluster prefix in lower case
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
