### PR TITLE
[deckhouse] Fix deckhouse cannot self update if converge was not done and update addon-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,8 @@ require (
 
 replace github.com/deckhouse/deckhouse/dhctl => ./dhctl
 
+replace github.com/flant/addon-operator => github.com/name212/addon-operator v1.0.4-0.20220228132112-53b1ab98e8e9
+
 // Remove 'in body' from errors, fix for Go 1.16 (https://github.com/go-openapi/validate/pull/138).
 replace github.com/go-openapi/validate => github.com/flant/go-openapi-validate v0.19.12-flant.0
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/flant/addon-operator v1.0.4
 	github.com/flant/kube-client v0.0.6
-	github.com/flant/shell-operator v1.0.8
+	github.com/flant/shell-operator v1.0.9-0.20220302082030-614d4cca72da
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/spec v0.19.8
@@ -57,7 +57,7 @@ require (
 
 replace github.com/deckhouse/deckhouse/dhctl => ./dhctl
 
-replace github.com/flant/addon-operator => github.com/name212/addon-operator v1.0.4-0.20220228132112-53b1ab98e8e9
+replace github.com/flant/addon-operator => github.com/name212/addon-operator v1.0.4-0.20220302082619-8fb436205183
 
 // Remove 'in body' from errors, fix for Go 1.16 (https://github.com/go-openapi/validate/pull/138).
 replace github.com/go-openapi/validate => github.com/flant/go-openapi-validate v0.19.12-flant.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.9.0
-	github.com/flant/addon-operator v1.0.4
+	github.com/flant/addon-operator v1.0.5-0.20220302103157-2ed84979179f
 	github.com/flant/kube-client v0.0.6
 	github.com/flant/shell-operator v1.0.9-0.20220302082030-614d4cca72da
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622
@@ -56,8 +56,6 @@ require (
 )
 
 replace github.com/deckhouse/deckhouse/dhctl => ./dhctl
-
-replace github.com/flant/addon-operator => github.com/name212/addon-operator v1.0.4-0.20220302082619-8fb436205183
 
 // Remove 'in body' from errors, fix for Go 1.16 (https://github.com/go-openapi/validate/pull/138).
 replace github.com/go-openapi/validate => github.com/flant/go-openapi-validate v0.19.12-flant.0

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a h1:PlStPekqPtTSWD
 github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
 github.com/flant/logboek v0.3.4 h1://0FHwS7hoLHTz7H+JlLheKlu298edC+qV61ca9OJBQ=
 github.com/flant/logboek v0.3.4/go.mod h1:/vKAVARjAIs2OlxxDRn7SvltNVcWMb1Ifo23kCDJZco=
-github.com/flant/shell-operator v1.0.8 h1:yPrjByvRHxveXfKuxD0yf07jOPD/Wv4c0YnaC15r7EE=
-github.com/flant/shell-operator v1.0.8/go.mod h1:bHcTpRq0k0c/kaVQl6sODi/Nz8mqmtmMk9ff9dxrpN4=
+github.com/flant/shell-operator v1.0.9-0.20220302082030-614d4cca72da h1:DPVDviZzDUWP3OSXB2I/Ttxu1K4fosxmDA3uHMTgcr8=
+github.com/flant/shell-operator v1.0.9-0.20220302082030-614d4cca72da/go.mod h1:bHcTpRq0k0c/kaVQl6sODi/Nz8mqmtmMk9ff9dxrpN4=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -675,8 +675,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/name212/addon-operator v1.0.4-0.20220228132112-53b1ab98e8e9 h1:JnophQyzpDaU2lkcmhAc9d4yp+3lbfusIZXfyWaR+NM=
-github.com/name212/addon-operator v1.0.4-0.20220228132112-53b1ab98e8e9/go.mod h1:G4HX7ggPvsXayUoYWTwfuNnF6Iw6Fe5jafE3kUWwA7g=
+github.com/name212/addon-operator v1.0.4-0.20220302082619-8fb436205183 h1:5k8o5NxlQ3wUmv74j+jFkijOR8lmH43507xaiDF3tYw=
+github.com/name212/addon-operator v1.0.4-0.20220302082619-8fb436205183/go.mod h1:9tUmk+zQ8SMHE/qLEwwkejjD+6+lBZivNsXxhIiVvNg=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
 github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv3Z8C4HTBu8GD/k=

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,6 @@ github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwo
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/flant/addon-operator v1.0.4 h1:m/Anfrq24g2cQABeCh5BUGGNR2jgT16DnyvEpPzTVHU=
-github.com/flant/addon-operator v1.0.4/go.mod h1:G4HX7ggPvsXayUoYWTwfuNnF6Iw6Fe5jafE3kUWwA7g=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v0.0.6 h1:cHFMf7xGtJOgg+KBuPcA+7q+M7IJRSgf2pHVStv2aj0=
@@ -677,6 +675,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/name212/addon-operator v1.0.4-0.20220228132112-53b1ab98e8e9 h1:JnophQyzpDaU2lkcmhAc9d4yp+3lbfusIZXfyWaR+NM=
+github.com/name212/addon-operator v1.0.4-0.20220228132112-53b1ab98e8e9/go.mod h1:G4HX7ggPvsXayUoYWTwfuNnF6Iw6Fe5jafE3kUWwA7g=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
 github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv3Z8C4HTBu8GD/k=

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,9 @@ github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwo
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/flant/addon-operator v1.0.4/go.mod h1:G4HX7ggPvsXayUoYWTwfuNnF6Iw6Fe5jafE3kUWwA7g=
+github.com/flant/addon-operator v1.0.5-0.20220302103157-2ed84979179f h1:GykDdQ0/5LvL6a0uo/jfZabl7JV5g/4W+DbjFiLzh/A=
+github.com/flant/addon-operator v1.0.5-0.20220302103157-2ed84979179f/go.mod h1:9tUmk+zQ8SMHE/qLEwwkejjD+6+lBZivNsXxhIiVvNg=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v0.0.6 h1:cHFMf7xGtJOgg+KBuPcA+7q+M7IJRSgf2pHVStv2aj0=
@@ -259,6 +262,7 @@ github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a h1:PlStPekqPtTSWD
 github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
 github.com/flant/logboek v0.3.4 h1://0FHwS7hoLHTz7H+JlLheKlu298edC+qV61ca9OJBQ=
 github.com/flant/logboek v0.3.4/go.mod h1:/vKAVARjAIs2OlxxDRn7SvltNVcWMb1Ifo23kCDJZco=
+github.com/flant/shell-operator v1.0.8/go.mod h1:bHcTpRq0k0c/kaVQl6sODi/Nz8mqmtmMk9ff9dxrpN4=
 github.com/flant/shell-operator v1.0.9-0.20220302082030-614d4cca72da h1:DPVDviZzDUWP3OSXB2I/Ttxu1K4fosxmDA3uHMTgcr8=
 github.com/flant/shell-operator v1.0.9-0.20220302082030-614d4cca72da/go.mod h1:bHcTpRq0k0c/kaVQl6sODi/Nz8mqmtmMk9ff9dxrpN4=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=

--- a/modules/020-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/020-deckhouse/hooks/check_deckhouse_release.go
@@ -52,6 +52,9 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			Crontab: "* * * * *", // every minute
 		},
 	},
+	Settings: &go_hook.HookConfigSettings{
+		EnableSchedulesOnStartup: true,
+	},
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:                         "releases",

--- a/modules/020-deckhouse/hooks/update_deckhouse_image.go
+++ b/modules/020-deckhouse/hooks/update_deckhouse_image.go
@@ -51,6 +51,9 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			Crontab: "*/15 * * * * *",
 		},
 	},
+	Settings: &go_hook.HookConfigSettings{
+		EnableSchedulesOnStartup: true,
+	},
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:       "deckhouse_pod",


### PR DESCRIPTION
## Description
 Update [addon](https://github.com/flant/addon-operator/pull/300) and shell [operators](https://github.com/flant/shell-operator/pull/360).

## Why do we need it, and what problem does it solve?
Deckhouse cannot self update if converge was not done.
It was be when we will have error during first converge and after fix it Deckhouse cannot get update. 
And we will need update image manually. 

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: global
type: fix
summary: Update addon-operator and shell-operator
impact_level: high
impact: Updating core component. We start schedule some hooks before first converge.
---
section: deckhouse
type: fix
summary: `Update Deckhouse` and `check Deckhouse release` hooks now schedule without waiting first converge.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
