### PR TITLE
[ingress-nginx] Deny locations with invalid auth URL

### DIFF
--- a/modules/402-ingress-nginx/images/controller-0-33/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-0-33/Dockerfile
@@ -7,6 +7,7 @@ COPY patches/lua-info.patch /
 COPY patches/omit-helm-secrets.patch /
 COPY patches/healthcheck.patch /
 COPY patches/pod-ip.patch /
+COPY patches/deny-invalid-auth-locations.patch /
 ENV GOARCH=amd64
 RUN apt-get update && apt-get install -y --no-install-recommends git mercurial patch && \
     git clone --branch controller-0.33.0 --depth 1 https://github.com/kubernetes/ingress-nginx.git /src && \
@@ -14,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git mercurial p
     patch -p1 < /pod-ip.patch && \
     patch -p1 < /omit-helm-secrets.patch && \
     patch -p1 < /healthcheck.patch && \
+    patch -p1 < /deny-invalid-auth-locations.patch && \
     make GO111MODULE=on USE_DOCKER=false build
 
 # luarocks assets for luajit artifact

--- a/modules/402-ingress-nginx/images/controller-0-33/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-0-33/patches/README.md
@@ -39,3 +39,12 @@ https://github.com/kubernetes/ingress-nginx/issues/2262
 ### Always set auth cookie
 
 Without always option toggled, ingress-nginx does not set the cookie in case if backend returns >=400 code, which may lead to dex refresh token invalidation.
+
+https://github.com/kubernetes/ingress-nginx/pull/8213
+
+### Deny locations with the invalid auth URL
+
+There is a problem, that when you set an invalid URL as a value for the nginx.ingress.kubernetes.io/auth-url annotation, the ingress controller allows accessing upstreams without authentication.
+Thus, this is considered a security hole. Users can accidentally set an invalid URL by hand or because of an error in helm templates.
+
+https://github.com/kubernetes/ingress-nginx/pull/8256

--- a/modules/402-ingress-nginx/images/controller-0-33/patches/deny-invalid-auth-locations.patch
+++ b/modules/402-ingress-nginx/images/controller-0-33/patches/deny-invalid-auth-locations.patch
@@ -1,0 +1,13 @@
+diff --git a/internal/ingress/annotations/authreq/main.go b/internal/ingress/annotations/authreq/main.go
+index 6cfcc383d4e..36af0e20839 100644
+--- a/internal/ingress/annotations/authreq/main.go
++++ b/internal/ingress/annotations/authreq/main.go
+@@ -164,7 +164,7 @@ func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
+
+ 	authURL, err := parser.StringToURL(urlString)
+ 	if err != nil {
+-		return nil, ing_errors.InvalidContent{Name: err.Error()}
++		return nil, ing_errors.LocationDenied{Reason: fmt.Errorf("could not parse auth-url annotation: %v", err)}
+ 	}
+
+ 	authMethod, _ := parser.GetStringAnnotation("auth-method", ing)

--- a/modules/402-ingress-nginx/images/controller-0-46/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-0-46/Dockerfile
@@ -7,6 +7,7 @@ COPY patches/lua-info.patch /
 COPY patches/makefile.patch /
 COPY patches/healthcheck.patch /
 COPY patches/pod-ip.patch /
+COPY patches/deny-invalid-auth-locations.patch /
 ENV GOARCH=amd64
 RUN apt-get update && apt-get install -y --no-install-recommends git mercurial patch && \
     git clone --branch controller-v0.46.0 --depth 1 https://github.com/kubernetes/ingress-nginx.git /src && \
@@ -14,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git mercurial p
     patch -p1 < /makefile.patch && \
     patch -p1 < /pod-ip.patch && \
     patch -p1 < /healthcheck.patch && \
+    patch -p1 < /deny-invalid-auth-locations.patch && \
     make GO111MODULE=on USE_DOCKER=false build
 
 # luarocks assets for luajit artifact

--- a/modules/402-ingress-nginx/images/controller-0-46/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-0-46/patches/README.md
@@ -32,3 +32,16 @@ https://github.com/kubernetes/ingress-nginx/issues/2262
 ### Makefile
 
 Run the build locally, not inside the container.
