### PR TITLE
[ci] tests run optimization

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -90,9 +90,11 @@ steps:
         if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
           DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${IMAGE_TAG}
           DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
+          DESTINATION_TESTS_IMAGE=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
         else
           DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${IMAGE_TAG}
           DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
+          DESTINATION_TESTS_IMAGE=${CI_REGISTRY_IMAGE}/tests:${IMAGE_TAG}
         fi
 
         echo "⚓️ [$(date -u)] Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
@@ -103,9 +105,14 @@ steps:
         DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
         pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DESTINATION_INSTALL_IMAGE}
 
+        echo "⚓️ [$(date -u)] Publish 'tests' image to dev-registry using tag ${IMAGE_TAG}".
+        TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
+        pull_push 'tests' ${TESTS_IMAGE_URL} ${DESTINATION_TESTS_IMAGE}
+
         echo "⚓️ [$(date -u)] Remove local tags."
         docker image rmi ${DESTINATION_IMAGE} || true
         docker image rmi ${DESTINATION_INSTALL_IMAGE} || true
+        docker image rmi ${DESTINATION_TESTS_IMAGE} || true
       fi
       rm -f images_tags_werf.json
 
@@ -135,6 +142,11 @@ steps:
           DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
           pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
 
+          echo "⚓️ [$(date -u)] Publish 'tests' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+          DECKHOUSE_DESTINATION_TESTS_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+          TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
+          pull_push 'tests' ${TESTS_IMAGE_URL} ${DECKHOUSE_DESTINATION_TESTS_IMAGE}
+
           echo "⚓️ [$(date -u)] Publish 'release-channel-version' image to deckhouse registry using tag ${IMAGE_TAG} ..."
           DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${IMAGE_TAG}
           RELEASE_CHANNEL_VERSION_IMAGE_URL="$(jq -r '.Images."release-channel-version".DockerImageName' images_tags_werf.json)"
@@ -143,6 +155,7 @@ steps:
           echo "⚓️ [$(date -u)] Remove local tags."
           docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true
           docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true
+          docker image rmi ${DECKHOUSE_DESTINATION_TESTS_IMAGE} || true
           docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true
 
           rm -f images_tags_werf.json

--- a/.github/ci_templates/tests.yml
+++ b/.github/ci_templates/tests.yml
@@ -63,8 +63,7 @@ steps:
       CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
     run: |
 {!{ if eq $buildType "release" }!}
-      REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-      TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${CI_COMMIT_REF_SLUG}
+      TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/fe/tests:${CI_COMMIT_REF_SLUG}
 {!{ else }!}
       TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${CI_COMMIT_REF_SLUG}
 {!{ end }!}

--- a/.github/ci_templates/tests.yml
+++ b/.github/ci_templates/tests.yml
@@ -47,6 +47,7 @@ docker_options: '-w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg'
 # <template: tests_template>
 {!{- $ctx       := index . 0 }!}
 {!{- $args_name := index . 1 }!}
+{!{- $buildType := index . 2 }!}
 {!{- $args_tmpl := printf "%s_run_args" $args_name }!}
 {!{- $default   := dict "image" "tests" "args" "echo no args" "docker_options" "" }!}
 {!{- $run       := coll.Merge (tmpl.Exec $args_tmpl | yaml) $default }!}
@@ -57,17 +58,22 @@ steps:
 {!{ tmpl.Exec "login_dev_registry_step"       $ctx | strings.Indent 2 }!}
 {!{ tmpl.Exec "login_readonly_registry_step"  $ctx | strings.Indent 2 }!}
   - name: Run tests
-    uses: {!{ index (ds "actions") "werf/actions/run" }!}
-    with:
-      channel: ${{env.WERF_CHANNEL}}
-      image: {!{ $run.image }!}
-      args: {!{ $run.args | squote }!}
     env:
-      WERF_SKIP_BUILD: "true"
-      WERF_DOCKER_OPTIONS: {!{ $run.docker_options | squote }!}
-      WERF_REPO: ${{ env.DEV_REGISTRY_PATH }}
-      CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
-      CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
-      CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+      DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+      CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+      CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+      CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+      CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+      CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+    run: |
+{!{ if eq $buildType "release" }!}
+      REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+      IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+      TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+{!{ else }!}
+      IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+      TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
+{!{ end }!}
+      docker run {!{ $run.docker_options }!} ${TESTS_IMAGE_URL} {!{ $run.args }!}
 # </template: tests_template>
 {!{- end -}!}

--- a/.github/ci_templates/tests.yml
+++ b/.github/ci_templates/tests.yml
@@ -60,19 +60,13 @@ steps:
   - name: Run tests
     env:
       DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-      CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-      CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
-      CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
       CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-      CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
     run: |
 {!{ if eq $buildType "release" }!}
       REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-      IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-      TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+      TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${CI_COMMIT_REF_SLUG}
 {!{ else }!}
