### PR TITLE
[user-authn] Fix dex build

### DIFF
--- a/modules/150-user-authn/images/dex/Dockerfile
+++ b/modules/150-user-authn/images/dex/Dockerfile
@@ -10,18 +10,12 @@ RUN wget https://github.com/dexidp/dex/archive/v2.31.0.tar.gz -O - | tar -xz --s
   && git apply /static-user-groups.patch
 RUN go build ./cmd/dex
 
-FROM ghcr.io/dexidp/dex@sha256:104e0ba05220915de6e5d122895658e671bd8a252dbb550d4d10b8245f691ad4 as dex
-
 FROM $BASE_ALPINE
 RUN apk add --no-cache --update ca-certificates openssl
 RUN mkdir -p /var/dex
 RUN chown -R 1001:1001 /var/dex
 RUN mkdir -p /etc/dex
 RUN chown -R 1001:1001 /etc/dex
-# Copy module files for CVE scanning / dependency analysis.
-COPY --from=dex /etc/dex/config.docker.yaml /etc/dex/
-COPY --from=dex /usr/local/src/dex/go.mod /usr/local/src/dex/go.sum /usr/local/src/dex/
-COPY --from=dex /usr/local/src/dex/api/v2/go.mod /usr/local/src/dex/api/v2/go.sum /usr/local/src/dex/api/v2/
 
 COPY --from=artifact /dex/dex /usr/local/bin/
 COPY --from=artifact /dex/web /web


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Remove unnecessary dependency on dex image

## Changelog entries

```changes
section: user-authn
type: fix
summary: Remove unnecessary dependency on dex image for build
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
