### PR TITLE
[docs] Fix article text in «Cloud provider — GCP: configuration» page

### DIFF
--- a/modules/030-cloud-provider-gcp/docs/CONFIGURATION_RU.md
+++ b/modules/030-cloud-provider-gcp/docs/CONFIGURATION_RU.md
@@ -6,7 +6,7 @@ title: "Сloud provider — GCP: настройки"
 
 Количество и параметры процесса заказа машин в облаке настраиваются в custom resource [`NodeGroup`](../../modules/040-node-manager/cr.html#nodegroup) модуля node-manager, в котором также указывается название используемого для этой группы узлов инстанс-класса (параметр `cloudInstances.classReference` NodeGroup). Инстанс-класс для cloud провайдера GCP — это custom resource [`GCPInstanceClass`](cr.html#gcpinstanceclass), в котором указываются конкретные параметры самих машин.
 
-Модуль автоматически создаёт StorageClasses, покрывающие все варианты дисков в GCP:
+Модуль автоматически создаёт StorageClass'ы, покрывающие все варианты дисков в GCP:
 
 | Тип | Репликация | Имя StorageClass |
 |---|---|---|
@@ -17,7 +17,7 @@ title: "Сloud provider — GCP: настройки"
 | ssd | none | pd-ssd-not-replicated |
 | ssd | regional | pd-ssd-replicated |
 
-Также он позволяет отфильтровать ненужные StorageClasses, указав их в параметре `exclude`.
+Также он позволяет отфильтровать ненужные StorageClass'ы, указав их в параметре `exclude`.
 
 ## Параметры
 

--- a/modules/030-cloud-provider-gcp/docs/CONFIGURATION_RU.md
+++ b/modules/030-cloud-provider-gcp/docs/CONFIGURATION_RU.md
@@ -2,9 +2,9 @@
 title: "Сloud provider — GCP: настройки"
 ---
 
-Модуль настраивается автоматически исходя из выбранной схемы размещения определяемой в параметрах структуры [GCPClusterConfiguration](cluster_configuration.html). В большинстве случаев нет необходимости ручной конфигурации модуля.
+Модуль настраивается автоматически, исходя из выбранной схемы размещения, определяемой в параметрах структуры [GCPClusterConfiguration](cluster_configuration.html). В большинстве случаев нет необходимости ручной конфигурации модуля.
 
-Количество и параметры процесса заказа машин в облаке настраиваются в custom resource [`NodeGroup`](../../modules/040-node-manager/cr.html#nodegroup) модуля node-manager, в котором также указывается название используемого для этой группы узлов instance-класса (параметр `cloudInstances.classReference` NodeGroup).  Instance-класс для cloud-провайдера GCP — это custom resource [`GCPInstanceClass`](cr.html#gcpinstanceclass), в котором указываются конкретные параметры самих машин.
+Количество и параметры процесса заказа машин в облаке настраиваются в custom resource [`NodeGroup`](../../modules/040-node-manager/cr.html#nodegroup) модуля node-manager, в котором также указывается название используемого для этой группы узлов инстанс-класса (параметр `cloudInstances.classReference` NodeGroup). Инстанс-класс для cloud провайдера GCP — это custom resource [`GCPInstanceClass`](cr.html#gcpinstanceclass), в котором указываются конкретные параметры самих машин.
 
 Модуль автоматически создаёт StorageClasses, покрывающие все варианты дисков в GCP:
 
@@ -17,7 +17,7 @@ title: "Сloud provider — GCP: настройки"
 | ssd | none | pd-ssd-not-replicated |
 | ssd | regional | pd-ssd-replicated |
 
-А также позволяет отфильтровать ненужные StorageClass, указанием их в параметре `exclude`.
+Также он позволяет отфильтровать ненужные StorageClasses, указав их в параметре `exclude`.
 
 ## Параметры
 

--- a/modules/030-cloud-provider-gcp/openapi/config-values.yaml
+++ b/modules/030-cloud-provider-gcp/openapi/config-values.yaml
@@ -9,16 +9,12 @@ properties:
           type: string
         description: |
           A list of StorageClass names (or regex expressions for names) to exclude from the creation in the cluster;
-            * Format — an array of strings;
-            * An optional parameter;
         x-examples:
         - ["pd-standard.*", "pd-ssd-replicated"]
       default:
         type: string
         description: |
           The name of StorageClass that will be used in the cluster by default;
-            * Format — a string;
-            * An optional parameter;
             * If the parameter is omitted, the default StorageClass is either:
               * an arbitrary StorageClass present in the cluster that has the default annotation;
               * the first StorageClass created by the module (in accordance with the order listed in the table above).

--- a/modules/030-cloud-provider-gcp/openapi/config-values.yaml
+++ b/modules/030-cloud-provider-gcp/openapi/config-values.yaml
@@ -16,7 +16,7 @@ properties:
         description: |
           The name of StorageClass that will be used in the cluster by default;
             * If the parameter is omitted, the default StorageClass is either:
-              * an arbitrary StorageClass present in the cluster that has the default annotation;
+              * existing default StorageClass (that has the annotation ([storageclass.kubernetes.io/is-default-class: "true"](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/#changing-the-default-storageclass));
               * the first StorageClass created by the module (in accordance with the order listed in the table above).
         x-examples:
         - "pd-ssd-not-replicated"

--- a/modules/030-cloud-provider-gcp/openapi/doc-ru-config-values.yaml
+++ b/modules/030-cloud-provider-gcp/openapi/doc-ru-config-values.yaml
@@ -16,7 +16,7 @@ properties:
         description: |
           Имя StorageClass, который будет использоваться в кластере по умолчанию.
             * Если параметр не задан, фактическим StorageClass по умолчанию будет либо:
-              * Присутствующий в кластере произвольный StorageClass с default аннотацией;
+              * Присутствующий в кластере StorageClass по умолчанию (имеющий аннотацию ([storageclass.kubernetes.io/is-default-class: "true"](https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/#changing-the-default-storageclass));
               * Первый StorageClass из создаваемых модулем (в порядке из таблицы выше).
         x-examples:
         - "pd-ssd-not-replicated"

--- a/modules/030-cloud-provider-gcp/openapi/doc-ru-config-values.yaml
+++ b/modules/030-cloud-provider-gcp/openapi/doc-ru-config-values.yaml
@@ -9,18 +9,14 @@ properties:
           type: string
         description: |
           Полные имена (или regex выражения имён) StorageClass, которые не будут созданы в кластере.
-            * Формат — массив строк.
-            * Опциональный параметр.
         x-examples:
         - ["pd-standard.*", "pd-ssd-replicated"]
       default:
         type: string
         description: |
           Имя StorageClass, который будет использоваться в кластере по умолчанию.
-            * Формат — строка.
-            * Опциональный параметр.
             * Если параметр не задан, фактическим StorageClass по умолчанию будет либо:
-              * Присутствующий в кластере произвольный StorageClass с default аннотацией.
+              * Присутствующий в кластере произвольный StorageClass с default аннотацией;
               * Первый StorageClass из создаваемых модулем (в порядке из таблицы выше).
         x-examples:
         - "pd-ssd-not-replicated"


### PR DESCRIPTION
## Description

The "Cloud provider — GCP: configuration" article reviewing and fixing.

## Changelog entries

```changes
module: docs
type: fix
description: "Review and fix the 'Cloud provider — GCP: configuration' article."
impact_level: low
```