-      IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-      TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
+      TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${CI_COMMIT_REF_SLUG}
 {!{ end }!}
       docker run {!{ $run.docker_options }!} ${TESTS_IMAGE_URL} {!{ $run.args }!}
 # </template: tests_template>

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -4,6 +4,9 @@
 # on every push to dev branches
 name: Build and test for dev branches
 on:
+  push:
+    branches:
+      - ci-tests-docker-run
   pull_request_target:
      types:
       - opened
@@ -95,7 +98,9 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-{!{ tmpl.Exec "tests_template" (slice $ctx "unit") | strings.Indent 4 }!}
+    env:
+      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
+{!{ tmpl.Exec "tests_template" (slice $ctx "unit" "dev") | strings.Indent 4 }!}
 
   matrix_tests:
     name: Matrix tests
@@ -103,7 +108,9 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-{!{ tmpl.Exec "tests_template" (slice $ctx "matrix") | strings.Indent 4 }!}
+    env:
+      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
+{!{ tmpl.Exec "tests_template" (slice $ctx "matrix" "dev") | strings.Indent 4 }!}
 
   dhctl_tests:
     name: Dhctl Tests
@@ -111,7 +118,9 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-{!{ tmpl.Exec "tests_template" (slice $ctx "dhctl") | strings.Indent 4 }!}
+    env:
+      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
+{!{ tmpl.Exec "tests_template" (slice $ctx "dhctl" "dev") | strings.Indent 4 }!}
 
   golangci_lint:
     name: GolangCI Lint
@@ -119,7 +128,9 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-{!{ tmpl.Exec "tests_template" (slice $ctx "golangci_lint") | strings.Indent 4 }!}
+    env:
+      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
+{!{ tmpl.Exec "tests_template" (slice $ctx "golangci_lint" "dev") | strings.Indent 4 }!}
 
   openapi_test_cases:
     name: OpenAPI Test Cases
@@ -127,7 +138,9 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-{!{ tmpl.Exec "tests_template" (slice $ctx "openapi_test_cases") | strings.Indent 4 }!}
+    env:
+      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
+{!{ tmpl.Exec "tests_template" (slice $ctx "openapi_test_cases" "dev") | strings.Indent 4 }!}
 
   web_links_test:
     name: Web links test
@@ -145,4 +158,6 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-{!{ tmpl.Exec "tests_template" (slice $ctx "validators") | strings.Indent 4 }!}
+    env:
+      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
+{!{ tmpl.Exec "tests_template" (slice $ctx "validators" "dev") | strings.Indent 4 }!}

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -20,7 +20,8 @@ env:
 # Note: Concurrency is currently in beta and subject to change.
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ${{ github.event.number }}-dev
+  #group: ${{ github.event.number }}-dev
+  group: ${{ github.event.number }}-dev-qqq
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -96,8 +96,6 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-    env:
-      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 {!{ tmpl.Exec "tests_template" (slice $ctx "unit" "dev") | strings.Indent 4 }!}
 
   matrix_tests:
@@ -106,8 +104,6 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-    env:
-      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 {!{ tmpl.Exec "tests_template" (slice $ctx "matrix" "dev") | strings.Indent 4 }!}
 
   dhctl_tests:
@@ -116,8 +112,6 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-    env:
-      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 {!{ tmpl.Exec "tests_template" (slice $ctx "dhctl" "dev") | strings.Indent 4 }!}
 
   golangci_lint:
@@ -126,8 +120,6 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-    env:
-      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 {!{ tmpl.Exec "tests_template" (slice $ctx "golangci_lint" "dev") | strings.Indent 4 }!}
 
   openapi_test_cases:
@@ -136,8 +128,6 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-    env:
-      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 {!{ tmpl.Exec "tests_template" (slice $ctx "openapi_test_cases" "dev") | strings.Indent 4 }!}
 
   web_links_test:
@@ -156,6 +146,4 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-    env:
-      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 {!{ tmpl.Exec "tests_template" (slice $ctx "validators" "dev") | strings.Indent 4 }!}

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -4,8 +4,7 @@
 # on every push to dev branches
 name: Build and test for dev branches
 on:
-  #pull_request_target:
-  pull_request:
+  pull_request_target:
      types:
       - opened
       - synchronize
@@ -20,8 +19,7 @@ env:
 # Note: Concurrency is currently in beta and subject to change.
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  #group: ${{ github.event.number }}-dev
-  group: ${{ github.event.number }}-dev-qqq
+  group: ${{ github.event.number }}-dev
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -4,10 +4,8 @@
 # on every push to dev branches
 name: Build and test for dev branches
 on:
-  push:
-    branches:
-      - ci-tests-docker-run
-  pull_request_target:
+  #pull_request_target:
+  pull_request:
      types:
       - opened
       - synchronize

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -117,8 +117,6 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-    env:
-      WERF_ENV: "FE"
 {!{ tmpl.Exec "tests_template" (slice $ctx "unit" "release") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.tests) | strings.Indent 6 }!}
 
