### PR TITLE
[upmeter] Fix numbers for string fields in yaml for UpmeterHookProbe CR template

### DIFF
--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/d8_clusterconfiguration.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/d8_clusterconfiguration.go
@@ -161,11 +161,11 @@ func newSetInitedValueChecker(dynamicClient dynamic.ResourceInterface, name stri
 apiVersion: deckhouse.io/v1
 kind: UpmeterHookProbe
 metadata:
-  name: %s
+  name: %q
   labels:
     heritage: upmeter
     app: upmeter
-    upmeter-agent: %s
+    upmeter-agent: %q
     upmeter-group: deckhouse
     upmeter-probe: cluster-configuration
 spec:
@@ -222,7 +222,8 @@ func (c *setInitedValueChecker) create(value string) check.Error {
 	decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 
 	obj := &unstructured.Unstructured{}
-	manifest := fmt.Sprintf(c.template, c.name, c.name, value)
+	objName, agentID := c.name, c.name
+	manifest := fmt.Sprintf(c.template, objName, agentID, value)
 
 	if _, _, err := decUnstructured.Decode([]byte(manifest), nil, obj); err != nil {
 		return check.ErrFail("cannot create UpmeterHookProbe object at runtime: %v", err)


### PR DESCRIPTION
## Description

Upmeter agent ID is generated as a string containing hexadecimal number. It is used as UpmeterHookProbe custom resource name and label value. The manifest for the CR is generated from text YAML template, there the ID is substituted unquoted.

When the ID consists of digits only, it is considered a number. The resulting manifests is rendered invalid on the creation of the CR object. This results in the downtime of "deckhouse/cluster-configuration" probe.

## Why do we need it, and what problem does it solve?

Fixes #994 , which is a floating bug.

## Changelog entries


```changes
section: upmeter
type: fix 
summary: Fixed floating causing false downtime of deckhouse/cluster-configuration probe 
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
