### PR TITLE
[linstor] grafana dashboard and alerts

### DIFF
--- a/modules/031-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
+++ b/modules/031-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
@@ -1,0 +1,2269 @@
+{
+  "__inputs": [
+    {
+      "name": "ds_prometheus",
+      "label": "main",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.2.6"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph (old)",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "gnetId": null,
+  "graphTooltip": 2,
+  "id": null,
+  "iteration": 1647374865827,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 33,
+      "panels": [],
+      "title": "LINSTOR",
+      "type": "row"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 18,
+        "x": 0,
+        "y": 1
+      },
+      "id": 41,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "((sum by (storage_pool)(linstor_storage_pool_capacity_total_bytes{exported_node=~\"$node\"} != 0)-sum by (storage_pool)(linstor_storage_pool_capacity_free_bytes{exported_node=~\"$node\"}))*100/sum by (storage_pool)(linstor_storage_pool_capacity_total_bytes{exported_node=~\"$node\"}))",
+          "hide": false,
+          "legendFormat": "{{ storage_pool }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Space Usage",
+      "type": "gauge"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 43,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (storage_pool) (linstor_storage_pool_capacity_total_bytes{exported_node=~\"$node\"} != 0)",
+          "hide": false,
+          "legendFormat": "{{ storage_pool }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Total",
+      "type": "stat"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 5
+      },
+      "id": 44,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (storage_pool) (linstor_storage_pool_capacity_free_bytes{exported_node=~\"$node\"} != 0)",
+          "hide": false,
+          "legendFormat": "{{ storage_pool }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Free",
+      "type": "stat"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 9
+      },
+      "id": 42,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (storage_pool) ((linstor_storage_pool_capacity_total_bytes{exported_node=~\"$node\"} != 0) - (linstor_storage_pool_capacity_free_bytes{exported_node=~\"$node\"} != 0))",
+          "hide": false,
+          "legendFormat": "{{ storage_pool }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Used",
+      "type": "stat"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 11
+      },
+      "id": 36,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(linstor_node_state{nodetype=\"SATELLITE\",exported_node=~\"$node\"} == 2) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes",
+      "type": "stat"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 11
+      },
+      "id": 38,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(linstor_storage_pool_capacity_total_bytes{driver!=\"DISKLESS\",exported_node=~\"$node\"}) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Storage Pools",
+      "type": "stat"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 11
+      },
+      "id": 35,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(linstor_resource_definition_count{}) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Resource Definitions",
+      "type": "stat"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 9,
+        "y": 11
+      },
+      "id": 37,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(linstor_resource_state{exported_node=~\"$node\"}) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Resources",
+      "type": "stat"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 57,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "pps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 11
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg_over_time(linstor_scrape_duration_seconds{node=~\"$node\"}[$__interval_sx3])",
+          "legendFormat": "allocated",
+          "refId": "A"
+        }
+      ],
+      "title": "Scrape Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 6
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 13
+      },
+      "id": 52,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (module) (round(increase(linstor_error_reports_count{module!=\"\", node=~\"$node\"}[$__interval_sx4])))",
+          "instant": false,
+          "legendFormat": "{{ module }}",
+          "refId": "A"
+        }
+      ],
+      "title": "New Error Reports",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 14
+      },
+      "id": 51,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(linstor_node_state{nodetype=\"SATELLITE\", exported_node=~\"$node\"} != 2) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Offline Nodes",
+      "type": "stat"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 4,
+        "y": 14
+      },
+      "id": 50,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(linstor_storage_pool_error_count{driver!=\"DISKLESS\", exported_node=~\"$node\"} != 0) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Failed Storage Pools",
+      "type": "stat"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 14
+      },
+      "id": 49,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count((linstor_volume_state{exported_node=~\"$node\"} != 1) != 4) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Failed Resources",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 46,
+      "panels": [],
+      "title": "Statistics",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${ds_prometheus}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 24,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": false
+      },
+      "percentage": false,
+      "pluginVersion": "8.2.6",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(drbd_device_written_bytes_total{node=~\"$node\"}[$__interval_sx3]) and topk(5, avg_over_time(drbd_device_written_bytes_total{node=~\"$node\"}[$__interval_sx3]) > 0)",
+          "instant": false,
+          "legendFormat": "{{name}} on {{node}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Write Rate (5 Most Active Volumes)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:104",
+          "format": "binBps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:105",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${ds_prometheus}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 25,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": false
+      },
+      "percentage": false,
+      "pluginVersion": "8.2.6",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(drbd_device_read_bytes_total{node=~\"$node\"}[$__interval_sx3]) and topk(5, avg_over_time(drbd_device_read_bytes_total{node=~\"$node\"}[$__interval_sx3]) > 0)",
+          "instant": false,
+          "legendFormat": "{{name}} on {{node}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Read Rate (5 Most Active Volumes)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:254",
+          "format": "binBps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:255",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${ds_prometheus}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "fill": 5,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "hiddenSeries": false,
+      "id": 47,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": false
+      },
+      "percentage": false,
+      "pluginVersion": "8.2.6",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": true,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (node) (rate(drbd_device_written_bytes_total{node=~\"$node\"}[$__interval_sx3]))",
+          "instant": false,
+          "legendFormat": "{{ node }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Write Rate by Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:410",
+          "format": "binBps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:411",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${ds_prometheus}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "fill": 5,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "hiddenSeries": false,
+      "id": 48,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": false
+      },
+      "percentage": false,
+      "pluginVersion": "8.2.6",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": true,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (node) (rate(drbd_device_read_bytes_total{node=~\"$node\"}[$__interval_sx3]))",
+          "instant": false,
+          "legendFormat": "{{ node }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Read Rate by Node",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:332",
+          "format": "binBps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:333",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": "${ds_prometheus}",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 8,
+      "panels": [],
+      "title": "DRBD",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": "${ds_prometheus}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 16,
+        "x": 0,
+        "y": 35
+      },
+      "id": 6,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "$$hashKey": "object:470",
+          "aggregation": "Last",
+          "decimals": 2,
+          "displayAliasType": "Warning / Critical",
+          "displayType": "Regular",
+          "displayValueWithAlias": "Never",
+          "exemplar": true,
+          "expr": "drbd_resource_resources{node=~\"$node\"}",
+          "legendFormat": "{{node}}",
+          "refId": "A",
+          "units": "none",
+          "valueHandler": "Number Threshold"
+        }
+      ],
+      "title": "Number of DRBD Resources",
+      "type": "gauge"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${ds_prometheus}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 35
+      },
+      "hiddenSeries": false,
+      "id": 27,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": false
+      },
+      "percentage": false,
+      "pluginVersion": "8.2.6",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg_over_time(scrape_duration_seconds{job=\"linstor-node\", node=~\"$node\"}[$__interval_sx3])",
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Scrape Duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:158",
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:159",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "description": "DRBD data out of sync with a peer",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 43
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(max by(name, volume) (drbd_peerdevice_outofsync_bytes{node=~\"$node\"} > 0)) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "out-of-sync data",
+      "type": "stat"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 46
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "count(count by (name) (drbd_connection_state{drbd_connection_state!=\"UpToDate\", drbd_connection_state!=\"Connected\", node=~\"$node\"} == 1)) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "disconnected",
+      "type": "stat"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "index": 0,
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 4,
+        "y": 46
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(count by (name) (drbd_device_quorum{node=~\"$node\"} == 0)) OR on() vector(0)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "count(drbd_device_quorum == 0)",
+          "hide": true,
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "without quorum",
+      "type": "stat"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 46
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(drbd_device_unintentionaldiskless{node=~\"$node\"} == 1) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "storage failure",
+      "type": "stat"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "description": "DRBD data out of sync with a peer",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 46
+      },
+      "id": 29,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(count by (name) (drbd_peerdevice_outofsync_bytes{node=~\"$node\"} > 0)) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "out-of-sync",
+      "type": "stat"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": null,
+            "displayMode": "auto",
+            "filterable": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "1": {
+                  "text": "No"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "id": 22,
+      "maxDataPoints": null,
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "drbd_connection_state"
+          }
+        ]
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "drbd_connection_state{drbd_connection_state!=\"UpToDate\", drbd_connection_state!=\"Connected\", node=~\"$node\"} == 1",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Disconnected DRBD Resources",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "instance": true,
+              "job": true,
+              "name": false,
+              "peer_node_id": true,
+              "tier": true
+            },
+            "indexByName": {
+              "Time": 1,
+              "Value": 10,
+              "__name__": 2,
+              "conn_name": 5,
+              "drbd_connection_state": 4,
+              "instance": 6,
+              "job": 7,
+              "name": 0,
+              "node": 3,
+              "peer_node_id": 8,
+              "tier": 9
+            },
+            "renameByName": {
+              "Value #A": "Quorum?",
+              "conn_name": "Remote Node",
+              "drbd_connection_state": "State",
+              "instance": "Instance",
+              "job": "",
+              "name": "DRBD Resource",
+              "node": "Node",
+              "peer_node_id": ""
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": null,
+            "displayMode": "auto",
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DRBD Resource"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 279
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Host"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 238
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Out of Sync"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 93
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "id": 16,
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "sum(drbd_peerdevice_outofsync_bytes{node=~\"$node\"}) by(name, node) > 0",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "DRBD Resources Out of Sync",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 3,
+              "name": 1,
+              "node": 2
+            },
+            "renameByName": {
+              "Time": "",
+              "Value": "Out of Sync",
+              "instance": "Host",
+              "name": "DRBD Resource",
+              "node": "Node"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Out of Sync"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": null,
+            "displayMode": "auto",
+            "filterable": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "1": {
+                  "text": "No"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "id": 31,
+      "maxDataPoints": null,
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(drbd_device_quorum{node=~\"$node\"} == 0) by(node, name)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "DRBD Resources Without Quorum",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "Quorum?",
+              "instance": "Instance",
+              "name": "DRBD Resource",
+              "node": "Node"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "${ds_prometheus}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": null,
+            "displayMode": "auto",
+            "filterable": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "1": {
+                  "text": "No"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "id": 30,
+      "maxDataPoints": null,
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true
+      },
+      "pluginVersion": "8.2.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(drbd_device_unintentionaldiskless{node=~\"$node\"} == 1) by(node, name, minor)",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "DRBD Resources with Storage Failure",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 4,
+              "minor": 3,
+              "name": 1,
+              "node": 2
+            },
+            "renameByName": {
+              "Value": "",
+              "Value #A": "Quorum?",
+              "instance": "Instance",
+              "minor": "Minor",
+              "name": "DRBD Resource",
+              "node": "Node"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 32,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "ds_prometheus",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${ds_prometheus}",
+        "definition": "label_values(drbdreactor_up, node)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "node",
+        "options": [],
+        "query": {
+          "query": "label_values(drbdreactor_up, node)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "2022-03-10T17:42:58.093Z",
+    "to": "2022-03-10T18:20:49.101Z"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "LINSTOR / DRBD",
+  "uid": "f_tZtVlMz",
+  "version": 19
+}

--- a/modules/031-linstor/monitoring/prometheus-rules/drbd-devices.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/drbd-devices.yaml
@@ -1,0 +1,158 @@
+- name: kubernetes.drbd.device_state
+  rules:
+    - alert: LinstorVolumeIsNotHealthy
+      expr: linstor_volume_state != 1 and linstor_volume_state != 4
+      for: 5m
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_grouped_by__main: "DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
+        summary: LINSTOR volume is not healthy
+        description: |
+          LINSTOR volume {{ $labels.resource }} on node {{ $labels.node }} is not healthy
+
+          The recommended course of action:
+          1. Check the LINSTOR node state: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor node list -n {{ $labels.node }}`
+          2. Check the LINSTOR resource states: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor resource list -r {{ $labels.resource }}`
+          3. View the status of the DRBD device and try to figure out why it is not UpToDate:
+             ```
+             kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-node -o name) -c linstor-satellite -- bash
+             drbdsetup status {{ $labels.name }} --verbose
+             dmesg --color=always | grep 'drbd {{ $labels.name }}'
+             ```
+
+    - alert: DrbdDeviceHasNoQuorum
+      expr: drbd_device_quorum == 0
+      for: 5m
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_grouped_by__main: "DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
+        summary: DRBD device has no quorum
+        description: |
+          DRBD device {{ $labels.name }} on node {{ $labels.node }} has no quorum
+
+          The recommended course of action:
+          1. Check the LINSTOR resource states: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor resource list -r {{ $labels.name }}`
+          2. View the status of the DRBD device:
+             ```
+             kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-node -o name) -c linstor-satellite -- bash
+             drbdsetup status {{ $labels.name }} --verbose
+             dmesg --color=always | grep 'drbd {{ $labels.name }}'
+             ```
+          3. Consider recreating failed resources in LINSTOR
+             ```
+             linstor resource delete {{ $labels.node }} {{ $labels.name }}
+             linstor resource-definition auto-place {{ $labels.name }}
+             linstor resource-definition wait-sync {{ $labels.name }}
+             ```
+
+    - alert: DrbdDeviceIsUnintentionalDiskless
+      expr: drbd_device_unintentionaldiskless == 1
+      for: 5m
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_grouped_by__main: "DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
+        summary: DRBD device is unintentional diskless
+        description: |
+          DRBD device {{ $labels.name }} on node {{ $labels.node }} unintentionally switched to diskless mode
+
+          The recommended course of action:
+          1. Check the LINSTOR resource state on {{ $labels.node }}: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor resource list -r {{ $labels.name }}`
+          2. Check the LINSTOR storage-pools on {{ $labels.node }}: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor storage-pools list -r {{ $labels.name }}`
+          3. View the status of the DRBD device:
+             ```
+             kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-node -o name) -c linstor-satellite -- bash
+             drbdsetup status {{ $labels.name }} --verbose
+             dmesg --color=always | grep 'drbd {{ $labels.name }}'
+             ```
+          4. Check the backing storage device: `lsblk`
+          5. Consider recreating failed resources in LINSTOR
+             ```
+             linstor resource delete {{ $labels.node }} {{ $labels.name }}
+             linstor resource-definition auto-place {{ $labels.name }}
+             linstor resource-definition wait-sync {{ $labels.name }}
+             ```
+
+    - alert: DrbdPeerDeviceIsOutOfSync
+      expr: drbd_peerdevice_outofsync_bytes > 0
+      for: 5m
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_grouped_by__main: "DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
+        summary: DRBD device has out-of-sync data
+        description: |
+          DRBD device {{ $labels.name }} on node {{ $labels.node }} has out-of-sync data with {{ $labels.conn_name }}
+
+          The recommended course of action:
+          1. Check the LINSTOR peer node state: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor node list -n {{ $labels.conn_name }}`
+          2. Check the LINSTOR resource states: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor resource list -r {{ $labels.name }}`
+          3. Check connectivity between {{ $labels.node }} and {{ $labels.conn_name }}
+          4. View the status of the DRBD device on the node and try to figure out why it is not UpToDate:
+             ```
+             kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.conn_name }} -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-node -o name) -c linstor-satellite -- bash
+             drbdsetup status {{ $labels.name }} --verbose
+             dmesg --color=always | grep 'drbd {{ $labels.name }}'
+             ```
+          5. Consider recreating failed resources in LINSTOR
+             ```
+             linstor resource delete {{ $labels.conn_name }} {{ $labels.name }}
+             linstor resource-definition auto-place {{ $labels.name }}
+             linstor resource-definition wait-sync {{ $labels.name }}
+             ```
+
+    - alert: DrbdDeviceIsNotConnected
+      expr: drbd_connection_state{drbd_connection_state!="UpToDate", drbd_connection_state!="Connected"} == 1
+      for: 5m
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_grouped_by__main: "DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
+        summary: DRBD device is not connected
+        description: |
+          DRBD device {{ $labels.name }} on node {{ $labels.node }} is not connected with {{ $labels.conn_name }}
+
+          The recommended course of action:
+          1. Check the LINSTOR peer node state: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor node list -n {{ $labels.conn_name }}`
+          2. Check the LINSTOR resource states: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor resource list -r {{ $labels.name }}`
+          3. Check connectivity between {{ $labels.node }} and {{ $labels.conn_name }}
+          4. View the status of the DRBD device on the node and try to figure out why it is not connected:
+             ```
+             kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.conn_name }} -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-node -o name) -c linstor-satellite -- bash
+             drbdsetup status {{ $labels.name }} --verbose
+             dmesg --color=always | grep 'drbd {{ $labels.name }}'
+             ```
+          5. Consider recreating failed resources in LINSTOR
+             ```
+             linstor resource delete {{ $labels.conn_name }} {{ $labels.name }}
+             linstor resource-definition auto-place {{ $labels.name }}
+             linstor resource-definition wait-sync {{ $labels.name }}
+             ```
+
+    - alert: DrbdDeviceHealth
+      expr: count by (name) (ALERTS{alertname=~"DrbdDeviceHasNoQuorum|DrbdDeviceIsUnintentionalDiskless|DrbdPeerDeviceIsOutOfSync|DrbdDeviceIsNotConnected", alertstate="firing"} OR label_replace(ALERTS{alertname=~"LinstorVolumeIsNotHealthy", alertstate="firing"}, "name", "$1", "resource", "(.*)"))
+      labels:
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_alert_type: "group"
+        summary: Some DRBD devices are not healthy
+        description: Refer to the relevant alerts for more information.

--- a/modules/031-linstor/monitoring/prometheus-rules/drbd-devices.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/drbd-devices.yaml
@@ -1,7 +1,7 @@
 - name: kubernetes.drbd.device_state
   rules:
-    - alert: LinstorVolumeIsNotHealthy
-      expr: linstor_volume_state != 1 and linstor_volume_state != 4
+    - alert: D8LinstorVolumeIsNotHealthy
+      expr: max by (exported_node, resource) (linstor_volume_state != 1 and linstor_volume_state != 4)
       for: 5m
       labels:
         severity_level: "6"
@@ -9,23 +9,23 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_grouped_by__main: "DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
         summary: LINSTOR volume is not healthy
         description: |
-          LINSTOR volume {{ $labels.resource }} on node {{ $labels.node }} is not healthy
+          LINSTOR volume {{ $labels.resource }} on node {{ $labels.exported_node }} is not healthy
 
           The recommended course of action:
-          1. Check the LINSTOR node state: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor node list -n {{ $labels.node }}`
+          1. Check the LINSTOR node state: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor node list -n {{ $labels.exported_node }}`
           2. Check the LINSTOR resource states: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor resource list -r {{ $labels.resource }}`
           3. View the status of the DRBD device and try to figure out why it is not UpToDate:
              ```
-             kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-node -o name) -c linstor-satellite -- bash
+             kubectl -n d8-linstor exec -ti $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.exported_node }} -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-node -o name) -c linstor-satellite -- bash
              drbdsetup status {{ $labels.name }} --verbose
              dmesg --color=always | grep 'drbd {{ $labels.name }}'
              ```
 
-    - alert: DrbdDeviceHasNoQuorum
-      expr: drbd_device_quorum == 0
+    - alert: D8DrbdDeviceHasNoQuorum
+      expr: max by (node, name) (drbd_device_quorum == 0)
       for: 5m
       labels:
         severity_level: "6"
@@ -33,7 +33,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_grouped_by__main: "DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
         summary: DRBD device has no quorum
         description: |
           DRBD device {{ $labels.name }} on node {{ $labels.node }} has no quorum
@@ -53,8 +53,8 @@
              linstor resource-definition wait-sync {{ $labels.name }}
              ```
 
-    - alert: DrbdDeviceIsUnintentionalDiskless
-      expr: drbd_device_unintentionaldiskless == 1
+    - alert: D8DrbdDeviceIsUnintentionalDiskless
+      expr: max by (node, name) (drbd_device_unintentionaldiskless == 1)
       for: 5m
       labels:
         severity_level: "6"
@@ -62,7 +62,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_grouped_by__main: "DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
         summary: DRBD device is unintentional diskless
         description: |
           DRBD device {{ $labels.name }} on node {{ $labels.node }} unintentionally switched to diskless mode
@@ -84,8 +84,8 @@
              linstor resource-definition wait-sync {{ $labels.name }}
              ```
 
-    - alert: DrbdPeerDeviceIsOutOfSync
-      expr: drbd_peerdevice_outofsync_bytes > 0
+    - alert: D8DrbdPeerDeviceIsOutOfSync
+      expr: max by (node, conn_name, name) (drbd_peerdevice_outofsync_bytes > 0)
       for: 5m
       labels:
         severity_level: "6"
@@ -93,7 +93,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_grouped_by__main: "DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
         summary: DRBD device has out-of-sync data
         description: |
           DRBD device {{ $labels.name }} on node {{ $labels.node }} has out-of-sync data with {{ $labels.conn_name }}
@@ -115,8 +115,8 @@
              linstor resource-definition wait-sync {{ $labels.name }}
              ```
 
-    - alert: DrbdDeviceIsNotConnected
-      expr: drbd_connection_state{drbd_connection_state!="UpToDate", drbd_connection_state!="Connected"} == 1
+    - alert: D8DrbdDeviceIsNotConnected
+      expr: max by (node, conn_name, name) (drbd_connection_state{drbd_connection_state!="UpToDate", drbd_connection_state!="Connected"} == 1)
       for: 5m
       labels:
         severity_level: "6"
@@ -124,7 +124,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_grouped_by__main: "DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
         summary: DRBD device is not connected
         description: |
           DRBD device {{ $labels.name }} on node {{ $labels.node }} is not connected with {{ $labels.conn_name }}
@@ -146,8 +146,8 @@
              linstor resource-definition wait-sync {{ $labels.name }}
              ```
 
-    - alert: DrbdDeviceHealth
-      expr: count by (name) (ALERTS{alertname=~"DrbdDeviceHasNoQuorum|DrbdDeviceIsUnintentionalDiskless|DrbdPeerDeviceIsOutOfSync|DrbdDeviceIsNotConnected", alertstate="firing"} OR label_replace(ALERTS{alertname=~"LinstorVolumeIsNotHealthy", alertstate="firing"}, "name", "$1", "resource", "(.*)"))
+    - alert: D8DrbdDeviceHealth
+      expr: count by (name) (ALERTS{alertname=~"D8DrbdDeviceHasNoQuorum|D8DrbdDeviceIsUnintentionalDiskless|D8DrbdPeerDeviceIsOutOfSync|D8DrbdDeviceIsNotConnected", alertstate="firing"} OR label_replace(ALERTS{alertname=~"D8LinstorVolumeIsNotHealthy", alertstate="firing"}, "name", "$1", "resource", "(.*)"))
       labels:
         tier: cluster
       annotations:

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-controller.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-controller.yaml
@@ -1,0 +1,96 @@
+- name: kubernetes.linstor.controller_state
+  rules:
+    - alert: LinstorControllerGrowingErrorReports
+      expr: sum by (module) (increase(linstor_error_reports_count{module="CONTROLLER"}[5m])) >= 20
+      for: 5m
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        summary: LINSTOR controller has errors
+        description: |
+          LINSTOR controller has continuously growing amount of error reports
+
+          The recommended course of action:
+          1. Check the Pod logs: `kubectl -n d8-linstor logs -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-controller -c linstor-controller`
+          2. Check the LINSTOR error reports: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor err list | grep 'C|linstor-controller'`
+
+    - alert: LinstorControllerTargetDown
+      expr: max by (job) (up{job="linstor-controller"} == 0)
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_pending_until_firing_for: "1m"
+        plk_grouped_by__main: "LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
+        plk_ignore_labels: "job"
+        summary: Prometheus cannot scrape the linstor-controller metrics.
+        description: |
+          The recommended course of action:
+          1. Check the Pod status: `kubectl -n d8-linstor get pod -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-controller`
+          2. Or check the Pod logs: `kubectl -n d8-linstor logs -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-controller -c linstor-controller`
+
+    - alert: LinstorControllerTargetAbsent
+      expr: absent(up{job="linstor-controller"}) == 1
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_pending_until_firing_for: "15m"
+        plk_ignore_labels: "job"
+        plk_grouped_by__main: "LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
+        summary: There is no `linstor-controller` target in Prometheus.
+        description: |
+          The recommended course of action:
+          1. Check the Pod status: `kubectl -n d8-linstor get pod -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-controller`
+          2. Or check the Pod logs: `kubectl -n d8-linstor logs -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-controller -c linstor-controller`
+
+    - alert: LinstorControllerPodIsNotReady
+      expr: min by (pod) (kube_pod_status_ready{condition="true", namespace="d8-linstor", pod=~"linstor-controller-.*"}) != 1
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_pending_until_firing_for: "30m"
+        plk_labels_as_annotations: "pod"
+        plk_grouped_by__main: "LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
+        summary: The linstor-controller Pod is NOT Ready.
+        description: |
+          The recommended course of action:
+          1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy linstor-controller`
+          2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-controller`
+
+    - alert: LinstorControllerPodIsNotRunning
+      expr: absent(kube_pod_status_phase{namespace="d8-linstor",phase="Running",pod=~"linstor-controller-.*"})
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_pending_until_firing_for: "30m"
+        plk_grouped_by__main: "LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
+        summary: The linstor-controller Pod is NOT Running.
+        description: |
+          The recommended course of action:
+          1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy linstor-controller`
+          2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-controller`
+
+    - alert: LinstorControllerHealth
+      expr: count(ALERTS{alertname=~"LinstorControllerGrowingErrorReports|LinstorControllerGrowingErrorReports|LinstorControllerTargetAbsent|LinstorControllerPodIsNotReady|LinstorControllerPodIsNotRunning", alertstate="firing"})
+      labels:
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_alert_type: "group"
+        summary: The linstor-controller does not work.
+        description: Refer to the relevant alerts for more information.

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-controller.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-controller.yaml
@@ -1,6 +1,6 @@
 - name: kubernetes.linstor.controller_state
   rules:
-    - alert: LinstorControllerGrowingErrorReports
+    - alert: D8LinstorControllerGrowingErrorReports
       expr: sum by (module) (increase(linstor_error_reports_count{module="CONTROLLER"}[5m])) >= 20
       for: 5m
       labels:
@@ -17,7 +17,7 @@
           1. Check the Pod logs: `kubectl -n d8-linstor logs -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-controller -c linstor-controller`
           2. Check the LINSTOR error reports: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor err list | grep 'C|linstor-controller'`
 
-    - alert: LinstorControllerTargetDown
+    - alert: D8LinstorControllerTargetDown
       expr: max by (job) (up{job="linstor-controller"} == 0)
       labels:
         severity_level: "6"
@@ -26,7 +26,7 @@
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
         plk_pending_until_firing_for: "1m"
-        plk_grouped_by__main: "LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
         plk_ignore_labels: "job"
         summary: Prometheus cannot scrape the linstor-controller metrics.
         description: |
@@ -34,7 +34,7 @@
           1. Check the Pod status: `kubectl -n d8-linstor get pod -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-controller`
           2. Or check the Pod logs: `kubectl -n d8-linstor logs -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-controller -c linstor-controller`
 
-    - alert: LinstorControllerTargetAbsent
+    - alert: D8LinstorControllerTargetAbsent
       expr: absent(up{job="linstor-controller"}) == 1
       labels:
         severity_level: "6"
@@ -44,14 +44,14 @@
         plk_markup_format: "markdown"
         plk_pending_until_firing_for: "15m"
         plk_ignore_labels: "job"
-        plk_grouped_by__main: "LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: There is no `linstor-controller` target in Prometheus.
         description: |
           The recommended course of action:
           1. Check the Pod status: `kubectl -n d8-linstor get pod -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-controller`
           2. Or check the Pod logs: `kubectl -n d8-linstor logs -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-controller -c linstor-controller`
 
-    - alert: LinstorControllerPodIsNotReady
+    - alert: D8LinstorControllerPodIsNotReady
       expr: min by (pod) (kube_pod_status_ready{condition="true", namespace="d8-linstor", pod=~"linstor-controller-.*"}) != 1
       labels:
         severity_level: "6"
@@ -61,14 +61,14 @@
         plk_markup_format: "markdown"
         plk_pending_until_firing_for: "30m"
         plk_labels_as_annotations: "pod"
-        plk_grouped_by__main: "LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-controller Pod is NOT Ready.
         description: |
           The recommended course of action:
           1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy linstor-controller`
           2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-controller`
 
-    - alert: LinstorControllerPodIsNotRunning
+    - alert: D8LinstorControllerPodIsNotRunning
       expr: absent(kube_pod_status_phase{namespace="d8-linstor",phase="Running",pod=~"linstor-controller-.*"})
       labels:
         severity_level: "6"
@@ -77,15 +77,15 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_pending_until_firing_for: "30m"
-        plk_grouped_by__main: "LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-controller Pod is NOT Running.
         description: |
           The recommended course of action:
           1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy linstor-controller`
           2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-controller`
 
-    - alert: LinstorControllerHealth
-      expr: count(ALERTS{alertname=~"LinstorControllerGrowingErrorReports|LinstorControllerGrowingErrorReports|LinstorControllerTargetAbsent|LinstorControllerPodIsNotReady|LinstorControllerPodIsNotRunning", alertstate="firing"})
+    - alert: D8LinstorControllerHealth
+      expr: count(ALERTS{alertname=~"D8LinstorControllerGrowingErrorReports|D8LinstorControllerGrowingErrorReports|D8LinstorControllerTargetAbsent|D8LinstorControllerPodIsNotReady|D8LinstorControllerPodIsNotRunning", alertstate="firing"})
       labels:
         tier: cluster
       annotations:

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-csi-controller.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-csi-controller.yaml
@@ -1,0 +1,45 @@
+- name: kubernetes.linstor.csi_controller_state
+  rules:
+    - alert: LinstorCsiControllerPodIsNotReady
+      expr: min by (pod) (kube_pod_status_ready{condition="true", namespace="d8-linstor", pod=~"linstor-csi-controller-.*"}) != 1
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_pending_until_firing_for: "30m"
+        plk_labels_as_annotations: "pod"
+        plk_grouped_by__main: "LinstorCsiControllerHealth,tier=~tier,prometheus=deckhouse"
+        summary: The linstor-csi-controller Pod is NOT Ready.
+        description: |
+          The recommended course of action:
+          1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy linstor-csi-controller`
+          2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app.kubernetes.io/component=csi-controller,app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-csi`
+
+    - alert: LinstorCsiControllerPodIsNotRunning
+      expr: absent(kube_pod_status_phase{namespace="d8-linstor",phase="Running",pod=~"linstor-csi-controller-.*"})
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_pending_until_firing_for: "30m"
+        plk_grouped_by__main: "LinstorCsiControllerHealth,tier=~tier,prometheus=deckhouse"
+        summary: The linstor-csi-controller Pod is NOT Running.
+        description: |
+          The recommended course of action:
+          1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy linstor-csi-controller`
+          2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app.kubernetes.io/component=csi-controller,app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-csi`
+
+    - alert: LinstorCsiControllerHealth
+      expr: count(ALERTS{alertname=~"LinstorCsiControllerPodIsNotReady|LinstorCsiControllerPodIsNotRunning", alertstate="firing"})
+      labels:
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_alert_type: "group"
+        summary: The linstor-csi-controller does not work.
+        description: Refer to the relevant alerts for more information.

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-csi-controller.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-csi-controller.yaml
@@ -1,6 +1,6 @@
 - name: kubernetes.linstor.csi_controller_state
   rules:
-    - alert: LinstorCsiControllerPodIsNotReady
+    - alert: D8LinstorCsiControllerPodIsNotReady
       expr: min by (pod) (kube_pod_status_ready{condition="true", namespace="d8-linstor", pod=~"linstor-csi-controller-.*"}) != 1
       labels:
         severity_level: "6"
@@ -10,14 +10,14 @@
         plk_markup_format: "markdown"
         plk_pending_until_firing_for: "30m"
         plk_labels_as_annotations: "pod"
-        plk_grouped_by__main: "LinstorCsiControllerHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorCsiControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-csi-controller Pod is NOT Ready.
         description: |
           The recommended course of action:
           1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy linstor-csi-controller`
           2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app.kubernetes.io/component=csi-controller,app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-csi`
 
-    - alert: LinstorCsiControllerPodIsNotRunning
+    - alert: D8LinstorCsiControllerPodIsNotRunning
       expr: absent(kube_pod_status_phase{namespace="d8-linstor",phase="Running",pod=~"linstor-csi-controller-.*"})
       labels:
         severity_level: "6"
@@ -26,15 +26,15 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_pending_until_firing_for: "30m"
-        plk_grouped_by__main: "LinstorCsiControllerHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorCsiControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-csi-controller Pod is NOT Running.
         description: |
           The recommended course of action:
           1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy linstor-csi-controller`
           2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app.kubernetes.io/component=csi-controller,app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-csi`
 
-    - alert: LinstorCsiControllerHealth
-      expr: count(ALERTS{alertname=~"LinstorCsiControllerPodIsNotReady|LinstorCsiControllerPodIsNotRunning", alertstate="firing"})
+    - alert: D8LinstorCsiControllerHealth
+      expr: count(ALERTS{alertname=~"D8LinstorCsiControllerPodIsNotReady|D8LinstorCsiControllerPodIsNotRunning", alertstate="firing"})
       labels:
         tier: cluster
       annotations:

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-csi-node.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-csi-node.yaml
@@ -1,0 +1,45 @@
+- name: kubernetes.linstor.csi_node_state
+  rules:
+    - alert: LinstorCsiNodePodIsNotReady
+      expr: min by (pod) (avg by(node,pod,namespace)(kube_pod_info{}) * on(pod, namespace) group_right(node) kube_pod_status_ready{condition="true", namespace="d8-linstor", pod=~"linstor-csi-node-.*"}) != 1
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_pending_until_firing_for: "30m"
+        plk_labels_as_annotations: "pod"
+        plk_grouped_by__main: "LinstorCsiNodeHealth,tier=~tier,prometheus=deckhouse"
+        summary: The linstor-csi-node Pod is NOT Ready.
+        description: |
+          The recommended course of action:
+          1. Retrieve details of the DaemonSet: `kubectl -n d8-linstor describe daemonset linstor-csi-node`
+          2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod --field-selector=spec.nodeName={{ $labels.node }} -l app.kubernetes.io/component=csi-node,app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-csi`
+
+    - alert: LinstorCsiNodePodIsNotRunning
+      expr: absent(avg by(node,pod,namespace)(kube_pod_info{}) * on(pod, namespace) group_right(node) kube_pod_status_phase{namespace="d8-linstor",phase="Running",pod=~"linstor-csi-node-.*"})
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_pending_until_firing_for: "30m"
+        plk_grouped_by__main: "LinstorCsiNodeHealth,tier=~tier,prometheus=deckhouse"
+        summary: The linstor-csi-node Pod is NOT Running.
+        description: |
+          The recommended course of action:
+          1. Retrieve details of the DaemonSet: `kubectl -n d8-linstor describe daemonset linstor-csi-node`
+          2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod --field-selector=spec.nodeName={{ $labels.node }} -l app.kubernetes.io/component=csi-node,app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-csi`
+
+    - alert: LinstorCsiNodeHealth
+      expr: count by (node) (ALERTS{alertname=~"LinstorCsiNodePodIsNotReady|LinstorCsiNodePodIsNotRunning", alertstate="firing"})
+      labels:
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_alert_type: "group"
+        summary: The linstor-csi-node does not work.
+        description: Refer to the relevant alerts for more information.

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-csi-node.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-csi-node.yaml
@@ -1,6 +1,6 @@
 - name: kubernetes.linstor.csi_node_state
   rules:
-    - alert: LinstorCsiNodePodIsNotReady
+    - alert: D8LinstorCsiNodePodIsNotReady
       expr: min by (pod) (avg by(node,pod,namespace)(kube_pod_info{}) * on(pod, namespace) group_right(node) kube_pod_status_ready{condition="true", namespace="d8-linstor", pod=~"linstor-csi-node-.*"}) != 1
       labels:
         severity_level: "6"
@@ -10,14 +10,14 @@
         plk_markup_format: "markdown"
         plk_pending_until_firing_for: "30m"
         plk_labels_as_annotations: "pod"
-        plk_grouped_by__main: "LinstorCsiNodeHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorCsiNodeHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-csi-node Pod is NOT Ready.
         description: |
           The recommended course of action:
           1. Retrieve details of the DaemonSet: `kubectl -n d8-linstor describe daemonset linstor-csi-node`
           2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod --field-selector=spec.nodeName={{ $labels.node }} -l app.kubernetes.io/component=csi-node,app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-csi`
 
-    - alert: LinstorCsiNodePodIsNotRunning
+    - alert: D8LinstorCsiNodePodIsNotRunning
       expr: absent(avg by(node,pod,namespace)(kube_pod_info{}) * on(pod, namespace) group_right(node) kube_pod_status_phase{namespace="d8-linstor",phase="Running",pod=~"linstor-csi-node-.*"})
       labels:
         severity_level: "6"
@@ -26,15 +26,15 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_pending_until_firing_for: "30m"
-        plk_grouped_by__main: "LinstorCsiNodeHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorCsiNodeHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-csi-node Pod is NOT Running.
         description: |
           The recommended course of action:
           1. Retrieve details of the DaemonSet: `kubectl -n d8-linstor describe daemonset linstor-csi-node`
           2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod --field-selector=spec.nodeName={{ $labels.node }} -l app.kubernetes.io/component=csi-node,app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-csi`
 
-    - alert: LinstorCsiNodeHealth
-      expr: count by (node) (ALERTS{alertname=~"LinstorCsiNodePodIsNotReady|LinstorCsiNodePodIsNotRunning", alertstate="firing"})
+    - alert: D8LinstorCsiNodeHealth
+      expr: count by (node) (ALERTS{alertname=~"D8LinstorCsiNodePodIsNotReady|D8LinstorCsiNodePodIsNotRunning", alertstate="firing"})
       labels:
         tier: cluster
       annotations:

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-ha-controller.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-ha-controller.yaml
@@ -1,0 +1,45 @@
+- name: kubernetes.linstor.ha-controller_state
+  rules:
+    - alert: LinstorHaControllerPodIsNotReady
+      expr: min by (pod) (kube_pod_status_ready{condition="true", namespace="d8-linstor", pod=~"linstor-ha-controller-.*"}) != 1
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_pending_until_firing_for: "30m"
+        plk_labels_as_annotations: "pod"
+        plk_grouped_by__main: "LinstorHaControllerHealth,tier=~tier,prometheus=deckhouse"
+        summary: The linstor-ha-controller Pod is NOT Ready.
+        description: |
+          The recommended course of action:
+          1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy linstor-ha-controller`
+          2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app=linstor-ha-controller`
+
+    - alert: LinstorHaControllerPodIsNotRunning
+      expr: absent(kube_pod_status_phase{namespace="d8-linstor",phase="Running",pod=~"linstor-ha-controller-.*"})
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_pending_until_firing_for: "30m"
+        plk_grouped_by__main: "LinstorHaControllerHealth,tier=~tier,prometheus=deckhouse"
+        summary: The linstor-ha-controller Pod is NOT Running.
+        description: |
+          The recommended course of action:
+          1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy linstor-ha-controller`
+          2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app=linstor-ha-controller`
+
+    - alert: LinstorHaControllerHealth
+      expr: count(ALERTS{alertname=~"LinstorHaControllerPodIsNotReady|LinstorHaControllerPodIsNotRunning", alertstate="firing"})
+      labels:
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_alert_type: "group"
+        summary: The linstor-ha-controller does not work.
+        description: Refer to the relevant alerts for more information.

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-ha-controller.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-ha-controller.yaml
@@ -1,6 +1,6 @@
 - name: kubernetes.linstor.ha-controller_state
   rules:
-    - alert: LinstorHaControllerPodIsNotReady
+    - alert: D8LinstorHaControllerPodIsNotReady
       expr: min by (pod) (kube_pod_status_ready{condition="true", namespace="d8-linstor", pod=~"linstor-ha-controller-.*"}) != 1
       labels:
         severity_level: "6"
@@ -10,14 +10,14 @@
         plk_markup_format: "markdown"
         plk_pending_until_firing_for: "30m"
         plk_labels_as_annotations: "pod"
-        plk_grouped_by__main: "LinstorHaControllerHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorHaControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-ha-controller Pod is NOT Ready.
         description: |
           The recommended course of action:
           1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy linstor-ha-controller`
           2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app=linstor-ha-controller`
 
-    - alert: LinstorHaControllerPodIsNotRunning
+    - alert: D8LinstorHaControllerPodIsNotRunning
       expr: absent(kube_pod_status_phase{namespace="d8-linstor",phase="Running",pod=~"linstor-ha-controller-.*"})
       labels:
         severity_level: "6"
@@ -26,15 +26,15 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_pending_until_firing_for: "30m"
-        plk_grouped_by__main: "LinstorHaControllerHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorHaControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-ha-controller Pod is NOT Running.
         description: |
           The recommended course of action:
           1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy linstor-ha-controller`
           2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app=linstor-ha-controller`
 
-    - alert: LinstorHaControllerHealth
-      expr: count(ALERTS{alertname=~"LinstorHaControllerPodIsNotReady|LinstorHaControllerPodIsNotRunning", alertstate="firing"})
+    - alert: D8LinstorHaControllerHealth
+      expr: count(ALERTS{alertname=~"D8LinstorHaControllerPodIsNotReady|D8LinstorHaControllerPodIsNotRunning", alertstate="firing"})
       labels:
         tier: cluster
       annotations:

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-node.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-node.yaml
@@ -1,0 +1,79 @@
+- name: kubernetes.linstor.node_state
+  rules:
+    - alert: LinstorNodeIsNotOnline
+      expr: linstor_node_state{nodetype="SATELLITE"} != 2
+      for: 5m
+      labels:
+        severity_level: "6"
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        summary: LINSTOR node is not ONLINE
+        description: |
+          LINSTOR node {{ $labels.node }} is not ONLINE
+
+          The recommended course of action:
+          1. Check the LINSTOR node status: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor node list -n {{ $labels.node }}`
+          2. Check the Pod status: `kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-node -o name`
+
+    - alert: LinstorSatelliteGrowingErrorReports
+      expr: sum by (hostname) (increase(linstor_error_reports_count{module="SATELLITE"}[5m])) >= 20
+      for: 5m
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_grouped_by__main: "LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
+        summary: LINSTOR satellite has errors
+        description: |
+          LINSTOR satellite {{ $labels.hostname }} has continuously growing amount of error reports
+
+          The recommended course of action:
+          1. Check the Pod logs: `kubectl -n d8-linstor logs $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-node -o name) -c linstor-satellite`
+          2. Check the LINSTOR error reports: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor err list -n {{ $labels.hostname }}`
+
+    - alert: LinstorNodePodIsNotReady
+      expr: min by (pod) (avg by(node,pod,namespace)(kube_pod_info{}) * on(pod, namespace) group_right(node) kube_pod_status_ready{condition="true", namespace="d8-linstor", pod=~"linstor-node-.*"}) != 1
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_pending_until_firing_for: "30m"
+        plk_labels_as_annotations: "pod"
+        plk_grouped_by__main: "LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
+        summary: The linstor-node Pod is NOT Ready.
+        description: |
+          The recommended course of action:
+          1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe daemonset linstor-node`
+          2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod --field-selector=spec.nodeName={{ $labels.node }} -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-node`
+
+    - alert: LinstorNodePodIsNotRunning
+      expr: absent(avg by(node,pod,namespace)(kube_pod_info{}) * on(pod, namespace) group_right(node) kube_pod_status_phase{namespace="d8-linstor",phase="Running",pod=~"linstor-node-.*"})
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_pending_until_firing_for: "30m"
+        plk_grouped_by__main: "LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
+        summary: The linstor-node Pod is NOT Running.
+        description: |
+          The recommended course of action:
+          1. Retrieve details of the DaemonSet: `kubectl -n d8-linstor describe daemonset linstor-node`
+          2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod --field-selector=spec.nodeName={{ $labels.node }} -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-node`
+
+    - alert: LinstorNodeHealth
+      expr: count by (node) (ALERTS{alertname=~"LinstorNodeIsNotOnline|LinstorSatelliteGrowingErrorReports|LinstorNodePodIsNotReady|LinstorNodePodIsNotRunning", alertstate="firing"})
+      labels:
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_alert_type: "group"
+        summary: Some LINSTOR nodes are not healthy
+        description: Refer to the relevant alerts for more information.

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-node.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-node.yaml
@@ -1,7 +1,7 @@
 - name: kubernetes.linstor.node_state
   rules:
-    - alert: LinstorNodeIsNotOnline
-      expr: linstor_node_state{nodetype="SATELLITE"} != 2
+    - alert: D8LinstorNodeIsNotOnline
+      expr: max by (exported_node) (linstor_node_state{nodetype="SATELLITE"} != 2)
       for: 5m
       labels:
         severity_level: "6"
@@ -16,7 +16,7 @@
           1. Check the LINSTOR node status: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor node list -n {{ $labels.node }}`
           2. Check the Pod status: `kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-node -o name`
 
-    - alert: LinstorSatelliteGrowingErrorReports
+    - alert: D8LinstorSatelliteGrowingErrorReports
       expr: sum by (hostname) (increase(linstor_error_reports_count{module="SATELLITE"}[5m])) >= 20
       for: 5m
       labels:
@@ -25,7 +25,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_grouped_by__main: "LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
         summary: LINSTOR satellite has errors
         description: |
           LINSTOR satellite {{ $labels.hostname }} has continuously growing amount of error reports
@@ -34,7 +34,7 @@
           1. Check the Pod logs: `kubectl -n d8-linstor logs $(kubectl -n d8-linstor get pod --field-selector=spec.nodeName={{ $labels.node }} -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-node -o name) -c linstor-satellite`
           2. Check the LINSTOR error reports: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor err list -n {{ $labels.hostname }}`
 
-    - alert: LinstorNodePodIsNotReady
+    - alert: D8LinstorNodePodIsNotReady
       expr: min by (pod) (avg by(node,pod,namespace)(kube_pod_info{}) * on(pod, namespace) group_right(node) kube_pod_status_ready{condition="true", namespace="d8-linstor", pod=~"linstor-node-.*"}) != 1
       labels:
         severity_level: "6"
@@ -44,14 +44,14 @@
         plk_markup_format: "markdown"
         plk_pending_until_firing_for: "30m"
         plk_labels_as_annotations: "pod"
-        plk_grouped_by__main: "LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-node Pod is NOT Ready.
         description: |
           The recommended course of action:
           1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe daemonset linstor-node`
           2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod --field-selector=spec.nodeName={{ $labels.node }} -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-node`
 
-    - alert: LinstorNodePodIsNotRunning
+    - alert: D8LinstorNodePodIsNotRunning
       expr: absent(avg by(node,pod,namespace)(kube_pod_info{}) * on(pod, namespace) group_right(node) kube_pod_status_phase{namespace="d8-linstor",phase="Running",pod=~"linstor-node-.*"})
       labels:
         severity_level: "6"
@@ -60,15 +60,15 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_pending_until_firing_for: "30m"
-        plk_grouped_by__main: "LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-node Pod is NOT Running.
         description: |
           The recommended course of action:
           1. Retrieve details of the DaemonSet: `kubectl -n d8-linstor describe daemonset linstor-node`
           2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod --field-selector=spec.nodeName={{ $labels.node }} -l app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-node`
 
-    - alert: LinstorNodeHealth
-      expr: count by (node) (ALERTS{alertname=~"LinstorNodeIsNotOnline|LinstorSatelliteGrowingErrorReports|LinstorNodePodIsNotReady|LinstorNodePodIsNotRunning", alertstate="firing"})
+    - alert: D8LinstorNodeHealth
+      expr: count by (node) (ALERTS{alertname=~"D8LinstorNodeIsNotOnline|D8LinstorSatelliteGrowingErrorReports|D8LinstorNodePodIsNotReady|D8LinstorNodePodIsNotRunning", alertstate="firing"})
       labels:
         tier: cluster
       annotations:

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-scheduler.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-scheduler.yaml
@@ -1,0 +1,45 @@
+- name: kubernetes.linstor.scheduler_state
+  rules:
+    - alert: LinstorSchedulerPodIsNotReady
+      expr: min by (pod) (kube_pod_status_ready{condition="true", namespace="d8-linstor", pod=~"linstor-scheduler-.*"}) != 1
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_pending_until_firing_for: "30m"
+        plk_labels_as_annotations: "pod"
+        plk_grouped_by__main: "LinstorSchedulerHealth,tier=~tier,prometheus=deckhouse"
+        summary: The linstor-scheduler Pod is NOT Ready.
+        description: |
+          The recommended course of action:
+          1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy linstor-scheduler`
+          2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app=linstor-scheduler`
+
+    - alert: LinstorSchedulerPodIsNotRunning
+      expr: absent(kube_pod_status_phase{namespace="d8-linstor",phase="Running",pod=~"linstor-scheduler-.*"})
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_pending_until_firing_for: "30m"
+        plk_grouped_by__main: "LinstorSchedulerHealth,tier=~tier,prometheus=deckhouse"
+        summary: The linstor-scheduler Pod is NOT Running.
+        description: |
+          The recommended course of action:
+          1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy linstor-scheduler`
+          2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app=linstor-scheduler`
+
+    - alert: LinstorSchedulerHealth
+      expr: count(ALERTS{alertname=~"LinstorSchedulerPodIsNotReady|LinstorSchedulerPodIsNotRunning", alertstate="firing"})
+      labels:
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_alert_type: "group"
+        summary: The linstor-scheduler does not work.
+        description: Refer to the relevant alerts for more information.

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-scheduler.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-scheduler.yaml
@@ -1,6 +1,6 @@
 - name: kubernetes.linstor.scheduler_state
   rules:
-    - alert: LinstorSchedulerPodIsNotReady
+    - alert: D8LinstorSchedulerPodIsNotReady
       expr: min by (pod) (kube_pod_status_ready{condition="true", namespace="d8-linstor", pod=~"linstor-scheduler-.*"}) != 1
       labels:
         severity_level: "6"
@@ -10,14 +10,14 @@
         plk_markup_format: "markdown"
         plk_pending_until_firing_for: "30m"
         plk_labels_as_annotations: "pod"
-        plk_grouped_by__main: "LinstorSchedulerHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorSchedulerHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-scheduler Pod is NOT Ready.
         description: |
           The recommended course of action:
           1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy linstor-scheduler`
           2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app=linstor-scheduler`
 
-    - alert: LinstorSchedulerPodIsNotRunning
+    - alert: D8LinstorSchedulerPodIsNotRunning
       expr: absent(kube_pod_status_phase{namespace="d8-linstor",phase="Running",pod=~"linstor-scheduler-.*"})
       labels:
         severity_level: "6"
@@ -26,15 +26,15 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_pending_until_firing_for: "30m"
-        plk_grouped_by__main: "LinstorSchedulerHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorSchedulerHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-scheduler Pod is NOT Running.
         description: |
           The recommended course of action:
           1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy linstor-scheduler`
           2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app=linstor-scheduler`
 
-    - alert: LinstorSchedulerHealth
-      expr: count(ALERTS{alertname=~"LinstorSchedulerPodIsNotReady|LinstorSchedulerPodIsNotRunning", alertstate="firing"})
+    - alert: D8LinstorSchedulerHealth
+      expr: count(ALERTS{alertname=~"D8LinstorSchedulerPodIsNotReady|D8LinstorSchedulerPodIsNotRunning", alertstate="firing"})
       labels:
         tier: cluster
       annotations:

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-storage-pools.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-storage-pools.yaml
@@ -1,0 +1,55 @@
+- name: kubernetes.linstor.storage_pool_state
+  rules:
+    - alert: LinstorStoragePoolHasErrors
+      expr: linstor_storage_pool_error_count != 0
+      for: 5m
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_grouped_by__main: "LinstorStoragePoolHealth,tier=~tier,prometheus=deckhouse"
+        summary: LINSTOR storage pool has errors
+        description: |
+          LINSTOR storage pool {{ $labels.storage_pool }} on node {{ $labels.exported_node }} has errors
+
+          The recommended course of action:
+          1. Check the LINSTOR storage pool: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor storage-pool list -n {{ $labels.exported_node }} -s {{ $labels.storage_pool }}`
+          2. Check backing storage devices
+
+    - alert: LinstorStoragePoolCapacityPressure
+      expr: linstor_storage_pool_capacity_free_bytes * 100 / linstor_storage_pool_capacity_total_bytes < 10
+      for: 5m
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_grouped_by__main: "LinstorStoragePoolHealth,tier=~tier,prometheus=deckhouse"
+        summary: Storage pool running out of free space 
+        description: |
+          LINSTOR storage pool {{ $labels.storage_pool }} on node {{ $labels.exported_node }} has less than 10% space left. Current free space: {{ $value }}%
+
+          The recommended course of action:
+          1. Check the LINSTOR storage pool: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor storage-pool list -n {{ $labels.exported_node }} -s {{ $labels.storage_pool }}`
+          2. Check the LINSTOR volumes: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor volume list -n {{ $labels.exported_node }} -s {{ $labels.storage_pool }}`
+          3. Consider adding more backing devices or relocating some resources to other nodes:
+             ```
+             alias linstor="kubectl exec -n d8-linstor deploy/linstor-controller -- linstor"
+             linstor resource-definition auto-place <res> --place-count +1 -s {{ $labels.storage_pool }}
+             linstor resource-definition wait-sync <res>
+             linstor resource delete {{ $labels.exported_node }} <res>
+             ```
+
+    - alert: LinstorStoragePoolHealth
+      expr: count by (storage_pool, exported_node) (ALERTS{alertname=~"LinstorStoragePoolHasErrors|LinstorStoragePoolCapacityPressure", alertstate="firing"})
+      labels:
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_alert_type: "group"
+        summary: Some LINSTOR storage-pools are not healthy
+        description: Refer to the relevant alerts for more information.

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-storage-pools.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-storage-pools.yaml
@@ -1,7 +1,7 @@
 - name: kubernetes.linstor.storage_pool_state
   rules:
-    - alert: LinstorStoragePoolHasErrors
-      expr: linstor_storage_pool_error_count != 0
+    - alert: D8LinstorStoragePoolHasErrors
+      expr: max by (exported_node, storage_pool) (linstor_storage_pool_error_count != 0)
       for: 5m
       labels:
         severity_level: "6"
@@ -9,7 +9,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_grouped_by__main: "LinstorStoragePoolHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorStoragePoolHealth,tier=~tier,prometheus=deckhouse"
         summary: LINSTOR storage pool has errors
         description: |
           LINSTOR storage pool {{ $labels.storage_pool }} on node {{ $labels.exported_node }} has errors
@@ -18,8 +18,8 @@
           1. Check the LINSTOR storage pool: `kubectl exec -n d8-linstor deploy/linstor-controller -- linstor storage-pool list -n {{ $labels.exported_node }} -s {{ $labels.storage_pool }}`
           2. Check backing storage devices
 
-    - alert: LinstorStoragePoolCapacityPressure
-      expr: linstor_storage_pool_capacity_free_bytes * 100 / linstor_storage_pool_capacity_total_bytes < 10
+    - alert: D8LinstorStoragePoolCapacityPressure
+      expr: max by (exported_node, storage_pool) (linstor_storage_pool_capacity_free_bytes * 100 / linstor_storage_pool_capacity_total_bytes < 10)
       for: 5m
       labels:
         severity_level: "6"
@@ -27,7 +27,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_grouped_by__main: "LinstorStoragePoolHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8LinstorStoragePoolHealth,tier=~tier,prometheus=deckhouse"
         summary: Storage pool running out of free space 
         description: |
           LINSTOR storage pool {{ $labels.storage_pool }} on node {{ $labels.exported_node }} has less than 10% space left. Current free space: {{ $value }}%
@@ -43,8 +43,8 @@
              linstor resource delete {{ $labels.exported_node }} <res>
              ```
 
-    - alert: LinstorStoragePoolHealth
-      expr: count by (storage_pool, exported_node) (ALERTS{alertname=~"LinstorStoragePoolHasErrors|LinstorStoragePoolCapacityPressure", alertstate="firing"})
+    - alert: D8LinstorStoragePoolHealth
+      expr: count by (storage_pool, exported_node) (ALERTS{alertname=~"D8LinstorStoragePoolHasErrors|D8LinstorStoragePoolCapacityPressure", alertstate="firing"})
       labels:
         tier: cluster
       annotations:

--- a/modules/031-linstor/monitoring/prometheus-rules/piraeus-operator.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/piraeus-operator.yaml
@@ -1,0 +1,79 @@
+- name: kubernetes.linstor.piraeus_operator_state
+  rules:
+    - alert: PiraeusOperatorTargetDown
+      expr: max by (job) (up{job="piraeus-operator"} == 0)
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_markup_format: "markdown"
+        plk_protocol_version: "1"
+        plk_pending_until_firing_for: "1m"
+        plk_grouped_by__main: "PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
+        plk_ignore_labels: "job"
+        summary: Prometheus cannot scrape the piraeus-operator metrics.
+        description: |
+          The recommended course of action:
+          1. Check the Pod status: `kubectl -n d8-linstor get pod -l app=piraeus-operator`
+          2. Or check the Pod logs: `kubectl -n d8-linstor logs -l app=piraeus-operator -c piraeus-operator`
+
+    - alert: PiraeusOperatorTargetAbsent
+      expr: absent(up{job="piraeus-operator"}) == 1
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_pending_until_firing_for: "15m"
+        plk_ignore_labels: "job"
+        plk_grouped_by__main: "PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
+        summary: There is no `piraeus-operator` target in Prometheus.
+        description: |
+          The recommended course of action:
+          1. Check the Pod status: `kubectl -n d8-linstor get pod -l app=piraeus-operator`
+          2. Or check the Pod logs: `kubectl -n d8-linstor logs -l app=piraeus-operator -c piraeus-operator`
+
+    - alert: PiraeusOperatorPodIsNotReady
+      expr: min by (pod) (kube_pod_status_ready{condition="true", namespace="d8-linstor", pod=~"piraeus-operator-.*"}) != 1
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_pending_until_firing_for: "30m"
+        plk_labels_as_annotations: "pod"
+        plk_grouped_by__main: "PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
+        summary: The piraeus-operator Pod is NOT Ready.
+        description: |
+          The recommended course of action:
+          1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy piraeus-operator`
+          2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app=piraeus-operator`
+
+    - alert: PiraeusOperatorPodIsNotRunning
+      expr: absent(kube_pod_status_phase{namespace="d8-linstor",phase="Running",pod=~"piraeus-operator-.*"})
+      labels:
+        severity_level: "6"
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_pending_until_firing_for: "30m"
+        plk_grouped_by__main: "PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
+        summary: The piraeus-operator Pod is NOT Running.
+        description: |
+          The recommended course of action:
+          1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy piraeus-operator`
+          2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app=piraeus-operator`
+
+    - alert: PiraeusOperatorHealth
+      expr: count(ALERTS{alertname=~"PiraeusOperatorTargetDown|PiraeusOperatorTargetAbsent|PiraeusOperatorPodIsNotReady|PiraeusOperatorPodIsNotRunning", alertstate="firing"})
+      labels:
+        tier: cluster
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_alert_type: "group"
+        summary: The piraeus-operator does not work.
+        description: Refer to the relevant alerts for more information.

--- a/modules/031-linstor/monitoring/prometheus-rules/piraeus-operator.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/piraeus-operator.yaml
@@ -1,6 +1,6 @@
 - name: kubernetes.linstor.piraeus_operator_state
   rules:
-    - alert: PiraeusOperatorTargetDown
+    - alert: D8PiraeusOperatorTargetDown
       expr: max by (job) (up{job="piraeus-operator"} == 0)
       labels:
         severity_level: "6"
@@ -9,7 +9,7 @@
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
         plk_pending_until_firing_for: "1m"
-        plk_grouped_by__main: "PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
         plk_ignore_labels: "job"
         summary: Prometheus cannot scrape the piraeus-operator metrics.
         description: |
@@ -17,7 +17,7 @@
           1. Check the Pod status: `kubectl -n d8-linstor get pod -l app=piraeus-operator`
           2. Or check the Pod logs: `kubectl -n d8-linstor logs -l app=piraeus-operator -c piraeus-operator`
 
-    - alert: PiraeusOperatorTargetAbsent
+    - alert: D8PiraeusOperatorTargetAbsent
       expr: absent(up{job="piraeus-operator"}) == 1
       labels:
         severity_level: "6"
@@ -27,14 +27,14 @@
         plk_markup_format: "markdown"
         plk_pending_until_firing_for: "15m"
         plk_ignore_labels: "job"
-        plk_grouped_by__main: "PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
         summary: There is no `piraeus-operator` target in Prometheus.
         description: |
           The recommended course of action:
           1. Check the Pod status: `kubectl -n d8-linstor get pod -l app=piraeus-operator`
           2. Or check the Pod logs: `kubectl -n d8-linstor logs -l app=piraeus-operator -c piraeus-operator`
 
-    - alert: PiraeusOperatorPodIsNotReady
+    - alert: D8PiraeusOperatorPodIsNotReady
       expr: min by (pod) (kube_pod_status_ready{condition="true", namespace="d8-linstor", pod=~"piraeus-operator-.*"}) != 1
       labels:
         severity_level: "6"
@@ -44,14 +44,14 @@
         plk_markup_format: "markdown"
         plk_pending_until_firing_for: "30m"
         plk_labels_as_annotations: "pod"
-        plk_grouped_by__main: "PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
         summary: The piraeus-operator Pod is NOT Ready.
         description: |
           The recommended course of action:
           1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy piraeus-operator`
           2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app=piraeus-operator`
 
-    - alert: PiraeusOperatorPodIsNotRunning
+    - alert: D8PiraeusOperatorPodIsNotRunning
       expr: absent(kube_pod_status_phase{namespace="d8-linstor",phase="Running",pod=~"piraeus-operator-.*"})
       labels:
         severity_level: "6"
@@ -60,15 +60,15 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_pending_until_firing_for: "30m"
-        plk_grouped_by__main: "PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
+        plk_grouped_by__main: "D8PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
         summary: The piraeus-operator Pod is NOT Running.
         description: |
           The recommended course of action:
           1. Retrieve details of the Deployment: `kubectl -n d8-linstor describe deploy piraeus-operator`
           2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-linstor describe pod -l app=piraeus-operator`
 
-    - alert: PiraeusOperatorHealth
-      expr: count(ALERTS{alertname=~"PiraeusOperatorTargetDown|PiraeusOperatorTargetAbsent|PiraeusOperatorPodIsNotReady|PiraeusOperatorPodIsNotRunning", alertstate="firing"})
+    - alert: D8PiraeusOperatorHealth
+      expr: count(ALERTS{alertname=~"D8PiraeusOperatorTargetDown|D8PiraeusOperatorTargetAbsent|D8PiraeusOperatorPodIsNotReady|D8PiraeusOperatorPodIsNotRunning", alertstate="firing"})
       labels:
         tier: cluster
       annotations:

--- a/modules/031-linstor/templates/monitoring.yaml
+++ b/modules/031-linstor/templates/monitoring.yaml
@@ -1,0 +1,1 @@
+{{- include "helm_lib_prometheus_rules" (list . "d8-linstor") }}

--- a/modules/031-linstor/templates/monitoring.yaml
+++ b/modules/031-linstor/templates/monitoring.yaml
@@ -1,1 +1,2 @@
+{{- include "helm_lib_grafana_dashboard_definitions" . }}
 {{- include "helm_lib_prometheus_rules" (list . "d8-linstor") }}


### PR DESCRIPTION
## Description
This PR introduces Grafana dashboard for LINSTOR and DRBD:

![Screenshot 2022-03-15 at 16-22-57 LINSTOR _ DRBD - Grafana](https://user-images.githubusercontent.com/7556217/158411980-9499d06b-c1ce-459d-81ea-a1ca40384f58.png)

![Screenshot 2022-03-15 at 21-44-39 LINSTOR _ DRBD - Grafana](https://user-images.githubusercontent.com/7556217/158469277-67bec951-4f8c-4812-824a-75752c896eab.png)

![Screenshot 2022-03-15 at 22-04-28 LINSTOR _ DRBD - Grafana](https://user-images.githubusercontent.com/7556217/158472304-59c20128-19ac-4608-be9a-35e521edaada.png)


## Why do we need it, and what problem does it solve?

Observability for LINSTOR.

fixes https://github.com/deckhouse/deckhouse/issues/907

## Changelog entries

```changes
---
section: linstor
type: feature
summary: Grafana dashboard for LINSTOR
impact_level: high
impact: Added Grafana dashboard to monitor LISNTOR cluster and DRBD resources
---
section: linstor
type: feature
summary: added alerts for LINSTOR
impact_level: high
impact: Add alerts with the recommended course of action to monitor LINSTOR, Piraeus-operator, capacity of storage-pools and resources states
```