### PR TITLE
[user-authz] Validate service account names

### DIFF
--- a/modules/140-user-authz/crds/crd.yaml
+++ b/modules/140-user-authz/crds/crd.yaml
@@ -109,6 +109,7 @@ spec:
                         example: 'some-group-name'
                       namespace:
                         type: string
+                        minLength: 1
                         maxLength: 63
                         pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                         description: 'ServiceAccount namespace.'

--- a/modules/140-user-authz/crds/crd.yaml
+++ b/modules/140-user-authz/crds/crd.yaml
@@ -100,17 +100,17 @@ spec:
                     properties:
                       kind:
                         type: string
-                        enum: [User,Group,ServiceAccount]
+                        enum: [User, Group, ServiceAccount]
                         description: 'Type of user identification resource.'
                         example: 'Group'
                       name:
                         type: string
-                        minLength: 1
                         description: 'Resource name.'
                         example: 'some-group-name'
                       namespace:
                         type: string
-                        minLength: 1
+                        maxLength: 63
+                        pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
                         description: 'ServiceAccount namespace.'
                 additionalRoles:
                   type: array

--- a/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
+++ b/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
@@ -64,13 +64,13 @@ function __main__() {
     # Group and User should not have a namespace
     namespace_failed=$(jq -rc '
     if .kind != "ServiceAccount" and .namespace != null
-    then "\(.kind)/\(.name)"
+    then "\(.kind) \(.name)"
     else false
     end
     ' <<< "$subject")
 
     if [[ "$namespace_failed" != "false" ]]; then
-      message="$message Namespace for the ServiceAccount $namespace_failed is not provided ;"
+      message="$message Namespace for the $namespace_failed must not be provided ;"
     fi
   done
 

--- a/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
+++ b/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source /shell_lib.sh
+
+function __config__(){
+  cat <<EOF
+configVersion: v1
+kubernetesValidating:
+- name: cluster-authorization-rules.deckhouse.io
+  group: main
+  rules:
+  - apiGroups:   ["deckhouse.io"]
+    apiVersions: ["*"]
+    operations:  ["CREATE", "UPDATE"]
+    resources:   ["clusterauthorizationrules"]
+    scope:       "Cluster"
+EOF
+}
+
+function __main__() {
+  subjects=$()
+
+  message="error:"
+
+  for subject in $(context::jq -r '.review.request.object.spec.subjects // [] | .[]'); do
+    res=$(jq -rc '
+    if
+      .kind == "ServiceAccount" and
+      (.name | test("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$") | not)
+    then
+      .name
+    else
+      false
+    end
+    ' <<< "$subject")
+
+    if [[ "$res" != "false" ]]; then
+      message="$message ServiceAccount name is invalid: $res ;"
+    fi
+  done
+
+  if [[ "$message" == "error:" ]]; then
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":true}
+EOF
+  else
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"$message"}
+EOF
+  fi
+}
+
+hook::run "$@"

--- a/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
+++ b/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
@@ -36,34 +36,41 @@ function __main__() {
 
   for subject in $(context::jq -rc '.review.request.object.spec.subjects // [] | .[]'); do
     # ServiceAccount name must be a valid domain name
-    res=$(jq -rc '
+    domain_failed=$(jq -rc '
     if
       .kind == "ServiceAccount" and
       (.name | test("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$") | not)
-    then
-      .name
-    else
-      false
+    then .name
+    else false
     end
     ' <<< "$subject")
 
-    if [[ "$res" != "false" ]]; then
-      message="$message ServiceAccount name is invalid: \"$res\" ;"
+    if [[ "$domain_failed" != "false" ]]; then
+      message="$message ServiceAccount name is invalid - $domain_failed ;"
     fi
 
     # ServiceAccount has to have namespace
-    res=$(jq -rc '
-    if
-      .kind == "ServiceAccount" and .namespace == null
-    then
-      .name
-    else
-      false
+    namespace_required=$(jq -rc '
+    if .kind == "ServiceAccount" and .namespace == null
+    then .name
+    else false
     end
     ' <<< "$subject")
 
-    if [[ "$res" != "false" ]]; then
-      message="$message Namespace for the ServiceAccount \"$res\" is not provided ;"
+    if [[ "$namespace_required" != "false" ]]; then
+      message="$message Namespace for the ServiceAccount $namespace_required is not provided ;"
+    fi
+
+    # Group and User should not have a namespace
+    namespace_failed=$(jq -rc '
+    if .kind != "ServiceAccount" and .namespace != null
+    then "\(.kind)/\(.name)"
+    else false
+    end
+    ' <<< "$subject")
+
+    if [[ "$namespace_failed" != "false" ]]; then
+      message="$message Namespace for the ServiceAccount $namespace_failed is not provided ;"
     fi
   done
 

--- a/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
+++ b/modules/140-user-authz/webhooks/validating/cluster_authorization_rule
@@ -32,11 +32,10 @@ EOF
 }
 
 function __main__() {
-  subjects=$()
-
   message="error:"
 
-  for subject in $(context::jq -r '.review.request.object.spec.subjects // [] | .[]'); do
+  for subject in $(context::jq -rc '.review.request.object.spec.subjects // [] | .[]'); do
+    # ServiceAccount name must be a valid domain name
     res=$(jq -rc '
     if
       .kind == "ServiceAccount" and
@@ -49,7 +48,22 @@ function __main__() {
     ' <<< "$subject")
 
     if [[ "$res" != "false" ]]; then
-      message="$message ServiceAccount name is invalid: $res ;"
+      message="$message ServiceAccount name is invalid: \"$res\" ;"
+    fi
+
+    # ServiceAccount has to have namespace
+    res=$(jq -rc '
+    if
+      .kind == "ServiceAccount" and .namespace == null
+    then
+      .name
+    else
+      false
+    end
+    ' <<< "$subject")
+
+    if [[ "$res" != "false" ]]; then
+      message="$message Namespace for the ServiceAccount \"$res\" is not provided ;"
     fi
   done
 


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Add validation webhook

## Why do we need it, and what problem does it solve?
* Validate ServiceAccount name using regex
* Validate that namespace of the ServiceAccount is provided
* Validate that namespace is not provided for the Group and UIser subjects

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: user-authz
type: fix
summary: Add more validations for the ClusterAuthorizationRule subjects section
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
