### PR TITLE
[user-authn] fix .spec.ldap.bindPW escaping in DexProvider

### DIFF
--- a/modules/150-user-authn/templates/dex/config.yaml
+++ b/modules/150-user-authn/templates/dex/config.yaml
@@ -108,7 +108,7 @@
         bindDN: {{ $provider.ldap.bindDN | quote }}
         {{- end }}
         {{- if $provider.ldap.bindPW  }}
-        bindPW: {{ $provider.ldap.bindPW }}
+        bindPW: '{{ $provider.ldap.bindPW }}'
         {{- end }}
         {{- if $provider.ldap.startTLS }}
         startTLS: true

--- a/modules/150-user-authn/templates/dex/config.yaml
+++ b/modules/150-user-authn/templates/dex/config.yaml
@@ -108,7 +108,7 @@
         bindDN: {{ $provider.ldap.bindDN | quote }}
         {{- end }}
         {{- if $provider.ldap.bindPW  }}
-        bindPW: {{ $provider.ldap.bindPW | quote }}
+        bindPW: {{ $provider.ldap.bindPW }}
         {{- end }}
         {{- if $provider.ldap.startTLS }}
         startTLS: true


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed `.spec.ldap.bindPW` escaping in `DexProvider`

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
The `\` character in the config turned into `\\`

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: user-authn
type: fix
summary: Fixed .spec.ldap.bindPW escaping in DexProvider
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
