### PR TITLE
[deckhouse-controller] feat: update core operators

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/main.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/flant/addon-operator/pkg/utils/stdliblogtologrus"
 	"github.com/flant/kube-client/klogtologrus"
 	sh_app "github.com/flant/shell-operator/pkg/app"
+	"github.com/flant/shell-operator/pkg/config"
 	sh_debug "github.com/flant/shell-operator/pkg/debug"
 	utils_signal "github.com/flant/shell-operator/pkg/utils/signal"
 	log "github.com/sirupsen/logrus"
@@ -65,7 +66,9 @@ func main() {
 	startCmd := kpApp.Command("start", "Start deckhouse.").
 		Default().
 		Action(func(c *kingpin.ParseContext) error {
-			sh_app.SetupLogging()
+			runtimeConfig := config.NewConfig()
+			// Init logging subsystem.
+			sh_app.SetupLogging(runtimeConfig)
 			log.Infof("deckhouse %s (addon-operator %s, shell-operator %s)", DeckhouseVersion, AddonOperatorVersion, ShellOperatorVersion)
 
 			// Set hook metrics listen port if flat is not passed.

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.9.0
-	github.com/flant/addon-operator v1.0.4-0.20220208071927-1b4e2c72f3db
+	github.com/flant/addon-operator v1.0.4
 	github.com/flant/kube-client v0.0.6
-	github.com/flant/shell-operator v1.0.8-0.20220121071428-6b7bd04272e5
+	github.com/flant/shell-operator v1.0.8
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/spec v0.19.8

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwo
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/flant/addon-operator v1.0.4-0.20220208071927-1b4e2c72f3db h1:kcXkD8PAWcAKoYOFVQB63lZi3v64CvZcQyjcL1RUmgQ=
-github.com/flant/addon-operator v1.0.4-0.20220208071927-1b4e2c72f3db/go.mod h1:jrqkO7KN1/teI3uVXg5W5CmyLTwPCQrpr/UTDhe5xDw=
+github.com/flant/addon-operator v1.0.4 h1:m/Anfrq24g2cQABeCh5BUGGNR2jgT16DnyvEpPzTVHU=
+github.com/flant/addon-operator v1.0.4/go.mod h1:G4HX7ggPvsXayUoYWTwfuNnF6Iw6Fe5jafE3kUWwA7g=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v0.0.6 h1:cHFMf7xGtJOgg+KBuPcA+7q+M7IJRSgf2pHVStv2aj0=
@@ -261,8 +261,8 @@ github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a h1:PlStPekqPtTSWD
 github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
 github.com/flant/logboek v0.3.4 h1://0FHwS7hoLHTz7H+JlLheKlu298edC+qV61ca9OJBQ=
 github.com/flant/logboek v0.3.4/go.mod h1:/vKAVARjAIs2OlxxDRn7SvltNVcWMb1Ifo23kCDJZco=
-github.com/flant/shell-operator v1.0.8-0.20220121071428-6b7bd04272e5 h1:ckkJXZjIMqUtKaudP4i+4wRtukC6k/kV2owmBw4Zg84=
-github.com/flant/shell-operator v1.0.8-0.20220121071428-6b7bd04272e5/go.mod h1:bHcTpRq0k0c/kaVQl6sODi/Nz8mqmtmMk9ff9dxrpN4=
+github.com/flant/shell-operator v1.0.8 h1:yPrjByvRHxveXfKuxD0yf07jOPD/Wv4c0YnaC15r7EE=
+github.com/flant/shell-operator v1.0.8/go.mod h1:bHcTpRq0k0c/kaVQl6sODi/Nz8mqmtmMk9ff9dxrpN4=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/testing/hooks/init.go
+++ b/testing/hooks/init.go
@@ -353,11 +353,16 @@ func HookExecutionConfigInit(initValues, initConfigValues string, k8sVersion ...
 	return hec
 }
 
-func (hec *HookExecutionConfig) KubeStateSetAndWaitForBindingContexts(newKubeState string, desiredQuantity int) hookcontext.GeneratedBindingContexts {
+func (hec *HookExecutionConfig) KubeStateSetAndWaitForBindingContexts(newKubeState string, _ int) hookcontext.GeneratedBindingContexts {
+	// The method is deprecated
+	return hec.KubeStateSet(newKubeState)
+}
+
+func (hec *HookExecutionConfig) KubeStateSet(newKubeState string) hookcontext.GeneratedBindingContexts {
 	var contexts hookcontext.GeneratedBindingContexts
 	var err error
 	if !hec.IsKubeStateInited {
-		hec.BindingContextController, err = hookcontext.NewBindingContextController(hec.hookConfig, hec.fakeClusterVersion)
+		hec.BindingContextController = hookcontext.NewBindingContextController(hec.hookConfig, hec.fakeClusterVersion)
 		if err != nil {
 			panic(err)
 		}
@@ -393,21 +398,13 @@ func (hec *HookExecutionConfig) KubeStateSetAndWaitForBindingContexts(newKubeSta
 		}
 		hec.IsKubeStateInited = true
 	} else {
-		if desiredQuantity > 0 {
-			contexts, err = hec.BindingContextController.ChangeStateAndWaitForBindingContexts(desiredQuantity, newKubeState)
-		} else {
-			contexts, err = hec.BindingContextController.ChangeState(newKubeState)
-		}
+		contexts, err = hec.BindingContextController.ChangeState(newKubeState)
 		if err != nil {
 			panic(err)
 		}
 	}
 
 	return contexts
-}
-
-func (hec *HookExecutionConfig) KubeStateSet(newKubeState string) hookcontext.GeneratedBindingContexts {
-	return hec.KubeStateSetAndWaitForBindingContexts(newKubeState, 0)
 }
 
 // GenerateOnStartupContext returns binding context for OnStartup.


### PR DESCRIPTION

## Description

Dependencies:
- addon-operator v1.0.4
- shell-operator v1.0.8

Changes:
- more debug commands: queue main, list snapshots
- set log level to debug in runtime
- continuous checking config, metric with errors counter

## Why do we need it, and what problem does it solve?

New features to ease debugging.


## Changelog entries

```changes
section: deckhouse-controller
type: feature
summary: update shell-operator and addon-operator
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