@@ -129,8 +127,6 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-    env:
-      WERF_ENV: "FE"
 {!{ tmpl.Exec "tests_template" (slice $ctx "matrix" "release") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.matrix_tests) | strings.Indent 6 }!}
 
@@ -141,8 +137,6 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-    env:
-      WERF_ENV: "FE"
 {!{ tmpl.Exec "tests_template" (slice $ctx "dhctl" "release") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.dhctl_tests) | strings.Indent 6 }!}
 
@@ -153,8 +147,6 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-    env:
-      WERF_ENV: "FE"
 {!{ tmpl.Exec "tests_template" (slice $ctx "golangci_lint" "release") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.golangci_lint) | strings.Indent 6 }!}
 
@@ -165,8 +157,6 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-    env:
-      WERF_ENV: "FE"
 {!{ tmpl.Exec "tests_template" (slice $ctx "openapi_test_cases" "release") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.openapi_test_cases) | strings.Indent 6 }!}
 
@@ -188,8 +178,6 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-    env:
-      WERF_ENV: "FE"
 {!{ tmpl.Exec "tests_template" (slice $ctx "validators" "release") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.validators) | strings.Indent 6 }!}
 

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -117,7 +117,9 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-{!{ tmpl.Exec "tests_template" (slice $ctx "unit") | strings.Indent 4 }!}
+    env:
+      WERF_ENV: "FE"
+{!{ tmpl.Exec "tests_template" (slice $ctx "unit" "release") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.tests) | strings.Indent 6 }!}
 
 {!{ $jobNames = coll.Merge $jobNames (dict "matrix_tests" "Matrix tests") }!}
@@ -127,7 +129,9 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-{!{ tmpl.Exec "tests_template" (slice $ctx "matrix") | strings.Indent 4 }!}
+    env:
+      WERF_ENV: "FE"
+{!{ tmpl.Exec "tests_template" (slice $ctx "matrix" "release") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.matrix_tests) | strings.Indent 6 }!}
 
 {!{ $jobNames = coll.Merge $jobNames (dict "dhctl_tests" "Matrix tests") }!}
@@ -137,7 +141,9 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-{!{ tmpl.Exec "tests_template" (slice $ctx "dhctl") | strings.Indent 4 }!}
+    env:
+      WERF_ENV: "FE"
+{!{ tmpl.Exec "tests_template" (slice $ctx "dhctl" "release") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.dhctl_tests) | strings.Indent 6 }!}
 
 {!{ $jobNames = coll.Merge $jobNames (dict "golangci_lint" "GolangCI Lint") }!}
@@ -147,7 +153,9 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-{!{ tmpl.Exec "tests_template" (slice $ctx "golangci_lint") | strings.Indent 4 }!}
+    env:
+      WERF_ENV: "FE"
+{!{ tmpl.Exec "tests_template" (slice $ctx "golangci_lint" "release") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.golangci_lint) | strings.Indent 6 }!}
 
 {!{ $jobNames = coll.Merge $jobNames (dict "openapi_test_cases" "OpenAPI Test Cases") }!}
@@ -157,7 +165,9 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-{!{ tmpl.Exec "tests_template" (slice $ctx "openapi_test_cases") | strings.Indent 4 }!}
+    env:
+      WERF_ENV: "FE"
+{!{ tmpl.Exec "tests_template" (slice $ctx "openapi_test_cases" "release") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.openapi_test_cases) | strings.Indent 6 }!}
 
 {!{ $jobNames = coll.Merge $jobNames (dict "web_links_test" "Web links test") }!}
@@ -178,7 +188,9 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-{!{ tmpl.Exec "tests_template" (slice $ctx "validators") | strings.Indent 4 }!}
+    env:
+      WERF_ENV: "FE"
+{!{ tmpl.Exec "tests_template" (slice $ctx "validators" "release") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.validators) | strings.Indent 6 }!}
 
 {!{/* Autodeploy site and docs to production env on push to main branch. */}!}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -637,8 +637,6 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-    env:
-      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -696,8 +694,6 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-    env:
-      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -755,8 +751,6 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-    env:
-      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -814,8 +808,6 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-    env:
-      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -873,8 +865,6 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-    env:
-      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1055,8 +1045,6 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-    env:
-      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -5,8 +5,7 @@
 # on every push to dev branches
 name: Build and test for dev branches
 on:
-  #pull_request_target:
-  pull_request:
+  pull_request_target:
      types:
       - opened
       - synchronize
