### PR TITLE
[istio] nodeSelector and tolerations customization for control-plane

### DIFF
--- a/ee/modules/110-istio/openapi/config-values.yaml
+++ b/ee/modules/110-istio/openapi/config-values.yaml
@@ -238,6 +238,39 @@ properties:
       root:
         type: string
         description: The root certificate in PEM format if `cert` is an intermediate certificate.
+  controlPlane:
+    type: object
+    description: istiod specific settings.
+    default: {}
+    properties:
+      nodeSelector:
+        type: object
+        additionalProperties:
+          type: string
+        description: |
+          Optional `nodeSelector` for istiod. The same as the `spec.nodeSelector` pod parameter in Kubernetes.
+
+          If the parameter is omitted or `false`, it will be determined [automatically](https://deckhouse.io/en/documentation/v1/#advanced-scheduling).
+      tolerations:
+        type: array
+        description: |
+          Optional `tolerations` for istiod. The same as `spec.tolerations` for the Kubernetes pod.
+
+          If the parameter is omitted or `false`, it will be determined [automatically](https://deckhouse.io/en/documentation/v1/#advanced-scheduling).
+        items:
+          type: object
+          properties:
+            effect:
+              type: string
+            key:
+              type: string
+            operator:
+              type: string
+            tolerationSeconds:
+              type: integer
+              format: int64
+            value:
+              type: string
   nodeSelector:
     type: object
     additionalProperties:

--- a/ee/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -130,6 +130,19 @@ properties:
         description: Цепочка сертификатов в формате PEM на случай  если `cert` — промежуточный сертификат.
       root:
         description: Корневой сертификат в формате PEM на  случай если `cert` — промежуточный сертификат.
+  controlPlane:
+    description: Настройки для компонента istiod.
+    properties:
+      nodeSelector:
+        description: |
+          Опциональный селектор для компонентa istiod. Структура, аналогичная `spec.nodeSelector` Kubernetes pod.
+
+          Если ничего не указано или указано `false` — будет [использоваться автоматика](https://deckhouse.io/ru/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).
+      tolerations:
+        description: |
+          Опциональные tolerations для компонента istiod. Структура, аналогичная  `spec.tolerations` в Kubernetes Pod.
+
+          Если ничего не указано или указано `false` — будет [использоваться автоматика](https://deckhouse.io/ru/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).
   nodeSelector:
     description: |
       Опциональный селектор для компонентов istio-operator, metadata-exporter и kiali. Структура, аналогичная `spec.nodeSelector` Kubernetes pod.

--- a/ee/modules/110-istio/template_tests/module_test.go
+++ b/ee/modules/110-istio/template_tests/module_test.go
@@ -79,6 +79,7 @@ const istioValues = `
       externalAuthentication: {}
       password: qqq
     outboundTrafficPolicyMode: AllowAny
+    controlPlane: {}
     sidecar:
       includeOutboundIPRanges: ["10.0.0.0/24"]
       excludeOutboundIPRanges: ["1.2.3.4/32"]

--- a/ee/modules/110-istio/templates/control-plane/iop.yaml
+++ b/ee/modules/110-istio/templates/control-plane/iop.yaml
@@ -145,9 +145,18 @@ spec:
         requests:
           cpu: 25m
           memory: 256Mi
-#TODO: affinity by revision
+  {{- if $.Values.istio.controlPlane.nodeSelector }}
+      nodeSelector:
+{{ $.Values.istio.controlPlane.nodeSelector | toYaml | nindent 8 }}
+  {{- else }}
       {{- include "helm_lib_node_selector" (tuple $ "master") | nindent 6 }}
+  {{- end }}
+  {{- if $.Values.istio.controlPlane.tolerations }}
+      tolerations:
+{{ $.Values.istio.controlPlane.tolerations | toYaml | nindent 8 }}
+  {{- else }}
       {{- include "helm_lib_tolerations" (tuple $ "master") | nindent 6 }}
+  {{- end }}
     telemetry:
       enabled: true
       v2:


### PR DESCRIPTION
## Description
nodeSelector and tolerations customization for control-plane

## Why do we need it, and what problem does it solve?
In some complex installations there could be need to schedule istiod to separate nodes.

## Changelog entries

```changes
section: istiod
type: feature
summary: nodeSelector and tolerations customization for control-plane
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
