### PR TITLE
[cloud-provider-openstack] Set volume availability zone in dhctl on bootstrap

### DIFF
--- a/ee/candi/cloud-providers/openstack/layouts/simple-with-internal-network/master-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/simple-with-internal-network/master-node/main.tf
@@ -37,6 +37,7 @@ module "kubernetes_data" {
   node_index = var.nodeIndex
   master_id = module.master.id
   volume_type = local.volume_type
+  volume_zone = local.zone
   tags = local.tags
 }
 

--- a/ee/candi/cloud-providers/openstack/layouts/simple-with-internal-network/variables.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/simple-with-internal-network/variables.tf
@@ -10,12 +10,12 @@ variable "providerClusterConfiguration" {
 }
 
 variable "nodeIndex" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "cloudConfig" {
-  type = string
+  type    = string
   default = ""
 }
 
@@ -24,11 +24,11 @@ variable "clusterUUID" {
 }
 
 locals {
-  prefix = var.clusterConfiguration.cloud.prefix
-  pod_subnet_cidr = var.clusterConfiguration.podSubnetCIDR
-  internal_subnet_name = var.providerClusterConfiguration.simpleWithInternalNetwork.internalSubnetName
+  prefix                = var.clusterConfiguration.cloud.prefix
+  pod_subnet_cidr       = var.clusterConfiguration.podSubnetCIDR
+  internal_subnet_name  = var.providerClusterConfiguration.simpleWithInternalNetwork.internalSubnetName
   external_network_name = lookup(var.providerClusterConfiguration.simpleWithInternalNetwork, "externalNetworkName", "")
-  pod_network_mode = lookup(var.providerClusterConfiguration.simpleWithInternalNetwork, "podNetworkMode", "DirectRoutingWithPortSecurityEnabled")
-  image_name = var.providerClusterConfiguration.masterNodeGroup.instanceClass.imageName
-  tags = lookup(var.providerClusterConfiguration, "tags", {})
+  pod_network_mode      = lookup(var.providerClusterConfiguration.simpleWithInternalNetwork, "podNetworkMode", "DirectRoutingWithPortSecurityEnabled")
+  image_name            = var.providerClusterConfiguration.masterNodeGroup.instanceClass.imageName
+  tags                  = lookup(var.providerClusterConfiguration, "tags", {})
 }

--- a/ee/candi/cloud-providers/openstack/layouts/simple/master-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/simple/master-node/main.tf
@@ -37,6 +37,7 @@ module "kubernetes_data" {
   node_index = var.nodeIndex
   master_id = openstack_compute_instance_v2.master.id
   volume_type = local.volume_type
+  volume_zone = local.zone
   tags = local.tags
 }
 
@@ -50,10 +51,11 @@ resource "openstack_blockstorage_volume_v2" "master" {
   size = local.root_disk_size
   image_id = data.openstack_images_image_v2.master.id
   metadata = local.metadata_tags
-  volume_type = local.volume_type
+  availability_zone = local.volume_type
   lifecycle {
     ignore_changes = [
       metadata,
+      availability_zone,
     ]
   }
 }

--- a/ee/candi/cloud-providers/openstack/layouts/simple/variables.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/simple/variables.tf
@@ -10,12 +10,12 @@ variable "providerClusterConfiguration" {
 }
 
 variable "nodeIndex" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "cloudConfig" {
-  type = string
+  type    = string
   default = ""
 }
 
