### PR TITLE
[flant-integration] added grafana-agent proxy_url option

### DIFF
--- a/ee/modules/600-flant-integration/templates/pricing/config.yaml
+++ b/ee/modules/600-flant-integration/templates/pricing/config.yaml
@@ -31,6 +31,18 @@ prometheus:
         action: labeldrop
     remote_write:
     - url: {{ .Values.flantIntegration.metrics.url }}
+  {{- if .Values.global.modules.proxy }}
+    {{- $proxy := "" }}
+    {{- if .Values.global.modules.proxy.httpProxy }}
+      {{- $proxy = .Values.global.modules.proxy.httpProxy }}
+    {{- end }}
+    {{- if .Values.global.modules.proxy.httpsProxy }}
+      {{- $proxy = .Values.global.modules.proxy.httpsProxy }}
+    {{- end }}
+    {{- if $proxy }}
+      proxy_url: {{ $proxy }}
+    {{- end }}
+  {{- end }}
       bearer_token: {{ .Values.flantIntegration.internal.licenseKey }}
       metadata_config:
         send: false


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added grafana-agent proxy_url option for proxy support if global proxy configuration is set.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: flant-pricing
type: feature
summary: Added grafana-agent proxy_url option for proxy support if global proxy configuration is set.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
