### PR TITLE
[deckhouse] Add changelog to DeckhouseRelease

### DIFF
--- a/modules/020-deckhouse/crds/deckhouse-release.yaml
+++ b/modules/020-deckhouse/crds/deckhouse-release.yaml
@@ -49,6 +49,14 @@ spec:
                   additionalProperties:
                     type: string
                   description: Deckhouse release requirements.
+                changelog:
+                  type: object
+                  description: Release's changelog for enabled modules.
+                  additionalProperties:
+                    type: string
+                changelogLink:
+                  type: string
+                  description: Link to site with full changelog for this release.
             status:
               type: object
               properties:

--- a/modules/020-deckhouse/crds/doc-ru-deckhouse-release.yaml
+++ b/modules/020-deckhouse/crds/doc-ru-deckhouse-release.yaml
@@ -19,6 +19,10 @@ spec:
                   description: Время, до которого отложено обновление, если релиз является частью canary-release.
                 requirements:
                   description: Требования для установки релиза.
+                changelog:
+                  description: Изменения включенных модулей в данном релизе.
+                changelogLink:
+                  description: Ссылка на страницу со всеми изменениями данного релиза.
             status:
               properties:
                 phase:

--- a/modules/020-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/020-deckhouse/hooks/check_deckhouse_release.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spaolacci/murmur3"
+	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
@@ -150,6 +151,8 @@ releaseLoop:
 		}
 	}
 
+	enabledModulesChangelog := releaseChecker.generateChangelogForEnabledModules(input)
+
 	release := &v1alpha1.DeckhouseRelease{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DeckhouseRelease",
@@ -159,9 +162,11 @@ releaseLoop:
 			Name: releaseName,
 		},
 		Spec: v1alpha1.DeckhouseReleaseSpec{
-			Version:      releaseChecker.releaseMetadata.Version,
-			ApplyAfter:   applyAfter,
-			Requirements: releaseChecker.releaseMetadata.Requirements,
+			Version:       releaseChecker.releaseMetadata.Version,
+			ApplyAfter:    applyAfter,
+			Requirements:  releaseChecker.releaseMetadata.Requirements,
+			Changelog:     enabledModulesChangelog,
+			ChangelogLink: fmt.Sprintf("https://github.com/deckhouse/deckhouse/releases/tag/%s", releaseChecker.releaseMetadata.Version),
 		},
 		Approved: false,
 	}
@@ -173,6 +178,59 @@ releaseLoop:
 	input.PatchCollector.Create(release, object_patch.IgnoreIfExists())
 
 	return nil
