### PR TITLE
[docs] Fix article text in «Cloud provider — GCP: Preparing environment» page

### DIFF
--- a/candi/cloud-providers/gcp/docs/ENVIRONMENT.md
+++ b/candi/cloud-providers/gcp/docs/ENVIRONMENT.md
@@ -25,44 +25,41 @@ To create a `service account key` in JSON format, click on [three vertical dots]
 
 To configure via the command line interface, follow these steps:
 
-1\. Export environment variables:
-
-```shell
-export PROJECT=sandbox
-export SERVICE_ACCOUNT_NAME=deckhouse
-```
-2\. Select a project:
-
-```shell
-gcloud config set project $PROJECT
-```
-3\. Create a service account:
-
-```shell
-gcloud iam service-accounts create $SERVICE_ACCOUNT_NAME
-```
-4\. Connect roles to the service account:
-
-```shell
-for role in roles/compute.admin roles/iam.serviceAccountUser roles/networkmanagement.admin; 
-do gcloud projects add-iam-policy-binding ${PROJECT} --member=serviceAccount:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com --role=${role}; done
-```
-List of roles required:
-```
-roles/compute.admin
-roles/iam.serviceAccountUser
-roles/networkmanagement.admin
-```
-
-5\. Verify service account roles:
-
-```shell
-gcloud projects get-iam-policy ${PROJECT} --flatten="bindings[].members" --format='table(bindings.role)' \
-      --filter="bindings.members:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com"
-```
-6\. Create a `service account key`:
-
-```shell
-gcloud iam service-accounts keys create --iam-account ${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com \
-      ~/service-account-key-${PROJECT}-${SERVICE_ACCOUNT_NAME}.json
-```
+1. Export environment variables:
+   ```shell
+   export PROJECT=sandbox
+   export SERVICE_ACCOUNT_NAME=deckhouse
+   ```
+2. Select a project:
+   
+   ```shell
+   gcloud config set project $PROJECT
+   ```
+3. Create a service account:
+   
+   ```shell
+   gcloud iam service-accounts create $SERVICE_ACCOUNT_NAME
+   ```
+4. Connect roles to the service account:
+   ```shell
+   for role in roles/compute.admin roles/iam.serviceAccountUser roles/networkmanagement.admin; 
+   do gcloud projects add-iam-policy-binding ${PROJECT} --member=serviceAccount:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com \
+      --role=${role}; done
+   ```
+   List of roles required:
+   ```
+   roles/compute.admin
+   roles/iam.serviceAccountUser
+   roles/networkmanagement.admin
+   ```
+   
+5. Verify service account roles:
+   ```shell
+   gcloud projects get-iam-policy ${PROJECT} --flatten="bindings[].members" --format='table(bindings.role)' \
+         --filter="bindings.members:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com"
+   ```
+6. Create a `service account key`:
+   ```shell
+   gcloud iam service-accounts keys create --iam-account ${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com \
+         ~/service-account-key-${PROJECT}-${SERVICE_ACCOUNT_NAME}.json
+   ```

--- a/candi/cloud-providers/gcp/docs/ENVIRONMENT.md
+++ b/candi/cloud-providers/gcp/docs/ENVIRONMENT.md
@@ -2,13 +2,11 @@
 title: "Cloud provider — GCP: Preparing environment"
 ---
 
