### PR TITLE
[cluster-provider-yandex] fix: existingZoneToSubnetIDMap is a forbidden property

### DIFF
--- a/modules/030-cloud-provider-yandex/openapi/values.yaml
+++ b/modules/030-cloud-provider-yandex/openapi/values.yaml
@@ -242,6 +242,19 @@ properties:
 
               They will serve as a basis for subnets in three Yandex.Cloud zones.
             pattern: '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$'
+          existingZoneToSubnetIDMap:
+            type: object
+            description: |
+              One or more pre-existing subnets mapped to respective zone.
+
+                  ```yaml
+                  ru-central1-a: e2lu8r1tbbtryhdpa9ro
+                  ru-central1-b: e2lu8r1tbbtryhdpa9ro
+                  ru-central1-c: e2lu8r1tbbtryhdpa9ro
+                  ```
+            additionalProperties:
+              type: string
+            pattern: '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$'
           labels:
             description: |
               Labels to attach to resources created in the Yandex.Cloud.

--- a/modules/030-cloud-provider-yandex/openapi/values.yaml
+++ b/modules/030-cloud-provider-yandex/openapi/values.yaml
@@ -254,7 +254,7 @@ properties:
                   ```
             additionalProperties:
               type: string
-            pattern: '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$'
+              minLength: 1
           labels:
             description: |
               Labels to attach to resources created in the Yandex.Cloud.


### PR DESCRIPTION
## Description


Add existingZoneToSubnetIDMap field to openapi/values.yaml to fix error on install:

```
cloud-provider-yandex/taskRunner: Module hook failed, requeue task to retry after delay. Failed count is 18. Error: 2 errors occurred:
* cannot apply values patch for module values
* cloudProviderYandex.internal.providerClusterConfiguration.existingZoneToSubnetIDMap is a forbidden property
```

## Why do we need it, and what problem does it solve?

Installation failed when set `existingZoneToSubnetIDMap` in `YandexClusterConfiguration`

## Changelog entries


```changes
section: cluster-provider-yandex
type: fix
summary: add existingZoneToSubnetIDMap field to openapi/values.yaml
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
