### PR TITLE
[ci] feat: support ghcr.io for testing and dry-run for docker pushes

### DIFF
--- a/.github/ci_development.md
+++ b/.github/ci_development.md
@@ -1,0 +1,43 @@
+# Workflows development
+
+## Templates
+
+Files in workflows directory render from 3 directories with templates: workflow_templates,
+ci_templates, and ci_includes. Use render-workflows.sh to render workflows directory
+after changing templates (requires Docker):
+
+```
+cd .github
+./render-workflows.sh
+```
+
+## Testing
+
+We use pull_request_target and workflow_dispatch events which require workflow file
+be committed in the main branch.
+There are additional repositories for workflow tests which do not interfere with ones in the main repo.
+
+Add remotes:
+
+```
+git remote add test-1 git@github.com:deckhouse/deckhouse-test-1
+git remote add test-2 git@github.com:deckhouse/deckhouse-test-2
+```
+
+Commit and push current branch to the main branch in test-1 repo:
+
+``` 
+git commit ...
+git push test-1 HEAD:main --force
+```
+
+### Differences with main repo:
+
+1. No two-repo schema for werf build.
+2. Final images are pushed to ghcr.io (e.g. ghcr.io/deckhouse/deckhouse-test-1).
+3. Repo for documentation and site images is ghcr.io.
+4. Only AWS and static providers available for E2E tests.
+5. No alerts on E2E fails in main branch.
+6. Push for deploy and suspend can be skipped with SKIP_PUSH_FOR_SUSPEND and SKIP_PUSH_FOR_DEPLOY variables.
+7. No registry cleanup.
+8. Autoclose for Dependabot PRs (can be enabled with secret ENABLE_DEPENDABOT_IN_FORKS=true).

--- a/.github/ci_includes/werf_envs.yml
+++ b/.github/ci_includes/werf_envs.yml
@@ -12,7 +12,7 @@ TEST_TIMEOUT: "15m"
 # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
 DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
 BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+# Registry for additional repositories used for testing Github Actions workflows.
+GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
 # </template: werf_envs>
 {!{- end -}!}

--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -22,16 +22,20 @@ steps:
 {!{- $buildType := index . 1 -}!}
 # <template: build_template>
 runs-on: [self-hosted, regular]
+outputs:
+  tests_image_name: ${{ steps.build.outputs.tests_image_name }}
 steps:
+{!{ if eq $buildType "release" }!}
   {!{ tmpl.Exec "started_at_output" $ctx | strings.Indent 2 }!}
+{!{ end }!}
   {!{ tmpl.Exec "checkout_full_step" $ctx | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_dev_registry_step" $ctx | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_readonly_registry_step" $ctx | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_rw_registry_step" $ctx | strings.Indent 2 }!}
-  {!{ tmpl.Exec "login_flant_registry_step" $ctx | strings.Indent 2 }!}
   {!{ tmpl.Exec "werf_install_step" $ctx | strings.Indent 2 }!}
 
   - name: Build and push deckhouse images
+    id: build
     env:
       DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
       CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
@@ -41,6 +45,7 @@ steps:
       CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
     run: |
       ## Source: .gitlab/ci_templates/build.yml
+
       # Put tags on produced images and push to dev and release repositories.
       #
       # There are 2 modes: "dev" and "release".
@@ -53,31 +58,53 @@ steps:
       # - Build using deckhouse registry as primary and dev-registry as secondary.
       # - Push dev, dev/install and release-channel-version images to deckhouse registry with tag equels to a Git tag.
 
-      # SRC is a name of image from werf.yaml.
-      # WERF_STAGE is a stage image name (from werf stage output).
+      # SRC_NAME is a name of image from werf.yaml.
+      # SRC is a source image name (stage name from werf build report).
       # DST is an image name for docker push.
-      function pull_push() {
-        SRC=$1
-        WERF_STAGE=$2
+      function pull_push_rmi() {
+        SRC_NAME=$1
+        SRC=$2
         DST=$3
-        echo "⚓️ 💫 [$(date -u)] Pull '${SRC}' image as ${WERF_STAGE}."
-        docker pull ${WERF_STAGE}
-        echo "⚓️ 💫 [$(date -u)] Tag '${SRC}' image as ${DST}."
-        docker image tag ${WERF_STAGE} ${DST}
-        echo "⚓️ 💫 [$(date -u)] Push '${SRC}' image as ${DST}."
+        echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+        docker pull ${SRC}
+        echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+        docker image tag ${SRC} ${DST}
+        echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
         docker image push ${DST}
+        echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+        docker image rmi ${DST} || true;
       }
 
       if [[ -n "${DEV_REGISTRY_PATH}" ]]; then export WERF_REPO="${DEV_REGISTRY_PATH}"; fi
       type werf && source $(werf ci-env github --verbose --as-file)
 
-      # This build put stages to "dev" registry.
-      # If "dev" registry is empty, stages are copied from FE cache.
-      REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-      werf build \
-        --secondary-repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} \
-        --parallel=true --parallel-tasks-limit=5 \
-        --report-path images_tags_werf.json
+      # CE/EE/FE -> ce/ee/fe
+      REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+      # Registry path to publish images for Git branches.
+      BRANCH_REGISTRY_PATH=
+      # Registry path to publish images for Git tags.
+      SEMVER_REGISTRY_PATH=
+
+      if [[ -n ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+        # Build using dev-registry as primary repo and prod registry as secondary (ro) repo.
+        # This build will put stages to "dev" registry. If "dev" registry is empty, existing stages are copied from prod registry.
+        werf build \
+          --secondary-repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} \
+          --parallel=true --parallel-tasks-limit=5 \
+          --report-path images_tags_werf.json
+        BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+        SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+      else
+        # DECKHOUSE_REGISTRY_HOST — this is not the main repo.
+        # Build using dev-registry as a single primary repo and push to Github Container Registry.
+        werf build \
+          --parallel=true --parallel-tasks-limit=5 \
+          --report-path images_tags_werf.json
+        BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+        SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+        echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
+      fi
 
       # Publish images for Git branch.
       if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -85,84 +112,64 @@ steps:
         # Use it as image tag.
         IMAGE_TAG=${CI_COMMIT_REF_SLUG}
 
-        echo "⚓️ [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
+        echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 
-        if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-          DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${IMAGE_TAG}
-          DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-          DESTINATION_TESTS_IMAGE=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
-        else
-          DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${IMAGE_TAG}
-          DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-          DESTINATION_TESTS_IMAGE=${CI_REGISTRY_IMAGE}/tests:${IMAGE_TAG}
-        fi
+        echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
+        DECKHOUSE_IMAGE_SRC="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
+        DECKHOUSE_IMAGE=${BRANCH_REGISTRY_PATH}:${IMAGE_TAG}
+        pull_push_rmi 'dev' ${DECKHOUSE_IMAGE_SRC} ${DECKHOUSE_IMAGE}
 
-        echo "⚓️ [$(date -u)] Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
-        DEV_IMAGE_URL="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
-        pull_push 'dev' ${DEV_IMAGE_URL} ${DESTINATION_IMAGE}
-
-        echo "⚓️ [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${IMAGE_TAG}".
-        DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
-        pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DESTINATION_INSTALL_IMAGE}
-
-        echo "⚓️ [$(date -u)] Publish 'tests' image to dev-registry using tag ${IMAGE_TAG}".
-        TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
-        pull_push 'tests' ${TESTS_IMAGE_URL} ${DESTINATION_TESTS_IMAGE}
-
-        echo "⚓️ [$(date -u)] Remove local tags."
-        docker image rmi ${DESTINATION_IMAGE} || true
-        docker image rmi ${DESTINATION_INSTALL_IMAGE} || true
-        docker image rmi ${DESTINATION_TESTS_IMAGE} || true
+        echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${IMAGE_TAG}".
+        INSTALL_IMAGE_SRC="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
+        INSTALL_IMAGE=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+        pull_push_rmi 'dev/install' ${INSTALL_IMAGE_SRC} ${INSTALL_IMAGE}
       fi
-      rm -f images_tags_werf.json
 
 {!{ if eq $buildType "release" }!}
       # Publish images for Git tag.
       if [[ -n "${CI_COMMIT_TAG}" ]]; then
-        if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-          # The Git tag may contain a '+' sign, so use slugify for this situation.
-          # Slugify doesn't change a tag with safe-only characters.
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+        # The Git tag may contain a '+' sign, so use slugify for this situation.
+        # Slugify doesn't change a tag with safe-only characters.
+        IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
 
-          echo "⚓️ [$(date -u)] Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
-          # Copy stages to deckhouse registry from dev registry.
+        echo "⚓️ 💫 [$(date -u)] Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
+        if [[ -n ${DECKHOUSE_REGISTRY_PATH} ]] ; then
+          # Copy stages to prod registry from dev registry.
           werf build \
-            --repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} \
+            --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
             --secondary-repo $WERF_REPO \
             --parallel=true --parallel-tasks-limit=5 \
             --report-path images_tags_werf.json
-
-          echo "⚓️ [$(date -u)] Publish 'dev' image to deckhouse registry using tag ${IMAGE_TAG} ..."
-          DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${IMAGE_TAG}
-          DEV_IMAGE_URL="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
-          pull_push 'dev' ${DEV_IMAGE_URL} ${DECKHOUSE_DESTINATION_IMAGE}
-
-          echo "⚓️ [$(date -u)] Publish 'dev/install' image to deckhouse registry using tag ${IMAGE_TAG} ..."
-          DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
-          DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
-          pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-
-          echo "⚓️ [$(date -u)] Publish 'tests' image to deckhouse registry using tag ${IMAGE_TAG} ..."
-          DECKHOUSE_DESTINATION_TESTS_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
-          TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
-          pull_push 'tests' ${TESTS_IMAGE_URL} ${DECKHOUSE_DESTINATION_TESTS_IMAGE}
-
-          echo "⚓️ [$(date -u)] Publish 'release-channel-version' image to deckhouse registry using tag ${IMAGE_TAG} ..."
-          DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${IMAGE_TAG}
-          RELEASE_CHANNEL_VERSION_IMAGE_URL="$(jq -r '.Images."release-channel-version".DockerImageName' images_tags_werf.json)"
-          pull_push 'release-channel-version' ${RELEASE_CHANNEL_VERSION_IMAGE_URL} ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE}
-
-          echo "⚓️ [$(date -u)] Remove local tags."
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true
-          docker image rmi ${DECKHOUSE_DESTINATION_TESTS_IMAGE} || true
-          docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true
-
-          rm -f images_tags_werf.json
-        else
-          echo "⚓️ [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. No publishing."
         fi
+        # Note: do not run second werf build for test repo, as it has no secondary repo.
+
+        echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+        DECKHOUSE_IMAGE_SRC="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
+        DECKHOUSE_IMAGE=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${IMAGE_TAG}
+        pull_push_rmi 'dev' ${DECKHOUSE_IMAGE_SRC} ${DECKHOUSE_IMAGE}
+
+        echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+        INSTALL_IMAGE_SRC="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
+        INSTALL_IMAGE=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+        pull_push_rmi 'dev/install' ${INSTALL_IMAGE_SRC} ${INSTALL_IMAGE}
+
+        echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+        RELEASE_CHANNEL_IMAGE_SRC="$(jq -r '.Images."release-channel-version".DockerImageName' images_tags_werf.json)"
+        RELEASE_CHANNEL_IMAGE=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${IMAGE_TAG}
+        pull_push_rmi 'release-channel-version' ${RELEASE_CHANNEL_IMAGE_SRC} ${RELEASE_CHANNEL_IMAGE}
       fi
 {!{- end }!}
+
+      # Save 'tests' image name to pass it as output for 'tests' jobs.
+      TESTS_IMAGE_NAME="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
+      # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+      echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+      # Encode as base64 to avoid github's secrets filter error: "Skip output since it may contain secret".
+      echo "::set-output name=tests_image_name::$(echo ${TESTS_IMAGE_NAME} | base64 -w0)"
+
+  - name: Cleanup
+    if: ${{ always() }}
+    run: |
+      rm -f images_tags_werf.json
 # </template: build_template>
 {!{ end }!}

--- a/.github/ci_templates/steps.yml
+++ b/.github/ci_templates/steps.yml
@@ -31,10 +31,18 @@
 # </template: checkout_from_event_ref_step>
 {!{- end }!}
 
+{!{/* if: ${{secrets.NNN}} not supported, additional step is required.  */}!}
 {!{ define "login_dev_registry_step" }!}
 # <template: login_dev_registry_step>
+- name: Check dev registry credentials
+  id: check_dev_registry
+  env:
+    HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+  run: |
+    if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
 - name: Login to dev registry
   uses: {!{ index (ds "actions") "docker/login-action" }!}
+  if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
   with:
     registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
     username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -45,8 +53,15 @@
 
 {!{ define "login_readonly_registry_step" }!}
 # <template: login_readonly_registry_step>
+- name: Check readonly registry credentials
+  id: check_readonly_registry
+  env:
+    HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+  run: |
+    if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
 - name: Login to readonly registry
   uses: {!{ index (ds "actions") "docker/login-action" }!}
+  if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
   with:
     registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
     username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -57,24 +72,59 @@
 
 {!{ define "login_rw_registry_step" }!}
 # <template: login_rw_registry_step>
+- name: Check rw registry credentials
+  id: check_rw_registry
+  env:
+    HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+  run: |
+    if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
 - name: Login to rw registry
   uses: {!{ index (ds "actions") "docker/login-action" }!}
+  if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
   with:
     registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
     username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
     password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+    logout: false
+- name: Login to Github Container Registry
+  uses: {!{ index (ds "actions") "docker/login-action" }!}
+  if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+  with:
+    registry: ghcr.io
+    username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+    password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
     logout: false
 # </template: login_rw_registry_step>
 {!{- end -}!}
 
 {!{ define "login_flant_registry_step" }!}
 # <template: login_flant_registry_step>
+- name: Check flant registry credentials
+  id: check_flant_registry
+  env:
+    HOST: ${{secrets.FLANT_REGISTRY_HOST}}
+  run: |
+    if [[ -n $HOST ]]; then
+      echo "::set-output name=has_flant_credentials::true"
+      echo "::set-output name=web_registry_path::${{secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+    else
+      echo "::set-output name=web_registry_path::${GHA_TEST_REGISTRY_PATH}"
+    fi
 - name: Login to flant registry
   uses: {!{ index (ds "actions") "docker/login-action" }!}
+  if: ${{ steps.check_flant_registry.outputs.has_flant_credentials == 'true' }}
   with:
     registry: ${{ secrets.FLANT_REGISTRY_HOST }}
     username: ${{ secrets.FLANT_REGISTRY_USER }}
     password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+    logout: false
+- name: Login to Github Container Registry
+  uses: {!{ index (ds "actions") "docker/login-action" }!}
+  if: ${{ steps.check_flant_registry.outputs.has_flant_credentials != 'true' }}
+  with:
+    registry: ghcr.io
+    username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+    password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
     logout: false
 # </template: login_flant_registry_step>
 {!{- end -}!}

--- a/.github/ci_templates/tests.yml
+++ b/.github/ci_templates/tests.yml
@@ -47,26 +47,33 @@ docker_options: '-w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg'
 # <template: tests_template>
 {!{- $ctx       := index . 0 }!}
 {!{- $args_name := index . 1 }!}
-{!{- $buildType := index . 2 }!}
+{!{- $build_job := index . 2 }!}
 {!{- $args_tmpl := printf "%s_run_args" $args_name }!}
 {!{- $default   := dict "image" "tests" "args" "echo no args" "docker_options" "" }!}
 {!{- $run       := coll.Merge (tmpl.Exec $args_tmpl | yaml) $default }!}
 runs-on: [self-hosted, regular]
 steps:
-{!{ tmpl.Exec "started_at_output"             $ctx | strings.Indent 2 }!}
-{!{ tmpl.Exec "checkout_full_step"            $ctx | strings.Indent 2 }!}
-{!{ tmpl.Exec "login_dev_registry_step"       $ctx | strings.Indent 2 }!}
-{!{ tmpl.Exec "login_readonly_registry_step"  $ctx | strings.Indent 2 }!}
+{!{ tmpl.Exec "started_at_output"       $ctx | strings.Indent 2 }!}
+{!{ tmpl.Exec "checkout_full_step"      $ctx | strings.Indent 2 }!}
+{!{ tmpl.Exec "login_dev_registry_step" $ctx | strings.Indent 2 }!}
+{!{ tmpl.Exec "login_rw_registry_step"  $ctx | strings.Indent 2 }!}
   - name: Run tests
     env:
-      DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-      CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+      TESTS_IMAGE_NAME: ${{needs.{!{$build_job}!}.outputs.tests_image_name}}
     run: |
-{!{ if eq $buildType "release" }!}
-      TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/fe/tests:${CI_COMMIT_REF_SLUG}
-{!{ else }!}
-      TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${CI_COMMIT_REF_SLUG}
-{!{ end }!}
-      docker run --pull always {!{ $run.docker_options }!} ${TESTS_IMAGE_URL} {!{ $run.args }!}
+      if [[ -z ${TESTS_IMAGE_NAME} ]] ; then
+        echo "TESTS_IMAGE_NAME is empty"
+        exit 1
+      fi
+
+      # Base64 decode image name.
+      TESTS_IMAGE_NAME=$(echo ${TESTS_IMAGE_NAME} | base64 -d)
+
+      # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+      echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+      echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
+      docker pull ${TESTS_IMAGE_NAME}
+      echo "⚓️ 🏎 [$(date -u)] Run tests..."
+      docker run {!{ $run.docker_options }!} ${TESTS_IMAGE_NAME} {!{ $run.args }!}
 # </template: tests_template>
 {!{- end -}!}

--- a/.github/ci_templates/web.yml
+++ b/.github/ci_templates/web.yml
@@ -14,7 +14,7 @@ steps:
     env:
       WERF_DIR: "docs/documentation"
       WERF_LOG_VERBOSE: "on"
-      WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+      WERF_REPO: ${{steps.check_flant_registry.outputs.web_registry_path}}
 # </template: doc_web_build_template>
 {!{- end -}!}
 
@@ -34,7 +34,7 @@ steps:
     env:
       WERF_DIR: "docs/site"
       WERF_LOG_VERBOSE: "on"
-      WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+      WERF_REPO: ${{steps.check_flant_registry.outputs.web_registry_path}}
 # </template: main_web_build_template>
 {!{- end -}!}
 
@@ -49,6 +49,8 @@ steps:
   {!{ tmpl.Exec "werf_install_step"            . | strings.Indent 2 }!}
 
   - name: Prepare site structure
+    env:
+      WEB_REGISTRY_PATH: ${{steps.check_flant_registry.outputs.web_registry_path}}
     run: |
       type werf
       werf version
@@ -59,7 +61,7 @@ steps:
       echo "_TMPDIR=$_TMPDIR" >> ${GITHUB_ENV}
       echo "_TMPDIR=$_TMPDIR"
 
-      export WERF_REPO="${FLANT_REGISTRY_PATH}"
+      export WERF_REPO="${WEB_REGISTRY_PATH}"
       echo -n 'use werf_repo'
       echo $WERF_REPO | tr 'a-z' 'A-Z'
 
@@ -148,7 +150,7 @@ steps:
     kube-config-base64-data: "{!{ $kubeConfig }!}"
     env: {!{ $webEnv }!}
   env:
-    WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+    WERF_REPO: ${{steps.check_flant_registry.outputs.web_registry_path}}
     WERF_DIR: "docs/documentation"
     WERF_RELEASE: "deckhouse-doc-${{ env.DOC_VERSION }}"
     WERF_NAMESPACE: {!{ $ns }!}
@@ -177,7 +179,7 @@ steps:
     kube-config-base64-data: "{!{ $kubeConfig }!}"
     env: {!{ $webEnv }!}
   env:
-    WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+    WERF_REPO: ${{steps.check_flant_registry.outputs.web_registry_path}}
     WERF_DIR: "docs/site"
     WERF_RELEASE: "deckhouse-site"
     WERF_NAMESPACE: {!{ $ns }!}

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -208,7 +208,7 @@ module.exports.updateCommentOnFinish = async ({
 
       // Info for not started job.
       if ((jobResult === 'cancelled' || jobResult === 'skipped') && !statusConfig.includes(',no-skipped')) {
-        nonReportedJobs += renderJobStatusOneLine({ status: jobResult, name: jobName }) + `\n`;
+        nonReportedJobs += renderJobStatusOneLine(jobResult, jobName) + `\n`;
       }
 
       // Restore information for overridden job. Only result, no elapsed time here.
@@ -646,7 +646,7 @@ const detectSlashCommand = ({ comment }) => {
   // User command is a command and a tag name.
   const parts = lines[0].split(/\s+/);
 
-  if ( ! /^\/[a-z\d_\-\/]+$/.test(parts[0])) {
+  if ( ! /^\/[a-z\d_\-\/.,]+$/.test(parts[0])) {
     return {notFoundMsg: 'not a slash command in the first line'};
   }
 

--- a/.github/scripts/js/comments.js
+++ b/.github/scripts/js/comments.js
@@ -37,7 +37,7 @@ module.exports.releaseIssueHeader = (context, gitRefInfo) => {
 }
 
 module.exports.commentJobStarted = (jobName, ref, buildUrl) => {
-  return `:fast_forward:\u00a0\`${jobName}\` for \`${ref}\` [started](${buildUrl}).;`
+  return `:fast_forward:\u00a0\`${jobName}\` for \`${ref}\` [started](${buildUrl}).`
 }
 
 module.exports.deleteJobStartedComments = (jobsReport) => {

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -95,7 +95,7 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-{!{ tmpl.Exec "tests_template" (slice $ctx "unit" "dev") | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "unit" "build_deckhouse") | strings.Indent 4 }!}
 
   matrix_tests:
     name: Matrix tests
@@ -103,7 +103,7 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-{!{ tmpl.Exec "tests_template" (slice $ctx "matrix" "dev") | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "matrix" "build_deckhouse") | strings.Indent 4 }!}
 
   dhctl_tests:
     name: Dhctl Tests
@@ -111,7 +111,7 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-{!{ tmpl.Exec "tests_template" (slice $ctx "dhctl" "dev") | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "dhctl" "build_deckhouse") | strings.Indent 4 }!}
 
   golangci_lint:
     name: GolangCI Lint
@@ -119,7 +119,7 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-{!{ tmpl.Exec "tests_template" (slice $ctx "golangci_lint" "dev") | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "golangci_lint" "build_deckhouse") | strings.Indent 4 }!}
 
   openapi_test_cases:
     name: OpenAPI Test Cases
@@ -127,7 +127,7 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-{!{ tmpl.Exec "tests_template" (slice $ctx "openapi_test_cases" "dev") | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "openapi_test_cases" "build_deckhouse") | strings.Indent 4 }!}
 
   web_links_test:
     name: Web links test
@@ -145,4 +145,4 @@ jobs:
       - git_info
       - pull_request_info
       - build_deckhouse
-{!{ tmpl.Exec "tests_template" (slice $ctx "validators" "dev") | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "validators" "build_deckhouse") | strings.Indent 4 }!}

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -116,8 +116,7 @@ jobs:
     needs:
       - git_info
       - build_fe
-    continue-on-error: true
-{!{ tmpl.Exec "tests_template" (slice $ctx "unit" "release") | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "unit" "build_fe") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.tests) | strings.Indent 6 }!}
 
 {!{ $jobNames = coll.Merge $jobNames (dict "matrix_tests" "Matrix tests") }!}
@@ -126,18 +125,16 @@ jobs:
     needs:
       - git_info
       - build_fe
-    continue-on-error: true
-{!{ tmpl.Exec "tests_template" (slice $ctx "matrix" "release") | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "matrix" "build_fe") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.matrix_tests) | strings.Indent 6 }!}
 
-{!{ $jobNames = coll.Merge $jobNames (dict "dhctl_tests" "Matrix tests") }!}
+{!{ $jobNames = coll.Merge $jobNames (dict "dhctl_tests" "Dhctl Tests") }!}
   dhctl_tests:
     name: {!{ $jobNames.dhctl_tests }!}
     needs:
       - git_info
       - build_fe
-    continue-on-error: true
-{!{ tmpl.Exec "tests_template" (slice $ctx "dhctl" "release") | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "dhctl" "build_fe") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.dhctl_tests) | strings.Indent 6 }!}
 
 {!{ $jobNames = coll.Merge $jobNames (dict "golangci_lint" "GolangCI Lint") }!}
@@ -146,8 +143,7 @@ jobs:
     needs:
       - git_info
       - build_fe
-    continue-on-error: true
-{!{ tmpl.Exec "tests_template" (slice $ctx "golangci_lint" "release") | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "golangci_lint" "build_fe") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.golangci_lint) | strings.Indent 6 }!}
 
 {!{ $jobNames = coll.Merge $jobNames (dict "openapi_test_cases" "OpenAPI Test Cases") }!}
@@ -156,8 +152,7 @@ jobs:
     needs:
       - git_info
       - build_fe
-    continue-on-error: true
-{!{ tmpl.Exec "tests_template" (slice $ctx "openapi_test_cases" "release") | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "openapi_test_cases" "build_fe") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.openapi_test_cases) | strings.Indent 6 }!}
 
 {!{ $jobNames = coll.Merge $jobNames (dict "web_links_test" "Web links test") }!}
@@ -167,7 +162,6 @@ jobs:
       - git_info
       - doc_web_build
       - main_web_build
-    continue-on-error: true
 {!{ tmpl.Exec "web_links_test_template" $ctx | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.web_links_test) | strings.Indent 6 }!}
 
@@ -177,8 +171,7 @@ jobs:
     needs:
       - git_info
       - build_fe