+}
+
+func (dcr *DeckhouseReleaseChecker) generateChangelogForEnabledModules(input *go_hook.HookInput) map[string]interface{} {
+	enabledModules := input.Values.Get("global.enabledModules").Array()
+	enabledModulesChangelog := make(map[string]interface{})
+
+	for _, enabledModule := range enabledModules {
+		if v, ok := dcr.releaseMetadata.Changelog[enabledModule.String()]; ok {
+			enabledModulesChangelog[enabledModule.String()] = v
+		}
+	}
+
+	// enable global modules
+	if v, ok := dcr.releaseMetadata.Changelog["global"]; ok {
+		enabledModulesChangelog["global"] = v
+	}
+
+	return enabledModulesChangelog
+}
+
+type releaseReader struct {
+	versionReader   *bytes.Buffer
+	changelogReader *bytes.Buffer
+}
+
+func (rr *releaseReader) untarLayer(rc io.Reader) error {
+	tr := tar.NewReader(rc)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			// end of archive
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		switch hdr.Name {
+		case "version.json":
+			_, err = io.Copy(rr.versionReader, tr)
+			if err != nil {
+				return err
+			}
+		case "changelog.yaml", "changelog.yml":
+			_, err = io.Copy(rr.changelogReader, tr)
+			if err != nil {
+				return err
+			}
+
+		default:
+			continue
+		}
+	}
 }
 
 func (dcr *DeckhouseReleaseChecker) fetchReleaseMetadata(image v1.Image) (releaseMetadata, error) {
@@ -187,7 +245,10 @@ func (dcr *DeckhouseReleaseChecker) fetchReleaseMetadata(image v1.Image) (releas
 		return meta, fmt.Errorf("no layers found")
 	}
 
-	var tarReader io.Reader
+	rr := &releaseReader{
+		versionReader:   bytes.NewBuffer(nil),
+		changelogReader: bytes.NewBuffer(nil),
+	}
 	for _, layer := range layers {
 		size, err := layer.Size()
 		if err != nil {
@@ -202,7 +263,7 @@ func (dcr *DeckhouseReleaseChecker) fetchReleaseMetadata(image v1.Image) (releas
 			return meta, err
 		}
 
-		tarReader, err = untarLayer(rc)
+		err = rr.untarLayer(rc)
 		if err != nil {
 			rc.Close()
 			dcr.logger.Warnf("layer is invalid: %s", err)
@@ -211,32 +272,23 @@ func (dcr *DeckhouseReleaseChecker) fetchReleaseMetadata(image v1.Image) (releas
 		rc.Close()
 	}
 
-	err = json.NewDecoder(tarReader).Decode(&meta)
-
-	return meta, err
-}
-
-func untarLayer(rc io.Reader) (io.Reader, error) {
-	result := bytes.NewBuffer(nil)
-	tr := tar.NewReader(rc)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			// end of archive
-			return result, nil
-		}
+	if rr.versionReader.Len() > 0 {
+		err = json.NewDecoder(rr.versionReader).Decode(&meta)
 		if err != nil {
-			return nil, err
+			return meta, err
 		}
-		if hdr.Name != "version.json" {
-			continue
-		}
-		if _, err := io.Copy(result, tr); err != nil {
-			return nil, err
-		}
-
-		return result, nil
 	}
+
+	if rr.changelogReader.Len() > 0 {
+		var changelog map[string]interface{}
+		err = yaml.NewDecoder(rr.changelogReader).Decode(&changelog)
+		if err != nil {
+			return meta, err
+		}
+		meta.Changelog = changelog
+	}
+
+	return meta, nil
 }
 
 type releaseMetadata struct {
@@ -244,6 +296,8 @@ type releaseMetadata struct {
 	Canary       map[string]canarySettings `json:"canary"`
 	Requirements map[string]string         `json:"requirements"`
 	Suspend      bool                      `json:"suspend"`
+
+	Changelog map[string]interface{}
 }
 
 type canarySettings struct {
@@ -298,7 +352,7 @@ func (dcr *DeckhouseReleaseChecker) FetchReleaseMetadata(previousImageHash strin
 		return "", err
 	}
 	if releaseMeta.Version == "" {
-		return "", fmt.Errorf("version not found. Probably image is broken or layer is not exist")
+		return "", fmt.Errorf("version not found. Probably image is broken or layer does not exist")
 	}
 
 	dcr.releaseMetadata = releaseMeta

--- a/modules/020-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/020-deckhouse/hooks/check_deckhouse_release.go
@@ -180,6 +180,8 @@ releaseLoop:
 	return nil
 }
 
+var globalModules = []string{"candi", "deckhouse-controller", "global"}
+
 func (dcr *DeckhouseReleaseChecker) generateChangelogForEnabledModules(input *go_hook.HookInput) map[string]interface{} {
 	enabledModules := input.Values.Get("global.enabledModules").Array()
 	enabledModulesChangelog := make(map[string]interface{})
@@ -191,8 +193,10 @@ func (dcr *DeckhouseReleaseChecker) generateChangelogForEnabledModules(input *go
 	}
 
 	// enable global modules
-	if v, ok := dcr.releaseMetadata.Changelog["global"]; ok {
-		enabledModulesChangelog["global"] = v
+	for _, globalModule := range globalModules {
+		if v, ok := dcr.releaseMetadata.Changelog[globalModule]; ok {
+			enabledModulesChangelog[globalModule] = v
+		}
 	}
 
 	return enabledModulesChangelog

--- a/modules/020-deckhouse/hooks/internal/v1alpha1/deckhouse_release.go
+++ b/modules/020-deckhouse/hooks/internal/v1alpha1/deckhouse_release.go
@@ -50,9 +50,11 @@ type DeckhouseRelease struct {
 }
 
 type DeckhouseReleaseSpec struct {
-	Version      string            `json:"version,omitempty"`
-	ApplyAfter   *time.Time        `json:"applyAfter,omitempty"`
-	Requirements map[string]string `json:"requirements,omitempty"`
+	Version       string                 `json:"version,omitempty"`
+	ApplyAfter    *time.Time             `json:"applyAfter,omitempty"`
+	Requirements  map[string]string      `json:"requirements,omitempty"`
+	Changelog     map[string]interface{} `json:"changelog,omitempty"`
+	ChangelogLink string                 `json:"changelogLink,omitempty"`
 }
 
 type DeckhouseReleaseStatus struct {

--- a/werf.yaml
+++ b/werf.yaml
@@ -695,6 +695,12 @@ shell:
     requirements='{{ .Files.Get "requirements.json" | fromJson | toJson }}'
     json="{\"version\": \"${version}\", \"canary\": ${canary}, \"requirements\": ${requirements}}"
     echo "$json" > /version.json
+#   changelog exists only for tags, we have to skip it for branches
+    {{- $changelog := index (.Files.Glob "CHANGELOG/CHANGELOG-*") (printf "CHANGELOG/CHANGELOG-%s.yml" (env "CI_COMMIT_REF_NAME")) }}
+    {{ if $changelog }}
+    echo -e '{{ $changelog | nindent 4 }}' > /changelog.yaml
+    {{ end }}
+
 
 # modules_images
 {{- define "module_image_template" }}


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Add changelog into DeckhouseRelease CR. Only enabledModules will be written in changelog
It will look like:
```yaml
apiVersion: deckhouse.io/v1alpha1
kind: DeckhouseRelease
approved: false
metadata:
  creationTimestamp: null
  name: v1-31-0
spec:
  changelog:
    cert-manager:
      fixes:
      - pull_request: https://github.com/deckhouse/deckhouse/pull/999
        summary: Remove D8CertmanagerOrphanSecretsWithoutCorrespondingCertificateResources
    global:
      features:
      - description: All master nodes will have  role in new exist clusters.
        note: Add migration for adding role. Bashible steps will be rerunned on master
          nodes.
        pull_request: https://github.com/deckhouse/deckhouse/pull/562
      - description: Update Kubernetes patch versions.
        pull_request: https://github.com/deckhouse/deckhouse/pull/558
      fixes:
      - description: Fix parsing deckhouse images repo if there is the sha256 sum
          in the image name
        pull_request: https://github.com/deckhouse/deckhouse/pull/527
      - description: Fix serialization of empty strings in secrets
        pull_request: https://github.com/deckhouse/deckhouse/pull/523
  changelogLink: https://github.com/deckhouse/deckhouse/releases/tag/v1.31.0
  version: v1.31.0
status:
  approved: false
  message: ""
  transitionTime: "0001-01-01T00:00:00Z"
```

## Why do we need it, and what problem does it solve?
It's useful to watch module changes from release inside the cluster. Also release will have a link to a full changelog.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse
type: feature
summary: Add changelog for enabled modules into a DeckhouseRelease CR
impact_level: low 
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
