### PR TITLE
[cloud-provider-openstack] Fix config formatting

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-openstack/template_tests/module_test.go
@@ -39,7 +39,7 @@ const globalValues = `
     clusterType: Cloud
     defaultCRI: Docker
     kind: ClusterConfiguration
-    kubernetesVersion: "1.19"
+    kubernetesVersion: "1.21"
     podSubnetCIDR: 10.111.0.0/16
     podSubnetNodeCIDRPrefix: "24"
     serviceSubnetCIDR: 10.222.0.0/16
@@ -50,26 +50,20 @@ const globalValues = `
     registryDockercfg: Y2ZnCg==
     tags:
       common:
-        csiExternalProvisioner116: imagehash
-        csiExternalAttacher116: imagehash
-        csiExternalResizer116: imagehash
-        csiNodeDriverRegistrar116: imagehash
-        csiExternalProvisioner119: imagehash
-        csiExternalAttacher119: imagehash
-        csiExternalResizer119: imagehash
-        csiNodeDriverRegistrar119: imagehash
+        csiExternalProvisioner121: imagehash
+        csiExternalAttacher121: imagehash
+        csiExternalResizer121: imagehash
+        csiNodeDriverRegistrar121: imagehash
         resolvWatcher: imagehash
       cloudProviderOpenstack:
-        cinderCsiPlugin116: imagehash
-        cinderCsiPlugin119: imagehash
-        cloudControllerManager116: imagehash
-        cloudControllerManager119: imagehash
+        cinderCsiPlugin121: imagehash
+        cloudControllerManager121: imagehash
   discovery:
     d8SpecificNodeCountByRole:
       master: 3
       worker: 1
     podSubnet: 10.0.1.0/16
-    kubernetesVersion: 1.16.4
+    kubernetesVersion: 1.21.4
     defaultStorageClass: fastssd
 `
 
@@ -246,6 +240,7 @@ monitor-delay = "2s"
 monitor-timeout = "1s"
 subnet-id = "my-subnet-id"
 floating-network-id = "my-floating-network-id"
+enable-ingress-hostname = true
 [BlockStorage]
 rescan-on-resize = true`
 			ccmConfig, err := base64.StdEncoding.DecodeString(ccmSecret.Field("data.cloud-config").String())

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/secret.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/secret.yaml
@@ -39,7 +39,7 @@ subnet-id = {{ .Values.cloudProviderOpenstack.internal.loadBalancer.subnetID | q
 floating-network-id = {{ .Values.cloudProviderOpenstack.internal.loadBalancer.floatingNetworkID | quote }}
     {{- end }}
   {{- end }}
-  {{- if semverCompare ">=1.21" .Values.global.discovery.kubernetesVersion -}}
+  {{- if semverCompare ">=1.21" .Values.global.discovery.kubernetesVersion }}
 enable-ingress-hostname = true
   {{- end }}
 [BlockStorage]


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
Without this fix, CCMs will be unable to approve new nodes for Kubernetes clusters >= 1.21 

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-openstack
type: fix
summary: Fix OpenStack CloudControllerManager configuration formatting
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