+
+### Always set auth cookie
+
+Without always option toggled, ingress-nginx does not set the cookie in case if backend returns >=400 code, which may lead to dex refresh token invalidation.
+
+https://github.com/kubernetes/ingress-nginx/pull/8213
+
+### Deny locations with the invalid auth URL
+
+There is a problem, that when you set an invalid URL as a value for the nginx.ingress.kubernetes.io/auth-url annotation, the ingress controller allows accessing upstreams without authentication.
+Thus, this is considered a security hole. Users can accidentally set an invalid URL by hand or because of an error in helm templates.
+
+https://github.com/kubernetes/ingress-nginx/pull/8256

--- a/modules/402-ingress-nginx/images/controller-0-46/patches/deny-invalid-auth-locations.patch
+++ b/modules/402-ingress-nginx/images/controller-0-46/patches/deny-invalid-auth-locations.patch
@@ -1,0 +1,13 @@
+diff --git a/internal/ingress/annotations/authreq/main.go b/internal/ingress/annotations/authreq/main.go
+index 6cfcc383d4e..36af0e20839 100644
+--- a/internal/ingress/annotations/authreq/main.go
++++ b/internal/ingress/annotations/authreq/main.go
+@@ -164,7 +164,7 @@ func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
+
+ 	authURL, err := parser.StringToURL(urlString)
+ 	if err != nil {
+-		return nil, ing_errors.InvalidContent{Name: err.Error()}
++		return nil, ing_errors.LocationDenied{Reason: fmt.Errorf("could not parse auth-url annotation: %v", err)}
+ 	}
+
+ 	authMethod, _ := parser.GetStringAnnotation("auth-method", ing)

--- a/modules/402-ingress-nginx/images/controller-0-48/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-0-48/Dockerfile
@@ -7,6 +7,7 @@ COPY patches/lua-info.patch /
 COPY patches/makefile.patch /
 COPY patches/healthcheck.patch /
 COPY patches/pod-ip.patch /
+COPY patches/deny-invalid-auth-locations.patch /
 ENV GOARCH=amd64
 RUN apt-get update && apt-get install -y --no-install-recommends git mercurial patch && \
     git clone --branch controller-v0.48.1 --depth 1 https://github.com/kubernetes/ingress-nginx.git /src && \
@@ -14,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git mercurial p
     patch -p1 < /makefile.patch && \
     patch -p1 < /pod-ip.patch && \
     patch -p1 < /healthcheck.patch && \
+    patch -p1 < /deny-invalid-auth-locations.patch && \
     make GO111MODULE=on USE_DOCKER=false build
 
 # luarocks assets for luajit artifact

--- a/modules/402-ingress-nginx/images/controller-0-48/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-0-48/patches/README.md
@@ -36,3 +36,12 @@ Run the build locally, not inside the container.
 ### Always set auth cookie
 
 Without always option toggled, ingress-nginx does not set the cookie in case if backend returns >=400 code, which may lead to dex refresh token invalidation.
+
+https://github.com/kubernetes/ingress-nginx/pull/8213
+
+### Deny locations with the invalid auth URL
+
+There is a problem, that when you set an invalid URL as a value for the nginx.ingress.kubernetes.io/auth-url annotation, the ingress controller allows accessing upstreams without authentication.
+Thus, this is considered a security hole. Users can accidentally set an invalid URL by hand or because of an error in helm templates.
+
+https://github.com/kubernetes/ingress-nginx/pull/8256

--- a/modules/402-ingress-nginx/images/controller-0-48/patches/deny-invalid-auth-locations.patch
+++ b/modules/402-ingress-nginx/images/controller-0-48/patches/deny-invalid-auth-locations.patch
@@ -1,0 +1,13 @@
+diff --git a/internal/ingress/annotations/authreq/main.go b/internal/ingress/annotations/authreq/main.go
+index 6cfcc383d4e..36af0e20839 100644
+--- a/internal/ingress/annotations/authreq/main.go
++++ b/internal/ingress/annotations/authreq/main.go
+@@ -164,7 +164,7 @@ func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
+
+ 	authURL, err := parser.StringToURL(urlString)
+ 	if err != nil {
+-		return nil, ing_errors.InvalidContent{Name: err.Error()}
++		return nil, ing_errors.LocationDenied{Reason: fmt.Errorf("could not parse auth-url annotation: %v", err)}
+ 	}
+
+ 	authMethod, _ := parser.GetStringAnnotation("auth-method", ing)