@@ -24,11 +24,11 @@ variable "clusterUUID" {
 }
 
 locals {
-  prefix = var.clusterConfiguration.cloud.prefix
-  pod_subnet_cidr = var.clusterConfiguration.podSubnetCIDR
+  prefix                = var.clusterConfiguration.cloud.prefix
+  pod_subnet_cidr       = var.clusterConfiguration.podSubnetCIDR
   external_network_name = var.providerClusterConfiguration.simple.externalNetworkName
   external_network_dhcp = lookup(var.providerClusterConfiguration.simple, "externalNetworkDHCP", true)
-  pod_network_mode = lookup(var.providerClusterConfiguration.simple, "podNetworkMode", "VXLAN")
-  image_name = var.providerClusterConfiguration.masterNodeGroup.instanceClass.imageName
-  tags = lookup(var.providerClusterConfiguration, "tags", {})
+  pod_network_mode      = lookup(var.providerClusterConfiguration.simple, "podNetworkMode", "VXLAN")
+  image_name            = var.providerClusterConfiguration.masterNodeGroup.instanceClass.imageName
+  tags                  = lookup(var.providerClusterConfiguration, "tags", {})
 }

--- a/ee/candi/cloud-providers/openstack/layouts/standard-with-no-router/master-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard-with-no-router/master-node/main.tf
@@ -41,6 +41,7 @@ module "kubernetes_data" {
   node_index = var.nodeIndex
   master_id = module.master.id
   volume_type = local.volume_type
+  volume_zone = local.zone
   tags = local.tags
 }
 