@@ -77,8 +76,7 @@ env:
 # Note: Concurrency is currently in beta and subject to change.
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  #group: ${{ github.event.number }}-dev
-  group: ${{ github.event.number }}-dev-qqq
+  group: ${{ github.event.number }}-dev
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -77,7 +77,8 @@ env:
 # Note: Concurrency is currently in beta and subject to change.
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: ${{ github.event.number }}-dev
+  #group: ${{ github.event.number }}-dev
+  group: ${{ github.event.number }}-dev-qqq
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -5,10 +5,8 @@
 # on every push to dev branches
 name: Build and test for dev branches
 on:
-  push:
-    branches:
-      - ci-tests-docker-run
-  pull_request_target:
+  #pull_request_target:
+  pull_request:
      types:
       - opened
       - synchronize
@@ -684,15 +682,10 @@ jobs:
       - name: Run tests
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
 
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
+          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test -timeout=${{env.TEST_TIMEOUT}} -vet=off ./modules/... ./global-hooks/...
     # </template: tests_template>
@@ -748,15 +741,10 @@ jobs:
       - name: Run tests
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
 
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
+          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test ./testing/matrix/ -v
     # </template: tests_template>
@@ -812,15 +800,10 @@ jobs:
       - name: Run tests
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
 
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
+          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -w /deckhouse/dhctl -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} make ci
     # </template: tests_template>
@@ -876,15 +859,10 @@ jobs:
       - name: Run tests
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
 
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
+          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} sh -c "go generate tools/register.go && golangci-lint run"
     # </template: tests_template>
@@ -940,15 +918,10 @@ jobs:
       - name: Run tests
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
 
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
+          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -v ${{github.workspace}}:/deckhouse -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} ginkgo -vet=off ./testing/openapi_cases/
     # </template: tests_template>
@@ -1127,15 +1100,10 @@ jobs:
       - name: Run tests
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
 
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
+          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...
     # </template: tests_template>

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -5,6 +5,9 @@
 # on every push to dev branches
 name: Build and test for dev branches
 on:
+  push:
+    branches:
+      - ci-tests-docker-run
   pull_request_target:
      types:
       - opened
@@ -488,9 +491,11 @@ jobs:
             if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
               DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${IMAGE_TAG}
               DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
+              DESTINATION_TESTS_IMAGE=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
             else
               DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${IMAGE_TAG}
               DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
+              DESTINATION_TESTS_IMAGE=${CI_REGISTRY_IMAGE}/tests:${IMAGE_TAG}
             fi
 
             echo "⚓️ [$(date -u)] Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
@@ -501,9 +506,14 @@ jobs:
             DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
             pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DESTINATION_INSTALL_IMAGE}
 
+            echo "⚓️ [$(date -u)] Publish 'tests' image to dev-registry using tag ${IMAGE_TAG}".
+            TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
+            pull_push 'tests' ${TESTS_IMAGE_URL} ${DESTINATION_TESTS_IMAGE}
+
             echo "⚓️ [$(date -u)] Remove local tags."
             docker image rmi ${DESTINATION_IMAGE} || true
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true
+            docker image rmi ${DESTINATION_TESTS_IMAGE} || true
           fi
           rm -f images_tags_werf.json
 
@@ -629,6 +639,8 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
+    env:
+      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -670,18 +682,19 @@ jobs:
           logout: false
       # </template: login_readonly_registry_step>
       - name: Run tests
-        uses: werf/actions/run@v1.2
-        with:
-          channel: ${{env.WERF_CHANNEL}}
-          image: tests
-          args: 'go test -timeout=${{env.TEST_TIMEOUT}} -vet=off ./modules/... ./global-hooks/...'
         env:
-          WERF_SKIP_BUILD: "true"
-          WERF_DOCKER_OPTIONS: '-w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg'
-          WERF_REPO: ${{ env.DEV_REGISTRY_PATH }}
-          CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
-          CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
-          CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+        run: |
+
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
+
+          docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test -timeout=${{env.TEST_TIMEOUT}} -vet=off ./modules/... ./global-hooks/...
     # </template: tests_template>
 
   matrix_tests:
@@ -690,6 +703,8 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
+    env:
+      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -731,18 +746,19 @@ jobs:
           logout: false
       # </template: login_readonly_registry_step>
       - name: Run tests
-        uses: werf/actions/run@v1.2
-        with:
-          channel: ${{env.WERF_CHANNEL}}
-          image: tests
-          args: 'go test ./testing/matrix/ -v'
         env:
-          WERF_SKIP_BUILD: "true"
-          WERF_DOCKER_OPTIONS: '-w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg'
-          WERF_REPO: ${{ env.DEV_REGISTRY_PATH }}
-          CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
-          CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
-          CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+        run: |
+
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
+
+          docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test ./testing/matrix/ -v
     # </template: tests_template>
 
   dhctl_tests:
@@ -751,6 +767,8 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
+    env:
+      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -792,18 +810,19 @@ jobs:
           logout: false
       # </template: login_readonly_registry_step>
       - name: Run tests