--- a/modules/402-ingress-nginx/images/controller-0-49/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-0-49/Dockerfile
@@ -7,6 +7,7 @@ COPY patches/lua-info.patch /
 COPY patches/makefile.patch /
 COPY patches/healthcheck.patch /
 COPY patches/pod-ip.patch /
+COPY patches/deny-invalid-auth-locations.patch /
 ENV GOARCH=amd64
 RUN apt-get update && apt-get install -y --no-install-recommends git mercurial patch && \
     git clone --branch controller-v0.49.1 --depth 1 https://github.com/kubernetes/ingress-nginx.git /src && \
@@ -14,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git mercurial p
     patch -p1 < /makefile.patch && \
     patch -p1 < /pod-ip.patch && \
     patch -p1 < /healthcheck.patch && \
+    patch -p1 < /deny-invalid-auth-locations.patch && \
     make GO111MODULE=on USE_DOCKER=false build
 
 # luarocks assets for luajit artifact
@@ -56,6 +58,7 @@ COPY --from=controller_0_26_1 /usr/local/openresty/luajit /usr/local/openresty/l
 COPY patches/balancer-lua.patch /
 COPY patches/nginx-tpl.patch /
 COPY patches/auth-cookie-always.patch /
+COPY patches/deny-invalid-auth-locations.patch /
 COPY rootfs /
 
 RUN apk update \
@@ -108,7 +111,8 @@ RUN apk update \
   && cd / \
   && patch -p1 < /balancer-lua.patch \
   && patch -p1 < /nginx-tpl.patch \
-  && patch -p1 < /auth-cookie-always.patch
+  && patch -p1 < /auth-cookie-always.patch  \
+  && patch -p1 < /deny-invalid-auth-locations.patch
 
 WORKDIR /
 USER www-data

--- a/modules/402-ingress-nginx/images/controller-0-49/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-0-49/Dockerfile
@@ -58,7 +58,6 @@ COPY --from=controller_0_26_1 /usr/local/openresty/luajit /usr/local/openresty/l
 COPY patches/balancer-lua.patch /
 COPY patches/nginx-tpl.patch /
 COPY patches/auth-cookie-always.patch /
-COPY patches/deny-invalid-auth-locations.patch /
 COPY rootfs /
 
 RUN apk update \
@@ -111,8 +110,7 @@ RUN apk update \
   && cd / \
   && patch -p1 < /balancer-lua.patch \
   && patch -p1 < /nginx-tpl.patch \
-  && patch -p1 < /auth-cookie-always.patch  \
-  && patch -p1 < /deny-invalid-auth-locations.patch
+  && patch -p1 < /auth-cookie-always.patch
 
 WORKDIR /
 USER www-data

--- a/modules/402-ingress-nginx/images/controller-0-49/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-0-49/patches/README.md
@@ -36,3 +36,12 @@ Run the build locally, not inside the container.
 ### Always set auth cookie
 
 Without always option toggled, ingress-nginx does not set the cookie in case if backend returns >=400 code, which may lead to dex refresh token invalidation.
+
+https://github.com/kubernetes/ingress-nginx/pull/8213
+
+### Deny locations with the invalid auth URL
+
+There is a problem, that when you set an invalid URL as a value for the nginx.ingress.kubernetes.io/auth-url annotation, the ingress controller allows accessing upstreams without authentication.
+Thus, this is considered a security hole. Users can accidentally set an invalid URL by hand or because of an error in helm templates.
+
+https://github.com/kubernetes/ingress-nginx/pull/8256