--- a/ee/candi/cloud-providers/openstack/layouts/standard-with-no-router/variables.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard-with-no-router/variables.tf
@@ -8,18 +8,18 @@ variable "clusterConfiguration" {
 variable "providerClusterConfiguration" {
   type = any
   validation {
-    condition = cidrsubnet(var.providerClusterConfiguration.standardWithNoRouter.internalNetworkCIDR, 0, 0) == var.providerClusterConfiguration.standardWithNoRouter.internalNetworkCIDR
+    condition     = cidrsubnet(var.providerClusterConfiguration.standardWithNoRouter.internalNetworkCIDR, 0, 0) == var.providerClusterConfiguration.standardWithNoRouter.internalNetworkCIDR
     error_message = "Invalid internalNetworkCIDR in OpenStackClusterConfiguration."
   }
 }
 
 variable "nodeIndex" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "cloudConfig" {
-  type = string
+  type    = string
   default = ""
 }
 
@@ -28,12 +28,12 @@ variable "clusterUUID" {
 }
 
 locals {
-  prefix = var.clusterConfiguration.cloud.prefix
-  pod_subnet_cidr = var.clusterConfiguration.podSubnetCIDR
+  prefix                = var.clusterConfiguration.cloud.prefix
+  pod_subnet_cidr       = var.clusterConfiguration.podSubnetCIDR
   internal_network_cidr = var.providerClusterConfiguration.standardWithNoRouter.internalNetworkCIDR
   external_network_name = var.providerClusterConfiguration.standardWithNoRouter.externalNetworkName
   external_network_dhcp = lookup(var.providerClusterConfiguration.standardWithNoRouter, "externalNetworkDHCP", true)
-  network_security = lookup(var.providerClusterConfiguration.standardWithNoRouter, "internalNetworkSecurity", true)
-  image_name = var.providerClusterConfiguration.masterNodeGroup.instanceClass.imageName
-  tags = lookup(var.providerClusterConfiguration, "tags", {})
+  network_security      = lookup(var.providerClusterConfiguration.standardWithNoRouter, "internalNetworkSecurity", true)
+  image_name            = var.providerClusterConfiguration.masterNodeGroup.instanceClass.imageName
+  tags                  = lookup(var.providerClusterConfiguration, "tags", {})
 }

--- a/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
@@ -125,7 +125,13 @@ resource "openstack_compute_floatingip_v2" "bastion" {
 }
 
 resource "openstack_compute_floatingip_associate_v2" "bastion" {
-  count       = local.bastion_instance != {} ? 1 : 0
-  floating_ip = openstack_compute_floatingip_v2.bastion[0].address
-  instance_id = openstack_compute_instance_v2.bastion[0].id
+  count                 = local.bastion_instance != {} ? 1 : 0
+  floating_ip           = openstack_compute_floatingip_v2.bastion[0].address
+  instance_id           = openstack_compute_instance_v2.bastion[0].id
+  wait_until_associated = true
+  lifecycle {
+    ignore_changes = [
+      wait_until_associated,
+    ]
+  }
 }

--- a/ee/candi/cloud-providers/openstack/layouts/standard/master-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/master-node/main.tf
@@ -41,6 +41,7 @@ module "kubernetes_data" {
   node_index  = var.nodeIndex
   master_id   = module.master.id
   volume_type = local.volume_type
+  volume_zone = local.zone
   tags        = local.tags
 }
 

--- a/ee/candi/cloud-providers/openstack/terraform-modules/kubernetes-data/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/kubernetes-data/main.tf
@@ -6,10 +6,12 @@ resource "openstack_blockstorage_volume_v2" "kubernetes_data" {
   description = "volume for etcd and kubernetes certs"
   size = 10
   volume_type = var.volume_type
+  availability_zone = var.volume_zone
   metadata = var.tags
   lifecycle {
     ignore_changes = [
       metadata,
+      availability_zone,
     ]
   }
 }

--- a/ee/candi/cloud-providers/openstack/terraform-modules/kubernetes-data/variables.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/kubernetes-data/variables.tf
@@ -17,6 +17,10 @@ variable "volume_type" {
   type = string
 }
 
+variable "volume_zone" {
+  type = string
+}
+
 variable "tags" {
   type = map(string)
 }

--- a/ee/candi/cloud-providers/openstack/terraform-modules/master/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/master/main.tf
@@ -10,26 +10,28 @@ data "openstack_images_image_v2" "master" {
 }
 
 resource "openstack_blockstorage_volume_v2" "master" {
-  count = var.root_disk_size == "" ? 0 : 1
-  name = join("-", [var.prefix, "master-root-volume", var.node_index])
-  size = var.root_disk_size
-  image_id = data.openstack_images_image_v2.master.id
-  metadata = local.metadata_tags
-  volume_type = var.volume_type
+  count             = var.root_disk_size == "" ? 0 : 1
+  name              = join("-", [var.prefix, "master-root-volume", var.node_index])
+  size              = var.root_disk_size
+  image_id          = data.openstack_images_image_v2.master.id
+  metadata          = local.metadata_tags
+  volume_type       = var.volume_type
+  availability_zone = var.zone
   lifecycle {
     ignore_changes = [
       metadata,
+      availability_zone,
     ]
   }
 }
 
 resource "openstack_compute_instance_v2" "master" {
-  name = join("-", [var.prefix, "master", var.node_index])
-  image_name = data.openstack_images_image_v2.master.name
-  flavor_name = var.flavor_name
-  key_pair = var.keypair_ssh_name
-  config_drive = var.config_drive
-  user_data = var.cloud_config == "" ? null : base64decode(var.cloud_config)
+  name              = join("-", [var.prefix, "master", var.node_index])
+  image_name        = data.openstack_images_image_v2.master.name
+  flavor_name       = var.flavor_name
+  key_pair          = var.keypair_ssh_name
+  config_drive      = var.config_drive
+  user_data         = var.cloud_config == "" ? null : base64decode(var.cloud_config)
   availability_zone = var.zone
 
   dynamic "network" {
@@ -43,10 +45,10 @@ resource "openstack_compute_instance_v2" "master" {
   dynamic "block_device" {
     for_each = var.root_disk_size == "" ? [] : list(openstack_blockstorage_volume_v2.master[0])
     content {
-      uuid = block_device.value["id"]
-      boot_index = 0
-      source_type = "volume"
-      destination_type = "volume"
+      uuid                  = block_device.value["id"]
+      boot_index            = 0
+      source_type           = "volume"
+      destination_type      = "volume"
       delete_on_termination = true
     }
   }
@@ -62,12 +64,19 @@ resource "openstack_compute_instance_v2" "master" {
 
 resource "openstack_compute_floatingip_v2" "master" {
   count = var.floating_ip_network == "" ? 0 : 1
-  pool = var.floating_ip_network
+  pool  = var.floating_ip_network
 }
 
 resource "openstack_compute_floatingip_associate_v2" "master" {
-  count = var.floating_ip_network == "" ? 0 : 1
-  floating_ip = openstack_compute_floatingip_v2.master[0].address
-  instance_id = openstack_compute_instance_v2.master.id
+  count                 = var.floating_ip_network == "" ? 0 : 1
+  floating_ip           = openstack_compute_floatingip_v2.master[0].address
+  instance_id           = openstack_compute_instance_v2.master.id
+  wait_until_associated = true
+
+  lifecycle {
+    ignore_changes = [
+      wait_until_associated,
+    ]
+  }
 }
 

--- a/ee/candi/cloud-providers/openstack/terraform-modules/providers.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/providers.tf
@@ -2,12 +2,12 @@
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 
 provider "openstack" {
-  auth_url = var.providerClusterConfiguration.provider.authURL
+  auth_url    = var.providerClusterConfiguration.provider.authURL
   domain_name = var.providerClusterConfiguration.provider.domainName
   cacert_file = lookup(var.providerClusterConfiguration.provider, "caCert", "")
   tenant_name = lookup(var.providerClusterConfiguration.provider, "tenantName", "")
-  tenant_id = lookup(var.providerClusterConfiguration.provider, "tenantID", "")
-  user_name = var.providerClusterConfiguration.provider.username
-  password = var.providerClusterConfiguration.provider.password
-  region = var.providerClusterConfiguration.provider.region
+  tenant_id   = lookup(var.providerClusterConfiguration.provider, "tenantID", "")
+  user_name   = var.providerClusterConfiguration.provider.username
+  password    = var.providerClusterConfiguration.provider.password
+  region      = var.providerClusterConfiguration.provider.region
 }

--- a/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
@@ -3,11 +3,11 @@
 
 locals {
   actual_zones = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(data.openstack_compute_availability_zones_v2.zones.names, var.providerClusterConfiguration.zones)) : data.openstack_compute_availability_zones_v2.zones.names
-  zones = lookup(local.ng, "zones", null) != null ? tolist(setintersection(local.actual_zones, local.ng["zones"])) : local.actual_zones
+  zones        = lookup(local.ng, "zones", null) != null ? tolist(setintersection(local.actual_zones, local.ng["zones"])) : local.actual_zones
 }
 
 module "security_groups" {
-  source = "/deckhouse/candi/cloud-providers/openstack/terraform-modules/security-groups"
+  source               = "/deckhouse/candi/cloud-providers/openstack/terraform-modules/security-groups"
   security_group_names = local.security_group_names
 }
 
@@ -19,14 +19,14 @@ data "openstack_images_image_v2" "image" {
 
 data "openstack_networking_network_v2" "network" {
   count = length(local.networks)
-  name = local.networks[count.index]
+  name  = local.networks[count.index]
 }
 
 resource "openstack_networking_port_v2" "port" {
-  count = length(local.networks)
-  name = join("-", [local.prefix, var.nodeGroupName, var.nodeIndex])
-  network_id = data.openstack_networking_network_v2.network[count.index].id
-  admin_state_up = "true"
+  count              = length(local.networks)
+  name               = join("-", [local.prefix, var.nodeGroupName, var.nodeIndex])
+  network_id         = data.openstack_networking_network_v2.network[count.index].id
+  admin_state_up     = "true"
   security_group_ids = try(index(local.networks_with_security_disabled, data.openstack_networking_network_v2.network[count.index].name), -1) == -1 ? module.security_groups.security_group_ids : []
 
   dynamic "allowed_address_pairs" {
@@ -39,25 +39,27 @@ resource "openstack_networking_port_v2" "port" {
 }
 
 resource "openstack_blockstorage_volume_v2" "volume" {
-  count = local.root_disk_size == "" ? 0 : 1
-  name = join("-", [local.prefix, var.nodeGroupName, var.nodeIndex])
-  size = local.root_disk_size
-  image_id = data.openstack_images_image_v2.image.id
-  metadata = local.metadata_tags
+  count             = local.root_disk_size == "" ? 0 : 1
+  name              = join("-", [local.prefix, var.nodeGroupName, var.nodeIndex])
+  size              = local.root_disk_size
+  image_id          = data.openstack_images_image_v2.image.id
+  metadata          = local.metadata_tags
+  availability_zone = element(local.zones, var.nodeIndex)
   lifecycle {
     ignore_changes = [
       metadata,
+      availability_zone,
     ]
   }
 }
 
 resource "openstack_compute_instance_v2" "node" {
-  name = join("-", [local.prefix, var.nodeGroupName, var.nodeIndex])
-  image_name = data.openstack_images_image_v2.image.name
-  flavor_name = local.flavor_name
-  key_pair = local.prefix
-  config_drive = local.config_drive
-  user_data = var.cloudConfig == "" ? "" : base64decode(var.cloudConfig)
+  name              = join("-", [local.prefix, var.nodeGroupName, var.nodeIndex])
+  image_name        = data.openstack_images_image_v2.image.name
+  flavor_name       = local.flavor_name
+  key_pair          = local.prefix
+  config_drive      = local.config_drive
+  user_data         = var.cloudConfig == "" ? "" : base64decode(var.cloudConfig)
   availability_zone = element(local.zones, var.nodeIndex)
 
   dynamic "network" {
@@ -71,10 +73,10 @@ resource "openstack_compute_instance_v2" "node" {
   dynamic "block_device" {
     for_each = local.root_disk_size == "" ? [] : list(openstack_blockstorage_volume_v2.volume[0])
     content {
-      uuid = block_device.value["id"]
-      boot_index = 0
-      source_type = "volume"
-      destination_type = "volume"
+      uuid                  = block_device.value["id"]
+      boot_index            = 0
+      source_type           = "volume"
+      destination_type      = "volume"
       delete_on_termination = true
     }
   }
@@ -90,12 +92,19 @@ resource "openstack_compute_instance_v2" "node" {
 
 resource "openstack_compute_floatingip_v2" "floating_ip" {
   count = length(local.floating_ip_pools)
-  pool = local.floating_ip_pools[count.index]
+  pool  = local.floating_ip_pools[count.index]
 }
 
 resource "openstack_compute_floatingip_associate_v2" "node" {
-  count = length(local.floating_ip_pools)
-  floating_ip = openstack_compute_floatingip_v2.floating_ip[count.index].address
-  instance_id = openstack_compute_instance_v2.node.id
+  count                 = length(local.floating_ip_pools)
+  floating_ip           = openstack_compute_floatingip_v2.floating_ip[count.index].address
+  instance_id           = openstack_compute_instance_v2.node.id
+  wait_until_associated = true
+
+  lifecycle {
+    ignore_changes = [
+      wait_until_associated,
+    ]
+  }
 }
 

--- a/ee/candi/cloud-providers/openstack/terraform-modules/variables.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/variables.tf
@@ -14,7 +14,7 @@ variable "nodeIndex" {
 }
 
 variable "cloudConfig" {
-  type = string
+  type    = string
   default = ""
 }
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- specify availability_zone for volumes created by dhctl
- ignore volume availability_zone changes
- add wait_until_associated flag for openstack_compute_floatingip_associate_v2

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fixes known issues with OpenStack clouds:
- volume types require availability_zone to be set
- floating IP can be attached in background, and it's better to specifically wait for this process to be completed

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-openstack
type: fix
summary: Set volume availability zone in dhctl on bootstrap
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
