### PR TITLE
[linstor] Switch rc to stable release

### DIFF
--- a/modules/031-linstor/images/linstor-server/Dockerfile
+++ b/modules/031-linstor/images/linstor-server/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_GOLANG_17_BUSTER
 FROM $BASE_DEBIAN as linstor-builder
 
 ARG LINSTOR_GITREPO=https://github.com/LINBIT/linstor-server
-ARG LINSTOR_VERSION=1.18.0-rc.3
+ARG LINSTOR_VERSION=1.18.0
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \


### PR DESCRIPTION
## Description
linstor-server v1.18 just been [released](https://github.com/LINBIT/linstor-server/releases/tag/v1.18.0). 

## Why do we need it, and what problem does it solve?

This PR is switching version of linstor-server from `v1.18-rc3` to `v1.18`

## Changelog entries

```changes
section: linstor
type: feature
summary: Switch rc to stable release
impact_level: low
```

