### PR TITLE
[istio][api-proxy] logging improvements

### DIFF
--- a/ee/modules/110-istio/hooks/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/alliance_metadata_merge.go
@@ -129,6 +129,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 		},
 	},
 	Schedule: []go_hook.ScheduleConfig{
+		// until the bug won't be solved https://github.com/istio/istio/issues/37925
 		// {Name: "cron", Crontab: "0 3 * * *"}, // once a day to refresh apiJWT
 		{Name: "cron", Crontab: "0 3 1 * *"}, // once a month to refresh apiJWT
 	},

--- a/ee/modules/110-istio/hooks/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/alliance_metadata_merge.go
@@ -129,7 +129,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 		},
 	},
 	Schedule: []go_hook.ScheduleConfig{
-		{Name: "cron", Crontab: "0 3 * * *"}, // once a day to refresh apiJWT
+		{Name: "cron", Crontab: "0 3 1 * *"}, // once a day to refresh apiJWT
 	},
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
 }, metadataMerge)
@@ -210,7 +210,9 @@ multiclustersLoop:
 			"sub":   input.Values.Get("global.discovery.clusterUUID").String(),
 			"scope": "api",
 		}
-		multiclusterInfo.APIJWT, err = jwt.GenerateJWT(privKey, claims, time.Hour*25)
+		// until the bug won't be solved https://github.com/istio/istio/issues/37925
+		// multiclusterInfo.APIJWT, err = jwt.GenerateJWT(privKey, claims, time.Hour*25)
+		multiclusterInfo.APIJWT, err = jwt.GenerateJWT(privKey, claims, time.Hour*24*366)
 		if err != nil {
 			input.LogEntry.Warnf("can't generate auth token for remote api of IstioMulticluster %s, error: %s", multiclusterInfo.Name, err.Error())
 			continue multiclustersLoop

--- a/ee/modules/110-istio/hooks/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/alliance_metadata_merge.go
@@ -129,7 +129,8 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 		},
 	},
 	Schedule: []go_hook.ScheduleConfig{
-		{Name: "cron", Crontab: "0 3 1 * *"}, // once a day to refresh apiJWT
+		// {Name: "cron", Crontab: "0 3 * * *"}, // once a day to refresh apiJWT
+		{Name: "cron", Crontab: "0 3 1 * *"}, // once a month to refresh apiJWT
 	},
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
 }, metadataMerge)

--- a/ee/modules/110-istio/hooks/alliance_metadata_merge_test.go
+++ b/ee/modules/110-istio/hooks/alliance_metadata_merge_test.go
@@ -410,7 +410,7 @@ status:
 			expM0Date := time.Unix(tokenM0Payload.Exp, 0)
 
 			Expect(nbfM0Date).Should(BeTemporally("~", time.Now().UTC(), 25*time.Second))
-			Expect(expM0Date).Should(BeTemporally("~", time.Now().Add(25*time.Hour).UTC(), 25*time.Second))
+			Expect(expM0Date).Should(BeTemporally("~", time.Now().Add(time.Hour*24*366).UTC(), 25*time.Second))
 
 			Expect(f.ValuesGet("istio.internal.remotePublicMetadata").String()).To(MatchJSON(`
 		{

--- a/ee/modules/110-istio/images/api-proxy/main.go
+++ b/ee/modules/110-istio/images/api-proxy/main.go
@@ -194,7 +194,6 @@ func httpHandlerApiProxy(w http.ResponseWriter, r *http.Request) {
 		ErrorLog:      logger,
 		FlushInterval: 50 * time.Millisecond,
 		ModifyResponse: func(resp *http.Response) error {
-			resp.Header.Set("X-Proxy", "Magical")
 			logger.Println("[apiserver]", resp.Status)
 			return nil
 		},

--- a/ee/modules/110-istio/images/api-proxy/main.go
+++ b/ee/modules/110-istio/images/api-proxy/main.go
@@ -90,7 +90,6 @@ func checkAuthn(header http.Header, scope string) error {
 		return fmt.Errorf("JWT is signed for wrong scope.")
 	}
 
-	fmt.Println("token", reqTokenString, "payloadBytes", payloadBytes, "exp", payload.Exp, "payload", payload)
 	if payload.Exp < time.Now().UTC().Unix() {
 		return fmt.Errorf("JWT token expired.")
 	}


### PR DESCRIPTION
## Description
* multicluster api access token `apiJWT` issuing for a year instead of a day.
* api-proxy logging improvements.

## Why do we need it, and what problem does it solve?
It is workaround for embarrassing [bug](https://github.com/istio/istio/issues/37925) which confuses us during debug (unwanted error messages).
api-proxy logging improvements also help us to debug multicluster problems.
 
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: istio
type: fix
summary: apiJWT exp prolongation and api-proxy logging improvements
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