-    continue-on-error: true
-{!{ tmpl.Exec "tests_template" (slice $ctx "validators" "release") | strings.Indent 4 }!}
+{!{ tmpl.Exec "tests_template" (slice $ctx "validators" "build_fe") | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.validators) | strings.Indent 6 }!}
 
 {!{/* Autodeploy site and docs to production env on push to main branch. */}!}
@@ -189,8 +182,7 @@ jobs:
       - git_info
       - doc_web_build
       - main_web_build
-    continue-on-error: true
-    if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' }}
+    if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' && github.repository == 'deckhouse/deckhouse' }}
     runs-on: [self-hosted, regular]
     steps:
 {!{ tmpl.Exec "started_at_output" . | strings.Indent 6 }!}
@@ -208,8 +200,7 @@ jobs:
     needs:
       - git_info
       - doc_web_build
-    continue-on-error: true
-    if: ${{ needs.git_info.outputs.ci_commit_tag != '' }}
+    if: ${{ needs.git_info.outputs.ci_commit_tag != '' && github.repository == 'deckhouse/deckhouse' }}
     runs-on: [self-hosted, regular]
     steps:
 {!{ tmpl.Exec "started_at_output" . | strings.Indent 6 }!}

--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -107,20 +107,35 @@ Jobs for visual control allowed editions when approving deploy to environments.
 {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "login_rw_registry_step" . | strings.Indent 6 }!}
 
+      - name: Check push enabled
+        id: check_push
+        env:
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
+          REPO: ${{github.repository}}
+        run: |
+          if [[ ${REPO} == "deckhouse/deckhouse" ]]; then
+            echo "::set-output name=enable::true"
+          fi
+          if [[ ${SKIP_PUSH_FOR_DEPLOY} != "true" ]]; then
+            echo "::set-output name=enable::true"
+          fi
+
 {!{/*
-Add 'publish' step for each edition.
+Add 'publish' step for each edition to repuplish semver tag images to channel tag:
+  - Pull deckhouse images from dev registry.
+  - Tag with channel name and push to dev and prod registries.
 
-'Publish' pulls deckhouse images from cache, tag them with channel name and push to dev and prod registries.
+Images to republish:
+  - dev as deckhouse/<EDITION>:<CHANNEL>
+  - dev/install as deckhouse/install/<EDITION>:<CHANNEL>
+  - release-channel-version deckhouse/release-channel/<EDITION>:<CHANNEL>
 
-Images to publish:
-- deckhouse main image ('dev')
-- install image with dhctl ('dev/install')
-- image with release process settings ('release-channel-version')
-
-Destination registries:
+Registries:
 - DEV_REGISTRY_PATH - dev registry, main stages storage.
 - DECKHOUSE_REGISTRY_HOST - prod registry for final images.
 
+Job supports running from forked or copied repo: 'ghcr.io/owner/repo'
+is used if DECKHOUSE_REGISTRY_HOST is not set.
 */}!}
 {!{ range $werfEnv := slice "CE" "EE" "FE" }!}
       - name: Publish release images for {!{ $werfEnv }!}
@@ -130,8 +145,38 @@ Destination registries:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: {!{ $werfEnv }!}
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
+            DST=$3
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_DEPLOY=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
 
           # Some precautions.
           shouldExit1=
@@ -154,94 +199,78 @@ Destination registries:
           echo "Publish {!{ $werfEnv }!} edition".
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL={!{ $channel }!}
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Source images from rw registry or from registry.
+          echo "⚓️ 💫 [$(date -u)] Start publishing Deckhouse images for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          #   3. Prepare image names: republish CI_COMMIT_TAG tag images in dev-registry
+          #   to RELEASE_CHANNEL tag image in prod registry.
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          PROD_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
+          DEV_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
+
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          PROD_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
+          DEV_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+          PROD_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+
+          #   4. Publish to dev registry if DECKHOUSE_REGISTRY_HOST is set (run in the main repo).
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            SOURCE_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-          else
-            SOURCE_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev' ${SOURCE_IMAGE} ${DEV_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${DEV_INSTALL_IMAGE}
           fi
 
-          docker image pull ${SOURCE_IMAGE}
-          docker image pull ${SOURCE_INSTALL_IMAGE}
-          docker image pull ${SOURCE_RELEASE_VERSION_IMAGE}
+          #   5. Publish prod images to rw registry.
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev' ${SOURCE_IMAGE} ${PROD_IMAGE}
 
-          #   4. Publish dev images to dev registry
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            DEV_DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
-            DEV_DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${PROD_INSTALL_IMAGE}
 
-            echo "Push 'dev' image ${SOURCE_IMAGE} to ${DEV_DESTINATION_IMAGE}"
-            docker image tag ${SOURCE_IMAGE} ${DEV_DESTINATION_IMAGE}
-            docker image push ${DEV_DESTINATION_IMAGE}
+          echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'release-channel-version' ${SOURCE_RELEASE_VERSION_IMAGE} ${PROD_RELEASE_VERSION_IMAGE}
 
-            echo "Delete local 'dev' image ${DEV_DESTINATION_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_IMAGE} || true;
-
-            echo "Push 'dev install' ${SOURCE_INSTALL_IMAGE} to image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image tag ${SOURCE_INSTALL_IMAGE} ${DEV_DESTINATION_INSTALL_IMAGE}
-            docker image push ${DEV_DESTINATION_INSTALL_IMAGE}
-
-            echo "Delete local 'dev install' image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_INSTALL_IMAGE} || true;
-          fi
-
-          #   5. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          fi
-
-          echo "Push 'prod' image ${SOURCE_IMAGE} to ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image tag ${SOURCE_IMAGE} ${DECKHOUSE_DESTINATION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE}
-          echo "Delete local 'prod' image ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-
-          echo "Push 'prod install' image ${SOURCE_INSTALL_IMAGE} to ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image tag ${SOURCE_INSTALL_IMAGE} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          echo "Delete local 'prod install' image ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-
-          echo "Push 'release version'  ${SOURCE_RELEASE_VERSION_IMAGE} to ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image tag ${SOURCE_RELEASE_VERSION_IMAGE} ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Delete local source image ${SOURCE_IMAGE}"
+          echo "⚓️  [$(date -u)] Remove local source images."
+          echo "  Delete local 'dev' source image ${SOURCE_IMAGE}"
           docker image rmi ${SOURCE_IMAGE} || true
-          echo "Delete local 'install' source image ${SOURCE_INSTALL_IMAGE}"
+
+          echo "  Delete local 'dev/install' source image ${SOURCE_INSTALL_IMAGE}"
           docker image rmi ${SOURCE_INSTALL_IMAGE} || true
-          echo "Delete local 'release version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
+
+          echo "  Delete local 'release-channel-version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
           docker image rmi ${SOURCE_RELEASE_VERSION_IMAGE} || true
 
+          #   6. Report.
           echo "Deckhouse images published:"
           echo "  Source: ${SOURCE_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_IMAGE}"
+          echo "  Prod: ${PROD_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_IMAGE}"
+          fi
           echo "Install images published:"
           echo "  Source: ${SOURCE_INSTALL_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_INSTALL_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_INSTALL_IMAGE}"
+          fi
+          echo "Release version image:"
+          echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
 
 {!{- end }!}
 

--- a/.github/workflow_templates/dispatch-slash-command.yml
+++ b/.github/workflow_templates/dispatch-slash-command.yml
@@ -4,13 +4,50 @@ on:
     types: [created]
 
 jobs:
+  conditions:
+    name: Check conditions
+    runs-on: ubuntu-latest
+    outputs:
+      trigger_for_release_issue: ${{steps.check.outputs.trigger_for_release_issue}}
+      trigger_for_changelog: ${{steps.check.outputs.trigger_for_changelog}}
+    steps:
+      - name: Check conditions for release issue
+        id: check
+        uses: {!{ index (ds "actions") "actions/github-script" }!}
+        with:
+          script: |
+            // Check for release issue.
+            const isReleaseIssue = context.payload.issue.labels.some((l) => l.name === 'issue/release');
+            const isPrivate = context.payload.repository.private;
+            const authorAssociation = context.payload.comment.author_association;
+            // Check for changelog PR.
+            const isPR = !!context.payload.issue.pull_request;
+            const milestoneState = context.payload.issue.milestone.state;
+            const hasChangelogLabel = context.payload.issue.labels.some((l) => l.name === 'changelog');
+            const hasAutoLabel = context.payload.issue.labels.some((l) => l.name === 'auto');
+            core.info(`Is release issue?       ${isReleaseIssue}`)
+            core.info(`Private repo?           ${isPrivate}`)
+            core.info(`Author association:     ${authorAssociation}`)
+            core.info(`Is PR?                  ${isPR}`)
+            core.info(`Milestone state:        ${milestoneState}`)
+            core.info(`Has 'changelog' label?  ${hasChangelogLabel}`)
+            core.info(`Has 'auto' label?       ${hasAutoLabel}`)
+
+            if (isReleaseIssue && (authorAssociation === 'OWNER' || authorAssociation === 'MEMBER' || (isPrivate && authorAssociation === 'COLLABORATOR'))) {
+              return core.setOutput('trigger_for_release_issue', 'true');
+            }
+
+            if (isPR && milestoneState === 'open' && hasChangelogLabel && hasAutoLabel) {
+              return core.setOutput('trigger_for_changelog', 'true');
+            }
+
+
   trigger_for_release_issue:
     name: Trigger workflow by comment
     runs-on: ubuntu-latest
-    if: |
-      contains(github.event.issue.labels.*.name, 'issue/release') &&
-      (github.event.comment.author_association == 'OWNER' ||
-       github.event.comment.author_association == 'MEMBER')
+    needs:
+      - conditions
+    if: ${{needs.conditions.outputs.trigger_for_release_issue == 'true'}}
     steps:
 {!{ tmpl.Exec "checkout_step" . | strings.Indent 6 }!}
       - name: Run workflow
@@ -24,11 +61,9 @@ jobs:
   trigger_for_changelog:
     name: Dispatch Changelog Event
     runs-on: ubuntu-latest
-    if: |
-      github.event.issue.pull_request &&
-      github.event.issue.milestone.state == 'open' &&
-      contains(github.event.issue.labels.*.name, 'changelog') &&
-      contains(github.event.issue.labels.*.name, 'auto')
+    needs:
+      - conditions
+    if: ${{needs.conditions.outputs.trigger_for_changelog == 'true'}}
     steps:
 {!{ tmpl.Exec "checkout_step" . | strings.Indent 6 }!}
       - name: Find milestone

--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -156,7 +156,6 @@ jobs:
 {!{ tmpl.Exec "checkout_from_event_ref_step" . | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_start" $ctx.jobName | strings.Indent 4 }!}
 {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 4 }!}
-{!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 4 }!}
 {!{ tmpl.Exec "login_rw_registry_step" . | strings.Indent 4 }!}
 {!{ tmpl.Exec "werf_install_step" . | strings.Indent 4 }!}
 
@@ -165,6 +164,9 @@ jobs:
       env:
         DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
         GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+        CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+        CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+        CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
       run: |
         # Random delay to sparse 'update comment' steps in time.
         delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -190,50 +192,37 @@ jobs:
         fi
         echo "::set-output name=tmppath::${tmppath}"
 
-        CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-        CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-        if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-          CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-          echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-        fi
-        if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-          CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-          echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-        fi
-        echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
         ## Deckhouse 'install' image name
         ## Source: ci_templates/build.yml
+
+        # Use dev-registry for Git branches.
+        BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+        # Use rw-registry for Git tags.
+        SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+        if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+          # Use Github Container Registry for test repositories.
+          BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+          SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+        fi
 
         IMAGE_NAME=
         if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
           # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-          # Use it as image tag.
-          IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-          else
-            IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-          fi
+          IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+          echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
         fi
-
         if [[ -n $CI_COMMIT_TAG ]] ; then
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-          else
-            echo "DECKHOUSE_REGISTRY_HOST is empty."
-            exit 1
-          fi
+          IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
         fi
 
         echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
         # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-        echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-        echo "Pull 'dev/install' image"
+        echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+        echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
         docker pull "${IMAGE_NAME}"
 
     - name: "Run e2e test: {!{ $ctx.providerName }!}/{!{ $ctx.criName }!}/{!{ $ctx.kubernetesVersion }!}"
@@ -247,7 +236,7 @@ jobs:
         WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
         CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
         CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-        CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+        CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         TMPPATH: ${{ steps.setup.outputs.tmppath}}
         PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -267,7 +256,7 @@ jobs:
         WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
         CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
         CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-        CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+        CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         TMPPATH: ${{ steps.setup.outputs.tmppath}}
         PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -296,8 +285,15 @@ jobs:
 
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,separate" $ctx.jobName) | strings.Indent 4 }!}
 
+    - name: Check alerting credentials
+      id: check_alerting
+      env:
+        KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+      run: |
+        if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
     - name: Alert on fail in default branch
-      if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+      if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
       env:
         PROVIDER: {!{ $ctx.providerName }!}
         CRI: {!{ $ctx.criName }!}

--- a/.github/workflow_templates/schedule-cleanup.yml
+++ b/.github/workflow_templates/schedule-cleanup.yml
@@ -33,7 +33,13 @@ jobs:
         env:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          ENABLE_REGISTRY_CLEANUP: ${{secrets.ENABLE_REGISTRY_CLEANUP}}
         run: |
+          if [[ ${ENABLE_REGISTRY_CLEANUP} != "true" ]] ; then
+            echo "⚓️ [$(date -u)] ENABLE_REGISTRY_CLEANUP is not 'true', skip running 'werf cleanup'."
+            exit 0
+          fi
+
           export WERF_REPO=${DEV_REGISTRY_PATH}
           type werf && source $(werf ci-env github --config werf_cleanup.yaml --verbose --as-file)
           werf cleanup --config werf_cleanup.yaml --without-kube