-        uses: werf/actions/run@v1.2
-        with:
-          channel: ${{env.WERF_CHANNEL}}
-          image: dhctl-tests
-          args: 'make ci'
         env:
-          WERF_SKIP_BUILD: "true"
-          WERF_DOCKER_OPTIONS: '-w /deckhouse/dhctl -v ${{env.HOME}}/go-pkg-cache:/go/pkg'
-          WERF_REPO: ${{ env.DEV_REGISTRY_PATH }}
-          CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
-          CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
-          CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+        run: |
+
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
+
+          docker run -w /deckhouse/dhctl -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} make ci
     # </template: tests_template>
 
   golangci_lint:
@@ -812,6 +831,8 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
+    env:
+      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -853,18 +874,19 @@ jobs:
           logout: false
       # </template: login_readonly_registry_step>
       - name: Run tests
-        uses: werf/actions/run@v1.2
-        with:
-          channel: ${{env.WERF_CHANNEL}}
-          image: tests
-          args: 'sh -c "go generate tools/register.go && golangci-lint run"'
         env:
-          WERF_SKIP_BUILD: "true"
-          WERF_DOCKER_OPTIONS: '-w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ${{env.HOME}}/go-pkg-cache:/go/pkg'
-          WERF_REPO: ${{ env.DEV_REGISTRY_PATH }}
-          CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
-          CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
-          CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+        run: |
+
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
+
+          docker run -w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} sh -c "go generate tools/register.go && golangci-lint run"
     # </template: tests_template>
 
   openapi_test_cases:
@@ -873,6 +895,8 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
+    env:
+      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -914,18 +938,19 @@ jobs:
           logout: false
       # </template: login_readonly_registry_step>
       - name: Run tests
-        uses: werf/actions/run@v1.2
-        with:
-          channel: ${{env.WERF_CHANNEL}}
-          image: tests
-          args: 'ginkgo -vet=off ./testing/openapi_cases/'
         env:
-          WERF_SKIP_BUILD: "true"
-          WERF_DOCKER_OPTIONS: '-v ${{github.workspace}}:/deckhouse -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg'
-          WERF_REPO: ${{ env.DEV_REGISTRY_PATH }}
-          CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
-          CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
-          CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+        run: |
+
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
+
+          docker run -v ${{github.workspace}}:/deckhouse -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} ginkgo -vet=off ./testing/openapi_cases/
     # </template: tests_template>
 
   web_links_test:
@@ -1057,6 +1082,8 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
+    env:
+      WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1098,16 +1125,17 @@ jobs:
           logout: false
       # </template: login_readonly_registry_step>
       - name: Run tests
-        uses: werf/actions/run@v1.2
-        with:
-          channel: ${{env.WERF_CHANNEL}}
-          image: tests
-          args: 'go test -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...'
         env:
-          WERF_SKIP_BUILD: "true"
-          WERF_DOCKER_OPTIONS: '-w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg'
-          WERF_REPO: ${{ env.DEV_REGISTRY_PATH }}
-          CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
-          CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
-          CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+        run: |
+
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
+
+          docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...
     # </template: tests_template>

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -1172,8 +1172,6 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-    env:
-      WERF_ENV: "FE"
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1219,8 +1217,7 @@ jobs:
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
 
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${CI_COMMIT_REF_SLUG}
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/fe/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test -timeout=${{env.TEST_TIMEOUT}} -vet=off ./modules/... ./global-hooks/...
     # </template: tests_template>
@@ -1262,8 +1259,6 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-    env:
-      WERF_ENV: "FE"
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1309,8 +1304,7 @@ jobs:
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
 
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${CI_COMMIT_REF_SLUG}
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/fe/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test ./testing/matrix/ -v
     # </template: tests_template>
@@ -1352,8 +1346,6 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-    env:
-      WERF_ENV: "FE"
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1399,8 +1391,7 @@ jobs:
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
 
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${CI_COMMIT_REF_SLUG}
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/fe/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -w /deckhouse/dhctl -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} make ci
     # </template: tests_template>
@@ -1442,8 +1433,6 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-    env:
-      WERF_ENV: "FE"
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1489,8 +1478,7 @@ jobs:
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
 
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${CI_COMMIT_REF_SLUG}
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/fe/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} sh -c "go generate tools/register.go && golangci-lint run"
     # </template: tests_template>
@@ -1532,8 +1520,6 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-    env:
-      WERF_ENV: "FE"
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1579,8 +1565,7 @@ jobs:
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
 
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${CI_COMMIT_REF_SLUG}
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/fe/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -v ${{github.workspace}}:/deckhouse -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} ginkgo -vet=off ./testing/openapi_cases/
     # </template: tests_template>
@@ -1774,8 +1759,6 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
-    env:
-      WERF_ENV: "FE"
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1821,8 +1804,7 @@ jobs:
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
 
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${CI_COMMIT_REF_SLUG}
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/fe/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...
     # </template: tests_template>

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -409,9 +409,11 @@ jobs:
             if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
               DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${IMAGE_TAG}
               DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
