### PR TITLE
[candi] Fix docker-stuck-containers-cleaner unit

### DIFF
--- a/candi/bashible/common-steps/node-group/089_setup_timer_to_run_docker_stuck_containers_cleaner.sh.tpl
+++ b/candi/bashible/common-steps/node-group/089_setup_timer_to_run_docker_stuck_containers_cleaner.sh.tpl
@@ -74,7 +74,7 @@ function main() {
   parse_arguments "$@"
 
   for container_id in $(get_stuck_containers); do
-    if ! image_sha="$(docker container inspect "$container_id" -f '{{`{{.Config.Image}}`}}`' 2> /dev/null)"; then
+    if ! image_sha="$(docker container inspect "$container_id" -f '{{`{{.Config.Image}}`}}' 2> /dev/null)"; then
       echo_err "Container $container_id was not found or it was removed on previous run"
       continue
     fi

--- a/candi/bashible/common-steps/node-group/089_setup_timer_to_run_docker_stuck_containers_cleaner.sh.tpl
+++ b/candi/bashible/common-steps/node-group/089_setup_timer_to_run_docker_stuck_containers_cleaner.sh.tpl
@@ -74,11 +74,12 @@ function main() {
   parse_arguments "$@"
 
   for container_id in $(get_stuck_containers); do
-    if ! image="$(docker container inspect "$container_id" -f '{{.Config.Image}}' 2> /dev/null)"; then
-      echo_err "Container $container_id was not found or it was remove on previous run"
+    if ! image_sha="$(docker container inspect "$container_id" -f '{{`{{.Config.Image}}`}}`' 2> /dev/null)"; then
+      echo_err "Container $container_id was not found or it was removed on previous run"
       continue
     fi
 
+    image="$(docker image inspect "$image_sha" -f '{{`{{index .RepoTags 0}}`}}')"
     echo "Container $container_id has image $image"
 
     if ! [[ "$image" =~ $image_pattern ]]; then


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- escape curly braces to prevent faulty bash script rendering
- get repo tag for comparison with pattern

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

```
if ! image="$(docker container inspect "$container_id" -f '<no value>' 2> /dev/null)"; then
      echo_err "Container $container_id was not found or it was remove on previous run"
      continue
fi
```


## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: Fix docker-stuck-containers-cleaner unit
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
