### PR TITLE
[docs][getting-started] Ask sudo password when bootstrapping bare metal cluster

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER.liquid
+++ b/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER.liquid
@@ -39,7 +39,8 @@ dhctl bootstrap \
   --ssh-user=<username> \
   --ssh-host=<master_ip> \
   --ssh-agent-private-keys=/tmp/.ssh/id_rsa \
-  --config=/config.yml
+  --config=/config.yml \
+  --ask-become-pass
 {%- elsif page.platform_type == "cloud" %}
 dhctl bootstrap \
   --ssh-user=<username> \
@@ -52,7 +53,7 @@ dhctl bootstrap \
 
 {%- if page.platform_type == "baremetal" or page.platform_type == "cloud" %}
 {%- if page.platform_type == "baremetal" %}
-`username` variable here refers to the user that generated the SSH key.
+`username` variable here refers to the user that generated the SSH key. If a password is required to run sudo on the server, then specify it in response to the request `[sudo] Password:`, otherwise leave it empty.
 {%- else %}
 `username` variable here refers to
 {%- if page.platform_code == "openstack" %} the default user for the relevant VM image.

--- a/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
@@ -39,7 +39,8 @@ dhctl bootstrap \
   --ssh-user=<username> \
   --ssh-host=<master_ip> \
   --ssh-agent-private-keys=/tmp/.ssh/id_rsa \
-  --config=/config.yml
+  --config=/config.yml \
+  --ask-become-pass
 {%- elsif page.platform_type == "cloud" %}
 dhctl bootstrap \
   --ssh-user=<username> \
@@ -52,7 +53,7 @@ dhctl bootstrap \
 
 {%- if page.platform_type == "baremetal" or page.platform_type == "cloud" %}
 {%- if page.platform_type == "baremetal" %}
-Здесь, переменная `username` — это имя пользователя, от которого генерировался SSH-ключ для установки.
+Здесь, переменная `username` — это имя пользователя, от которого генерировался SSH-ключ для установки. Если для запуска sudo на сервере необходим пароль, то укажите его в ответ на запрос `[sudo] Password:`, иначе — оставьте пустым.
 {%- else %}
 Здесь, переменная `username` —
 {%- if page.platform_code == "openstack" %} имя пользователя по умолчанию для выбранного образа виртуальной машины.


### PR DESCRIPTION
## Description
Add `--ask-become-pass` option to the bare metal bootstrap command in the Getting Started.

## Changelog entries
```changes
section: docs
type: fix
summary: "Ask sudo password in the Getting Started when bootstrapping bare metal cluster."
impact_level: low
```