+              DESTINATION_TESTS_IMAGE=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
             else
               DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${IMAGE_TAG}
               DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
+              DESTINATION_TESTS_IMAGE=${CI_REGISTRY_IMAGE}/tests:${IMAGE_TAG}
             fi
 
             echo "⚓️ [$(date -u)] Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
@@ -422,9 +424,14 @@ jobs:
             DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
             pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DESTINATION_INSTALL_IMAGE}
 
+            echo "⚓️ [$(date -u)] Publish 'tests' image to dev-registry using tag ${IMAGE_TAG}".
+            TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
+            pull_push 'tests' ${TESTS_IMAGE_URL} ${DESTINATION_TESTS_IMAGE}
+
             echo "⚓️ [$(date -u)] Remove local tags."
             docker image rmi ${DESTINATION_IMAGE} || true
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true
+            docker image rmi ${DESTINATION_TESTS_IMAGE} || true
           fi
           rm -f images_tags_werf.json
 
@@ -454,6 +461,11 @@ jobs:
               DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
               pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
 
+              echo "⚓️ [$(date -u)] Publish 'tests' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+              DECKHOUSE_DESTINATION_TESTS_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+              TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
+              pull_push 'tests' ${TESTS_IMAGE_URL} ${DECKHOUSE_DESTINATION_TESTS_IMAGE}
+
               echo "⚓️ [$(date -u)] Publish 'release-channel-version' image to deckhouse registry using tag ${IMAGE_TAG} ..."
               DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${IMAGE_TAG}
               RELEASE_CHANNEL_VERSION_IMAGE_URL="$(jq -r '.Images."release-channel-version".DockerImageName' images_tags_werf.json)"
@@ -462,6 +474,7 @@ jobs:
               echo "⚓️ [$(date -u)] Remove local tags."
               docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true
               docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true
+              docker image rmi ${DECKHOUSE_DESTINATION_TESTS_IMAGE} || true
               docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true
 
               rm -f images_tags_werf.json
@@ -636,9 +649,11 @@ jobs:
             if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
               DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${IMAGE_TAG}
               DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
+              DESTINATION_TESTS_IMAGE=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
             else
               DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${IMAGE_TAG}
               DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
+              DESTINATION_TESTS_IMAGE=${CI_REGISTRY_IMAGE}/tests:${IMAGE_TAG}
             fi
 
             echo "⚓️ [$(date -u)] Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
@@ -649,9 +664,14 @@ jobs:
             DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
             pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DESTINATION_INSTALL_IMAGE}
 
+            echo "⚓️ [$(date -u)] Publish 'tests' image to dev-registry using tag ${IMAGE_TAG}".
+            TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
+            pull_push 'tests' ${TESTS_IMAGE_URL} ${DESTINATION_TESTS_IMAGE}
+
             echo "⚓️ [$(date -u)] Remove local tags."
             docker image rmi ${DESTINATION_IMAGE} || true
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true
+            docker image rmi ${DESTINATION_TESTS_IMAGE} || true
           fi
           rm -f images_tags_werf.json
 
@@ -681,6 +701,11 @@ jobs:
               DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
               pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
 
+              echo "⚓️ [$(date -u)] Publish 'tests' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+              DECKHOUSE_DESTINATION_TESTS_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+              TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
+              pull_push 'tests' ${TESTS_IMAGE_URL} ${DECKHOUSE_DESTINATION_TESTS_IMAGE}
+
               echo "⚓️ [$(date -u)] Publish 'release-channel-version' image to deckhouse registry using tag ${IMAGE_TAG} ..."
               DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${IMAGE_TAG}
               RELEASE_CHANNEL_VERSION_IMAGE_URL="$(jq -r '.Images."release-channel-version".DockerImageName' images_tags_werf.json)"
@@ -689,6 +714,7 @@ jobs:
               echo "⚓️ [$(date -u)] Remove local tags."
               docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true
               docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true
+              docker image rmi ${DECKHOUSE_DESTINATION_TESTS_IMAGE} || true
               docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true
 
               rm -f images_tags_werf.json
@@ -863,9 +889,11 @@ jobs:
             if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
               DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${IMAGE_TAG}
               DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
+              DESTINATION_TESTS_IMAGE=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
             else
               DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${IMAGE_TAG}
               DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
+              DESTINATION_TESTS_IMAGE=${CI_REGISTRY_IMAGE}/tests:${IMAGE_TAG}
             fi
 
             echo "⚓️ [$(date -u)] Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
@@ -876,9 +904,14 @@ jobs:
             DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
             pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DESTINATION_INSTALL_IMAGE}
 