-You need to create a service account so that Deckhouse can manage resources in the Google Cloud. The detailed instructions for creating a service account are available in the [provider's documentation](https://cloud.google.com/iam/docs/service-accounts).
+You need to create a service account so that Deckhouse can manage resources in the Google Cloud. Below is a brief sequence of steps to create a service account. If you need detailed instructions, you can find them in the [provider's documentation](https://cloud.google.com/iam/docs/service-accounts).
 
 > **Note!** The created `service account key` cannot be restored, you can only delete and create a new one.
 
-Below is a brief sequence of required actions.
-
-## Setup using Google cloud console
+## Setup using Google Cloud Console
 
 Follow this [link](https://console.cloud.google.com/iam-admin/serviceaccounts), select your project and create a new service account or select an existing one.
 
@@ -46,7 +44,8 @@ gcloud iam service-accounts create $SERVICE_ACCOUNT_NAME
 4\. Connect roles to the service account:
 
 ```shell
-for role in roles/compute.admin roles/iam.serviceAccountUser roles/networkmanagement.admin; do gcloud projects add-iam-policy-binding ${PROJECT} --member=serviceAccount:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com --role=${role}; done
+for role in roles/compute.admin roles/iam.serviceAccountUser roles/networkmanagement.admin; 
+do gcloud projects add-iam-policy-binding ${PROJECT} --member=serviceAccount:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com --role=${role}; done
 ```
 List of roles required:
 ```

--- a/candi/cloud-providers/gcp/docs/ENVIRONMENT.md
+++ b/candi/cloud-providers/gcp/docs/ENVIRONMENT.md
@@ -2,15 +2,17 @@
 title: "Cloud provider — GCP: Preparing environment"
 ---
 
-You need to create a service account so that Deckhouse can manage resources in the Google Cloud. The detailed instructions for creating a service account are available in the [provider's documentation](https://cloud.google.com/iam/docs/service-accounts). Below is a brief sequence of required actions:
+You need to create a service account so that Deckhouse can manage resources in the Google Cloud. The detailed instructions for creating a service account are available in the [provider's documentation](https://cloud.google.com/iam/docs/service-accounts).
 
-> **Note!** 'service account key` cannot be restored, you can only delete and create a new one.
+> **Note!** The created `service account key` cannot be restored, you can only delete and create a new one.
+
+Below is a brief sequence of required actions.
 
 ## Setup using Google cloud console
 
 Follow this [link](https://console.cloud.google.com/iam-admin/serviceaccounts), select your project and create a new service account or select an existing one.
 
-List of roles required:
+The account must be assigned several necessary roles:
 ```
 Compute Admin
 Service Account User
@@ -19,10 +21,33 @@ Network Management Admin
 
 You can add roles when creating a service account or edit them [here](https://console.cloud.google.com/iam-admin/iam).
 
-To create a `service account key` in JSON format, click on [three vertical dots](https://console.cloud.google.com/iam-admin/serviceaccounts) in the Actions column and select Manage keys. Next, click on Add key -> Create new key -> Key type -> JSON.
+To create a `service account key` in JSON format, click on [three vertical dots](https://console.cloud.google.com/iam-admin/serviceaccounts) in the Actions column and select `Manage keys`. Next, click on `Add key` -> `Create new key` -> `Key type` -> `JSON`.
 
 ## Setup using gcloud CLI
 
+To configure via the command line interface, follow these steps:
+
+1\. Export environment variables:
+
+```shell
+export PROJECT=sandbox
+export SERVICE_ACCOUNT_NAME=deckhouse
+```
+2\. Select a project:
+
+```shell
+gcloud config set project $PROJECT
+```
+3\. Create a service account:
+
+```shell
+gcloud iam service-accounts create $SERVICE_ACCOUNT_NAME
+```
+4\. Connect roles to the service account:
+
+```shell
+for role in roles/compute.admin roles/iam.serviceAccountUser roles/networkmanagement.admin; do gcloud projects add-iam-policy-binding ${PROJECT} --member=serviceAccount:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com --role=${role}; done
+```
 List of roles required:
 ```
 roles/compute.admin
@@ -30,36 +55,15 @@ roles/iam.serviceAccountUser
 roles/networkmanagement.admin
 ```
 
-- Export environment variables:
+5\. Verify service account roles:
 
-  ```shell
-  export PROJECT=sandbox
-  export SERVICE_ACCOUNT_NAME=deckhouse
-  ```
-- Select a project:
-
-  ```shell
-  gcloud config set project $PROJECT
-  ```
-- Create a service account:
-
-  ```shell
-  gcloud iam service-accounts create $SERVICE_ACCOUNT_NAME
-  ```
-- Connect roles to the service account:
-
-  ```shell
-  for role in roles/compute.admin roles/iam.serviceAccountUser roles/networkmanagement.admin; do gcloud projects add-iam-policy-binding ${PROJECT} --member=serviceAccount:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com --role=${role}; done
-  ```
-- Verify service account roles:
-
-  ```shell
-  gcloud projects get-iam-policy ${PROJECT} --flatten="bindings[].members" --format='table(bindings.role)' \
+```shell
+gcloud projects get-iam-policy ${PROJECT} --flatten="bindings[].members" --format='table(bindings.role)' \
       --filter="bindings.members:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com"
-  ```
-- Create a service account key:
+```
+6\. Create a `service account key`:
 
-  ```shell
-  gcloud iam service-accounts keys create --iam-account ${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com \
+```shell
+gcloud iam service-accounts keys create --iam-account ${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com \
       ~/service-account-key-${PROJECT}-${SERVICE_ACCOUNT_NAME}.json
-  ```
+```

--- a/candi/cloud-providers/gcp/docs/ENVIRONMENT_RU.md
+++ b/candi/cloud-providers/gcp/docs/ENVIRONMENT_RU.md
@@ -8,7 +8,7 @@ title: "Cloud provider — GCP: подготовка окружения"
 
 ## Настройка через Google Cloud Console
 
-Перейдите по [ссылке](https://console.cloud.google.com/iam-admin/serviceaccounts), выберите проект и создайте новый service account (также можно выбрать уже существующий).
+Перейдите [по ссылке](https://console.cloud.google.com/iam-admin/serviceaccounts), выберите проект и создайте новый service account (также можно выбрать уже существующий).
 
 Созданному service account'у должны быть присвоены несколько необходимых ролей:
 ```

--- a/candi/cloud-providers/gcp/docs/ENVIRONMENT_RU.md
+++ b/candi/cloud-providers/gcp/docs/ENVIRONMENT_RU.md
@@ -25,45 +25,41 @@ Network Management Admin
 
 Для настройки через интерфейс командной строки выполните следующие шаги:
 
-1\. Экспортируйте переменные окружения:
-
-```shell
-export PROJECT=sandbox
-export SERVICE_ACCOUNT_NAME=deckhouse
-```
-2\. Выберите project:
-
-```shell
-gcloud config set project $PROJECT
-```
-3\. Создайте service account:
-
-```shell
-gcloud iam service-accounts create $SERVICE_ACCOUNT_NAME
-```
-4\. Присвойте роли созданному service account:
-
-```shell
-for role in roles/compute.admin roles/iam.serviceAccountUser roles/networkmanagement.admin; 
-do gcloud projects add-iam-policy-binding ${PROJECT} --member=serviceAccount:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com --role=${role}; done
-```
-    
-Список необходимых ролей:
-```
-roles/compute.admin
-roles/iam.serviceAccountUser
-roles/networkmanagement.admin
-```
-
-5\. Выполните проверку ролей service account:
-
-```shell
-gcloud projects get-iam-policy ${PROJECT} --flatten="bindings[].members" --format='table(bindings.role)' \
-      --filter="bindings.members:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com"
-```
-6\. Создайте `service account key`:
-
-```shell
-gcloud iam service-accounts keys create --iam-account ${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com \
-      ~/service-account-key-${PROJECT}-${SERVICE_ACCOUNT_NAME}.json
-```
+1. Экспортируйте переменные окружения:
+   ```shell
+   export PROJECT=sandbox
+   export SERVICE_ACCOUNT_NAME=deckhouse
+   ```
+2. Выберите project:
+   
+   ```shell
+   gcloud config set project $PROJECT
+   ```
+3. Создайте service account:
+   
+   ```shell
+   gcloud iam service-accounts create $SERVICE_ACCOUNT_NAME
+   ```
+4. Присвойте роли созданному service account:
+   ```shell
+   for role in roles/compute.admin roles/iam.serviceAccountUser roles/networkmanagement.admin; 
+   do gcloud projects add-iam-policy-binding ${PROJECT} --member=serviceAccount:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com \
+      --role=${role}; done
+   ```
+   
+   Список необходимых ролей:
+   ```
+   roles/compute.admin
+   roles/iam.serviceAccountUser
+   roles/networkmanagement.admin
+   ```
+5. Выполните проверку ролей service account:
+   ```shell
+   gcloud projects get-iam-policy ${PROJECT} --flatten="bindings[].members" --format='table(bindings.role)' \
+         --filter="bindings.members:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com"
+   ```
+6. Создайте `service account key`:
+   ```shell
+   gcloud iam service-accounts keys create --iam-account ${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com \
+         ~/service-account-key-${PROJECT}-${SERVICE_ACCOUNT_NAME}.json
+   ```

--- a/candi/cloud-providers/gcp/docs/ENVIRONMENT_RU.md
+++ b/candi/cloud-providers/gcp/docs/ENVIRONMENT_RU.md
@@ -2,27 +2,53 @@
 title: "Cloud provider — GCP: подготовка окружения"
 ---
 
-Чтобы Deckhouse смог управлять ресурсами в облаке Google, необходимо создать сервисный аккаунт. Подробная инструкция по этому действию доступна в [документации провайдера](https://cloud.google.com/iam/docs/service-accounts). Далее представлена краткая последовательность необходимых действий:
+Для того, чтобы Deckhouse смог управлять ресурсами в Google Cloud, в последнем необходимо создать сервисный аккаунт. Подробная инструкция по этому действию доступна [в документации провайдера](https://cloud.google.com/iam/docs/service-accounts).
 
-> **Внимание!** `service account key` невозможно восстановить, только удалить и создать новый.
+> **Внимание!** Созданный `service account key` невозможно восстановить, только удалить и создать новый.
+
+Далее представлена краткая последовательность необходимых действий.
 
 ## Настройка через Google cloud console
 
-Переходим по [ссылке](https://console.cloud.google.com/iam-admin/serviceaccounts) , выбираем проект и создаем новый сервис-аккаунт или выбираем существующий.
+Перейдите по [ссылке](https://console.cloud.google.com/iam-admin/serviceaccounts), выберите проект и создайте новый сервисный аккаунт (также можно выбрать уже существующий).
 
-Список необходимых ролей:
+Аккаунту должны быть присвоены несколько необходимых ролей:
 ```
 Compute Admin
 Service Account User
 Network Management Admin
 ```
 
-Роли можно прикрепить на этапе создания сервис-аккаунта, либо изменить на [странице](https://console.cloud.google.com/iam-admin/iam).
+Роли можно присвоить на этапе создания сервисного аккаунта, либо изменить [на этой странице](https://console.cloud.google.com/iam-admin/iam).
 
-Чтобы получить `service account key` в JSON-формате, на [странице](https://console.cloud.google.com/iam-admin/serviceaccounts) в колонке Actions необходимо кликнуть на три вертикальные точки и выбрать Create key, тип ключа JSON.
+Чтобы получить `service account key` в JSON-формате, [на странице](https://console.cloud.google.com/iam-admin/serviceaccounts) в колонке Actions нажмите  на три вертикальные точки и выберите `Manage keys`. Затем нажмите `Add key` -> `Create new key` -> `Key type` -> `JSON`.
 
 ## Настройка через gcloud CLI
 
+Для настройки через интерфейс командной строки выполните следующие шаги:
+
+1\. Экспортируйте переменные окружения:
+
+```shell
+export PROJECT=sandbox
+export SERVICE_ACCOUNT_NAME=deckhouse
+```
+2\. Выберите project:
+
+```shell
+gcloud config set project $PROJECT
+```
+3\. Создайте service account:
+
+```shell
+gcloud iam service-accounts create $SERVICE_ACCOUNT_NAME
+```
+4\. Присвойте роли созданному service account:
+
+```shell
+for role in roles/compute.admin roles/iam.serviceAccountUser roles/networkmanagement.admin; do gcloud projects add-iam-policy-binding ${PROJECT} --member=serviceAccount:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com --role=${role}; done
+```
+    
 Список необходимых ролей:
 ```
 roles/compute.admin
@@ -30,36 +56,15 @@ roles/iam.serviceAccountUser
 roles/networkmanagement.admin
 ```
 
-- Экспортируйте переменные окружения:
+5\. Выполните проверку ролей service account:
 
-  ```shell
-  export PROJECT=sandbox
-  export SERVICE_ACCOUNT_NAME=deckhouse
-  ```
-- Выберите project:
-
-  ```shell
-  gcloud config set project $PROJECT
-  ```
-- Создайте service account:
-
-  ```shell
-  gcloud iam service-accounts create $SERVICE_ACCOUNT_NAME
-  ```
-- Прикрепите роли к service account:
-
-  ```shell
-  for role in roles/compute.admin roles/iam.serviceAccountUser roles/networkmanagement.admin; do gcloud projects add-iam-policy-binding ${PROJECT} --member=serviceAccount:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com --role=${role}; done
-  ```
-- Выполните проверку ролей service account:
-
-  ```shell
-  gcloud projects get-iam-policy ${PROJECT} --flatten="bindings[].members" --format='table(bindings.role)' \
+```shell
+gcloud projects get-iam-policy ${PROJECT} --flatten="bindings[].members" --format='table(bindings.role)' \
       --filter="bindings.members:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com"
-  ```
-- Создайте service account key:
+```
+6\. Создайте `service account key`:
 
-  ```shell
-  gcloud iam service-accounts keys create --iam-account ${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com \
+```shell
+gcloud iam service-accounts keys create --iam-account ${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com \
       ~/service-account-key-${PROJECT}-${SERVICE_ACCOUNT_NAME}.json
-  ```
+```

--- a/candi/cloud-providers/gcp/docs/ENVIRONMENT_RU.md
+++ b/candi/cloud-providers/gcp/docs/ENVIRONMENT_RU.md
@@ -2,24 +2,22 @@
 title: "Cloud provider — GCP: подготовка окружения"
 ---
 
-Для того, чтобы Deckhouse смог управлять ресурсами в Google Cloud, в последнем необходимо создать сервисный аккаунт. Подробная инструкция по этому действию доступна [в документации провайдера](https://cloud.google.com/iam/docs/service-accounts).
+Для того чтобы Deckhouse мог управлять ресурсами, в Google Cloud необходимо создать service account. Далее представлена краткая последовательность действий по созданию service account. Если вам необходима более подробная инструкция, вы можете найти ее [в документации провайдера](https://cloud.google.com/iam/docs/service-accounts).
 
 > **Внимание!** Созданный `service account key` невозможно восстановить, только удалить и создать новый.
 
-Далее представлена краткая последовательность необходимых действий.
+## Настройка через Google Cloud Console
 
-## Настройка через Google cloud console
+Перейдите по [ссылке](https://console.cloud.google.com/iam-admin/serviceaccounts), выберите проект и создайте новый service account (также можно выбрать уже существующий).
 
-Перейдите по [ссылке](https://console.cloud.google.com/iam-admin/serviceaccounts), выберите проект и создайте новый сервисный аккаунт (также можно выбрать уже существующий).
-
-Аккаунту должны быть присвоены несколько необходимых ролей:
+Созданному service account'у должны быть присвоены несколько необходимых ролей:
 ```
 Compute Admin
 Service Account User
 Network Management Admin
 ```
 
-Роли можно присвоить на этапе создания сервисного аккаунта, либо изменить [на этой странице](https://console.cloud.google.com/iam-admin/iam).
+Роли можно присвоить на этапе создания service account'а, либо изменить [на этой странице](https://console.cloud.google.com/iam-admin/iam).
 
 Чтобы получить `service account key` в JSON-формате, [на странице](https://console.cloud.google.com/iam-admin/serviceaccounts) в колонке Actions нажмите  на три вертикальные точки и выберите `Manage keys`. Затем нажмите `Add key` -> `Create new key` -> `Key type` -> `JSON`.
 
@@ -46,7 +44,8 @@ gcloud iam service-accounts create $SERVICE_ACCOUNT_NAME
 4\. Присвойте роли созданному service account:
 
 ```shell
-for role in roles/compute.admin roles/iam.serviceAccountUser roles/networkmanagement.admin; do gcloud projects add-iam-policy-binding ${PROJECT} --member=serviceAccount:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com --role=${role}; done
+for role in roles/compute.admin roles/iam.serviceAccountUser roles/networkmanagement.admin; 
+do gcloud projects add-iam-policy-binding ${PROJECT} --member=serviceAccount:${SERVICE_ACCOUNT_NAME}@${PROJECT}.iam.gserviceaccount.com --role=${role}; done
 ```
     
 Список необходимых ролей:


### PR DESCRIPTION
## Description

The "Cloud provider — GCP: Preparing environment" article reviewing and fixing.

## Changelog entries

```changes
module: docs
type: fix
description: "Review and fix the 'Cloud provider — GCP: Preparing environment' article."
impact_level: low
```