--- a/modules/402-ingress-nginx/images/controller-0-49/patches/deny-invalid-auth-locations.patch
+++ b/modules/402-ingress-nginx/images/controller-0-49/patches/deny-invalid-auth-locations.patch
@@ -1,0 +1,13 @@
+diff --git a/internal/ingress/annotations/authreq/main.go b/internal/ingress/annotations/authreq/main.go
+index 6cfcc383d4e..36af0e20839 100644
+--- a/internal/ingress/annotations/authreq/main.go
++++ b/internal/ingress/annotations/authreq/main.go
+@@ -164,7 +164,7 @@ func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
+
+ 	authURL, err := parser.StringToURL(urlString)
+ 	if err != nil {
+-		return nil, ing_errors.InvalidContent{Name: err.Error()}
++		return nil, ing_errors.LocationDenied{Reason: fmt.Errorf("could not parse auth-url annotation: %v", err)}
+ 	}
+
+ 	authMethod, _ := parser.GetStringAnnotation("auth-method", ing)

--- a/modules/402-ingress-nginx/images/controller-1-0/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-0/Dockerfile
@@ -6,12 +6,14 @@ WORKDIR /src/
 COPY patches/lua-info.patch /
 COPY patches/makefile.patch /
 COPY patches/healthcheck.patch /
+COPY patches/deny-invalid-auth-locations.patch /
 ENV GOARCH=amd64
 RUN apt-get update && apt-get install -y --no-install-recommends git mercurial patch && \
     git clone --branch controller-v1.0.4 --depth 1 https://github.com/kubernetes/ingress-nginx.git /src && \
     patch -p1 < /lua-info.patch && \
     patch -p1 < /makefile.patch && \
     patch -p1 < /healthcheck.patch && \
+    patch -p1 < /deny-invalid-auth-locations.patch && \
     make GO111MODULE=on USE_DOCKER=false build
 
 # luarocks assets for luajit artifact
@@ -107,7 +109,6 @@ RUN apk update \
   && patch -p1 < /balancer-lua.patch \
   && patch -p1 < /nginx-tpl.patch \
   && patch -p1 < /auth-cookie-always.patch
-
 WORKDIR /
 USER www-data
 EXPOSE 80 443

--- a/modules/402-ingress-nginx/images/controller-1-0/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-0/patches/README.md
@@ -30,3 +30,12 @@ Run the build locally, not inside the container.
 ### Always set auth cookie
 
 Without always option toggled, ingress-nginx does not set the cookie in case if backend returns >=400 code, which may lead to dex refresh token invalidation.
+
+https://github.com/kubernetes/ingress-nginx/pull/8213
+
+### Deny locations with the invalid auth URL
+
+There is a problem, that when you set an invalid URL as a value for the nginx.ingress.kubernetes.io/auth-url annotation, the ingress controller allows accessing upstreams without authentication.
+Thus, this is considered a security hole. Users can accidentally set an invalid URL by hand or because of an error in helm templates.
+
+https://github.com/kubernetes/ingress-nginx/pull/8256

--- a/modules/402-ingress-nginx/images/controller-1-0/patches/deny-invalid-auth-locations.patch
+++ b/modules/402-ingress-nginx/images/controller-1-0/patches/deny-invalid-auth-locations.patch
@@ -1,0 +1,13 @@
+diff --git a/internal/ingress/annotations/authreq/main.go b/internal/ingress/annotations/authreq/main.go
+index 6cfcc383d4e..36af0e20839 100644
+--- a/internal/ingress/annotations/authreq/main.go
++++ b/internal/ingress/annotations/authreq/main.go
+@@ -164,7 +164,7 @@ func (a authReq) Parse(ing *networking.Ingress) (interface{}, error) {
+
+ 	authURL, err := parser.StringToURL(urlString)
+ 	if err != nil {
+-		return nil, ing_errors.InvalidContent{Name: err.Error()}
++		return nil, ing_errors.LocationDenied{Reason: fmt.Errorf("could not parse auth-url annotation: %v", err)}
+ 	}
+
+ 	authMethod, _ := parser.GetStringAnnotation("auth-method", ing)


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
This is a patch that will help to avoid the explosion of sensitive data if the invalid auth URL is provided accidentally.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ingress-nginx
type: feature
summary:  Deny locations with invalid auth URL
impact_level: high
impact: Ingress controllers of version >=0.33 will be restarted.
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