+            echo "⚓️ [$(date -u)] Publish 'tests' image to dev-registry using tag ${IMAGE_TAG}".
+            TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
+            pull_push 'tests' ${TESTS_IMAGE_URL} ${DESTINATION_TESTS_IMAGE}
+
             echo "⚓️ [$(date -u)] Remove local tags."
             docker image rmi ${DESTINATION_IMAGE} || true
             docker image rmi ${DESTINATION_INSTALL_IMAGE} || true
+            docker image rmi ${DESTINATION_TESTS_IMAGE} || true
           fi
           rm -f images_tags_werf.json
 
@@ -908,6 +941,11 @@ jobs:
               DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
               pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
 
+              echo "⚓️ [$(date -u)] Publish 'tests' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+              DECKHOUSE_DESTINATION_TESTS_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+              TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
+              pull_push 'tests' ${TESTS_IMAGE_URL} ${DECKHOUSE_DESTINATION_TESTS_IMAGE}
+
               echo "⚓️ [$(date -u)] Publish 'release-channel-version' image to deckhouse registry using tag ${IMAGE_TAG} ..."
               DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${IMAGE_TAG}
               RELEASE_CHANNEL_VERSION_IMAGE_URL="$(jq -r '.Images."release-channel-version".DockerImageName' images_tags_werf.json)"
@@ -916,6 +954,7 @@ jobs:
               echo "⚓️ [$(date -u)] Remove local tags."
               docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true
               docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true
+              docker image rmi ${DECKHOUSE_DESTINATION_TESTS_IMAGE} || true
               docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true
 
               rm -f images_tags_werf.json
@@ -1133,6 +1172,8 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
+    env:
+      WERF_ENV: "FE"
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1173,18 +1214,20 @@ jobs:
           logout: false
       # </template: login_readonly_registry_step>
       - name: Run tests
-        uses: werf/actions/run@v1.2
-        with:
-          channel: ${{env.WERF_CHANNEL}}
-          image: tests
-          args: 'go test -timeout=${{env.TEST_TIMEOUT}} -vet=off ./modules/... ./global-hooks/...'
         env:
-          WERF_SKIP_BUILD: "true"
-          WERF_DOCKER_OPTIONS: '-w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg'
-          WERF_REPO: ${{ env.DEV_REGISTRY_PATH }}
-          CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
-          CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
-          CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+        run: |
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+
+          docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test -timeout=${{env.TEST_TIMEOUT}} -vet=off ./modules/... ./global-hooks/...
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1224,6 +1267,8 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
+    env:
+      WERF_ENV: "FE"
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1264,18 +1309,20 @@ jobs:
           logout: false
       # </template: login_readonly_registry_step>
       - name: Run tests
-        uses: werf/actions/run@v1.2
-        with:
-          channel: ${{env.WERF_CHANNEL}}
-          image: tests
-          args: 'go test ./testing/matrix/ -v'
         env:
-          WERF_SKIP_BUILD: "true"
-          WERF_DOCKER_OPTIONS: '-w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg'
-          WERF_REPO: ${{ env.DEV_REGISTRY_PATH }}
-          CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
-          CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
-          CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+        run: |
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+
+          docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test ./testing/matrix/ -v
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1315,6 +1362,8 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
+    env:
+      WERF_ENV: "FE"
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1355,18 +1404,20 @@ jobs:
           logout: false
       # </template: login_readonly_registry_step>
       - name: Run tests
-        uses: werf/actions/run@v1.2
-        with:
-          channel: ${{env.WERF_CHANNEL}}
-          image: dhctl-tests
-          args: 'make ci'
         env:
-          WERF_SKIP_BUILD: "true"
-          WERF_DOCKER_OPTIONS: '-w /deckhouse/dhctl -v ${{env.HOME}}/go-pkg-cache:/go/pkg'
-          WERF_REPO: ${{ env.DEV_REGISTRY_PATH }}
-          CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
-          CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
-          CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+        run: |
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+
+          docker run -w /deckhouse/dhctl -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} make ci
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1406,6 +1457,8 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
+    env:
+      WERF_ENV: "FE"
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1446,18 +1499,20 @@ jobs:
           logout: false
       # </template: login_readonly_registry_step>
       - name: Run tests
-        uses: werf/actions/run@v1.2
-        with:
-          channel: ${{env.WERF_CHANNEL}}
-          image: tests
-          args: 'sh -c "go generate tools/register.go && golangci-lint run"'
         env:
-          WERF_SKIP_BUILD: "true"
-          WERF_DOCKER_OPTIONS: '-w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ${{env.HOME}}/go-pkg-cache:/go/pkg'
-          WERF_REPO: ${{ env.DEV_REGISTRY_PATH }}
-          CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
-          CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
-          CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+        run: |
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+
+          docker run -w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} sh -c "go generate tools/register.go && golangci-lint run"
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1497,6 +1552,8 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
+    env:
+      WERF_ENV: "FE"
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1537,18 +1594,20 @@ jobs:
           logout: false
       # </template: login_readonly_registry_step>
       - name: Run tests