--- a/.github/workflow_templates/suspend-channel.multi.yml
+++ b/.github/workflow_templates/suspend-channel.multi.yml
@@ -54,7 +54,6 @@ jobs:
 {!{ tmpl.Exec "checkout_from_event_ref_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "update_comment_on_start" $workflowName | strings.Indent 6 }!}
 {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 6 }!}
-{!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "login_rw_registry_step" . | strings.Indent 6 }!}
 
 {!{/*
@@ -71,7 +70,32 @@ Destination registries:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: {!{ $werfEnv }!}
+          SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function push_rmi() {
+            SRC_NAME=$1
+            DST=$2
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_SUSPEND=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
+
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -83,33 +107,34 @@ Destination registries:
           fi
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL={!{ $channel }!}
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          echo "⚓️ 💫 [$(date -u)] Start publishing 'release-channel suspend' image for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          DST_REGISTRY_PATH=${DECKHOUSE_REGISTRY_HOST}/deckhouse
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DST_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${DST_REGISTRY_PATH}'"
           fi
+
+          #   3. Build and publish release-channel image to prod registry.
+          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
 
           echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+          docker build . -t "${RELEASE_VERSION_IMAGE}"
 
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
+          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
 
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+
 {!{- end }!}
 
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,final" $workflowName) | strings.Indent 6 }!}

--- a/.github/workflow_templates/validation.yml
+++ b/.github/workflow_templates/validation.yml
@@ -26,6 +26,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  close_dependabot_prs_for_forks:
+    name: Autoclose Dependabot PRs for forks
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' && github.repository != 'deckhouse/deckhouse' }}
+    env:
+      ENABLE_DEPENDABOT_IN_FORKS: ${{ secrets.ENABLE_DEPENDABOT_IN_FORKS }}
+    steps:
+      - name: Close PR
+        uses: {!{ index (ds "actions") "actions/github-script" }!}
+        with:
+          github-token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          script: |
+            // Keep PR if explicitly enabled.
+            const {ENABLE_DEPENDABOT_IN_FORKS} = process.env;
+            const prNum = context.payload.pull_request.number;
+            const repo = context.payload.repository.full_name;
+            if (ENABLE_DEPENDABOT_IN_FORKS === 'true') {
+              core.info(`Secret ENABLE_DEPENDABOT_IN_FORKS is 'true', proceed with validation for PR#${prNUM} in repo ${repo}.`);
+              return
+            }
+            core.info(`Secret ENABLE_DEPENDABOT_IN_FORKS is not 'true', close PR#${prNum} in repo ${repo}.`);
+            return await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNum,
+              state: 'closed'
+            });
+
 {!{ tmpl.Exec "pull_request_info_job" $ctx | strings.Indent 2 }!}
 
   # Get pull request info for validation scripts.

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -26,8 +26,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
 
 
@@ -334,8 +334,15 @@ jobs:
       # </template: checkout_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -364,15 +371,10 @@ jobs:
       WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
     # <template: build_template>
     runs-on: [self-hosted, regular]
+    outputs:
+      tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:
 
-      # <template: started_at_output>
-      - name: Job started timestamp
-        id: started_at
-        run: |
-          unixTimestamp=$(date +%s)
-          echo "::set-output name=started_at::${unixTimestamp}"
-      # </template: started_at_output>
 
       # <template: checkout_full_step>
       - name: Checkout sources
@@ -383,8 +385,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -393,8 +402,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -403,24 +419,29 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_rw_registry_step>
-
-      # <template: login_flant_registry_step>
-      - name: Login to flant registry
+      - name: Login to Github Container Registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
         with:
-          registry: ${{ secrets.FLANT_REGISTRY_HOST }}
-          username: ${{ secrets.FLANT_REGISTRY_USER }}
-          password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_flant_registry_step>
+      # </template: login_rw_registry_step>
 
       # <template: werf_install_step>
       - name: Install werf CLI
@@ -430,6 +451,7 @@ jobs:
       # </template: werf_install_step>
 
       - name: Build and push deckhouse images
+        id: build
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
@@ -439,6 +461,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
           ## Source: .gitlab/ci_templates/build.yml
+
           # Put tags on produced images and push to dev and release repositories.
           #
           # There are 2 modes: "dev" and "release".
@@ -451,31 +474,53 @@ jobs:
           # - Build using deckhouse registry as primary and dev-registry as secondary.
           # - Push dev, dev/install and release-channel-version images to deckhouse registry with tag equels to a Git tag.
 
-          # SRC is a name of image from werf.yaml.
-          # WERF_STAGE is a stage image name (from werf stage output).
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name (stage name from werf build report).
           # DST is an image name for docker push.
-          function pull_push() {
-            SRC=$1
-            WERF_STAGE=$2
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
             DST=$3
-            echo "⚓️ 💫 [$(date -u)] Pull '${SRC}' image as ${WERF_STAGE}."
-            docker pull ${WERF_STAGE}
-            echo "⚓️ 💫 [$(date -u)] Tag '${SRC}' image as ${DST}."
-            docker image tag ${WERF_STAGE} ${DST}
-            echo "⚓️ 💫 [$(date -u)] Push '${SRC}' image as ${DST}."
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+            echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
             docker image push ${DST}
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
           }
 
           if [[ -n "${DEV_REGISTRY_PATH}" ]]; then export WERF_REPO="${DEV_REGISTRY_PATH}"; fi
           type werf && source $(werf ci-env github --verbose --as-file)
 
-          # This build put stages to "dev" registry.
-          # If "dev" registry is empty, stages are copied from FE cache.
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          werf build \
-            --secondary-repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} \
-            --parallel=true --parallel-tasks-limit=5 \
-            --report-path images_tags_werf.json
+          # CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          # Registry path to publish images for Git branches.
+          BRANCH_REGISTRY_PATH=
+          # Registry path to publish images for Git tags.
+          SEMVER_REGISTRY_PATH=
+
+          if [[ -n ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Build using dev-registry as primary repo and prod registry as secondary (ro) repo.
+            # This build will put stages to "dev" registry. If "dev" registry is empty, existing stages are copied from prod registry.
+            werf build \
+              --secondary-repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} \
+              --parallel=true --parallel-tasks-limit=5 \
+              --report-path images_tags_werf.json
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+            SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          else
+            # DECKHOUSE_REGISTRY_HOST — this is not the main repo.
+            # Build using dev-registry as a single primary repo and push to Github Container Registry.
+            werf build \
+              --parallel=true --parallel-tasks-limit=5 \
+              --report-path images_tags_werf.json
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
+          fi
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -483,38 +528,32 @@ jobs:
             # Use it as image tag.
             IMAGE_TAG=${CI_COMMIT_REF_SLUG}
 
-            echo "⚓️ [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
+            echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${IMAGE_TAG}
-              DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-              DESTINATION_TESTS_IMAGE=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
-            else
-              DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${IMAGE_TAG}
-              DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-              DESTINATION_TESTS_IMAGE=${CI_REGISTRY_IMAGE}/tests:${IMAGE_TAG}
-            fi
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
+            DECKHOUSE_IMAGE_SRC="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
+            DECKHOUSE_IMAGE=${BRANCH_REGISTRY_PATH}:${IMAGE_TAG}
+            pull_push_rmi 'dev' ${DECKHOUSE_IMAGE_SRC} ${DECKHOUSE_IMAGE}
 
-            echo "⚓️ [$(date -u)] Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
-            DEV_IMAGE_URL="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
-            pull_push 'dev' ${DEV_IMAGE_URL} ${DESTINATION_IMAGE}
-
-            echo "⚓️ [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${IMAGE_TAG}".
-            DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
-            pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DESTINATION_INSTALL_IMAGE}
-
-            echo "⚓️ [$(date -u)] Publish 'tests' image to dev-registry using tag ${IMAGE_TAG}".
-            TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
-            pull_push 'tests' ${TESTS_IMAGE_URL} ${DESTINATION_TESTS_IMAGE}
-
-            echo "⚓️ [$(date -u)] Remove local tags."
-            docker image rmi ${DESTINATION_IMAGE} || true
-            docker image rmi ${DESTINATION_INSTALL_IMAGE} || true
-            docker image rmi ${DESTINATION_TESTS_IMAGE} || true
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${IMAGE_TAG}".
+            INSTALL_IMAGE_SRC="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
+            INSTALL_IMAGE=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+            pull_push_rmi 'dev/install' ${INSTALL_IMAGE_SRC} ${INSTALL_IMAGE}
           fi
+
+
+
+          # Save 'tests' image name to pass it as output for 'tests' jobs.
+          TESTS_IMAGE_NAME="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          # Encode as base64 to avoid github's secrets filter error: "Skip output since it may contain secret".
+          echo "::set-output name=tests_image_name::$(echo ${TESTS_IMAGE_NAME} | base64 -w0)"
+
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
           rm -f images_tags_werf.json
-
-
     # </template: build_template>
 
 
@@ -545,8 +584,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -555,12 +601,32 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_flant_registry_step>
+      - name: Check flant registry credentials
+        id: check_flant_registry
+        env:
+          HOST: ${{secrets.FLANT_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "::set-output name=has_flant_credentials::true"
+            echo "::set-output name=web_registry_path::${{secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+          else
+            echo "::set-output name=web_registry_path::${GHA_TEST_REGISTRY_PATH}"
+          fi
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials == 'true' }}
         with:
           registry: ${{ secrets.FLANT_REGISTRY_HOST }}
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_flant_registry_step>
 
@@ -571,7 +637,7 @@ jobs:
         env:
           WERF_DIR: "docs/documentation"
           WERF_LOG_VERBOSE: "on"
-          WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+          WERF_REPO: ${{steps.check_flant_registry.outputs.web_registry_path}}
     # </template: doc_web_build_template>
 
   main_web_build:
@@ -601,8 +667,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -611,12 +684,32 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_flant_registry_step>
+      - name: Check flant registry credentials
+        id: check_flant_registry
+        env:
+          HOST: ${{secrets.FLANT_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "::set-output name=has_flant_credentials::true"
+            echo "::set-output name=web_registry_path::${{secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+          else
+            echo "::set-output name=web_registry_path::${GHA_TEST_REGISTRY_PATH}"
+          fi
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials == 'true' }}
         with:
           registry: ${{ secrets.FLANT_REGISTRY_HOST }}
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_flant_registry_step>
 
@@ -627,7 +720,7 @@ jobs:
         env:
           WERF_DIR: "docs/site"
           WERF_LOG_VERBOSE: "on"
-          WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+          WERF_REPO: ${{steps.check_flant_registry.outputs.web_registry_path}}
     # </template: main_web_build_template>
 
   tests:
@@ -658,8 +751,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -667,24 +767,48 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_readonly_registry_step>
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          TESTS_IMAGE_NAME: ${{needs.build_deckhouse.outputs.tests_image_name}}
         run: |
+          if [[ -z ${TESTS_IMAGE_NAME} ]] ; then
+            echo "TESTS_IMAGE_NAME is empty"
+            exit 1
+          fi
 
-          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${CI_COMMIT_REF_SLUG}
+          # Base64 decode image name.
+          TESTS_IMAGE_NAME=$(echo ${TESTS_IMAGE_NAME} | base64 -d)
 
-          docker run --pull always -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test -timeout=${{env.TEST_TIMEOUT}} -vet=off ./modules/... ./global-hooks/...
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
+          docker pull ${TESTS_IMAGE_NAME}
+          echo "⚓️ 🏎 [$(date -u)] Run tests..."
+          docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} go test -timeout=${{env.TEST_TIMEOUT}} -vet=off ./modules/... ./global-hooks/...
     # </template: tests_template>
 
   matrix_tests:
@@ -715,8 +839,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -724,24 +855,48 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_readonly_registry_step>
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          TESTS_IMAGE_NAME: ${{needs.build_deckhouse.outputs.tests_image_name}}
         run: |
+          if [[ -z ${TESTS_IMAGE_NAME} ]] ; then
+            echo "TESTS_IMAGE_NAME is empty"
+            exit 1
+          fi
 
-          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${CI_COMMIT_REF_SLUG}
+          # Base64 decode image name.
+          TESTS_IMAGE_NAME=$(echo ${TESTS_IMAGE_NAME} | base64 -d)
 
-          docker run --pull always -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test ./testing/matrix/ -v
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
+          docker pull ${TESTS_IMAGE_NAME}
+          echo "⚓️ 🏎 [$(date -u)] Run tests..."
+          docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} go test ./testing/matrix/ -v
     # </template: tests_template>
 
   dhctl_tests:
@@ -772,8 +927,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -781,24 +943,48 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_readonly_registry_step>
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          TESTS_IMAGE_NAME: ${{needs.build_deckhouse.outputs.tests_image_name}}
         run: |
+          if [[ -z ${TESTS_IMAGE_NAME} ]] ; then
+            echo "TESTS_IMAGE_NAME is empty"
+            exit 1
+          fi
 
-          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${CI_COMMIT_REF_SLUG}
+          # Base64 decode image name.
+          TESTS_IMAGE_NAME=$(echo ${TESTS_IMAGE_NAME} | base64 -d)
 
-          docker run --pull always -w /deckhouse/dhctl -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} make ci
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
+          docker pull ${TESTS_IMAGE_NAME}
+          echo "⚓️ 🏎 [$(date -u)] Run tests..."
+          docker run -w /deckhouse/dhctl -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} make ci
     # </template: tests_template>
 
   golangci_lint:
@@ -829,8 +1015,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -838,24 +1031,48 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_readonly_registry_step>
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          TESTS_IMAGE_NAME: ${{needs.build_deckhouse.outputs.tests_image_name}}
         run: |
+          if [[ -z ${TESTS_IMAGE_NAME} ]] ; then
+            echo "TESTS_IMAGE_NAME is empty"
+            exit 1
+          fi
 
-          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${CI_COMMIT_REF_SLUG}
+          # Base64 decode image name.
+          TESTS_IMAGE_NAME=$(echo ${TESTS_IMAGE_NAME} | base64 -d)
 
-          docker run --pull always -w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} sh -c "go generate tools/register.go && golangci-lint run"
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
+          docker pull ${TESTS_IMAGE_NAME}
+          echo "⚓️ 🏎 [$(date -u)] Run tests..."
+          docker run -w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} sh -c "go generate tools/register.go && golangci-lint run"
     # </template: tests_template>
 
   openapi_test_cases:
@@ -886,8 +1103,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -895,24 +1119,48 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_readonly_registry_step>
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          TESTS_IMAGE_NAME: ${{needs.build_deckhouse.outputs.tests_image_name}}
         run: |
+          if [[ -z ${TESTS_IMAGE_NAME} ]] ; then
+            echo "TESTS_IMAGE_NAME is empty"
+            exit 1
+          fi
 
-          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${CI_COMMIT_REF_SLUG}
+          # Base64 decode image name.
+          TESTS_IMAGE_NAME=$(echo ${TESTS_IMAGE_NAME} | base64 -d)
 
-          docker run --pull always -v ${{github.workspace}}:/deckhouse -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} ginkgo -vet=off ./testing/openapi_cases/
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
+          docker pull ${TESTS_IMAGE_NAME}
+          echo "⚓️ 🏎 [$(date -u)] Run tests..."
+          docker run -v ${{github.workspace}}:/deckhouse -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} ginkgo -vet=off ./testing/openapi_cases/
     # </template: tests_template>
 
   web_links_test:
@@ -944,8 +1192,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -954,12 +1209,32 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_flant_registry_step>
+      - name: Check flant registry credentials
+        id: check_flant_registry
+        env:
+          HOST: ${{secrets.FLANT_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "::set-output name=has_flant_credentials::true"
+            echo "::set-output name=web_registry_path::${{secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+          else
+            echo "::set-output name=web_registry_path::${GHA_TEST_REGISTRY_PATH}"
+          fi
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials == 'true' }}
         with:
           registry: ${{ secrets.FLANT_REGISTRY_HOST }}
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_flant_registry_step>
 
@@ -971,6 +1246,8 @@ jobs:
       # </template: werf_install_step>
 
       - name: Prepare site structure
+        env:
+          WEB_REGISTRY_PATH: ${{steps.check_flant_registry.outputs.web_registry_path}}
         run: |
           type werf
           werf version
@@ -981,7 +1258,7 @@ jobs:
           echo "_TMPDIR=$_TMPDIR" >> ${GITHUB_ENV}
           echo "_TMPDIR=$_TMPDIR"
 
-          export WERF_REPO="${FLANT_REGISTRY_PATH}"
+          export WERF_REPO="${WEB_REGISTRY_PATH}"
           echo -n 'use werf_repo'
           echo $WERF_REPO | tr 'a-z' 'A-Z'
 
@@ -1066,8 +1343,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1075,22 +1359,46 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_readonly_registry_step>
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          TESTS_IMAGE_NAME: ${{needs.build_deckhouse.outputs.tests_image_name}}
         run: |
+          if [[ -z ${TESTS_IMAGE_NAME} ]] ; then
+            echo "TESTS_IMAGE_NAME is empty"
+            exit 1
+          fi
 
-          TESTS_IMAGE_URL=${DEV_REGISTRY_PATH}/tests:${CI_COMMIT_REF_SLUG}
+          # Base64 decode image name.
+          TESTS_IMAGE_NAME=$(echo ${TESTS_IMAGE_NAME} | base64 -d)
 
-          docker run --pull always -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
+          docker pull ${TESTS_IMAGE_NAME}
+          echo "⚓️ 🏎 [$(date -u)] Run tests..."
+          docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} go test -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...
     # </template: tests_template>

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -34,8 +34,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
 
 
@@ -226,8 +226,15 @@ jobs:
       # </template: checkout_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -286,7 +293,10 @@ jobs:
       WERF_ENV: "FE"
     # <template: build_template>
     runs-on: [self-hosted, regular]
+    outputs:
+      tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:
+
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -296,6 +306,7 @@ jobs:
           echo "::set-output name=started_at::${unixTimestamp}"
       # </template: started_at_output>
 
+
       # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -304,8 +315,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -314,8 +332,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -324,24 +349,29 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_rw_registry_step>
-
-      # <template: login_flant_registry_step>
-      - name: Login to flant registry
+      - name: Login to Github Container Registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
         with:
-          registry: ${{ secrets.FLANT_REGISTRY_HOST }}
-          username: ${{ secrets.FLANT_REGISTRY_USER }}
-          password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_flant_registry_step>
+      # </template: login_rw_registry_step>
 
       # <template: werf_install_step>
       - name: Install werf CLI
@@ -351,6 +381,7 @@ jobs:
       # </template: werf_install_step>
 
       - name: Build and push deckhouse images
+        id: build
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
@@ -360,6 +391,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
           ## Source: .gitlab/ci_templates/build.yml
+
           # Put tags on produced images and push to dev and release repositories.
           #
           # There are 2 modes: "dev" and "release".
@@ -372,31 +404,53 @@ jobs:
           # - Build using deckhouse registry as primary and dev-registry as secondary.
           # - Push dev, dev/install and release-channel-version images to deckhouse registry with tag equels to a Git tag.
 
-          # SRC is a name of image from werf.yaml.
-          # WERF_STAGE is a stage image name (from werf stage output).
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name (stage name from werf build report).
           # DST is an image name for docker push.
-          function pull_push() {
-            SRC=$1
-            WERF_STAGE=$2
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
             DST=$3
-            echo "⚓️ 💫 [$(date -u)] Pull '${SRC}' image as ${WERF_STAGE}."
-            docker pull ${WERF_STAGE}
-            echo "⚓️ 💫 [$(date -u)] Tag '${SRC}' image as ${DST}."
-            docker image tag ${WERF_STAGE} ${DST}
-            echo "⚓️ 💫 [$(date -u)] Push '${SRC}' image as ${DST}."
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+            echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
             docker image push ${DST}
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
           }
 
           if [[ -n "${DEV_REGISTRY_PATH}" ]]; then export WERF_REPO="${DEV_REGISTRY_PATH}"; fi
           type werf && source $(werf ci-env github --verbose --as-file)
 
-          # This build put stages to "dev" registry.
-          # If "dev" registry is empty, stages are copied from FE cache.
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          werf build \
-            --secondary-repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} \
-            --parallel=true --parallel-tasks-limit=5 \
-            --report-path images_tags_werf.json
+          # CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          # Registry path to publish images for Git branches.
+          BRANCH_REGISTRY_PATH=
+          # Registry path to publish images for Git tags.
+          SEMVER_REGISTRY_PATH=
+
+          if [[ -n ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Build using dev-registry as primary repo and prod registry as secondary (ro) repo.
+            # This build will put stages to "dev" registry. If "dev" registry is empty, existing stages are copied from prod registry.
+            werf build \
+              --secondary-repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} \
+              --parallel=true --parallel-tasks-limit=5 \
+              --report-path images_tags_werf.json
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+            SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          else
+            # DECKHOUSE_REGISTRY_HOST — this is not the main repo.
+            # Build using dev-registry as a single primary repo and push to Github Container Registry.
+            werf build \
+              --parallel=true --parallel-tasks-limit=5 \
+              --report-path images_tags_werf.json
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
+          fi
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -404,84 +458,64 @@ jobs:
             # Use it as image tag.
             IMAGE_TAG=${CI_COMMIT_REF_SLUG}
 
-            echo "⚓️ [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
+            echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${IMAGE_TAG}
-              DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-              DESTINATION_TESTS_IMAGE=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
-            else
-              DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${IMAGE_TAG}
-              DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-              DESTINATION_TESTS_IMAGE=${CI_REGISTRY_IMAGE}/tests:${IMAGE_TAG}
-            fi
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
+            DECKHOUSE_IMAGE_SRC="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
+            DECKHOUSE_IMAGE=${BRANCH_REGISTRY_PATH}:${IMAGE_TAG}
+            pull_push_rmi 'dev' ${DECKHOUSE_IMAGE_SRC} ${DECKHOUSE_IMAGE}
 
-            echo "⚓️ [$(date -u)] Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
-            DEV_IMAGE_URL="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
-            pull_push 'dev' ${DEV_IMAGE_URL} ${DESTINATION_IMAGE}
-
-            echo "⚓️ [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${IMAGE_TAG}".
-            DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
-            pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DESTINATION_INSTALL_IMAGE}
-
-            echo "⚓️ [$(date -u)] Publish 'tests' image to dev-registry using tag ${IMAGE_TAG}".
-            TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
-            pull_push 'tests' ${TESTS_IMAGE_URL} ${DESTINATION_TESTS_IMAGE}
-
-            echo "⚓️ [$(date -u)] Remove local tags."
-            docker image rmi ${DESTINATION_IMAGE} || true
-            docker image rmi ${DESTINATION_INSTALL_IMAGE} || true
-            docker image rmi ${DESTINATION_TESTS_IMAGE} || true
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${IMAGE_TAG}".
+            INSTALL_IMAGE_SRC="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
+            INSTALL_IMAGE=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+            pull_push_rmi 'dev/install' ${INSTALL_IMAGE_SRC} ${INSTALL_IMAGE}
           fi
-          rm -f images_tags_werf.json
 
 
           # Publish images for Git tag.
           if [[ -n "${CI_COMMIT_TAG}" ]]; then
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              # The Git tag may contain a '+' sign, so use slugify for this situation.
-              # Slugify doesn't change a tag with safe-only characters.
-              IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            # The Git tag may contain a '+' sign, so use slugify for this situation.
+            # Slugify doesn't change a tag with safe-only characters.
+            IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
 
-              echo "⚓️ [$(date -u)] Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
-              # Copy stages to deckhouse registry from dev registry.
+            echo "⚓️ 💫 [$(date -u)] Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
+            if [[ -n ${DECKHOUSE_REGISTRY_PATH} ]] ; then
+              # Copy stages to prod registry from dev registry.
               werf build \
-                --repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} \
+                --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --report-path images_tags_werf.json
-
-              echo "⚓️ [$(date -u)] Publish 'dev' image to deckhouse registry using tag ${IMAGE_TAG} ..."
-              DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${IMAGE_TAG}
-              DEV_IMAGE_URL="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
-              pull_push 'dev' ${DEV_IMAGE_URL} ${DECKHOUSE_DESTINATION_IMAGE}
-
-              echo "⚓️ [$(date -u)] Publish 'dev/install' image to deckhouse registry using tag ${IMAGE_TAG} ..."
-              DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
-              DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
-              pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-
-              echo "⚓️ [$(date -u)] Publish 'tests' image to deckhouse registry using tag ${IMAGE_TAG} ..."
-              DECKHOUSE_DESTINATION_TESTS_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
-              TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
-              pull_push 'tests' ${TESTS_IMAGE_URL} ${DECKHOUSE_DESTINATION_TESTS_IMAGE}
-
-              echo "⚓️ [$(date -u)] Publish 'release-channel-version' image to deckhouse registry using tag ${IMAGE_TAG} ..."
-              DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${IMAGE_TAG}
-              RELEASE_CHANNEL_VERSION_IMAGE_URL="$(jq -r '.Images."release-channel-version".DockerImageName' images_tags_werf.json)"
-              pull_push 'release-channel-version' ${RELEASE_CHANNEL_VERSION_IMAGE_URL} ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE}
-
-              echo "⚓️ [$(date -u)] Remove local tags."
-              docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true
-              docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true
-              docker image rmi ${DECKHOUSE_DESTINATION_TESTS_IMAGE} || true
-              docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true
-
-              rm -f images_tags_werf.json
-            else
-              echo "⚓️ [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. No publishing."
             fi
+            # Note: do not run second werf build for test repo, as it has no secondary repo.
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+            DECKHOUSE_IMAGE_SRC="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
+            DECKHOUSE_IMAGE=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${IMAGE_TAG}
+            pull_push_rmi 'dev' ${DECKHOUSE_IMAGE_SRC} ${DECKHOUSE_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+            INSTALL_IMAGE_SRC="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
+            INSTALL_IMAGE=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            pull_push_rmi 'dev/install' ${INSTALL_IMAGE_SRC} ${INSTALL_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+            RELEASE_CHANNEL_IMAGE_SRC="$(jq -r '.Images."release-channel-version".DockerImageName' images_tags_werf.json)"
+            RELEASE_CHANNEL_IMAGE=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${IMAGE_TAG}
+            pull_push_rmi 'release-channel-version' ${RELEASE_CHANNEL_IMAGE_SRC} ${RELEASE_CHANNEL_IMAGE}
           fi
+
+          # Save 'tests' image name to pass it as output for 'tests' jobs.
+          TESTS_IMAGE_NAME="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          # Encode as base64 to avoid github's secrets filter error: "Skip output since it may contain secret".
+          echo "::set-output name=tests_image_name::$(echo ${TESTS_IMAGE_NAME} | base64 -w0)"
+
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          rm -f images_tags_werf.json
     # </template: build_template>
 
       # <template: update_comment_on_finish>
@@ -526,7 +560,10 @@ jobs:
       WERF_ENV: "EE"
     # <template: build_template>
     runs-on: [self-hosted, regular]
+    outputs:
+      tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:
+
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -536,6 +573,7 @@ jobs:
           echo "::set-output name=started_at::${unixTimestamp}"
       # </template: started_at_output>
 
+
       # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -544,8 +582,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -554,8 +599,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -564,24 +616,29 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_rw_registry_step>
-
-      # <template: login_flant_registry_step>
-      - name: Login to flant registry
+      - name: Login to Github Container Registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
         with:
-          registry: ${{ secrets.FLANT_REGISTRY_HOST }}
-          username: ${{ secrets.FLANT_REGISTRY_USER }}
-          password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_flant_registry_step>
+      # </template: login_rw_registry_step>
 
       # <template: werf_install_step>
       - name: Install werf CLI
@@ -591,6 +648,7 @@ jobs:
       # </template: werf_install_step>
 
       - name: Build and push deckhouse images
+        id: build
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
@@ -600,6 +658,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
           ## Source: .gitlab/ci_templates/build.yml
+
           # Put tags on produced images and push to dev and release repositories.
           #
           # There are 2 modes: "dev" and "release".
@@ -612,31 +671,53 @@ jobs:
           # - Build using deckhouse registry as primary and dev-registry as secondary.
           # - Push dev, dev/install and release-channel-version images to deckhouse registry with tag equels to a Git tag.
 
-          # SRC is a name of image from werf.yaml.
-          # WERF_STAGE is a stage image name (from werf stage output).
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name (stage name from werf build report).
           # DST is an image name for docker push.
-          function pull_push() {
-            SRC=$1
-            WERF_STAGE=$2
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
             DST=$3
-            echo "⚓️ 💫 [$(date -u)] Pull '${SRC}' image as ${WERF_STAGE}."
-            docker pull ${WERF_STAGE}
-            echo "⚓️ 💫 [$(date -u)] Tag '${SRC}' image as ${DST}."
-            docker image tag ${WERF_STAGE} ${DST}
-            echo "⚓️ 💫 [$(date -u)] Push '${SRC}' image as ${DST}."
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+            echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
             docker image push ${DST}
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
           }
 
           if [[ -n "${DEV_REGISTRY_PATH}" ]]; then export WERF_REPO="${DEV_REGISTRY_PATH}"; fi
           type werf && source $(werf ci-env github --verbose --as-file)
 
-          # This build put stages to "dev" registry.
-          # If "dev" registry is empty, stages are copied from FE cache.
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          werf build \
-            --secondary-repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} \
-            --parallel=true --parallel-tasks-limit=5 \
-            --report-path images_tags_werf.json
+          # CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          # Registry path to publish images for Git branches.
+          BRANCH_REGISTRY_PATH=
+          # Registry path to publish images for Git tags.
+          SEMVER_REGISTRY_PATH=
+
+          if [[ -n ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Build using dev-registry as primary repo and prod registry as secondary (ro) repo.
+            # This build will put stages to "dev" registry. If "dev" registry is empty, existing stages are copied from prod registry.
+            werf build \
+              --secondary-repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} \
+              --parallel=true --parallel-tasks-limit=5 \
+              --report-path images_tags_werf.json
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+            SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          else
+            # DECKHOUSE_REGISTRY_HOST — this is not the main repo.
+            # Build using dev-registry as a single primary repo and push to Github Container Registry.
+            werf build \
+              --parallel=true --parallel-tasks-limit=5 \
+              --report-path images_tags_werf.json
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
+          fi
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -644,84 +725,64 @@ jobs:
             # Use it as image tag.
             IMAGE_TAG=${CI_COMMIT_REF_SLUG}
 
-            echo "⚓️ [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
+            echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${IMAGE_TAG}
-              DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-              DESTINATION_TESTS_IMAGE=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
-            else
-              DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${IMAGE_TAG}
-              DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-              DESTINATION_TESTS_IMAGE=${CI_REGISTRY_IMAGE}/tests:${IMAGE_TAG}
-            fi
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
+            DECKHOUSE_IMAGE_SRC="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
+            DECKHOUSE_IMAGE=${BRANCH_REGISTRY_PATH}:${IMAGE_TAG}
+            pull_push_rmi 'dev' ${DECKHOUSE_IMAGE_SRC} ${DECKHOUSE_IMAGE}
 
-            echo "⚓️ [$(date -u)] Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
-            DEV_IMAGE_URL="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
-            pull_push 'dev' ${DEV_IMAGE_URL} ${DESTINATION_IMAGE}
-
-            echo "⚓️ [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${IMAGE_TAG}".
-            DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
-            pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DESTINATION_INSTALL_IMAGE}
-
-            echo "⚓️ [$(date -u)] Publish 'tests' image to dev-registry using tag ${IMAGE_TAG}".
-            TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
-            pull_push 'tests' ${TESTS_IMAGE_URL} ${DESTINATION_TESTS_IMAGE}
-
-            echo "⚓️ [$(date -u)] Remove local tags."
-            docker image rmi ${DESTINATION_IMAGE} || true
-            docker image rmi ${DESTINATION_INSTALL_IMAGE} || true
-            docker image rmi ${DESTINATION_TESTS_IMAGE} || true
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${IMAGE_TAG}".
+            INSTALL_IMAGE_SRC="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
+            INSTALL_IMAGE=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+            pull_push_rmi 'dev/install' ${INSTALL_IMAGE_SRC} ${INSTALL_IMAGE}
           fi
-          rm -f images_tags_werf.json
 
 
           # Publish images for Git tag.
           if [[ -n "${CI_COMMIT_TAG}" ]]; then
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              # The Git tag may contain a '+' sign, so use slugify for this situation.
-              # Slugify doesn't change a tag with safe-only characters.
-              IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            # The Git tag may contain a '+' sign, so use slugify for this situation.
+            # Slugify doesn't change a tag with safe-only characters.
+            IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
 
-              echo "⚓️ [$(date -u)] Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
-              # Copy stages to deckhouse registry from dev registry.
+            echo "⚓️ 💫 [$(date -u)] Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
+            if [[ -n ${DECKHOUSE_REGISTRY_PATH} ]] ; then
+              # Copy stages to prod registry from dev registry.
               werf build \
-                --repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} \
+                --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --report-path images_tags_werf.json
-
-              echo "⚓️ [$(date -u)] Publish 'dev' image to deckhouse registry using tag ${IMAGE_TAG} ..."
-              DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${IMAGE_TAG}
-              DEV_IMAGE_URL="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
-              pull_push 'dev' ${DEV_IMAGE_URL} ${DECKHOUSE_DESTINATION_IMAGE}
-
-              echo "⚓️ [$(date -u)] Publish 'dev/install' image to deckhouse registry using tag ${IMAGE_TAG} ..."
-              DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
-              DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
-              pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-
-              echo "⚓️ [$(date -u)] Publish 'tests' image to deckhouse registry using tag ${IMAGE_TAG} ..."
-              DECKHOUSE_DESTINATION_TESTS_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
-              TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
-              pull_push 'tests' ${TESTS_IMAGE_URL} ${DECKHOUSE_DESTINATION_TESTS_IMAGE}
-
-              echo "⚓️ [$(date -u)] Publish 'release-channel-version' image to deckhouse registry using tag ${IMAGE_TAG} ..."
-              DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${IMAGE_TAG}
-              RELEASE_CHANNEL_VERSION_IMAGE_URL="$(jq -r '.Images."release-channel-version".DockerImageName' images_tags_werf.json)"
-              pull_push 'release-channel-version' ${RELEASE_CHANNEL_VERSION_IMAGE_URL} ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE}
-
-              echo "⚓️ [$(date -u)] Remove local tags."
-              docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true
-              docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true
-              docker image rmi ${DECKHOUSE_DESTINATION_TESTS_IMAGE} || true
-              docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true
-
-              rm -f images_tags_werf.json
-            else
-              echo "⚓️ [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. No publishing."
             fi
+            # Note: do not run second werf build for test repo, as it has no secondary repo.
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+            DECKHOUSE_IMAGE_SRC="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
+            DECKHOUSE_IMAGE=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${IMAGE_TAG}
+            pull_push_rmi 'dev' ${DECKHOUSE_IMAGE_SRC} ${DECKHOUSE_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+            INSTALL_IMAGE_SRC="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
+            INSTALL_IMAGE=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            pull_push_rmi 'dev/install' ${INSTALL_IMAGE_SRC} ${INSTALL_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+            RELEASE_CHANNEL_IMAGE_SRC="$(jq -r '.Images."release-channel-version".DockerImageName' images_tags_werf.json)"
+            RELEASE_CHANNEL_IMAGE=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${IMAGE_TAG}
+            pull_push_rmi 'release-channel-version' ${RELEASE_CHANNEL_IMAGE_SRC} ${RELEASE_CHANNEL_IMAGE}
           fi
+
+          # Save 'tests' image name to pass it as output for 'tests' jobs.
+          TESTS_IMAGE_NAME="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          # Encode as base64 to avoid github's secrets filter error: "Skip output since it may contain secret".
+          echo "::set-output name=tests_image_name::$(echo ${TESTS_IMAGE_NAME} | base64 -w0)"
+
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          rm -f images_tags_werf.json
     # </template: build_template>
 
       # <template: update_comment_on_finish>
@@ -766,7 +827,10 @@ jobs:
       WERF_ENV: "CE"
     # <template: build_template>
     runs-on: [self-hosted, regular]
+    outputs:
+      tests_image_name: ${{ steps.build.outputs.tests_image_name }}
     steps:
+
 
       # <template: started_at_output>
       - name: Job started timestamp
@@ -776,6 +840,7 @@ jobs:
           echo "::set-output name=started_at::${unixTimestamp}"
       # </template: started_at_output>
 
+
       # <template: checkout_full_step>
       - name: Checkout sources
         uses: actions/checkout@v2.4.0
@@ -784,8 +849,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -794,8 +866,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -804,24 +883,29 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_rw_registry_step>
-
-      # <template: login_flant_registry_step>
-      - name: Login to flant registry
+      - name: Login to Github Container Registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
         with:
-          registry: ${{ secrets.FLANT_REGISTRY_HOST }}
-          username: ${{ secrets.FLANT_REGISTRY_USER }}
-          password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_flant_registry_step>
+      # </template: login_rw_registry_step>
 
       # <template: werf_install_step>
       - name: Install werf CLI
@@ -831,6 +915,7 @@ jobs:
       # </template: werf_install_step>
 
       - name: Build and push deckhouse images
+        id: build
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
@@ -840,6 +925,7 @@ jobs:
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
           ## Source: .gitlab/ci_templates/build.yml
+
           # Put tags on produced images and push to dev and release repositories.
           #
           # There are 2 modes: "dev" and "release".
@@ -852,31 +938,53 @@ jobs:
           # - Build using deckhouse registry as primary and dev-registry as secondary.
           # - Push dev, dev/install and release-channel-version images to deckhouse registry with tag equels to a Git tag.
 
-          # SRC is a name of image from werf.yaml.
-          # WERF_STAGE is a stage image name (from werf stage output).
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name (stage name from werf build report).
           # DST is an image name for docker push.
-          function pull_push() {
-            SRC=$1
-            WERF_STAGE=$2
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
             DST=$3
-            echo "⚓️ 💫 [$(date -u)] Pull '${SRC}' image as ${WERF_STAGE}."
-            docker pull ${WERF_STAGE}
-            echo "⚓️ 💫 [$(date -u)] Tag '${SRC}' image as ${DST}."
-            docker image tag ${WERF_STAGE} ${DST}
-            echo "⚓️ 💫 [$(date -u)] Push '${SRC}' image as ${DST}."
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+            echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
             docker image push ${DST}
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
           }
 
           if [[ -n "${DEV_REGISTRY_PATH}" ]]; then export WERF_REPO="${DEV_REGISTRY_PATH}"; fi
           type werf && source $(werf ci-env github --verbose --as-file)
 
-          # This build put stages to "dev" registry.
-          # If "dev" registry is empty, stages are copied from FE cache.
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          werf build \
-            --secondary-repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} \
-            --parallel=true --parallel-tasks-limit=5 \
-            --report-path images_tags_werf.json
+          # CE/EE/FE -> ce/ee/fe
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+
+          # Registry path to publish images for Git branches.
+          BRANCH_REGISTRY_PATH=
+          # Registry path to publish images for Git tags.
+          SEMVER_REGISTRY_PATH=
+
+          if [[ -n ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Build using dev-registry as primary repo and prod registry as secondary (ro) repo.
+            # This build will put stages to "dev" registry. If "dev" registry is empty, existing stages are copied from prod registry.
+            werf build \
+              --secondary-repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} \
+              --parallel=true --parallel-tasks-limit=5 \
+              --report-path images_tags_werf.json
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+            SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          else
+            # DECKHOUSE_REGISTRY_HOST — this is not the main repo.
+            # Build using dev-registry as a single primary repo and push to Github Container Registry.
+            werf build \
+              --parallel=true --parallel-tasks-limit=5 \
+              --report-path images_tags_werf.json
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
+          fi
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -884,84 +992,64 @@ jobs:
             # Use it as image tag.
             IMAGE_TAG=${CI_COMMIT_REF_SLUG}
 
-            echo "⚓️ [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
+            echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              DESTINATION_IMAGE=${DEV_REGISTRY_PATH}:${IMAGE_TAG}
-              DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-              DESTINATION_TESTS_IMAGE=${DEV_REGISTRY_PATH}/tests:${IMAGE_TAG}
-            else
-              DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${IMAGE_TAG}
-              DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-              DESTINATION_TESTS_IMAGE=${CI_REGISTRY_IMAGE}/tests:${IMAGE_TAG}
-            fi
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
+            DECKHOUSE_IMAGE_SRC="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
+            DECKHOUSE_IMAGE=${BRANCH_REGISTRY_PATH}:${IMAGE_TAG}
+            pull_push_rmi 'dev' ${DECKHOUSE_IMAGE_SRC} ${DECKHOUSE_IMAGE}
 
-            echo "⚓️ [$(date -u)] Publish 'dev' image to dev-registry using tag ${IMAGE_TAG}".
-            DEV_IMAGE_URL="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
-            pull_push 'dev' ${DEV_IMAGE_URL} ${DESTINATION_IMAGE}
-
-            echo "⚓️ [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${IMAGE_TAG}".
-            DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
-            pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DESTINATION_INSTALL_IMAGE}
-
-            echo "⚓️ [$(date -u)] Publish 'tests' image to dev-registry using tag ${IMAGE_TAG}".
-            TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
-            pull_push 'tests' ${TESTS_IMAGE_URL} ${DESTINATION_TESTS_IMAGE}
-
-            echo "⚓️ [$(date -u)] Remove local tags."
-            docker image rmi ${DESTINATION_IMAGE} || true
-            docker image rmi ${DESTINATION_INSTALL_IMAGE} || true
-            docker image rmi ${DESTINATION_TESTS_IMAGE} || true
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${IMAGE_TAG}".
+            INSTALL_IMAGE_SRC="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
+            INSTALL_IMAGE=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+            pull_push_rmi 'dev/install' ${INSTALL_IMAGE_SRC} ${INSTALL_IMAGE}
           fi
-          rm -f images_tags_werf.json
 
 
           # Publish images for Git tag.
           if [[ -n "${CI_COMMIT_TAG}" ]]; then
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              # The Git tag may contain a '+' sign, so use slugify for this situation.
-              # Slugify doesn't change a tag with safe-only characters.
-              IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+            # The Git tag may contain a '+' sign, so use slugify for this situation.
+            # Slugify doesn't change a tag with safe-only characters.
+            IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
 
-              echo "⚓️ [$(date -u)] Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
-              # Copy stages to deckhouse registry from dev registry.
+            echo "⚓️ 💫 [$(date -u)] Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
+            if [[ -n ${DECKHOUSE_REGISTRY_PATH} ]] ; then
+              # Copy stages to prod registry from dev registry.
               werf build \
-                --repo ${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX} \
+                --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
                 --secondary-repo $WERF_REPO \
                 --parallel=true --parallel-tasks-limit=5 \
                 --report-path images_tags_werf.json
-
-              echo "⚓️ [$(date -u)] Publish 'dev' image to deckhouse registry using tag ${IMAGE_TAG} ..."
-              DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${IMAGE_TAG}
-              DEV_IMAGE_URL="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
-              pull_push 'dev' ${DEV_IMAGE_URL} ${DECKHOUSE_DESTINATION_IMAGE}
-
-              echo "⚓️ [$(date -u)] Publish 'dev/install' image to deckhouse registry using tag ${IMAGE_TAG} ..."
-              DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
-              DEV_INSTALL_IMAGE_URL="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
-              pull_push 'dev/install' ${DEV_INSTALL_IMAGE_URL} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-
-              echo "⚓️ [$(date -u)] Publish 'tests' image to deckhouse registry using tag ${IMAGE_TAG} ..."
-              DECKHOUSE_DESTINATION_TESTS_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/tests:${IMAGE_TAG}
-              TESTS_IMAGE_URL="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
-              pull_push 'tests' ${TESTS_IMAGE_URL} ${DECKHOUSE_DESTINATION_TESTS_IMAGE}
-
-              echo "⚓️ [$(date -u)] Publish 'release-channel-version' image to deckhouse registry using tag ${IMAGE_TAG} ..."
-              DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${IMAGE_TAG}
-              RELEASE_CHANNEL_VERSION_IMAGE_URL="$(jq -r '.Images."release-channel-version".DockerImageName' images_tags_werf.json)"
-              pull_push 'release-channel-version' ${RELEASE_CHANNEL_VERSION_IMAGE_URL} ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE}
-
-              echo "⚓️ [$(date -u)] Remove local tags."
-              docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true
-              docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true
-              docker image rmi ${DECKHOUSE_DESTINATION_TESTS_IMAGE} || true
-              docker image rmi ${DESTINATION_RELEASE_CHANNEL_VERSION_IMAGE} || true
-
-              rm -f images_tags_werf.json
-            else
-              echo "⚓️ [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. No publishing."
             fi
+            # Note: do not run second werf build for test repo, as it has no secondary repo.
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+            DECKHOUSE_IMAGE_SRC="$(jq -r '.Images."dev".DockerImageName' images_tags_werf.json)"
+            DECKHOUSE_IMAGE=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${IMAGE_TAG}
+            pull_push_rmi 'dev' ${DECKHOUSE_IMAGE_SRC} ${DECKHOUSE_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+            INSTALL_IMAGE_SRC="$(jq -r '.Images."dev/install".DockerImageName' images_tags_werf.json)"
+            INSTALL_IMAGE=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            pull_push_rmi 'dev/install' ${INSTALL_IMAGE_SRC} ${INSTALL_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to deckhouse registry using tag ${IMAGE_TAG} ..."
+            RELEASE_CHANNEL_IMAGE_SRC="$(jq -r '.Images."release-channel-version".DockerImageName' images_tags_werf.json)"
+            RELEASE_CHANNEL_IMAGE=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${IMAGE_TAG}
+            pull_push_rmi 'release-channel-version' ${RELEASE_CHANNEL_IMAGE_SRC} ${RELEASE_CHANNEL_IMAGE}
           fi
+
+          # Save 'tests' image name to pass it as output for 'tests' jobs.
+          TESTS_IMAGE_NAME="$(jq -r '.Images."tests".DockerImageName' images_tags_werf.json)"
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          # Encode as base64 to avoid github's secrets filter error: "Skip output since it may contain secret".
+          echo "::set-output name=tests_image_name::$(echo ${TESTS_IMAGE_NAME} | base64 -w0)"
+
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          rm -f images_tags_werf.json
     # </template: build_template>
 
       # <template: update_comment_on_finish>
@@ -1021,8 +1109,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -1031,12 +1126,32 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_flant_registry_step>
+      - name: Check flant registry credentials
+        id: check_flant_registry
+        env:
+          HOST: ${{secrets.FLANT_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "::set-output name=has_flant_credentials::true"
+            echo "::set-output name=web_registry_path::${{secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+          else
+            echo "::set-output name=web_registry_path::${GHA_TEST_REGISTRY_PATH}"
+          fi
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials == 'true' }}
         with:
           registry: ${{ secrets.FLANT_REGISTRY_HOST }}
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_flant_registry_step>
 
@@ -1047,7 +1162,7 @@ jobs:
         env:
           WERF_DIR: "docs/documentation"
           WERF_LOG_VERBOSE: "on"
-          WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+          WERF_REPO: ${{steps.check_flant_registry.outputs.web_registry_path}}
     # </template: doc_web_build_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1106,8 +1221,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -1116,12 +1238,32 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_flant_registry_step>
+      - name: Check flant registry credentials
+        id: check_flant_registry
+        env:
+          HOST: ${{secrets.FLANT_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "::set-output name=has_flant_credentials::true"
+            echo "::set-output name=web_registry_path::${{secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+          else
+            echo "::set-output name=web_registry_path::${GHA_TEST_REGISTRY_PATH}"
+          fi
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials == 'true' }}
         with:
           registry: ${{ secrets.FLANT_REGISTRY_HOST }}
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_flant_registry_step>
 
@@ -1132,7 +1274,7 @@ jobs:
         env:
           WERF_DIR: "docs/site"
           WERF_LOG_VERBOSE: "on"
-          WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+          WERF_REPO: ${{steps.check_flant_registry.outputs.web_registry_path}}
     # </template: main_web_build_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1171,7 +1313,6 @@ jobs:
     needs:
       - git_info
       - build_fe
-    continue-on-error: true
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1193,8 +1334,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1202,24 +1350,48 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_readonly_registry_step>
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          TESTS_IMAGE_NAME: ${{needs.build_fe.outputs.tests_image_name}}
         run: |
+          if [[ -z ${TESTS_IMAGE_NAME} ]] ; then
+            echo "TESTS_IMAGE_NAME is empty"
+            exit 1
+          fi
 
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/fe/tests:${CI_COMMIT_REF_SLUG}
+          # Base64 decode image name.
+          TESTS_IMAGE_NAME=$(echo ${TESTS_IMAGE_NAME} | base64 -d)
 
-          docker run --pull always -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test -timeout=${{env.TEST_TIMEOUT}} -vet=off ./modules/... ./global-hooks/...
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
+          docker pull ${TESTS_IMAGE_NAME}
+          echo "⚓️ 🏎 [$(date -u)] Run tests..."
+          docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} go test -timeout=${{env.TEST_TIMEOUT}} -vet=off ./modules/... ./global-hooks/...
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1258,7 +1430,6 @@ jobs:
     needs:
       - git_info
       - build_fe
-    continue-on-error: true
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1280,8 +1451,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1289,24 +1467,48 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_readonly_registry_step>
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          TESTS_IMAGE_NAME: ${{needs.build_fe.outputs.tests_image_name}}
         run: |
+          if [[ -z ${TESTS_IMAGE_NAME} ]] ; then
+            echo "TESTS_IMAGE_NAME is empty"
+            exit 1
+          fi
 
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/fe/tests:${CI_COMMIT_REF_SLUG}
+          # Base64 decode image name.
+          TESTS_IMAGE_NAME=$(echo ${TESTS_IMAGE_NAME} | base64 -d)
 
-          docker run --pull always -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test ./testing/matrix/ -v
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
+          docker pull ${TESTS_IMAGE_NAME}
+          echo "⚓️ 🏎 [$(date -u)] Run tests..."
+          docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} go test ./testing/matrix/ -v
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1341,11 +1543,10 @@ jobs:
 
 
   dhctl_tests:
-    name: Matrix tests
+    name: Dhctl Tests
     needs:
       - git_info
       - build_fe
-    continue-on-error: true
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1367,8 +1568,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1376,24 +1584,48 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_readonly_registry_step>
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          TESTS_IMAGE_NAME: ${{needs.build_fe.outputs.tests_image_name}}
         run: |
+          if [[ -z ${TESTS_IMAGE_NAME} ]] ; then
+            echo "TESTS_IMAGE_NAME is empty"
+            exit 1
+          fi
 
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/fe/tests:${CI_COMMIT_REF_SLUG}
+          # Base64 decode image name.
+          TESTS_IMAGE_NAME=$(echo ${TESTS_IMAGE_NAME} | base64 -d)
 
-          docker run --pull always -w /deckhouse/dhctl -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} make ci
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
+          docker pull ${TESTS_IMAGE_NAME}
+          echo "⚓️ 🏎 [$(date -u)] Run tests..."
+          docker run -w /deckhouse/dhctl -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} make ci
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1408,7 +1640,7 @@ jobs:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           script: |
             const statusConfig = 'job,one-line';
-            const name = 'Matrix tests';
+            const name = 'Dhctl Tests';
             const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
             const jobContext = JSON.parse(process.env.JOB_CONTEXT);
             const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
@@ -1432,7 +1664,6 @@ jobs:
     needs:
       - git_info
       - build_fe
-    continue-on-error: true
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1454,8 +1685,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1463,24 +1701,48 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_readonly_registry_step>
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          TESTS_IMAGE_NAME: ${{needs.build_fe.outputs.tests_image_name}}
         run: |
+          if [[ -z ${TESTS_IMAGE_NAME} ]] ; then
+            echo "TESTS_IMAGE_NAME is empty"
+            exit 1
+          fi
 
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/fe/tests:${CI_COMMIT_REF_SLUG}
+          # Base64 decode image name.
+          TESTS_IMAGE_NAME=$(echo ${TESTS_IMAGE_NAME} | base64 -d)
 
-          docker run --pull always -w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} sh -c "go generate tools/register.go && golangci-lint run"
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
+          docker pull ${TESTS_IMAGE_NAME}
+          echo "⚓️ 🏎 [$(date -u)] Run tests..."
+          docker run -w /deckhouse -v ${{github.workspace}}:/deckhouse -e "TERM=xterm-256color" -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} sh -c "go generate tools/register.go && golangci-lint run"
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1519,7 +1781,6 @@ jobs:
     needs:
       - git_info
       - build_fe
-    continue-on-error: true
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1541,8 +1802,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1550,24 +1818,48 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_readonly_registry_step>
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          TESTS_IMAGE_NAME: ${{needs.build_fe.outputs.tests_image_name}}
         run: |
+          if [[ -z ${TESTS_IMAGE_NAME} ]] ; then
+            echo "TESTS_IMAGE_NAME is empty"
+            exit 1
+          fi
 
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/fe/tests:${CI_COMMIT_REF_SLUG}
+          # Base64 decode image name.
+          TESTS_IMAGE_NAME=$(echo ${TESTS_IMAGE_NAME} | base64 -d)
 
-          docker run --pull always -v ${{github.workspace}}:/deckhouse -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} ginkgo -vet=off ./testing/openapi_cases/
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
+          docker pull ${TESTS_IMAGE_NAME}
+          echo "⚓️ 🏎 [$(date -u)] Run tests..."
+          docker run -v ${{github.workspace}}:/deckhouse -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} ginkgo -vet=off ./testing/openapi_cases/
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1607,7 +1899,6 @@ jobs:
       - git_info
       - doc_web_build
       - main_web_build
-    continue-on-error: true
     # <template: web_links_test_template>
     runs-on: [self-hosted, regular]
     steps:
@@ -1628,8 +1919,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -1638,12 +1936,32 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_flant_registry_step>
+      - name: Check flant registry credentials
+        id: check_flant_registry
+        env:
+          HOST: ${{secrets.FLANT_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "::set-output name=has_flant_credentials::true"
+            echo "::set-output name=web_registry_path::${{secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+          else
+            echo "::set-output name=web_registry_path::${GHA_TEST_REGISTRY_PATH}"
+          fi
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials == 'true' }}
         with:
           registry: ${{ secrets.FLANT_REGISTRY_HOST }}
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_flant_registry_step>
 
@@ -1655,6 +1973,8 @@ jobs:
       # </template: werf_install_step>
 
       - name: Prepare site structure
+        env:
+          WEB_REGISTRY_PATH: ${{steps.check_flant_registry.outputs.web_registry_path}}
         run: |
           type werf
           werf version
@@ -1665,7 +1985,7 @@ jobs:
           echo "_TMPDIR=$_TMPDIR" >> ${GITHUB_ENV}
           echo "_TMPDIR=$_TMPDIR"
 
-          export WERF_REPO="${FLANT_REGISTRY_PATH}"
+          export WERF_REPO="${WEB_REGISTRY_PATH}"
           echo -n 'use werf_repo'
           echo $WERF_REPO | tr 'a-z' 'A-Z'
 
@@ -1758,7 +2078,6 @@ jobs:
     needs:
       - git_info
       - build_fe
-    continue-on-error: true
 
     # <template: tests_template>
     runs-on: [self-hosted, regular]
@@ -1780,8 +2099,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1789,24 +2115,48 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
-      # </template: login_readonly_registry_step>
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
       - name: Run tests
         env:
-          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          TESTS_IMAGE_NAME: ${{needs.build_fe.outputs.tests_image_name}}
         run: |
+          if [[ -z ${TESTS_IMAGE_NAME} ]] ; then
+            echo "TESTS_IMAGE_NAME is empty"
+            exit 1
+          fi
 
-          TESTS_IMAGE_URL=${DECKHOUSE_REGISTRY_HOST}/deckhouse/fe/tests:${CI_COMMIT_REF_SLUG}
+          # Base64 decode image name.
+          TESTS_IMAGE_NAME=$(echo ${TESTS_IMAGE_NAME} | base64 -d)
 
-          docker run --pull always -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_URL} go test -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Tests image name: '${TESTS_IMAGE_NAME}'" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ 📥 [$(date -u)] Pull 'tests' image..."
+          docker pull ${TESTS_IMAGE_NAME}
+          echo "⚓️ 🏎 [$(date -u)] Run tests..."
+          docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} go test -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...
     # </template: tests_template>
       # <template: update_comment_on_finish>
       - name: Update comment on finish
@@ -1847,8 +2197,7 @@ jobs:
       - git_info
       - doc_web_build
       - main_web_build
-    continue-on-error: true
-    if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' }}
+    if: ${{ needs.git_info.outputs.ci_commit_ref_name == 'main' && github.repository == 'deckhouse/deckhouse' }}
     runs-on: [self-hosted, regular]
     steps:
 
@@ -1868,12 +2217,32 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_flant_registry_step>
+      - name: Check flant registry credentials
+        id: check_flant_registry
+        env:
+          HOST: ${{secrets.FLANT_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "::set-output name=has_flant_credentials::true"
+            echo "::set-output name=web_registry_path::${{secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+          else
+            echo "::set-output name=web_registry_path::${GHA_TEST_REGISTRY_PATH}"
+          fi
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials == 'true' }}
         with:
           registry: ${{ secrets.FLANT_REGISTRY_HOST }}
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_flant_registry_step>
 
@@ -1892,7 +2261,7 @@ jobs:
           kube-config-base64-data: "${{ secrets.KUBECONFIG_BASE64_PROD }}"
           env: web-production
         env:
-          WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+          WERF_REPO: ${{steps.check_flant_registry.outputs.web_registry_path}}
           WERF_DIR: "docs/documentation"
           WERF_RELEASE: "deckhouse-doc-${{ env.DOC_VERSION }}"
           WERF_NAMESPACE: deckhouse-web-production
@@ -1908,7 +2277,7 @@ jobs:
           kube-config-base64-data: "${{ secrets.KUBECONFIG_BASE64_PROD }}"
           env: web-production
         env:
-          WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+          WERF_REPO: ${{steps.check_flant_registry.outputs.web_registry_path}}
           WERF_DIR: "docs/site"
           WERF_RELEASE: "deckhouse-site"
           WERF_NAMESPACE: deckhouse-web-production
@@ -1955,8 +2324,7 @@ jobs:
     needs:
       - git_info
       - doc_web_build
-    continue-on-error: true
-    if: ${{ needs.git_info.outputs.ci_commit_tag != '' }}
+    if: ${{ needs.git_info.outputs.ci_commit_tag != '' && github.repository == 'deckhouse/deckhouse' }}
     runs-on: [self-hosted, regular]
     steps:
 
@@ -1976,12 +2344,32 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_flant_registry_step>
+      - name: Check flant registry credentials
+        id: check_flant_registry
+        env:
+          HOST: ${{secrets.FLANT_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "::set-output name=has_flant_credentials::true"
+            echo "::set-output name=web_registry_path::${{secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+          else
+            echo "::set-output name=web_registry_path::${GHA_TEST_REGISTRY_PATH}"
+          fi
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials == 'true' }}
         with:
           registry: ${{ secrets.FLANT_REGISTRY_HOST }}
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_flant_registry_step>
 
@@ -2000,7 +2388,7 @@ jobs:
           kube-config-base64-data: "${{ secrets.KUBECONFIG_BASE64_DEV }}"
           env: web-stage
         env:
-          WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+          WERF_REPO: ${{steps.check_flant_registry.outputs.web_registry_path}}
           WERF_DIR: "docs/documentation"
           WERF_RELEASE: "deckhouse-doc-${{ env.DOC_VERSION }}"
           WERF_NAMESPACE: deckhouse-web-stage
@@ -2016,7 +2404,7 @@ jobs:
           kube-config-base64-data: "${{ secrets.KUBECONFIG_BASE64_PROD }}"
           env: web-production
         env:
-          WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+          WERF_REPO: ${{steps.check_flant_registry.outputs.web_registry_path}}
           WERF_DIR: "docs/documentation"
           WERF_RELEASE: "deckhouse-doc-${{ env.DOC_VERSION }}"
           WERF_NAMESPACE: deckhouse-web-production
@@ -2079,7 +2467,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"build_ce":"Build CE","build_ee":"Build EE","build_fe":"Build FE","deploy_latest_web":"Deploy latest doc and site","deploy_tagged_doc":"Deploy tagged documentation","dhctl_tests":"Matrix tests","doc_web_build":"Doc web build","go_generate":"Go Generate","golangci_lint":"GolangCI Lint","main_web_build":"Main web build","matrix_tests":"Matrix tests","openapi_test_cases":"OpenAPI Test Cases","tests":"Tests","validators":"Validators","web_links_test":"Web links test"}
+        {"build_ce":"Build CE","build_ee":"Build EE","build_fe":"Build FE","deploy_latest_web":"Deploy latest doc and site","deploy_tagged_doc":"Deploy tagged documentation","dhctl_tests":"Dhctl Tests","doc_web_build":"Doc web build","go_generate":"Go Generate","golangci_lint":"GolangCI Lint","main_web_build":"Main web build","matrix_tests":"Matrix tests","openapi_test_cases":"OpenAPI Test Cases","tests":"Tests","validators":"Validators","web_links_test":"Web links test"}
     steps:
 
       # <template: checkout_step>

--- a/.github/workflows/changelog-by-milestone.yml
+++ b/.github/workflows/changelog-by-milestone.yml
@@ -27,14 +27,14 @@ jobs:
             const number = context.issue.number
 
             if (!context.payload.issue.pull_request) {
-              core.notice(`Issue #${number} is not a pull request`)
+              core.notice(`Issue #${number} is not a pull request. Skip changelog regeneration.`)
               return "skip"
             }
 
             if (context.payload.action !== 'milestoned' && context.payload.action !== 'demilestoned') {
               // we support only milestoned because of race condition when milestone is changed
               // core.notice(`The PR #${number} payload action is not "milestoned" or "demilestoned", it is "${context.eventName}"`)
-              core.notice(`The PR #${number} payload action is not "milestoned", it is "${context.payload.action}"`)
+              core.notice(`The PR #${number} payload action is not "milestoned", it is "${context.payload.action}". Skip changelog regeneration.`)
               return "skip"
             }
 
@@ -45,7 +45,7 @@ jobs:
             });
 
             if (!pr) {
-              core.notice(`Issue #${number} is not a pull request`)
+              core.notice(`Issue #${number} is not a pull request. Skip changelog regeneration.`)
               return "skip"
             }
 
@@ -56,16 +56,16 @@ jobs:
             }
 
             if (pr.state !== 'closed') {
-              core.notice(`The PR #${number} is open (not closed)`)
+              core.notice(`The PR #${number} is open (not closed). Skip changelog regeneration.`)
               return "skip"
             }
 
             if (!pr.merged) {
-              core.notice(`The PR #${number} is not merged`)
+              core.notice(`The PR #${number} is not merged. Skip changelog regeneration.`)
               return "skip"
             }
 
-            core.notice('OK to re-generate changelogs')
+            core.notice('OK to regenerate changelogs')
             return "ok"
     outputs:
       ok: ${{ steps.pr.outputs.result }}

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -35,8 +35,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: alpha
 
@@ -219,8 +219,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -229,8 +236,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -239,14 +253,42 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
       # </template: login_rw_registry_step>
+
+      - name: Check push enabled
+        id: check_push
+        env:
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
+          REPO: ${{github.repository}}
+        run: |
+          if [[ ${REPO} == "deckhouse/deckhouse" ]]; then
+            echo "::set-output name=enable::true"
+          fi
+          if [[ ${SKIP_PUSH_FOR_DEPLOY} != "true" ]]; then
+            echo "::set-output name=enable::true"
+          fi
 
 
 
@@ -257,8 +299,38 @@ jobs:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: CE
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
+            DST=$3
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_DEPLOY=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
 
           # Some precautions.
           shouldExit1=
@@ -281,94 +353,78 @@ jobs:
           echo "Publish CE edition".
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=alpha
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Source images from rw registry or from registry.
+          echo "⚓️ 💫 [$(date -u)] Start publishing Deckhouse images for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          #   3. Prepare image names: republish CI_COMMIT_TAG tag images in dev-registry
+          #   to RELEASE_CHANNEL tag image in prod registry.
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          PROD_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
+          DEV_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
+
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          PROD_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
+          DEV_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+          PROD_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+
+          #   4. Publish to dev registry if DECKHOUSE_REGISTRY_HOST is set (run in the main repo).
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            SOURCE_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-          else
-            SOURCE_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev' ${SOURCE_IMAGE} ${DEV_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${DEV_INSTALL_IMAGE}
           fi
 
-          docker image pull ${SOURCE_IMAGE}
-          docker image pull ${SOURCE_INSTALL_IMAGE}
-          docker image pull ${SOURCE_RELEASE_VERSION_IMAGE}
+          #   5. Publish prod images to rw registry.
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev' ${SOURCE_IMAGE} ${PROD_IMAGE}
 
-          #   4. Publish dev images to dev registry
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            DEV_DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
-            DEV_DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${PROD_INSTALL_IMAGE}
 
-            echo "Push 'dev' image ${SOURCE_IMAGE} to ${DEV_DESTINATION_IMAGE}"
-            docker image tag ${SOURCE_IMAGE} ${DEV_DESTINATION_IMAGE}
-            docker image push ${DEV_DESTINATION_IMAGE}
+          echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'release-channel-version' ${SOURCE_RELEASE_VERSION_IMAGE} ${PROD_RELEASE_VERSION_IMAGE}
 
-            echo "Delete local 'dev' image ${DEV_DESTINATION_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_IMAGE} || true;
-
-            echo "Push 'dev install' ${SOURCE_INSTALL_IMAGE} to image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image tag ${SOURCE_INSTALL_IMAGE} ${DEV_DESTINATION_INSTALL_IMAGE}
-            docker image push ${DEV_DESTINATION_INSTALL_IMAGE}
-
-            echo "Delete local 'dev install' image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_INSTALL_IMAGE} || true;
-          fi
-
-          #   5. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          fi
-
-          echo "Push 'prod' image ${SOURCE_IMAGE} to ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image tag ${SOURCE_IMAGE} ${DECKHOUSE_DESTINATION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE}
-          echo "Delete local 'prod' image ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-
-          echo "Push 'prod install' image ${SOURCE_INSTALL_IMAGE} to ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image tag ${SOURCE_INSTALL_IMAGE} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          echo "Delete local 'prod install' image ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-
-          echo "Push 'release version'  ${SOURCE_RELEASE_VERSION_IMAGE} to ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image tag ${SOURCE_RELEASE_VERSION_IMAGE} ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Delete local source image ${SOURCE_IMAGE}"
+          echo "⚓️  [$(date -u)] Remove local source images."
+          echo "  Delete local 'dev' source image ${SOURCE_IMAGE}"
           docker image rmi ${SOURCE_IMAGE} || true
-          echo "Delete local 'install' source image ${SOURCE_INSTALL_IMAGE}"
+
+          echo "  Delete local 'dev/install' source image ${SOURCE_INSTALL_IMAGE}"
           docker image rmi ${SOURCE_INSTALL_IMAGE} || true
-          echo "Delete local 'release version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
+
+          echo "  Delete local 'release-channel-version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
           docker image rmi ${SOURCE_RELEASE_VERSION_IMAGE} || true
 
+          #   6. Report.
           echo "Deckhouse images published:"
           echo "  Source: ${SOURCE_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_IMAGE}"
+          echo "  Prod: ${PROD_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_IMAGE}"
+          fi
           echo "Install images published:"
           echo "  Source: ${SOURCE_INSTALL_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_INSTALL_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_INSTALL_IMAGE}"
+          fi
+          echo "Release version image:"
+          echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
         if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
         env:
@@ -376,8 +432,38 @@ jobs:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: EE
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
+            DST=$3
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_DEPLOY=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
 
           # Some precautions.
           shouldExit1=
@@ -400,94 +486,78 @@ jobs:
           echo "Publish EE edition".
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=alpha
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Source images from rw registry or from registry.
+          echo "⚓️ 💫 [$(date -u)] Start publishing Deckhouse images for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          #   3. Prepare image names: republish CI_COMMIT_TAG tag images in dev-registry
+          #   to RELEASE_CHANNEL tag image in prod registry.
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          PROD_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
+          DEV_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
+
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          PROD_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
+          DEV_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+          PROD_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+
+          #   4. Publish to dev registry if DECKHOUSE_REGISTRY_HOST is set (run in the main repo).
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            SOURCE_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-          else
-            SOURCE_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev' ${SOURCE_IMAGE} ${DEV_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${DEV_INSTALL_IMAGE}
           fi
 
-          docker image pull ${SOURCE_IMAGE}
-          docker image pull ${SOURCE_INSTALL_IMAGE}
-          docker image pull ${SOURCE_RELEASE_VERSION_IMAGE}
+          #   5. Publish prod images to rw registry.
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev' ${SOURCE_IMAGE} ${PROD_IMAGE}
 
-          #   4. Publish dev images to dev registry
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            DEV_DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
-            DEV_DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${PROD_INSTALL_IMAGE}
 
-            echo "Push 'dev' image ${SOURCE_IMAGE} to ${DEV_DESTINATION_IMAGE}"
-            docker image tag ${SOURCE_IMAGE} ${DEV_DESTINATION_IMAGE}
-            docker image push ${DEV_DESTINATION_IMAGE}
+          echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'release-channel-version' ${SOURCE_RELEASE_VERSION_IMAGE} ${PROD_RELEASE_VERSION_IMAGE}
 
-            echo "Delete local 'dev' image ${DEV_DESTINATION_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_IMAGE} || true;
-
-            echo "Push 'dev install' ${SOURCE_INSTALL_IMAGE} to image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image tag ${SOURCE_INSTALL_IMAGE} ${DEV_DESTINATION_INSTALL_IMAGE}
-            docker image push ${DEV_DESTINATION_INSTALL_IMAGE}
-
-            echo "Delete local 'dev install' image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_INSTALL_IMAGE} || true;
-          fi
-
-          #   5. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          fi
-
-          echo "Push 'prod' image ${SOURCE_IMAGE} to ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image tag ${SOURCE_IMAGE} ${DECKHOUSE_DESTINATION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE}
-          echo "Delete local 'prod' image ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-
-          echo "Push 'prod install' image ${SOURCE_INSTALL_IMAGE} to ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image tag ${SOURCE_INSTALL_IMAGE} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          echo "Delete local 'prod install' image ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-
-          echo "Push 'release version'  ${SOURCE_RELEASE_VERSION_IMAGE} to ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image tag ${SOURCE_RELEASE_VERSION_IMAGE} ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Delete local source image ${SOURCE_IMAGE}"
+          echo "⚓️  [$(date -u)] Remove local source images."
+          echo "  Delete local 'dev' source image ${SOURCE_IMAGE}"
           docker image rmi ${SOURCE_IMAGE} || true
-          echo "Delete local 'install' source image ${SOURCE_INSTALL_IMAGE}"
+
+          echo "  Delete local 'dev/install' source image ${SOURCE_INSTALL_IMAGE}"
           docker image rmi ${SOURCE_INSTALL_IMAGE} || true
-          echo "Delete local 'release version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
+
+          echo "  Delete local 'release-channel-version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
           docker image rmi ${SOURCE_RELEASE_VERSION_IMAGE} || true
 
+          #   6. Report.
           echo "Deckhouse images published:"
           echo "  Source: ${SOURCE_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_IMAGE}"
+          echo "  Prod: ${PROD_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_IMAGE}"
+          fi
           echo "Install images published:"
           echo "  Source: ${SOURCE_INSTALL_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_INSTALL_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_INSTALL_IMAGE}"
+          fi
+          echo "Release version image:"
+          echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
         if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
         env:
@@ -495,8 +565,38 @@ jobs:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: FE
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
+            DST=$3
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_DEPLOY=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
 
           # Some precautions.
           shouldExit1=
@@ -519,94 +619,78 @@ jobs:
           echo "Publish FE edition".
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=alpha
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Source images from rw registry or from registry.
+          echo "⚓️ 💫 [$(date -u)] Start publishing Deckhouse images for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          #   3. Prepare image names: republish CI_COMMIT_TAG tag images in dev-registry
+          #   to RELEASE_CHANNEL tag image in prod registry.
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          PROD_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
+          DEV_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
+
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          PROD_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
+          DEV_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+          PROD_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+
+          #   4. Publish to dev registry if DECKHOUSE_REGISTRY_HOST is set (run in the main repo).
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            SOURCE_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-          else
-            SOURCE_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev' ${SOURCE_IMAGE} ${DEV_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${DEV_INSTALL_IMAGE}
           fi
 
-          docker image pull ${SOURCE_IMAGE}
-          docker image pull ${SOURCE_INSTALL_IMAGE}
-          docker image pull ${SOURCE_RELEASE_VERSION_IMAGE}
+          #   5. Publish prod images to rw registry.
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev' ${SOURCE_IMAGE} ${PROD_IMAGE}
 
-          #   4. Publish dev images to dev registry
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            DEV_DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
-            DEV_DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${PROD_INSTALL_IMAGE}
 
-            echo "Push 'dev' image ${SOURCE_IMAGE} to ${DEV_DESTINATION_IMAGE}"
-            docker image tag ${SOURCE_IMAGE} ${DEV_DESTINATION_IMAGE}
-            docker image push ${DEV_DESTINATION_IMAGE}
+          echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'release-channel-version' ${SOURCE_RELEASE_VERSION_IMAGE} ${PROD_RELEASE_VERSION_IMAGE}
 
-            echo "Delete local 'dev' image ${DEV_DESTINATION_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_IMAGE} || true;
-
-            echo "Push 'dev install' ${SOURCE_INSTALL_IMAGE} to image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image tag ${SOURCE_INSTALL_IMAGE} ${DEV_DESTINATION_INSTALL_IMAGE}
-            docker image push ${DEV_DESTINATION_INSTALL_IMAGE}
-
-            echo "Delete local 'dev install' image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_INSTALL_IMAGE} || true;
-          fi
-
-          #   5. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          fi
-
-          echo "Push 'prod' image ${SOURCE_IMAGE} to ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image tag ${SOURCE_IMAGE} ${DECKHOUSE_DESTINATION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE}
-          echo "Delete local 'prod' image ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-
-          echo "Push 'prod install' image ${SOURCE_INSTALL_IMAGE} to ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image tag ${SOURCE_INSTALL_IMAGE} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          echo "Delete local 'prod install' image ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-
-          echo "Push 'release version'  ${SOURCE_RELEASE_VERSION_IMAGE} to ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image tag ${SOURCE_RELEASE_VERSION_IMAGE} ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Delete local source image ${SOURCE_IMAGE}"
+          echo "⚓️  [$(date -u)] Remove local source images."
+          echo "  Delete local 'dev' source image ${SOURCE_IMAGE}"
           docker image rmi ${SOURCE_IMAGE} || true
-          echo "Delete local 'install' source image ${SOURCE_INSTALL_IMAGE}"
+
+          echo "  Delete local 'dev/install' source image ${SOURCE_INSTALL_IMAGE}"
           docker image rmi ${SOURCE_INSTALL_IMAGE} || true
-          echo "Delete local 'release version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
+
+          echo "  Delete local 'release-channel-version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
           docker image rmi ${SOURCE_RELEASE_VERSION_IMAGE} || true
 
+          #   6. Report.
           echo "Deckhouse images published:"
           echo "  Source: ${SOURCE_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_IMAGE}"
+          echo "  Prod: ${PROD_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_IMAGE}"
+          fi
           echo "Install images published:"
           echo "  Source: ${SOURCE_INSTALL_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_INSTALL_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_INSTALL_IMAGE}"
+          fi
+          echo "Release version image:"
+          echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
 
       - name: Update release branch
         if: ${{ success() }}

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -35,8 +35,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: beta
 
@@ -219,8 +219,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -229,8 +236,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -239,14 +253,42 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
       # </template: login_rw_registry_step>
+
+      - name: Check push enabled
+        id: check_push
+        env:
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
+          REPO: ${{github.repository}}
+        run: |
+          if [[ ${REPO} == "deckhouse/deckhouse" ]]; then
+            echo "::set-output name=enable::true"
+          fi
+          if [[ ${SKIP_PUSH_FOR_DEPLOY} != "true" ]]; then
+            echo "::set-output name=enable::true"
+          fi
 
 
 
@@ -257,8 +299,38 @@ jobs:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: CE
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
+            DST=$3
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_DEPLOY=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
 
           # Some precautions.
           shouldExit1=
@@ -281,94 +353,78 @@ jobs:
           echo "Publish CE edition".
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=beta
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Source images from rw registry or from registry.
+          echo "⚓️ 💫 [$(date -u)] Start publishing Deckhouse images for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          #   3. Prepare image names: republish CI_COMMIT_TAG tag images in dev-registry
+          #   to RELEASE_CHANNEL tag image in prod registry.
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          PROD_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
+          DEV_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
+
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          PROD_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
+          DEV_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+          PROD_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+
+          #   4. Publish to dev registry if DECKHOUSE_REGISTRY_HOST is set (run in the main repo).
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            SOURCE_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-          else
-            SOURCE_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev' ${SOURCE_IMAGE} ${DEV_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${DEV_INSTALL_IMAGE}
           fi
 
-          docker image pull ${SOURCE_IMAGE}
-          docker image pull ${SOURCE_INSTALL_IMAGE}
-          docker image pull ${SOURCE_RELEASE_VERSION_IMAGE}
+          #   5. Publish prod images to rw registry.
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev' ${SOURCE_IMAGE} ${PROD_IMAGE}
 
-          #   4. Publish dev images to dev registry
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            DEV_DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
-            DEV_DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${PROD_INSTALL_IMAGE}
 
-            echo "Push 'dev' image ${SOURCE_IMAGE} to ${DEV_DESTINATION_IMAGE}"
-            docker image tag ${SOURCE_IMAGE} ${DEV_DESTINATION_IMAGE}
-            docker image push ${DEV_DESTINATION_IMAGE}
+          echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'release-channel-version' ${SOURCE_RELEASE_VERSION_IMAGE} ${PROD_RELEASE_VERSION_IMAGE}
 
-            echo "Delete local 'dev' image ${DEV_DESTINATION_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_IMAGE} || true;
-
-            echo "Push 'dev install' ${SOURCE_INSTALL_IMAGE} to image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image tag ${SOURCE_INSTALL_IMAGE} ${DEV_DESTINATION_INSTALL_IMAGE}
-            docker image push ${DEV_DESTINATION_INSTALL_IMAGE}
-
-            echo "Delete local 'dev install' image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_INSTALL_IMAGE} || true;
-          fi
-
-          #   5. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          fi
-
-          echo "Push 'prod' image ${SOURCE_IMAGE} to ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image tag ${SOURCE_IMAGE} ${DECKHOUSE_DESTINATION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE}
-          echo "Delete local 'prod' image ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-
-          echo "Push 'prod install' image ${SOURCE_INSTALL_IMAGE} to ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image tag ${SOURCE_INSTALL_IMAGE} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          echo "Delete local 'prod install' image ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-
-          echo "Push 'release version'  ${SOURCE_RELEASE_VERSION_IMAGE} to ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image tag ${SOURCE_RELEASE_VERSION_IMAGE} ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Delete local source image ${SOURCE_IMAGE}"
+          echo "⚓️  [$(date -u)] Remove local source images."
+          echo "  Delete local 'dev' source image ${SOURCE_IMAGE}"
           docker image rmi ${SOURCE_IMAGE} || true
-          echo "Delete local 'install' source image ${SOURCE_INSTALL_IMAGE}"
+
+          echo "  Delete local 'dev/install' source image ${SOURCE_INSTALL_IMAGE}"
           docker image rmi ${SOURCE_INSTALL_IMAGE} || true
-          echo "Delete local 'release version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
+
+          echo "  Delete local 'release-channel-version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
           docker image rmi ${SOURCE_RELEASE_VERSION_IMAGE} || true
 
+          #   6. Report.
           echo "Deckhouse images published:"
           echo "  Source: ${SOURCE_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_IMAGE}"
+          echo "  Prod: ${PROD_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_IMAGE}"
+          fi
           echo "Install images published:"
           echo "  Source: ${SOURCE_INSTALL_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_INSTALL_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_INSTALL_IMAGE}"
+          fi
+          echo "Release version image:"
+          echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
         if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
         env:
@@ -376,8 +432,38 @@ jobs:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: EE
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
+            DST=$3
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_DEPLOY=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
 
           # Some precautions.
           shouldExit1=
@@ -400,94 +486,78 @@ jobs:
           echo "Publish EE edition".
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=beta
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Source images from rw registry or from registry.
+          echo "⚓️ 💫 [$(date -u)] Start publishing Deckhouse images for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          #   3. Prepare image names: republish CI_COMMIT_TAG tag images in dev-registry
+          #   to RELEASE_CHANNEL tag image in prod registry.
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          PROD_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
+          DEV_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
+
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          PROD_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
+          DEV_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+          PROD_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+
+          #   4. Publish to dev registry if DECKHOUSE_REGISTRY_HOST is set (run in the main repo).
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            SOURCE_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-          else
-            SOURCE_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev' ${SOURCE_IMAGE} ${DEV_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${DEV_INSTALL_IMAGE}
           fi
 
-          docker image pull ${SOURCE_IMAGE}
-          docker image pull ${SOURCE_INSTALL_IMAGE}
-          docker image pull ${SOURCE_RELEASE_VERSION_IMAGE}
+          #   5. Publish prod images to rw registry.
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev' ${SOURCE_IMAGE} ${PROD_IMAGE}
 
-          #   4. Publish dev images to dev registry
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            DEV_DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
-            DEV_DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${PROD_INSTALL_IMAGE}
 
-            echo "Push 'dev' image ${SOURCE_IMAGE} to ${DEV_DESTINATION_IMAGE}"
-            docker image tag ${SOURCE_IMAGE} ${DEV_DESTINATION_IMAGE}
-            docker image push ${DEV_DESTINATION_IMAGE}
+          echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'release-channel-version' ${SOURCE_RELEASE_VERSION_IMAGE} ${PROD_RELEASE_VERSION_IMAGE}
 
-            echo "Delete local 'dev' image ${DEV_DESTINATION_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_IMAGE} || true;
-
-            echo "Push 'dev install' ${SOURCE_INSTALL_IMAGE} to image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image tag ${SOURCE_INSTALL_IMAGE} ${DEV_DESTINATION_INSTALL_IMAGE}
-            docker image push ${DEV_DESTINATION_INSTALL_IMAGE}
-
-            echo "Delete local 'dev install' image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_INSTALL_IMAGE} || true;
-          fi
-
-          #   5. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          fi
-
-          echo "Push 'prod' image ${SOURCE_IMAGE} to ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image tag ${SOURCE_IMAGE} ${DECKHOUSE_DESTINATION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE}
-          echo "Delete local 'prod' image ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-
-          echo "Push 'prod install' image ${SOURCE_INSTALL_IMAGE} to ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image tag ${SOURCE_INSTALL_IMAGE} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          echo "Delete local 'prod install' image ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-
-          echo "Push 'release version'  ${SOURCE_RELEASE_VERSION_IMAGE} to ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image tag ${SOURCE_RELEASE_VERSION_IMAGE} ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Delete local source image ${SOURCE_IMAGE}"
+          echo "⚓️  [$(date -u)] Remove local source images."
+          echo "  Delete local 'dev' source image ${SOURCE_IMAGE}"
           docker image rmi ${SOURCE_IMAGE} || true
-          echo "Delete local 'install' source image ${SOURCE_INSTALL_IMAGE}"
+
+          echo "  Delete local 'dev/install' source image ${SOURCE_INSTALL_IMAGE}"
           docker image rmi ${SOURCE_INSTALL_IMAGE} || true
-          echo "Delete local 'release version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
+
+          echo "  Delete local 'release-channel-version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
           docker image rmi ${SOURCE_RELEASE_VERSION_IMAGE} || true
 
+          #   6. Report.
           echo "Deckhouse images published:"
           echo "  Source: ${SOURCE_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_IMAGE}"
+          echo "  Prod: ${PROD_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_IMAGE}"
+          fi
           echo "Install images published:"
           echo "  Source: ${SOURCE_INSTALL_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_INSTALL_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_INSTALL_IMAGE}"
+          fi
+          echo "Release version image:"
+          echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
         if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
         env:
@@ -495,8 +565,38 @@ jobs:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: FE
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
+            DST=$3
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_DEPLOY=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
 
           # Some precautions.
           shouldExit1=
@@ -519,94 +619,78 @@ jobs:
           echo "Publish FE edition".
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=beta
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Source images from rw registry or from registry.
+          echo "⚓️ 💫 [$(date -u)] Start publishing Deckhouse images for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          #   3. Prepare image names: republish CI_COMMIT_TAG tag images in dev-registry
+          #   to RELEASE_CHANNEL tag image in prod registry.
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          PROD_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
+          DEV_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
+
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          PROD_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
+          DEV_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+          PROD_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+
+          #   4. Publish to dev registry if DECKHOUSE_REGISTRY_HOST is set (run in the main repo).
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            SOURCE_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-          else
-            SOURCE_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev' ${SOURCE_IMAGE} ${DEV_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${DEV_INSTALL_IMAGE}
           fi
 
-          docker image pull ${SOURCE_IMAGE}
-          docker image pull ${SOURCE_INSTALL_IMAGE}
-          docker image pull ${SOURCE_RELEASE_VERSION_IMAGE}
+          #   5. Publish prod images to rw registry.
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev' ${SOURCE_IMAGE} ${PROD_IMAGE}
 
-          #   4. Publish dev images to dev registry
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            DEV_DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
-            DEV_DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${PROD_INSTALL_IMAGE}
 
-            echo "Push 'dev' image ${SOURCE_IMAGE} to ${DEV_DESTINATION_IMAGE}"
-            docker image tag ${SOURCE_IMAGE} ${DEV_DESTINATION_IMAGE}
-            docker image push ${DEV_DESTINATION_IMAGE}
+          echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'release-channel-version' ${SOURCE_RELEASE_VERSION_IMAGE} ${PROD_RELEASE_VERSION_IMAGE}
 
-            echo "Delete local 'dev' image ${DEV_DESTINATION_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_IMAGE} || true;
-
-            echo "Push 'dev install' ${SOURCE_INSTALL_IMAGE} to image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image tag ${SOURCE_INSTALL_IMAGE} ${DEV_DESTINATION_INSTALL_IMAGE}
-            docker image push ${DEV_DESTINATION_INSTALL_IMAGE}
-
-            echo "Delete local 'dev install' image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_INSTALL_IMAGE} || true;
-          fi
-
-          #   5. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          fi
-
-          echo "Push 'prod' image ${SOURCE_IMAGE} to ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image tag ${SOURCE_IMAGE} ${DECKHOUSE_DESTINATION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE}
-          echo "Delete local 'prod' image ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-
-          echo "Push 'prod install' image ${SOURCE_INSTALL_IMAGE} to ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image tag ${SOURCE_INSTALL_IMAGE} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          echo "Delete local 'prod install' image ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-
-          echo "Push 'release version'  ${SOURCE_RELEASE_VERSION_IMAGE} to ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image tag ${SOURCE_RELEASE_VERSION_IMAGE} ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Delete local source image ${SOURCE_IMAGE}"
+          echo "⚓️  [$(date -u)] Remove local source images."
+          echo "  Delete local 'dev' source image ${SOURCE_IMAGE}"
           docker image rmi ${SOURCE_IMAGE} || true
-          echo "Delete local 'install' source image ${SOURCE_INSTALL_IMAGE}"
+
+          echo "  Delete local 'dev/install' source image ${SOURCE_INSTALL_IMAGE}"
           docker image rmi ${SOURCE_INSTALL_IMAGE} || true
-          echo "Delete local 'release version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
+
+          echo "  Delete local 'release-channel-version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
           docker image rmi ${SOURCE_RELEASE_VERSION_IMAGE} || true
 
+          #   6. Report.
           echo "Deckhouse images published:"
           echo "  Source: ${SOURCE_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_IMAGE}"
+          echo "  Prod: ${PROD_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_IMAGE}"
+          fi
           echo "Install images published:"
           echo "  Source: ${SOURCE_INSTALL_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_INSTALL_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_INSTALL_IMAGE}"
+          fi
+          echo "Release version image:"
+          echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
 
       - name: Update release branch
         if: ${{ success() }}

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -35,8 +35,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: early-access
 
@@ -219,8 +219,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -229,8 +236,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -239,14 +253,42 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
       # </template: login_rw_registry_step>
+
+      - name: Check push enabled
+        id: check_push
+        env:
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
+          REPO: ${{github.repository}}
+        run: |
+          if [[ ${REPO} == "deckhouse/deckhouse" ]]; then
+            echo "::set-output name=enable::true"
+          fi
+          if [[ ${SKIP_PUSH_FOR_DEPLOY} != "true" ]]; then
+            echo "::set-output name=enable::true"
+          fi
 
 
 
@@ -257,8 +299,38 @@ jobs:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: CE
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
+            DST=$3
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_DEPLOY=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
 
           # Some precautions.
           shouldExit1=
@@ -281,94 +353,78 @@ jobs:
           echo "Publish CE edition".
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=early-access
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Source images from rw registry or from registry.
+          echo "⚓️ 💫 [$(date -u)] Start publishing Deckhouse images for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          #   3. Prepare image names: republish CI_COMMIT_TAG tag images in dev-registry
+          #   to RELEASE_CHANNEL tag image in prod registry.
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          PROD_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
+          DEV_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
+
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          PROD_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
+          DEV_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+          PROD_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+
+          #   4. Publish to dev registry if DECKHOUSE_REGISTRY_HOST is set (run in the main repo).
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            SOURCE_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-          else
-            SOURCE_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev' ${SOURCE_IMAGE} ${DEV_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${DEV_INSTALL_IMAGE}
           fi
 
-          docker image pull ${SOURCE_IMAGE}
-          docker image pull ${SOURCE_INSTALL_IMAGE}
-          docker image pull ${SOURCE_RELEASE_VERSION_IMAGE}
+          #   5. Publish prod images to rw registry.
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev' ${SOURCE_IMAGE} ${PROD_IMAGE}
 
-          #   4. Publish dev images to dev registry
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            DEV_DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
-            DEV_DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${PROD_INSTALL_IMAGE}
 
-            echo "Push 'dev' image ${SOURCE_IMAGE} to ${DEV_DESTINATION_IMAGE}"
-            docker image tag ${SOURCE_IMAGE} ${DEV_DESTINATION_IMAGE}
-            docker image push ${DEV_DESTINATION_IMAGE}
+          echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'release-channel-version' ${SOURCE_RELEASE_VERSION_IMAGE} ${PROD_RELEASE_VERSION_IMAGE}
 
-            echo "Delete local 'dev' image ${DEV_DESTINATION_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_IMAGE} || true;
-
-            echo "Push 'dev install' ${SOURCE_INSTALL_IMAGE} to image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image tag ${SOURCE_INSTALL_IMAGE} ${DEV_DESTINATION_INSTALL_IMAGE}
-            docker image push ${DEV_DESTINATION_INSTALL_IMAGE}
-
-            echo "Delete local 'dev install' image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_INSTALL_IMAGE} || true;
-          fi
-
-          #   5. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          fi
-
-          echo "Push 'prod' image ${SOURCE_IMAGE} to ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image tag ${SOURCE_IMAGE} ${DECKHOUSE_DESTINATION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE}
-          echo "Delete local 'prod' image ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-
-          echo "Push 'prod install' image ${SOURCE_INSTALL_IMAGE} to ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image tag ${SOURCE_INSTALL_IMAGE} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          echo "Delete local 'prod install' image ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-
-          echo "Push 'release version'  ${SOURCE_RELEASE_VERSION_IMAGE} to ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image tag ${SOURCE_RELEASE_VERSION_IMAGE} ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Delete local source image ${SOURCE_IMAGE}"
+          echo "⚓️  [$(date -u)] Remove local source images."
+          echo "  Delete local 'dev' source image ${SOURCE_IMAGE}"
           docker image rmi ${SOURCE_IMAGE} || true
-          echo "Delete local 'install' source image ${SOURCE_INSTALL_IMAGE}"
+
+          echo "  Delete local 'dev/install' source image ${SOURCE_INSTALL_IMAGE}"
           docker image rmi ${SOURCE_INSTALL_IMAGE} || true
-          echo "Delete local 'release version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
+
+          echo "  Delete local 'release-channel-version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
           docker image rmi ${SOURCE_RELEASE_VERSION_IMAGE} || true
 
+          #   6. Report.
           echo "Deckhouse images published:"
           echo "  Source: ${SOURCE_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_IMAGE}"
+          echo "  Prod: ${PROD_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_IMAGE}"
+          fi
           echo "Install images published:"
           echo "  Source: ${SOURCE_INSTALL_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_INSTALL_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_INSTALL_IMAGE}"
+          fi
+          echo "Release version image:"
+          echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
         if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
         env:
@@ -376,8 +432,38 @@ jobs:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: EE
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
+            DST=$3
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_DEPLOY=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
 
           # Some precautions.
           shouldExit1=
@@ -400,94 +486,78 @@ jobs:
           echo "Publish EE edition".
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=early-access
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Source images from rw registry or from registry.
+          echo "⚓️ 💫 [$(date -u)] Start publishing Deckhouse images for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          #   3. Prepare image names: republish CI_COMMIT_TAG tag images in dev-registry
+          #   to RELEASE_CHANNEL tag image in prod registry.
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          PROD_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
+          DEV_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
+
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          PROD_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
+          DEV_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+          PROD_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+
+          #   4. Publish to dev registry if DECKHOUSE_REGISTRY_HOST is set (run in the main repo).
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            SOURCE_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-          else
-            SOURCE_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev' ${SOURCE_IMAGE} ${DEV_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${DEV_INSTALL_IMAGE}
           fi
 
-          docker image pull ${SOURCE_IMAGE}
-          docker image pull ${SOURCE_INSTALL_IMAGE}
-          docker image pull ${SOURCE_RELEASE_VERSION_IMAGE}
+          #   5. Publish prod images to rw registry.
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev' ${SOURCE_IMAGE} ${PROD_IMAGE}
 
-          #   4. Publish dev images to dev registry
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            DEV_DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
-            DEV_DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${PROD_INSTALL_IMAGE}
 
-            echo "Push 'dev' image ${SOURCE_IMAGE} to ${DEV_DESTINATION_IMAGE}"
-            docker image tag ${SOURCE_IMAGE} ${DEV_DESTINATION_IMAGE}
-            docker image push ${DEV_DESTINATION_IMAGE}
+          echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'release-channel-version' ${SOURCE_RELEASE_VERSION_IMAGE} ${PROD_RELEASE_VERSION_IMAGE}
 
-            echo "Delete local 'dev' image ${DEV_DESTINATION_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_IMAGE} || true;
-
-            echo "Push 'dev install' ${SOURCE_INSTALL_IMAGE} to image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image tag ${SOURCE_INSTALL_IMAGE} ${DEV_DESTINATION_INSTALL_IMAGE}
-            docker image push ${DEV_DESTINATION_INSTALL_IMAGE}
-
-            echo "Delete local 'dev install' image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_INSTALL_IMAGE} || true;
-          fi
-
-          #   5. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          fi
-
-          echo "Push 'prod' image ${SOURCE_IMAGE} to ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image tag ${SOURCE_IMAGE} ${DECKHOUSE_DESTINATION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE}
-          echo "Delete local 'prod' image ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-
-          echo "Push 'prod install' image ${SOURCE_INSTALL_IMAGE} to ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image tag ${SOURCE_INSTALL_IMAGE} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          echo "Delete local 'prod install' image ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-
-          echo "Push 'release version'  ${SOURCE_RELEASE_VERSION_IMAGE} to ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image tag ${SOURCE_RELEASE_VERSION_IMAGE} ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Delete local source image ${SOURCE_IMAGE}"
+          echo "⚓️  [$(date -u)] Remove local source images."
+          echo "  Delete local 'dev' source image ${SOURCE_IMAGE}"
           docker image rmi ${SOURCE_IMAGE} || true
-          echo "Delete local 'install' source image ${SOURCE_INSTALL_IMAGE}"
+
+          echo "  Delete local 'dev/install' source image ${SOURCE_INSTALL_IMAGE}"
           docker image rmi ${SOURCE_INSTALL_IMAGE} || true
-          echo "Delete local 'release version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
+
+          echo "  Delete local 'release-channel-version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
           docker image rmi ${SOURCE_RELEASE_VERSION_IMAGE} || true
 
+          #   6. Report.
           echo "Deckhouse images published:"
           echo "  Source: ${SOURCE_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_IMAGE}"
+          echo "  Prod: ${PROD_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_IMAGE}"
+          fi
           echo "Install images published:"
           echo "  Source: ${SOURCE_INSTALL_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_INSTALL_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_INSTALL_IMAGE}"
+          fi
+          echo "Release version image:"
+          echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
         if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
         env:
@@ -495,8 +565,38 @@ jobs:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: FE
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
+            DST=$3
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_DEPLOY=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
 
           # Some precautions.
           shouldExit1=
@@ -519,94 +619,78 @@ jobs:
           echo "Publish FE edition".
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=early-access
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Source images from rw registry or from registry.
+          echo "⚓️ 💫 [$(date -u)] Start publishing Deckhouse images for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          #   3. Prepare image names: republish CI_COMMIT_TAG tag images in dev-registry
+          #   to RELEASE_CHANNEL tag image in prod registry.
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          PROD_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
+          DEV_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
+
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          PROD_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
+          DEV_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+          PROD_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+
+          #   4. Publish to dev registry if DECKHOUSE_REGISTRY_HOST is set (run in the main repo).
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            SOURCE_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-          else
-            SOURCE_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev' ${SOURCE_IMAGE} ${DEV_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${DEV_INSTALL_IMAGE}
           fi
 
-          docker image pull ${SOURCE_IMAGE}
-          docker image pull ${SOURCE_INSTALL_IMAGE}
-          docker image pull ${SOURCE_RELEASE_VERSION_IMAGE}
+          #   5. Publish prod images to rw registry.
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev' ${SOURCE_IMAGE} ${PROD_IMAGE}
 
-          #   4. Publish dev images to dev registry
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            DEV_DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
-            DEV_DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${PROD_INSTALL_IMAGE}
 
-            echo "Push 'dev' image ${SOURCE_IMAGE} to ${DEV_DESTINATION_IMAGE}"
-            docker image tag ${SOURCE_IMAGE} ${DEV_DESTINATION_IMAGE}
-            docker image push ${DEV_DESTINATION_IMAGE}
+          echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'release-channel-version' ${SOURCE_RELEASE_VERSION_IMAGE} ${PROD_RELEASE_VERSION_IMAGE}
 
-            echo "Delete local 'dev' image ${DEV_DESTINATION_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_IMAGE} || true;
-
-            echo "Push 'dev install' ${SOURCE_INSTALL_IMAGE} to image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image tag ${SOURCE_INSTALL_IMAGE} ${DEV_DESTINATION_INSTALL_IMAGE}
-            docker image push ${DEV_DESTINATION_INSTALL_IMAGE}
-
-            echo "Delete local 'dev install' image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_INSTALL_IMAGE} || true;
-          fi
-
-          #   5. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          fi
-
-          echo "Push 'prod' image ${SOURCE_IMAGE} to ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image tag ${SOURCE_IMAGE} ${DECKHOUSE_DESTINATION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE}
-          echo "Delete local 'prod' image ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-
-          echo "Push 'prod install' image ${SOURCE_INSTALL_IMAGE} to ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image tag ${SOURCE_INSTALL_IMAGE} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          echo "Delete local 'prod install' image ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-
-          echo "Push 'release version'  ${SOURCE_RELEASE_VERSION_IMAGE} to ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image tag ${SOURCE_RELEASE_VERSION_IMAGE} ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Delete local source image ${SOURCE_IMAGE}"
+          echo "⚓️  [$(date -u)] Remove local source images."
+          echo "  Delete local 'dev' source image ${SOURCE_IMAGE}"
           docker image rmi ${SOURCE_IMAGE} || true
-          echo "Delete local 'install' source image ${SOURCE_INSTALL_IMAGE}"
+
+          echo "  Delete local 'dev/install' source image ${SOURCE_INSTALL_IMAGE}"
           docker image rmi ${SOURCE_INSTALL_IMAGE} || true
-          echo "Delete local 'release version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
+
+          echo "  Delete local 'release-channel-version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
           docker image rmi ${SOURCE_RELEASE_VERSION_IMAGE} || true
 
+          #   6. Report.
           echo "Deckhouse images published:"
           echo "  Source: ${SOURCE_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_IMAGE}"
+          echo "  Prod: ${PROD_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_IMAGE}"
+          fi
           echo "Install images published:"
           echo "  Source: ${SOURCE_INSTALL_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_INSTALL_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_INSTALL_IMAGE}"
+          fi
+          echo "Release version image:"
+          echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
 
       - name: Update release branch
         if: ${{ success() }}

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -35,8 +35,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: rock-solid
 
@@ -219,8 +219,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -229,8 +236,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -239,14 +253,42 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
       # </template: login_rw_registry_step>
+
+      - name: Check push enabled
+        id: check_push
+        env:
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
+          REPO: ${{github.repository}}
+        run: |
+          if [[ ${REPO} == "deckhouse/deckhouse" ]]; then
+            echo "::set-output name=enable::true"
+          fi
+          if [[ ${SKIP_PUSH_FOR_DEPLOY} != "true" ]]; then
+            echo "::set-output name=enable::true"
+          fi
 
 
 
@@ -257,8 +299,38 @@ jobs:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: CE
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
+            DST=$3
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_DEPLOY=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
 
           # Some precautions.
           shouldExit1=
@@ -281,94 +353,78 @@ jobs:
           echo "Publish CE edition".
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=rock-solid
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Source images from rw registry or from registry.
+          echo "⚓️ 💫 [$(date -u)] Start publishing Deckhouse images for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          #   3. Prepare image names: republish CI_COMMIT_TAG tag images in dev-registry
+          #   to RELEASE_CHANNEL tag image in prod registry.
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          PROD_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
+          DEV_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
+
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          PROD_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
+          DEV_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+          PROD_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+
+          #   4. Publish to dev registry if DECKHOUSE_REGISTRY_HOST is set (run in the main repo).
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            SOURCE_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-          else
-            SOURCE_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev' ${SOURCE_IMAGE} ${DEV_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${DEV_INSTALL_IMAGE}
           fi
 
-          docker image pull ${SOURCE_IMAGE}
-          docker image pull ${SOURCE_INSTALL_IMAGE}
-          docker image pull ${SOURCE_RELEASE_VERSION_IMAGE}
+          #   5. Publish prod images to rw registry.
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev' ${SOURCE_IMAGE} ${PROD_IMAGE}
 
-          #   4. Publish dev images to dev registry
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            DEV_DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
-            DEV_DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${PROD_INSTALL_IMAGE}
 
-            echo "Push 'dev' image ${SOURCE_IMAGE} to ${DEV_DESTINATION_IMAGE}"
-            docker image tag ${SOURCE_IMAGE} ${DEV_DESTINATION_IMAGE}
-            docker image push ${DEV_DESTINATION_IMAGE}
+          echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'release-channel-version' ${SOURCE_RELEASE_VERSION_IMAGE} ${PROD_RELEASE_VERSION_IMAGE}
 
-            echo "Delete local 'dev' image ${DEV_DESTINATION_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_IMAGE} || true;
-
-            echo "Push 'dev install' ${SOURCE_INSTALL_IMAGE} to image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image tag ${SOURCE_INSTALL_IMAGE} ${DEV_DESTINATION_INSTALL_IMAGE}
-            docker image push ${DEV_DESTINATION_INSTALL_IMAGE}
-
-            echo "Delete local 'dev install' image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_INSTALL_IMAGE} || true;
-          fi
-
-          #   5. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          fi
-
-          echo "Push 'prod' image ${SOURCE_IMAGE} to ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image tag ${SOURCE_IMAGE} ${DECKHOUSE_DESTINATION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE}
-          echo "Delete local 'prod' image ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-
-          echo "Push 'prod install' image ${SOURCE_INSTALL_IMAGE} to ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image tag ${SOURCE_INSTALL_IMAGE} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          echo "Delete local 'prod install' image ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-
-          echo "Push 'release version'  ${SOURCE_RELEASE_VERSION_IMAGE} to ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image tag ${SOURCE_RELEASE_VERSION_IMAGE} ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Delete local source image ${SOURCE_IMAGE}"
+          echo "⚓️  [$(date -u)] Remove local source images."
+          echo "  Delete local 'dev' source image ${SOURCE_IMAGE}"
           docker image rmi ${SOURCE_IMAGE} || true
-          echo "Delete local 'install' source image ${SOURCE_INSTALL_IMAGE}"
+
+          echo "  Delete local 'dev/install' source image ${SOURCE_INSTALL_IMAGE}"
           docker image rmi ${SOURCE_INSTALL_IMAGE} || true
-          echo "Delete local 'release version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
+
+          echo "  Delete local 'release-channel-version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
           docker image rmi ${SOURCE_RELEASE_VERSION_IMAGE} || true
 
+          #   6. Report.
           echo "Deckhouse images published:"
           echo "  Source: ${SOURCE_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_IMAGE}"
+          echo "  Prod: ${PROD_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_IMAGE}"
+          fi
           echo "Install images published:"
           echo "  Source: ${SOURCE_INSTALL_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_INSTALL_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_INSTALL_IMAGE}"
+          fi
+          echo "Release version image:"
+          echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
         if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
         env:
@@ -376,8 +432,38 @@ jobs:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: EE
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
+            DST=$3
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_DEPLOY=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
 
           # Some precautions.
           shouldExit1=
@@ -400,94 +486,78 @@ jobs:
           echo "Publish EE edition".
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=rock-solid
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Source images from rw registry or from registry.
+          echo "⚓️ 💫 [$(date -u)] Start publishing Deckhouse images for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          #   3. Prepare image names: republish CI_COMMIT_TAG tag images in dev-registry
+          #   to RELEASE_CHANNEL tag image in prod registry.
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          PROD_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
+          DEV_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
+
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          PROD_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
+          DEV_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+          PROD_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+
+          #   4. Publish to dev registry if DECKHOUSE_REGISTRY_HOST is set (run in the main repo).
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            SOURCE_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-          else
-            SOURCE_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev' ${SOURCE_IMAGE} ${DEV_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${DEV_INSTALL_IMAGE}
           fi
 
-          docker image pull ${SOURCE_IMAGE}
-          docker image pull ${SOURCE_INSTALL_IMAGE}
-          docker image pull ${SOURCE_RELEASE_VERSION_IMAGE}
+          #   5. Publish prod images to rw registry.
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev' ${SOURCE_IMAGE} ${PROD_IMAGE}
 
-          #   4. Publish dev images to dev registry
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            DEV_DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
-            DEV_DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${PROD_INSTALL_IMAGE}
 
-            echo "Push 'dev' image ${SOURCE_IMAGE} to ${DEV_DESTINATION_IMAGE}"
-            docker image tag ${SOURCE_IMAGE} ${DEV_DESTINATION_IMAGE}
-            docker image push ${DEV_DESTINATION_IMAGE}
+          echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'release-channel-version' ${SOURCE_RELEASE_VERSION_IMAGE} ${PROD_RELEASE_VERSION_IMAGE}
 
-            echo "Delete local 'dev' image ${DEV_DESTINATION_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_IMAGE} || true;
-
-            echo "Push 'dev install' ${SOURCE_INSTALL_IMAGE} to image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image tag ${SOURCE_INSTALL_IMAGE} ${DEV_DESTINATION_INSTALL_IMAGE}
-            docker image push ${DEV_DESTINATION_INSTALL_IMAGE}
-
-            echo "Delete local 'dev install' image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_INSTALL_IMAGE} || true;
-          fi
-
-          #   5. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          fi
-
-          echo "Push 'prod' image ${SOURCE_IMAGE} to ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image tag ${SOURCE_IMAGE} ${DECKHOUSE_DESTINATION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE}
-          echo "Delete local 'prod' image ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-
-          echo "Push 'prod install' image ${SOURCE_INSTALL_IMAGE} to ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image tag ${SOURCE_INSTALL_IMAGE} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          echo "Delete local 'prod install' image ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-
-          echo "Push 'release version'  ${SOURCE_RELEASE_VERSION_IMAGE} to ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image tag ${SOURCE_RELEASE_VERSION_IMAGE} ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Delete local source image ${SOURCE_IMAGE}"
+          echo "⚓️  [$(date -u)] Remove local source images."
+          echo "  Delete local 'dev' source image ${SOURCE_IMAGE}"
           docker image rmi ${SOURCE_IMAGE} || true
-          echo "Delete local 'install' source image ${SOURCE_INSTALL_IMAGE}"
+
+          echo "  Delete local 'dev/install' source image ${SOURCE_INSTALL_IMAGE}"
           docker image rmi ${SOURCE_INSTALL_IMAGE} || true
-          echo "Delete local 'release version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
+
+          echo "  Delete local 'release-channel-version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
           docker image rmi ${SOURCE_RELEASE_VERSION_IMAGE} || true
 
+          #   6. Report.
           echo "Deckhouse images published:"
           echo "  Source: ${SOURCE_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_IMAGE}"
+          echo "  Prod: ${PROD_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_IMAGE}"
+          fi
           echo "Install images published:"
           echo "  Source: ${SOURCE_INSTALL_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_INSTALL_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_INSTALL_IMAGE}"
+          fi
+          echo "Release version image:"
+          echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
         if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
         env:
@@ -495,8 +565,38 @@ jobs:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: FE
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
+            DST=$3
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_DEPLOY=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
 
           # Some precautions.
           shouldExit1=
@@ -519,94 +619,78 @@ jobs:
           echo "Publish FE edition".
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=rock-solid
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Source images from rw registry or from registry.
+          echo "⚓️ 💫 [$(date -u)] Start publishing Deckhouse images for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          #   3. Prepare image names: republish CI_COMMIT_TAG tag images in dev-registry
+          #   to RELEASE_CHANNEL tag image in prod registry.
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          PROD_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
+          DEV_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
+
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          PROD_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
+          DEV_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+          PROD_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+
+          #   4. Publish to dev registry if DECKHOUSE_REGISTRY_HOST is set (run in the main repo).
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            SOURCE_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-          else
-            SOURCE_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev' ${SOURCE_IMAGE} ${DEV_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${DEV_INSTALL_IMAGE}
           fi
 
-          docker image pull ${SOURCE_IMAGE}
-          docker image pull ${SOURCE_INSTALL_IMAGE}
-          docker image pull ${SOURCE_RELEASE_VERSION_IMAGE}
+          #   5. Publish prod images to rw registry.
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev' ${SOURCE_IMAGE} ${PROD_IMAGE}
 
-          #   4. Publish dev images to dev registry
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            DEV_DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
-            DEV_DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${PROD_INSTALL_IMAGE}
 
-            echo "Push 'dev' image ${SOURCE_IMAGE} to ${DEV_DESTINATION_IMAGE}"
-            docker image tag ${SOURCE_IMAGE} ${DEV_DESTINATION_IMAGE}
-            docker image push ${DEV_DESTINATION_IMAGE}
+          echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'release-channel-version' ${SOURCE_RELEASE_VERSION_IMAGE} ${PROD_RELEASE_VERSION_IMAGE}
 
-            echo "Delete local 'dev' image ${DEV_DESTINATION_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_IMAGE} || true;
-
-            echo "Push 'dev install' ${SOURCE_INSTALL_IMAGE} to image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image tag ${SOURCE_INSTALL_IMAGE} ${DEV_DESTINATION_INSTALL_IMAGE}
-            docker image push ${DEV_DESTINATION_INSTALL_IMAGE}
-
-            echo "Delete local 'dev install' image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_INSTALL_IMAGE} || true;
-          fi
-
-          #   5. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          fi
-
-          echo "Push 'prod' image ${SOURCE_IMAGE} to ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image tag ${SOURCE_IMAGE} ${DECKHOUSE_DESTINATION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE}
-          echo "Delete local 'prod' image ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-
-          echo "Push 'prod install' image ${SOURCE_INSTALL_IMAGE} to ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image tag ${SOURCE_INSTALL_IMAGE} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          echo "Delete local 'prod install' image ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-
-          echo "Push 'release version'  ${SOURCE_RELEASE_VERSION_IMAGE} to ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image tag ${SOURCE_RELEASE_VERSION_IMAGE} ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Delete local source image ${SOURCE_IMAGE}"
+          echo "⚓️  [$(date -u)] Remove local source images."
+          echo "  Delete local 'dev' source image ${SOURCE_IMAGE}"
           docker image rmi ${SOURCE_IMAGE} || true
-          echo "Delete local 'install' source image ${SOURCE_INSTALL_IMAGE}"
+
+          echo "  Delete local 'dev/install' source image ${SOURCE_INSTALL_IMAGE}"
           docker image rmi ${SOURCE_INSTALL_IMAGE} || true
-          echo "Delete local 'release version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
+
+          echo "  Delete local 'release-channel-version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
           docker image rmi ${SOURCE_RELEASE_VERSION_IMAGE} || true
 
+          #   6. Report.
           echo "Deckhouse images published:"
           echo "  Source: ${SOURCE_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_IMAGE}"
+          echo "  Prod: ${PROD_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_IMAGE}"
+          fi
           echo "Install images published:"
           echo "  Source: ${SOURCE_INSTALL_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_INSTALL_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_INSTALL_IMAGE}"
+          fi
+          echo "Release version image:"
+          echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
 
       - name: Update release branch
         if: ${{ success() }}

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -35,8 +35,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: stable
 
@@ -219,8 +219,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -229,8 +236,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -239,14 +253,42 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
           logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
       # </template: login_rw_registry_step>
+
+      - name: Check push enabled
+        id: check_push
+        env:
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
+          REPO: ${{github.repository}}
+        run: |
+          if [[ ${REPO} == "deckhouse/deckhouse" ]]; then
+            echo "::set-output name=enable::true"
+          fi
+          if [[ ${SKIP_PUSH_FOR_DEPLOY} != "true" ]]; then
+            echo "::set-output name=enable::true"
+          fi
 
 
 
@@ -257,8 +299,38 @@ jobs:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: CE
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
+            DST=$3
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_DEPLOY=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
 
           # Some precautions.
           shouldExit1=
@@ -281,94 +353,78 @@ jobs:
           echo "Publish CE edition".
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=stable
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Source images from rw registry or from registry.
+          echo "⚓️ 💫 [$(date -u)] Start publishing Deckhouse images for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          #   3. Prepare image names: republish CI_COMMIT_TAG tag images in dev-registry
+          #   to RELEASE_CHANNEL tag image in prod registry.
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          PROD_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
+          DEV_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
+
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          PROD_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
+          DEV_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+          PROD_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+
+          #   4. Publish to dev registry if DECKHOUSE_REGISTRY_HOST is set (run in the main repo).
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            SOURCE_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-          else
-            SOURCE_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev' ${SOURCE_IMAGE} ${DEV_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${DEV_INSTALL_IMAGE}
           fi
 
-          docker image pull ${SOURCE_IMAGE}
-          docker image pull ${SOURCE_INSTALL_IMAGE}
-          docker image pull ${SOURCE_RELEASE_VERSION_IMAGE}
+          #   5. Publish prod images to rw registry.
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev' ${SOURCE_IMAGE} ${PROD_IMAGE}
 
-          #   4. Publish dev images to dev registry
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            DEV_DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
-            DEV_DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${PROD_INSTALL_IMAGE}
 
-            echo "Push 'dev' image ${SOURCE_IMAGE} to ${DEV_DESTINATION_IMAGE}"
-            docker image tag ${SOURCE_IMAGE} ${DEV_DESTINATION_IMAGE}
-            docker image push ${DEV_DESTINATION_IMAGE}
+          echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'release-channel-version' ${SOURCE_RELEASE_VERSION_IMAGE} ${PROD_RELEASE_VERSION_IMAGE}
 
-            echo "Delete local 'dev' image ${DEV_DESTINATION_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_IMAGE} || true;
-
-            echo "Push 'dev install' ${SOURCE_INSTALL_IMAGE} to image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image tag ${SOURCE_INSTALL_IMAGE} ${DEV_DESTINATION_INSTALL_IMAGE}
-            docker image push ${DEV_DESTINATION_INSTALL_IMAGE}
-
-            echo "Delete local 'dev install' image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_INSTALL_IMAGE} || true;
-          fi
-
-          #   5. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          fi
-
-          echo "Push 'prod' image ${SOURCE_IMAGE} to ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image tag ${SOURCE_IMAGE} ${DECKHOUSE_DESTINATION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE}
-          echo "Delete local 'prod' image ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-
-          echo "Push 'prod install' image ${SOURCE_INSTALL_IMAGE} to ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image tag ${SOURCE_INSTALL_IMAGE} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          echo "Delete local 'prod install' image ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-
-          echo "Push 'release version'  ${SOURCE_RELEASE_VERSION_IMAGE} to ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image tag ${SOURCE_RELEASE_VERSION_IMAGE} ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Delete local source image ${SOURCE_IMAGE}"
+          echo "⚓️  [$(date -u)] Remove local source images."
+          echo "  Delete local 'dev' source image ${SOURCE_IMAGE}"
           docker image rmi ${SOURCE_IMAGE} || true
-          echo "Delete local 'install' source image ${SOURCE_INSTALL_IMAGE}"
+
+          echo "  Delete local 'dev/install' source image ${SOURCE_INSTALL_IMAGE}"
           docker image rmi ${SOURCE_INSTALL_IMAGE} || true
-          echo "Delete local 'release version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
+
+          echo "  Delete local 'release-channel-version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
           docker image rmi ${SOURCE_RELEASE_VERSION_IMAGE} || true
 
+          #   6. Report.
           echo "Deckhouse images published:"
           echo "  Source: ${SOURCE_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_IMAGE}"
+          echo "  Prod: ${PROD_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_IMAGE}"
+          fi
           echo "Install images published:"
           echo "  Source: ${SOURCE_INSTALL_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_INSTALL_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_INSTALL_IMAGE}"
+          fi
+          echo "Release version image:"
+          echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
         if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
         env:
@@ -376,8 +432,38 @@ jobs:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: EE
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
+            DST=$3
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_DEPLOY=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
 
           # Some precautions.
           shouldExit1=
@@ -400,94 +486,78 @@ jobs:
           echo "Publish EE edition".
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=stable
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Source images from rw registry or from registry.
+          echo "⚓️ 💫 [$(date -u)] Start publishing Deckhouse images for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          #   3. Prepare image names: republish CI_COMMIT_TAG tag images in dev-registry
+          #   to RELEASE_CHANNEL tag image in prod registry.
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          PROD_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
+          DEV_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
+
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          PROD_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
+          DEV_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+          PROD_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+
+          #   4. Publish to dev registry if DECKHOUSE_REGISTRY_HOST is set (run in the main repo).
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            SOURCE_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-          else
-            SOURCE_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev' ${SOURCE_IMAGE} ${DEV_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${DEV_INSTALL_IMAGE}
           fi
 
-          docker image pull ${SOURCE_IMAGE}
-          docker image pull ${SOURCE_INSTALL_IMAGE}
-          docker image pull ${SOURCE_RELEASE_VERSION_IMAGE}
+          #   5. Publish prod images to rw registry.
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev' ${SOURCE_IMAGE} ${PROD_IMAGE}
 
-          #   4. Publish dev images to dev registry
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            DEV_DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
-            DEV_DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${PROD_INSTALL_IMAGE}
 
-            echo "Push 'dev' image ${SOURCE_IMAGE} to ${DEV_DESTINATION_IMAGE}"
-            docker image tag ${SOURCE_IMAGE} ${DEV_DESTINATION_IMAGE}
-            docker image push ${DEV_DESTINATION_IMAGE}
+          echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'release-channel-version' ${SOURCE_RELEASE_VERSION_IMAGE} ${PROD_RELEASE_VERSION_IMAGE}
 
-            echo "Delete local 'dev' image ${DEV_DESTINATION_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_IMAGE} || true;
-
-            echo "Push 'dev install' ${SOURCE_INSTALL_IMAGE} to image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image tag ${SOURCE_INSTALL_IMAGE} ${DEV_DESTINATION_INSTALL_IMAGE}
-            docker image push ${DEV_DESTINATION_INSTALL_IMAGE}
-
-            echo "Delete local 'dev install' image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_INSTALL_IMAGE} || true;
-          fi
-
-          #   5. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          fi
-
-          echo "Push 'prod' image ${SOURCE_IMAGE} to ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image tag ${SOURCE_IMAGE} ${DECKHOUSE_DESTINATION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE}
-          echo "Delete local 'prod' image ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-
-          echo "Push 'prod install' image ${SOURCE_INSTALL_IMAGE} to ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image tag ${SOURCE_INSTALL_IMAGE} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          echo "Delete local 'prod install' image ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-
-          echo "Push 'release version'  ${SOURCE_RELEASE_VERSION_IMAGE} to ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image tag ${SOURCE_RELEASE_VERSION_IMAGE} ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Delete local source image ${SOURCE_IMAGE}"
+          echo "⚓️  [$(date -u)] Remove local source images."
+          echo "  Delete local 'dev' source image ${SOURCE_IMAGE}"
           docker image rmi ${SOURCE_IMAGE} || true
-          echo "Delete local 'install' source image ${SOURCE_INSTALL_IMAGE}"
+
+          echo "  Delete local 'dev/install' source image ${SOURCE_INSTALL_IMAGE}"
           docker image rmi ${SOURCE_INSTALL_IMAGE} || true
-          echo "Delete local 'release version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
+
+          echo "  Delete local 'release-channel-version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
           docker image rmi ${SOURCE_RELEASE_VERSION_IMAGE} || true
 
+          #   6. Report.
           echo "Deckhouse images published:"
           echo "  Source: ${SOURCE_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_IMAGE}"
+          echo "  Prod: ${PROD_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_IMAGE}"
+          fi
           echo "Install images published:"
           echo "  Source: ${SOURCE_INSTALL_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_INSTALL_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_INSTALL_IMAGE}"
+          fi
+          echo "Release version image:"
+          echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
         if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
         env:
@@ -495,8 +565,38 @@ jobs:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: FE
+          SKIP_PUSH_FOR_DEPLOY: ${{secrets.SKIP_PUSH_FOR_DEPLOY}}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
+
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function pull_push_rmi() {
+            SRC_NAME=$1
+            SRC=$2
+            DST=$3
+            echo "⚓️ 📥 [$(date -u)] Pull '${SRC_NAME}' image as ${SRC}."
+            docker pull ${SRC}
+            echo "⚓️ 🏷 [$(date -u)] Tag '${SRC_NAME}' image as ${DST}."
+            docker image tag ${SRC} ${DST}
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_DEPLOY=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
 
           # Some precautions.
           shouldExit1=
@@ -519,94 +619,78 @@ jobs:
           echo "Publish FE edition".
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=stable
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Source images from rw registry or from registry.
+          echo "⚓️ 💫 [$(date -u)] Start publishing Deckhouse images for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          PROD_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            PROD_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish using Github Container Registry: '${PROD_REGISTRY_PATH}'"
+          fi
+
+          #   3. Prepare image names: republish CI_COMMIT_TAG tag images in dev-registry
+          #   to RELEASE_CHANNEL tag image in prod registry.
+          SOURCE_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
+          PROD_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
+          DEV_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
+
+          SOURCE_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
+          PROD_INSTALL_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
+          DEV_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+
+          SOURCE_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+          PROD_RELEASE_VERSION_IMAGE=${PROD_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+
+          #   4. Publish to dev registry if DECKHOUSE_REGISTRY_HOST is set (run in the main repo).
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            SOURCE_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
-          else
-            SOURCE_IMAGE=${CI_REGISTRY_IMAGE}:${CI_COMMIT_TAG};
-            SOURCE_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${CI_COMMIT_TAG};
-            SOURCE_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${CI_COMMIT_TAG};
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev' ${SOURCE_IMAGE} ${DEV_IMAGE}
+
+            echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to dev-registry using tag ${RELEASE_CHANNEL}".
+            pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${DEV_INSTALL_IMAGE}
           fi
 
-          docker image pull ${SOURCE_IMAGE}
-          docker image pull ${SOURCE_INSTALL_IMAGE}
-          docker image pull ${SOURCE_RELEASE_VERSION_IMAGE}
+          #   5. Publish prod images to rw registry.
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev' ${SOURCE_IMAGE} ${PROD_IMAGE}
 
-          #   4. Publish dev images to dev registry
-          if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-            DEV_DESTINATION_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL}
-            DEV_DESTINATION_INSTALL_IMAGE=${DEV_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL}
+          echo "⚓️ 💫 [$(date -u)] Publish 'dev/install' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'dev/install' ${SOURCE_INSTALL_IMAGE} ${PROD_INSTALL_IMAGE}
 
-            echo "Push 'dev' image ${SOURCE_IMAGE} to ${DEV_DESTINATION_IMAGE}"
-            docker image tag ${SOURCE_IMAGE} ${DEV_DESTINATION_IMAGE}
-            docker image push ${DEV_DESTINATION_IMAGE}
+          echo "⚓️ 💫 [$(date -u)] Publish 'release-channel-version' image to rw-registry using tag ${RELEASE_CHANNEL}".
+          pull_push_rmi 'release-channel-version' ${SOURCE_RELEASE_VERSION_IMAGE} ${PROD_RELEASE_VERSION_IMAGE}
 
-            echo "Delete local 'dev' image ${DEV_DESTINATION_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_IMAGE} || true;
-
-            echo "Push 'dev install' ${SOURCE_INSTALL_IMAGE} to image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image tag ${SOURCE_INSTALL_IMAGE} ${DEV_DESTINATION_INSTALL_IMAGE}
-            docker image push ${DEV_DESTINATION_INSTALL_IMAGE}
-
-            echo "Delete local 'dev install' image ${DEV_DESTINATION_INSTALL_IMAGE}"
-            docker image rmi ${DEV_DESTINATION_INSTALL_IMAGE} || true;
-          fi
-
-          #   5. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_IMAGE=${CI_REGISTRY_IMAGE}:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_INSTALL_IMAGE=${CI_REGISTRY_IMAGE}/install:${RELEASE_CHANNEL};
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          fi
-
-          echo "Push 'prod' image ${SOURCE_IMAGE} to ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image tag ${SOURCE_IMAGE} ${DECKHOUSE_DESTINATION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_IMAGE}
-          echo "Delete local 'prod' image ${DECKHOUSE_DESTINATION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_IMAGE} || true;
-
-          echo "Push 'prod install' image ${SOURCE_INSTALL_IMAGE} to ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image tag ${SOURCE_INSTALL_IMAGE} ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}
-          echo "Delete local 'prod install' image ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_INSTALL_IMAGE} || true;
-
-          echo "Push 'release version'  ${SOURCE_RELEASE_VERSION_IMAGE} to ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image tag ${SOURCE_RELEASE_VERSION_IMAGE} ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Delete local source image ${SOURCE_IMAGE}"
+          echo "⚓️  [$(date -u)] Remove local source images."
+          echo "  Delete local 'dev' source image ${SOURCE_IMAGE}"
           docker image rmi ${SOURCE_IMAGE} || true
-          echo "Delete local 'install' source image ${SOURCE_INSTALL_IMAGE}"
+
+          echo "  Delete local 'dev/install' source image ${SOURCE_INSTALL_IMAGE}"
           docker image rmi ${SOURCE_INSTALL_IMAGE} || true
-          echo "Delete local 'release version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
+
+          echo "  Delete local 'release-channel-version' source image ${SOURCE_RELEASE_VERSION_IMAGE}"
           docker image rmi ${SOURCE_RELEASE_VERSION_IMAGE} || true
 
+          #   6. Report.
           echo "Deckhouse images published:"
           echo "  Source: ${SOURCE_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_IMAGE}"
+          echo "  Prod: ${PROD_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_IMAGE}"
+          fi
           echo "Install images published:"
           echo "  Source: ${SOURCE_INSTALL_IMAGE}"
-          echo "  Prod: ${DECKHOUSE_DESTINATION_INSTALL_IMAGE}"
-          echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_INSTALL_IMAGE}"
+          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+          echo "  Dev: ${DEV_INSTALL_IMAGE}"
+          fi
+          echo "Release version image:"
+          echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
+          echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
 
       - name: Update release branch
         if: ${{ success() }}

--- a/.github/workflows/deploy-web-stage.yml
+++ b/.github/workflows/deploy-web-stage.yml
@@ -44,8 +44,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
 
 
@@ -237,8 +237,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -247,8 +254,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -257,12 +271,32 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_flant_registry_step>
+      - name: Check flant registry credentials
+        id: check_flant_registry
+        env:
+          HOST: ${{secrets.FLANT_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "::set-output name=has_flant_credentials::true"
+            echo "::set-output name=web_registry_path::${{secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+          else
+            echo "::set-output name=web_registry_path::${GHA_TEST_REGISTRY_PATH}"
+          fi
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials == 'true' }}
         with:
           registry: ${{ secrets.FLANT_REGISTRY_HOST }}
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_flant_registry_step>
 
@@ -274,7 +308,7 @@ jobs:
           kube-config-base64-data: "${{ secrets.KUBECONFIG_BASE64_DEV }}"
           env: web-stage
         env:
-          WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+          WERF_REPO: ${{steps.check_flant_registry.outputs.web_registry_path}}
           WERF_DIR: "docs/site"
           WERF_RELEASE: "deckhouse-site"
           WERF_NAMESPACE: deckhouse-web-stage
@@ -299,7 +333,7 @@ jobs:
           kube-config-base64-data: "${{ secrets.KUBECONFIG_BASE64_DEV }}"
           env: web-stage
         env:
-          WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+          WERF_REPO: ${{steps.check_flant_registry.outputs.web_registry_path}}
           WERF_DIR: "docs/documentation"
           WERF_RELEASE: "deckhouse-doc-${{ env.DOC_VERSION }}"
           WERF_NAMESPACE: deckhouse-web-stage

--- a/.github/workflows/deploy-web-test.yml
+++ b/.github/workflows/deploy-web-test.yml
@@ -44,8 +44,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
 
 
@@ -237,8 +237,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -247,8 +254,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to readonly registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
@@ -257,12 +271,32 @@ jobs:
       # </template: login_readonly_registry_step>
 
       # <template: login_flant_registry_step>
+      - name: Check flant registry credentials
+        id: check_flant_registry
+        env:
+          HOST: ${{secrets.FLANT_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then
+            echo "::set-output name=has_flant_credentials::true"
+            echo "::set-output name=web_registry_path::${{secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+          else
+            echo "::set-output name=web_registry_path::${GHA_TEST_REGISTRY_PATH}"
+          fi
       - name: Login to flant registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials == 'true' }}
         with:
           registry: ${{ secrets.FLANT_REGISTRY_HOST }}
           username: ${{ secrets.FLANT_REGISTRY_USER }}
           password: ${{ secrets.FLANT_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_flant_registry.outputs.has_flant_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_flant_registry_step>
 
@@ -274,7 +308,7 @@ jobs:
           kube-config-base64-data: "${{ secrets.KUBECONFIG_BASE64_DEV }}"
           env: web-test
         env:
-          WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+          WERF_REPO: ${{steps.check_flant_registry.outputs.web_registry_path}}
           WERF_DIR: "docs/site"
           WERF_RELEASE: "deckhouse-site"
           WERF_NAMESPACE: deckhouse-web-test
@@ -299,7 +333,7 @@ jobs:
           kube-config-base64-data: "${{ secrets.KUBECONFIG_BASE64_DEV }}"
           env: web-test
         env:
-          WERF_REPO: ${{env.FLANT_REGISTRY_PATH}}
+          WERF_REPO: ${{steps.check_flant_registry.outputs.web_registry_path}}
           WERF_DIR: "docs/documentation"
           WERF_RELEASE: "deckhouse-doc-${{ env.DOC_VERSION }}"
           WERF_NAMESPACE: deckhouse-web-test

--- a/.github/workflows/dispatch-slash-command.yml
+++ b/.github/workflows/dispatch-slash-command.yml
@@ -8,13 +8,50 @@ on:
     types: [created]
 
 jobs:
+  conditions:
+    name: Check conditions
+    runs-on: ubuntu-latest
+    outputs:
+      trigger_for_release_issue: ${{steps.check.outputs.trigger_for_release_issue}}
+      trigger_for_changelog: ${{steps.check.outputs.trigger_for_changelog}}
+    steps:
+      - name: Check conditions for release issue
+        id: check
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            // Check for release issue.
+            const isReleaseIssue = context.payload.issue.labels.some((l) => l.name === 'issue/release');
+            const isPrivate = context.payload.repository.private;
+            const authorAssociation = context.payload.comment.author_association;
+            // Check for changelog PR.
+            const isPR = !!context.payload.issue.pull_request;
+            const milestoneState = context.payload.issue.milestone.state;
+            const hasChangelogLabel = context.payload.issue.labels.some((l) => l.name === 'changelog');
+            const hasAutoLabel = context.payload.issue.labels.some((l) => l.name === 'auto');
+            core.info(`Is release issue?       ${isReleaseIssue}`)
+            core.info(`Private repo?           ${isPrivate}`)
+            core.info(`Author association:     ${authorAssociation}`)
+            core.info(`Is PR?                  ${isPR}`)
+            core.info(`Milestone state:        ${milestoneState}`)
+            core.info(`Has 'changelog' label?  ${hasChangelogLabel}`)
+            core.info(`Has 'auto' label?       ${hasAutoLabel}`)
+
+            if (isReleaseIssue && (authorAssociation === 'OWNER' || authorAssociation === 'MEMBER' || (isPrivate && authorAssociation === 'COLLABORATOR'))) {
+              return core.setOutput('trigger_for_release_issue', 'true');
+            }
+
+            if (isPR && milestoneState === 'open' && hasChangelogLabel && hasAutoLabel) {
+              return core.setOutput('trigger_for_changelog', 'true');
+            }
+
+
   trigger_for_release_issue:
     name: Trigger workflow by comment
     runs-on: ubuntu-latest
-    if: |
-      contains(github.event.issue.labels.*.name, 'issue/release') &&
-      (github.event.comment.author_association == 'OWNER' ||
-       github.event.comment.author_association == 'MEMBER')
+    needs:
+      - conditions
+    if: ${{needs.conditions.outputs.trigger_for_release_issue == 'true'}}
     steps:
 
       # <template: checkout_step>
@@ -33,11 +70,9 @@ jobs:
   trigger_for_changelog:
     name: Dispatch Changelog Event
     runs-on: ubuntu-latest
-    if: |
-      github.event.issue.pull_request &&
-      github.event.issue.milestone.state == 'open' &&
-      contains(github.event.issue.labels.*.name, 'changelog') &&
-      contains(github.event.issue.labels.*.name, 'auto')
+    needs:
+      - conditions
+    if: ${{needs.conditions.outputs.trigger_for_changelog == 'true'}}
     steps:
 
       # <template: checkout_step>

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -49,8 +49,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
 
 
@@ -267,8 +267,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -276,23 +283,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -308,6 +320,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -333,50 +348,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: AWS/Docker/1.19"
@@ -390,7 +392,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -449,7 +451,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -546,8 +548,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -631,8 +640,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -640,23 +656,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -672,6 +693,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -697,50 +721,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: AWS/Docker/1.20"
@@ -754,7 +765,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -813,7 +824,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -910,8 +921,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -995,8 +1013,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1004,23 +1029,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1036,6 +1066,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1061,50 +1094,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: AWS/Docker/1.21"
@@ -1118,7 +1138,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1177,7 +1197,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1274,8 +1294,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -1359,8 +1386,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1368,23 +1402,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1400,6 +1439,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1425,50 +1467,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: AWS/Docker/1.22"
@@ -1482,7 +1511,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1541,7 +1570,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1638,8 +1667,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -1723,8 +1759,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1732,23 +1775,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1764,6 +1812,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1789,50 +1840,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: AWS/Containerd/1.19"
@@ -1846,7 +1884,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1905,7 +1943,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2002,8 +2040,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -2087,8 +2132,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2096,23 +2148,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2128,6 +2185,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2153,50 +2213,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: AWS/Containerd/1.20"
@@ -2210,7 +2257,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2269,7 +2316,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2366,8 +2413,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -2451,8 +2505,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2460,23 +2521,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2492,6 +2558,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2517,50 +2586,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: AWS/Containerd/1.21"
@@ -2574,7 +2630,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2633,7 +2689,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2730,8 +2786,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -2815,8 +2878,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2824,23 +2894,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2856,6 +2931,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2881,50 +2959,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: AWS/Containerd/1.22"
@@ -2938,7 +3003,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2997,7 +3062,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -3094,8 +3159,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: AWS
           CRI: Containerd

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -49,8 +49,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
 
 
@@ -267,8 +267,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -276,23 +283,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -308,6 +320,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -333,50 +348,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Azure/Docker/1.19"
@@ -390,7 +392,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -453,7 +455,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -554,8 +556,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -639,8 +648,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -648,23 +664,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -680,6 +701,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -705,50 +729,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Azure/Docker/1.20"
@@ -762,7 +773,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -825,7 +836,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -926,8 +937,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -1011,8 +1029,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1020,23 +1045,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1052,6 +1082,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1077,50 +1110,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Azure/Docker/1.21"
@@ -1134,7 +1154,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1197,7 +1217,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1298,8 +1318,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -1383,8 +1410,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1392,23 +1426,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1424,6 +1463,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1449,50 +1491,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Azure/Docker/1.22"
@@ -1506,7 +1535,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1569,7 +1598,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1670,8 +1699,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -1755,8 +1791,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1764,23 +1807,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1796,6 +1844,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1821,50 +1872,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Azure/Containerd/1.19"
@@ -1878,7 +1916,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1941,7 +1979,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2042,8 +2080,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -2127,8 +2172,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2136,23 +2188,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2168,6 +2225,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2193,50 +2253,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Azure/Containerd/1.20"
@@ -2250,7 +2297,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2313,7 +2360,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2414,8 +2461,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -2499,8 +2553,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2508,23 +2569,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2540,6 +2606,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2565,50 +2634,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Azure/Containerd/1.21"
@@ -2622,7 +2678,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2685,7 +2741,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2786,8 +2842,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -2871,8 +2934,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2880,23 +2950,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2912,6 +2987,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2937,50 +3015,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Azure/Containerd/1.22"
@@ -2994,7 +3059,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -3057,7 +3122,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -3158,8 +3223,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Azure
           CRI: Containerd

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -49,8 +49,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
 
 
@@ -267,8 +267,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -276,23 +283,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -308,6 +320,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -333,50 +348,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: GCP/Docker/1.19"
@@ -390,7 +392,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -447,7 +449,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -542,8 +544,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -627,8 +636,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -636,23 +652,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -668,6 +689,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -693,50 +717,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: GCP/Docker/1.20"
@@ -750,7 +761,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -807,7 +818,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -902,8 +913,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -987,8 +1005,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -996,23 +1021,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1028,6 +1058,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1053,50 +1086,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: GCP/Docker/1.21"
@@ -1110,7 +1130,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1167,7 +1187,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1262,8 +1282,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -1347,8 +1374,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1356,23 +1390,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1388,6 +1427,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1413,50 +1455,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: GCP/Docker/1.22"
@@ -1470,7 +1499,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1527,7 +1556,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1622,8 +1651,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -1707,8 +1743,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1716,23 +1759,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1748,6 +1796,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1773,50 +1824,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: GCP/Containerd/1.19"
@@ -1830,7 +1868,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1887,7 +1925,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1982,8 +2020,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -2067,8 +2112,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2076,23 +2128,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2108,6 +2165,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2133,50 +2193,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: GCP/Containerd/1.20"
@@ -2190,7 +2237,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2247,7 +2294,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2342,8 +2389,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -2427,8 +2481,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2436,23 +2497,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2468,6 +2534,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2493,50 +2562,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: GCP/Containerd/1.21"
@@ -2550,7 +2606,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2607,7 +2663,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2702,8 +2758,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -2787,8 +2850,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2796,23 +2866,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2828,6 +2903,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2853,50 +2931,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: GCP/Containerd/1.22"
@@ -2910,7 +2975,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2967,7 +3032,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -3062,8 +3127,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: GCP
           CRI: Containerd

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -49,8 +49,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
 
 
@@ -267,8 +267,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -276,23 +283,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -308,6 +320,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -333,50 +348,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: OpenStack/Docker/1.19"
@@ -390,7 +392,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -447,7 +449,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -542,8 +544,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -627,8 +636,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -636,23 +652,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -668,6 +689,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -693,50 +717,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: OpenStack/Docker/1.20"
@@ -750,7 +761,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -807,7 +818,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -902,8 +913,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -987,8 +1005,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -996,23 +1021,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1028,6 +1058,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1053,50 +1086,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: OpenStack/Docker/1.21"
@@ -1110,7 +1130,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1167,7 +1187,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1262,8 +1282,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -1347,8 +1374,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1356,23 +1390,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1388,6 +1427,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1413,50 +1455,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: OpenStack/Docker/1.22"
@@ -1470,7 +1499,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1527,7 +1556,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1622,8 +1651,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -1707,8 +1743,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1716,23 +1759,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1748,6 +1796,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1773,50 +1824,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: OpenStack/Containerd/1.19"
@@ -1830,7 +1868,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1887,7 +1925,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1982,8 +2020,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -2067,8 +2112,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2076,23 +2128,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2108,6 +2165,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2133,50 +2193,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: OpenStack/Containerd/1.20"
@@ -2190,7 +2237,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2247,7 +2294,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2342,8 +2389,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -2427,8 +2481,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2436,23 +2497,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2468,6 +2534,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2493,50 +2562,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: OpenStack/Containerd/1.21"
@@ -2550,7 +2606,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2607,7 +2663,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2702,8 +2758,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -2787,8 +2850,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2796,23 +2866,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2828,6 +2903,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2853,50 +2931,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: OpenStack/Containerd/1.22"
@@ -2910,7 +2975,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2967,7 +3032,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -3062,8 +3127,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: OpenStack
           CRI: Containerd

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -49,8 +49,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
 
 
@@ -267,8 +267,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -276,23 +283,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -308,6 +320,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -333,50 +348,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Static/Docker/1.19"
@@ -390,7 +392,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -447,7 +449,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -542,8 +544,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Static
           CRI: Docker
@@ -627,8 +636,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -636,23 +652,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -668,6 +689,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -693,50 +717,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Static/Docker/1.20"
@@ -750,7 +761,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -807,7 +818,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -902,8 +913,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Static
           CRI: Docker
@@ -987,8 +1005,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -996,23 +1021,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1028,6 +1058,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1053,50 +1086,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Static/Docker/1.21"
@@ -1110,7 +1130,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1167,7 +1187,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1262,8 +1282,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Static
           CRI: Docker
@@ -1347,8 +1374,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1356,23 +1390,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1388,6 +1427,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1413,50 +1455,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Static/Docker/1.22"
@@ -1470,7 +1499,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1527,7 +1556,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1622,8 +1651,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Static
           CRI: Docker
@@ -1707,8 +1743,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1716,23 +1759,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1748,6 +1796,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1773,50 +1824,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Static/Containerd/1.19"
@@ -1830,7 +1868,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1887,7 +1925,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1982,8 +2020,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -2067,8 +2112,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2076,23 +2128,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2108,6 +2165,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2133,50 +2193,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Static/Containerd/1.20"
@@ -2190,7 +2237,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2247,7 +2294,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2342,8 +2389,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -2427,8 +2481,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2436,23 +2497,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2468,6 +2534,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2493,50 +2562,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Static/Containerd/1.21"
@@ -2550,7 +2606,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2607,7 +2663,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2702,8 +2758,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -2787,8 +2850,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2796,23 +2866,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2828,6 +2903,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2853,50 +2931,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Static/Containerd/1.22"
@@ -2910,7 +2975,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2967,7 +3032,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -3062,8 +3127,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Static
           CRI: Containerd

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -49,8 +49,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
 
 
@@ -267,8 +267,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -276,23 +283,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -308,6 +320,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -333,50 +348,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: vSphere/Docker/1.19"
@@ -390,7 +392,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -449,7 +451,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -546,8 +548,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -631,8 +640,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -640,23 +656,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -672,6 +693,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -697,50 +721,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: vSphere/Docker/1.20"
@@ -754,7 +765,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -813,7 +824,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -910,8 +921,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -995,8 +1013,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1004,23 +1029,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1036,6 +1066,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1061,50 +1094,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: vSphere/Docker/1.21"
@@ -1118,7 +1138,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1177,7 +1197,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1274,8 +1294,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -1359,8 +1386,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1368,23 +1402,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1400,6 +1439,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1425,50 +1467,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: vSphere/Docker/1.22"
@@ -1482,7 +1511,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1541,7 +1570,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1638,8 +1667,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -1723,8 +1759,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1732,23 +1775,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1764,6 +1812,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1789,50 +1840,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: vSphere/Containerd/1.19"
@@ -1846,7 +1884,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1905,7 +1943,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2002,8 +2040,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -2087,8 +2132,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2096,23 +2148,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2128,6 +2185,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2153,50 +2213,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: vSphere/Containerd/1.20"
@@ -2210,7 +2257,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2269,7 +2316,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2366,8 +2413,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -2451,8 +2505,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2460,23 +2521,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2492,6 +2558,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2517,50 +2586,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: vSphere/Containerd/1.21"
@@ -2574,7 +2630,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2633,7 +2689,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2730,8 +2786,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -2815,8 +2878,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2824,23 +2894,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2856,6 +2931,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2881,50 +2959,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: vSphere/Containerd/1.22"
@@ -2938,7 +3003,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2997,7 +3062,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -3094,8 +3159,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: vSphere
           CRI: Containerd

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -49,8 +49,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
 
 
@@ -267,8 +267,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -276,23 +283,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -308,6 +320,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -333,50 +348,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.19"
@@ -390,7 +392,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -451,7 +453,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -550,8 +552,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -635,8 +644,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -644,23 +660,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -676,6 +697,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -701,50 +725,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.20"
@@ -758,7 +769,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -819,7 +830,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -918,8 +929,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -1003,8 +1021,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1012,23 +1037,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1044,6 +1074,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1069,50 +1102,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.21"
@@ -1126,7 +1146,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1187,7 +1207,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1286,8 +1306,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -1371,8 +1398,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1380,23 +1414,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1412,6 +1451,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1437,50 +1479,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.22"
@@ -1494,7 +1523,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1555,7 +1584,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1654,8 +1683,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -1739,8 +1775,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -1748,23 +1791,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -1780,6 +1828,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -1805,50 +1856,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.19"
@@ -1862,7 +1900,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -1923,7 +1961,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2022,8 +2060,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -2107,8 +2152,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2116,23 +2168,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2148,6 +2205,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2173,50 +2233,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.20"
@@ -2230,7 +2277,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2291,7 +2338,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2390,8 +2437,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -2475,8 +2529,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2484,23 +2545,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2516,6 +2582,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2541,50 +2610,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.21"
@@ -2598,7 +2654,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2659,7 +2715,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -2758,8 +2814,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -2843,8 +2906,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -2852,23 +2922,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -2884,6 +2959,9 @@ jobs:
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         run: |
           # Random delay to sparse 'update comment' steps in time.
           delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
@@ -2909,50 +2987,37 @@ jobs:
           fi
           echo "::set-output name=tmppath::${tmppath}"
 
-          CI_COMMIT_TAG="${{needs.git_info.outputs.ci_commit_tag}}"
-          CI_COMMIT_BRANCH="${{needs.git_info.outputs.ci_commit_branch}}"
-
-          if [[ -n "${CI_COMMIT_TAG}" ]] ; then
-            CI_COMMIT_REF_SLUG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_TAG}"
-          fi
-          if [[ -n "${CI_COMMIT_BRANCH}" ]] ; then
-            CI_COMMIT_REF_SLUG="${{needs.git_info.outputs.ci_commit_ref_slug}}"
-            echo "Deckhouse Deployment will use docker tag '${CI_COMMIT_REF_SLUG}' to test branch ${CI_COMMIT_BRANCH}"
-          fi
-          echo "::set-output name=ci_commit_ref_slug::${CI_COMMIT_REF_SLUG}"
-
           ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
 
           IMAGE_NAME=
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
-
-            if [[ -n "${DEV_REGISTRY_PATH}" ]]; then
-              IMAGE_NAME=${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}
-            else
-              IMAGE_NAME=${CI_REGISTRY_IMAGE}/install:${IMAGE_TAG}
-            fi
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
           fi
-
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
-            else
-              echo "DECKHOUSE_REGISTRY_HOST is empty."
-              exit 1
-            fi
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
           fi
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
-          echo "Pull 'dev/install' image"
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.22"
@@ -2966,7 +3031,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -3027,7 +3092,7 @@ jobs:
           WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{steps.setup.outputs.ci_commit_ref_slug}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
           TMPPATH: ${{ steps.setup.outputs.tmppath}}
           PREFIX: ${{ steps.setup.outputs.prefix}}
@@ -3126,8 +3191,15 @@ jobs:
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
 
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
       - name: Alert on fail in default branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd

--- a/.github/workflows/schedule-cleanup.yml
+++ b/.github/workflows/schedule-cleanup.yml
@@ -24,8 +24,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
 
 
@@ -167,8 +167,15 @@ jobs:
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -186,7 +193,13 @@ jobs:
         env:
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          ENABLE_REGISTRY_CLEANUP: ${{secrets.ENABLE_REGISTRY_CLEANUP}}
         run: |
+          if [[ ${ENABLE_REGISTRY_CLEANUP} != "true" ]] ; then
+            echo "⚓️ [$(date -u)] ENABLE_REGISTRY_CLEANUP is not 'true', skip running 'werf cleanup'."
+            exit 0
+          fi
+
           export WERF_REPO=${DEV_REGISTRY_PATH}
           type werf && source $(werf ci-env github --config werf_cleanup.yaml --verbose --as-file)
           werf cleanup --config werf_cleanup.yaml --without-kube

--- a/.github/workflows/suspend-alpha.yml
+++ b/.github/workflows/suspend-alpha.yml
@@ -32,8 +32,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: alpha
 
@@ -153,8 +153,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -162,23 +169,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -189,7 +201,32 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: CE
+          SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function push_rmi() {
+            SRC_NAME=$1
+            DST=$2
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_SUSPEND=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
+
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -201,39 +238,63 @@ jobs:
           fi
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=alpha
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          echo "⚓️ 💫 [$(date -u)] Start publishing 'release-channel suspend' image for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          DST_REGISTRY_PATH=${DECKHOUSE_REGISTRY_HOST}/deckhouse
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DST_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${DST_REGISTRY_PATH}'"
           fi
+
+          #   3. Build and publish release-channel image to prod registry.
+          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
 
           echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+          docker build . -t "${RELEASE_VERSION_IMAGE}"
 
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: EE
+          SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function push_rmi() {
+            SRC_NAME=$1
+            DST=$2
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_SUSPEND=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
+
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -245,39 +306,63 @@ jobs:
           fi
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=alpha
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          echo "⚓️ 💫 [$(date -u)] Start publishing 'release-channel suspend' image for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          DST_REGISTRY_PATH=${DECKHOUSE_REGISTRY_HOST}/deckhouse
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DST_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${DST_REGISTRY_PATH}'"
           fi
+
+          #   3. Build and publish release-channel image to prod registry.
+          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
 
           echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+          docker build . -t "${RELEASE_VERSION_IMAGE}"
 
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: FE
+          SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function push_rmi() {
+            SRC_NAME=$1
+            DST=$2
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_SUSPEND=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
+
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -289,33 +374,32 @@ jobs:
           fi
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=alpha
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          echo "⚓️ 💫 [$(date -u)] Start publishing 'release-channel suspend' image for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          DST_REGISTRY_PATH=${DECKHOUSE_REGISTRY_HOST}/deckhouse
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DST_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${DST_REGISTRY_PATH}'"
           fi
+
+          #   3. Build and publish release-channel image to prod registry.
+          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
 
           echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+          docker build . -t "${RELEASE_VERSION_IMAGE}"
 
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/suspend-beta.yml
+++ b/.github/workflows/suspend-beta.yml
@@ -32,8 +32,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: beta
 
@@ -153,8 +153,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -162,23 +169,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -189,7 +201,32 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: CE
+          SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function push_rmi() {
+            SRC_NAME=$1
+            DST=$2
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_SUSPEND=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
+
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -201,39 +238,63 @@ jobs:
           fi
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=beta
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          echo "⚓️ 💫 [$(date -u)] Start publishing 'release-channel suspend' image for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          DST_REGISTRY_PATH=${DECKHOUSE_REGISTRY_HOST}/deckhouse
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DST_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${DST_REGISTRY_PATH}'"
           fi
+
+          #   3. Build and publish release-channel image to prod registry.
+          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
 
           echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+          docker build . -t "${RELEASE_VERSION_IMAGE}"
 
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: EE
+          SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function push_rmi() {
+            SRC_NAME=$1
+            DST=$2
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_SUSPEND=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
+
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -245,39 +306,63 @@ jobs:
           fi
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=beta
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          echo "⚓️ 💫 [$(date -u)] Start publishing 'release-channel suspend' image for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          DST_REGISTRY_PATH=${DECKHOUSE_REGISTRY_HOST}/deckhouse
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DST_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${DST_REGISTRY_PATH}'"
           fi
+
+          #   3. Build and publish release-channel image to prod registry.
+          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
 
           echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+          docker build . -t "${RELEASE_VERSION_IMAGE}"
 
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: FE
+          SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function push_rmi() {
+            SRC_NAME=$1
+            DST=$2
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_SUSPEND=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
+
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -289,33 +374,32 @@ jobs:
           fi
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=beta
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          echo "⚓️ 💫 [$(date -u)] Start publishing 'release-channel suspend' image for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          DST_REGISTRY_PATH=${DECKHOUSE_REGISTRY_HOST}/deckhouse
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DST_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${DST_REGISTRY_PATH}'"
           fi
+
+          #   3. Build and publish release-channel image to prod registry.
+          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
 
           echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+          docker build . -t "${RELEASE_VERSION_IMAGE}"
 
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/suspend-early-access.yml
+++ b/.github/workflows/suspend-early-access.yml
@@ -32,8 +32,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: early-access
 
@@ -153,8 +153,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -162,23 +169,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -189,7 +201,32 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: CE
+          SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function push_rmi() {
+            SRC_NAME=$1
+            DST=$2
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_SUSPEND=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
+
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -201,39 +238,63 @@ jobs:
           fi
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=early-access
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          echo "⚓️ 💫 [$(date -u)] Start publishing 'release-channel suspend' image for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          DST_REGISTRY_PATH=${DECKHOUSE_REGISTRY_HOST}/deckhouse
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DST_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${DST_REGISTRY_PATH}'"
           fi
+
+          #   3. Build and publish release-channel image to prod registry.
+          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
 
           echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+          docker build . -t "${RELEASE_VERSION_IMAGE}"
 
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: EE
+          SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function push_rmi() {
+            SRC_NAME=$1
+            DST=$2
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_SUSPEND=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
+
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -245,39 +306,63 @@ jobs:
           fi
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=early-access
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          echo "⚓️ 💫 [$(date -u)] Start publishing 'release-channel suspend' image for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          DST_REGISTRY_PATH=${DECKHOUSE_REGISTRY_HOST}/deckhouse
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DST_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${DST_REGISTRY_PATH}'"
           fi
+
+          #   3. Build and publish release-channel image to prod registry.
+          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
 
           echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+          docker build . -t "${RELEASE_VERSION_IMAGE}"
 
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: FE
+          SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function push_rmi() {
+            SRC_NAME=$1
+            DST=$2
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_SUSPEND=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
+
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -289,33 +374,32 @@ jobs:
           fi
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=early-access
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          echo "⚓️ 💫 [$(date -u)] Start publishing 'release-channel suspend' image for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          DST_REGISTRY_PATH=${DECKHOUSE_REGISTRY_HOST}/deckhouse
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DST_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${DST_REGISTRY_PATH}'"
           fi
+
+          #   3. Build and publish release-channel image to prod registry.
+          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
 
           echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+          docker build . -t "${RELEASE_VERSION_IMAGE}"
 
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/suspend-rock-solid.yml
+++ b/.github/workflows/suspend-rock-solid.yml
@@ -32,8 +32,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: rock-solid
 
@@ -153,8 +153,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -162,23 +169,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -189,7 +201,32 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: CE
+          SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function push_rmi() {
+            SRC_NAME=$1
+            DST=$2
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_SUSPEND=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
+
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -201,39 +238,63 @@ jobs:
           fi
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=rock-solid
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          echo "⚓️ 💫 [$(date -u)] Start publishing 'release-channel suspend' image for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          DST_REGISTRY_PATH=${DECKHOUSE_REGISTRY_HOST}/deckhouse
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DST_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${DST_REGISTRY_PATH}'"
           fi
+
+          #   3. Build and publish release-channel image to prod registry.
+          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
 
           echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+          docker build . -t "${RELEASE_VERSION_IMAGE}"
 
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: EE
+          SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function push_rmi() {
+            SRC_NAME=$1
+            DST=$2
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_SUSPEND=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
+
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -245,39 +306,63 @@ jobs:
           fi
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=rock-solid
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          echo "⚓️ 💫 [$(date -u)] Start publishing 'release-channel suspend' image for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          DST_REGISTRY_PATH=${DECKHOUSE_REGISTRY_HOST}/deckhouse
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DST_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${DST_REGISTRY_PATH}'"
           fi
+
+          #   3. Build and publish release-channel image to prod registry.
+          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
 
           echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+          docker build . -t "${RELEASE_VERSION_IMAGE}"
 
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: FE
+          SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function push_rmi() {
+            SRC_NAME=$1
+            DST=$2
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_SUSPEND=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
+
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -289,33 +374,32 @@ jobs:
           fi
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=rock-solid
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          echo "⚓️ 💫 [$(date -u)] Start publishing 'release-channel suspend' image for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          DST_REGISTRY_PATH=${DECKHOUSE_REGISTRY_HOST}/deckhouse
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DST_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${DST_REGISTRY_PATH}'"
           fi
+
+          #   3. Build and publish release-channel image to prod registry.
+          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
 
           echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+          docker build . -t "${RELEASE_VERSION_IMAGE}"
 
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/suspend-stable.yml
+++ b/.github/workflows/suspend-stable.yml
@@ -32,8 +32,8 @@ env:
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in Github.
   DEV_REGISTRY_PATH: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss"
   BASE_IMAGES_REGISTRY_PATH: "registry.deckhouse.io/base_images/"
-
-  FLANT_REGISTRY_PATH: "${{ secrets.FLANT_REGISTRY_HOST }}/sys/deckhouse-oss"
+  # Registry for additional repositories used for testing Github Actions workflows.
+  GHA_TEST_REGISTRY_PATH: "ghcr.io/${{ github.repository }}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: stable
 
@@ -153,8 +153,15 @@ jobs:
       # </template: update_comment_on_start>
 
       # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to dev registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -162,23 +169,28 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-      # <template: login_readonly_registry_step>
-      - name: Login to readonly registry
-        uses: docker/login-action@v1.10.0
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
-          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
-          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
-          logout: false
-      # </template: login_readonly_registry_step>
-
       # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
       - name: Login to rw registry
         uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
           username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
           password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
           logout: false
       # </template: login_rw_registry_step>
 
@@ -189,7 +201,32 @@ jobs:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: CE
+          SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function push_rmi() {
+            SRC_NAME=$1
+            DST=$2
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_SUSPEND=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
+
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -201,39 +238,63 @@ jobs:
           fi
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=stable
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          echo "⚓️ 💫 [$(date -u)] Start publishing 'release-channel suspend' image for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          DST_REGISTRY_PATH=${DECKHOUSE_REGISTRY_HOST}/deckhouse
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DST_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${DST_REGISTRY_PATH}'"
           fi
+
+          #   3. Build and publish release-channel image to prod registry.
+          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
 
           echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+          docker build . -t "${RELEASE_VERSION_IMAGE}"
 
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: EE
+          SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function push_rmi() {
+            SRC_NAME=$1
+            DST=$2
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_SUSPEND=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
+
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -245,39 +306,63 @@ jobs:
           fi
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=stable
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          echo "⚓️ 💫 [$(date -u)] Start publishing 'release-channel suspend' image for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          DST_REGISTRY_PATH=${DECKHOUSE_REGISTRY_HOST}/deckhouse
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DST_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${DST_REGISTRY_PATH}'"
           fi
+
+          #   3. Build and publish release-channel image to prod registry.
+          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
 
           echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+          docker build . -t "${RELEASE_VERSION_IMAGE}"
 
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           WERF_ENV: FE
+          SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
+          # SRC_NAME is a name of image from werf.yaml.
+          # SRC is a source image name.
+          # DST is an image name for docker push.
+          function push_rmi() {
+            SRC_NAME=$1
+            DST=$2
+
+            enable_push="true"
+            if [[ ${GITHUB_REPOSITORY} != "deckhouse/deckhouse" ]]; then
+              if [[ ${SKIP_PUSH_FOR_SUSPEND} == "true" ]]; then
+                enable_push="false"
+                echo "⚓️ ❎ [$(date -u)] SKIP_PUSH_FOR_SUSPEND=true, skip running 'docker image push ${DST}'."
+              fi
+            fi
+
+            if [[ ${enable_push} == "true" ]] ; then
+              echo "⚓️ 📤 [$(date -u)] Push '${SRC_NAME}' image as ${DST}."
+              docker image push ${DST}
+            fi
+
+            echo "⚓️ 🧹 [$(date -u)] Remove local tag for '${SRC_NAME}'."
+            docker image rmi ${DST} || true;
+          }
+
           # Some precautions.
           if [[ -z $DEV_REGISTRY_PATH ]] ; then
             echo "DEV_REGISTRY_PATH is not set!"
@@ -289,33 +374,32 @@ jobs:
           fi
 
           # Variables
-          #   1. CE/EE/FE -> ce/ee/fe
+          #   1. Edition and channel.
+          # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-          echo "Registry suffix - ${REGISTRY_SUFFIX}"
-
-          #   2. alpha: [EE] -> alpha , beta: [CE] -> beta
           RELEASE_CHANNEL=stable
-          echo "Release channel - ${RELEASE_CHANNEL}"
 
-          #   3. Publish prod images to rw registry
-          if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
-          else
-            DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE=${CI_REGISTRY_IMAGE}/deckhouse/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL};
+          echo "⚓️ 💫 [$(date -u)] Start publishing 'release-channel suspend' image for '${REGISTRY_SUFFIX}' edition onto '${RELEASE_CHANNEL}' release channel."
+
+          #   2. Prod registry: use github packages if DECKHOUSE_REGISTRY_HOST not set (run in the test repo).
+          DST_REGISTRY_PATH=${DECKHOUSE_REGISTRY_HOST}/deckhouse
+          if [[ -z "${DECKHOUSE_REGISTRY_HOST}" ]]; then
+            DST_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+            echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${DST_REGISTRY_PATH}'"
           fi
+
+          #   3. Build and publish release-channel image to prod registry.
+          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
 
           echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t $DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE
+          docker build . -t "${RELEASE_VERSION_IMAGE}"
 
-          docker image push ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}
-          echo "Delete local 'release version' image ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
-          docker image rmi ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE} || true
-
-          echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -27,6 +27,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  close_dependabot_prs_for_forks:
+    name: Autoclose Dependabot PRs for forks
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' && github.repository != 'deckhouse/deckhouse' }}
+    env:
+      ENABLE_DEPENDABOT_IN_FORKS: ${{ secrets.ENABLE_DEPENDABOT_IN_FORKS }}
+    steps:
+      - name: Close PR
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          script: |
+            // Keep PR if explicitly enabled.
+            const {ENABLE_DEPENDABOT_IN_FORKS} = process.env;
+            const prNum = context.payload.pull_request.number;
+            const repo = context.payload.repository.full_name;
+            if (ENABLE_DEPENDABOT_IN_FORKS === 'true') {
+              core.info(`Secret ENABLE_DEPENDABOT_IN_FORKS is 'true', proceed with validation for PR#${prNUM} in repo ${repo}.`);
+              return
+            }
+            core.info(`Secret ENABLE_DEPENDABOT_IN_FORKS is not 'true', close PR#${prNum} in repo ${repo}.`);
+            return await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNum,
+              state: 'closed'
+            });
+
 
   # <template: pull_request_info>
   pull_request_info:


### PR DESCRIPTION
## Description

Change workflows to support additional repos for testing further CI changes.

Differences between workflows in main repo and test repos:

1. No two-repo schema for werf build.
2. Final images are pushed to ghcr.io (e.g. ghcr.io/deckhouse/deckhouse-test-1).
3. Repo for documentation and site images is ghcr.io.
4. Only AWS and static providers available for E2E tests.
5. No alerts on E2E fails in main branch.
6. Push for deploy and suspend can be skipped with SKIP_PUSH_FOR_SUSPEND and SKIP_PUSH_FOR_DEPLOY variables.
7. No registry cleanup.
8. Autoclose for Dependabot PRs (can be enabled with secret ENABLE_DEPENDABOT_IN_FORKS=true). There is no option to turn off dependabot in repo without deleting its config from Git.
9. Conditional docker logins.
10. Use stage image to run tests in build workflows.

Also, some fixes:

- Remove continue-on-error to get real status in needs.context.
- Support slash commands in private repo.
- Fix typos in commenting on build.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

The best way to test CI changes is to use separate repo, so this PR make it possible.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: fix
summary: support for additional repos to test CI cnahges
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