-        uses: werf/actions/run@v1.2
-        with:
-          channel: ${{env.WERF_CHANNEL}}
-          image: tests
-          args: 'ginkgo -vet=off ./testing/openapi_cases/'
         env:
-          WERF_SKIP_BUILD: "true"
-          WERF_DOCKER_OPTIONS: '-v ${{github.workspace}}:/deckhouse -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg'
-          WERF_REPO: ${{ env.DEV_REGISTRY_PATH }}
-          CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
-          CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
-          CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+        run: |
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+
+          docker run -v ${{github.workspace}}:/deckhouse -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} ginkgo -vet=off ./testing/openapi_cases/
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1740,6 +1799,8 @@ jobs:
       - git_info
       - build_fe
     continue-on-error: true
+    env:
+      WERF_ENV: "FE"
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1780,18 +1841,20 @@ jobs:
           logout: false
       # </template: login_readonly_registry_step>
       - name: Run tests
-        uses: werf/actions/run@v1.2
-        with:
-          channel: ${{env.WERF_CHANNEL}}
-          image: tests
-          args: 'go test -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...'
         env:
-          WERF_SKIP_BUILD: "true"
-          WERF_DOCKER_OPTIONS: '-w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg'
-          WERF_REPO: ${{ env.DEV_REGISTRY_PATH }}
-          CI_COMMIT_TAG: ${{ needs.git_info.outputs.ci_commit_tag }}
-          CI_COMMIT_REF_NAME: ${{ needs.git_info.outputs.ci_commit_ref_name }}
-          CI_PIPELINE_CREATED_AT: ${{ needs.git_info.outputs.ci_pipeline_created_at }}
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+        run: |
+
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+
+          docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -1216,16 +1216,11 @@ jobs:
       - name: Run tests
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
 
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test -timeout=${{env.TEST_TIMEOUT}} -vet=off ./modules/... ./global-hooks/...
     # </template: tests_template>
@@ -1311,16 +1306,11 @@ jobs:
       - name: Run tests
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
 
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test ./testing/matrix/ -v
     # </template: tests_template>
@@ -1406,16 +1396,11 @@ jobs:
       - name: Run tests
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
 
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -w /deckhouse/dhctl -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} make ci
     # </template: tests_template>
@@ -1501,16 +1486,11 @@ jobs:
       - name: Run tests
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
 
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} sh -c "go generate tools/register.go && golangci-lint run"
     # </template: tests_template>
@@ -1596,16 +1576,11 @@ jobs:
       - name: Run tests
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
 
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -v ${{github.workspace}}:/deckhouse -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} ginkgo -vet=off ./testing/openapi_cases/
     # </template: tests_template>
@@ -1843,16 +1818,11 @@ jobs:
       - name: Run tests
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
 
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
+          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${CI_COMMIT_REF_SLUG}
 
           docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...
     # </template: tests_template>

--- a/modules/150-user-authn/images/dex/Dockerfile
+++ b/modules/150-user-authn/images/dex/Dockerfile
@@ -10,7 +10,7 @@ RUN wget https://github.com/dexidp/dex/archive/v2.31.0.tar.gz -O - | tar -xz --s
   && git apply /static-user-groups.patch
 RUN go build ./cmd/dex
 
-FROM ghcr.io/dexidp/dex@sha256:104e0ba05220915de6e5d122895658e671bd8a252dbb550d4d10b8245f691ad4 as dex
+FROM dexidp/dex:v2.30.0 as dex
 
 FROM $BASE_ALPINE
 RUN apk add --no-cache --update ca-certificates openssl

--- a/modules/150-user-authn/images/dex/Dockerfile
+++ b/modules/150-user-authn/images/dex/Dockerfile
@@ -10,7 +10,7 @@ RUN wget https://github.com/dexidp/dex/archive/v2.31.0.tar.gz -O - | tar -xz --s
   && git apply /static-user-groups.patch
 RUN go build ./cmd/dex
 
-FROM dexidp/dex:v2.30.0 as dex
+FROM ghcr.io/dexidp/dex@sha256:104e0ba05220915de6e5d122895658e671bd8a252dbb550d4d10b8245f691ad4 as dex
 
 FROM $BASE_ALPINE
 RUN apk add --no-cache --update ca-certificates openssl


### PR DESCRIPTION
## Description
Tests running — migration from `werf run` to `docker run`.

## Why do we need it, and what problem does it solve?
After [build optimization](https://github.com/deckhouse/deckhouse/pull/616), the tests image werf.yaml become quite complicated, so it takes a lot of time to just run the ready-to-use image via `werf run`. So we use `docker run`.

## Changelog entries

```changes
section: ci
type: fix
summary: Tests running — migration from `werf run` to `docker run`.
impact_level: low
```

## Additional info
- [ ] @diafour the `Enable FE` job doesn't work in my pr :(.

