### PR TITLE
[ci] feat: jobs to control editions when approving deploy

### DIFF
--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -45,23 +45,16 @@ env:
 jobs:
 {!{ tmpl.Exec "git_info_job" . | strings.Indent 2 }!}
 
-  run_deploy:
-    name: Deploy deckhouse to {!{ .channel }!} channel
-    environment:
-      name: {!{ .channel }!}
-    needs:
-      - git_info
-    runs-on: [self-hosted, regular]
+  detect_editions:
+    name: Detect editions
+    runs-on: ubuntu-latest
+    outputs:
+      DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
+      DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}
+      DEPLOY_FE: ${{steps.detect_editions.outputs.DEPLOY_FE}}
     steps:
-{!{ tmpl.Exec "started_at_output" . | strings.Indent 6 }!}
-{!{ tmpl.Exec "checkout_from_event_ref_step" . | strings.Indent 6 }!}
-{!{ tmpl.Exec "update_comment_on_start" $workflowName | strings.Indent 6 }!}
-{!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 6 }!}
-{!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 6 }!}
-{!{ tmpl.Exec "login_rw_registry_step" . | strings.Indent 6 }!}
-
-      - name: Filter editions
-        id: filter_editions
+      - name: Detect editions
+        id: detect_editions
         env:
           EDITIONS: ${{ github.event.inputs.editions }}
         run: |
@@ -72,7 +65,7 @@ jobs:
           for edition in CE EE FE ; do
             if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
               echo "  - enable deploy of ${edition} edition."
-              echo "::set-output name=DEPLOY_${edition}::yes"
+              echo "::set-output name=DEPLOY_${edition}::true"
               RESTRICTED=yes
             fi
           done
@@ -80,41 +73,85 @@ jobs:
           if [[ $RESTRICTED == "no" ]] ; then
             echo "No restrictions. Enable deploy to all editions."
             for edition in CE EE FE ; do
-              echo "::set-output name=DEPLOY_${edition}::yes"
+              echo "::set-output name=DEPLOY_${edition}::true"
             done
           fi
 
 {!{/*
-Pull deckhouse images from cache, tag with channel name and push to dev and prod registries.
-Images:
-- deckhouse image
-- deckhouse/install image
-- deckhouse/release-channel image
+Jobs for visual control allowed editions when approving deploy to environments.
+*/}!}
+{!{ range $werfEnv := slice "CE" "EE" "FE" }!}
+  enable_{!{$werfEnv}!}:
+    if: ${{ needs.detect_editions.outputs.DEPLOY_{!{$werfEnv}!} == 'true' }}
+    name: Enable {!{$werfEnv}!}
+    needs:
+      - detect_editions
+    runs-on: ubuntu-latest
+    steps:
+      - run: ": Enable {!{$werfEnv}!}"
+{!{ end }!}
+
+  run_deploy:
+    name: Deploy ${{needs.git_info.outputs.ci_commit_tag}} to {!{ .channel }!}
+    environment:
+      name: {!{ .channel }!}
+    needs:
+      - git_info
+      - detect_editions
+    runs-on: [self-hosted, regular]
+    steps:
+{!{ tmpl.Exec "started_at_output" . | strings.Indent 6 }!}
+{!{ tmpl.Exec "checkout_from_event_ref_step" . | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_start" $workflowName | strings.Indent 6 }!}
+{!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 6 }!}
+{!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 6 }!}
+{!{ tmpl.Exec "login_rw_registry_step" . | strings.Indent 6 }!}
+
+{!{/*
+Add 'publish' step for each edition.
+
+'Publish' pulls deckhouse images from cache, tag them with channel name and push to dev and prod registries.
+
+Images to publish:
+- deckhouse main image ('dev')
+- install image with dhctl ('dev/install')
+- image with release process settings ('release-channel-version')
+
 Destination registries:
-- DECKHOUSE_REGISTRY_HOST
-- DEV_REGISTRY_PATH
+- DEV_REGISTRY_PATH - dev registry, main stages storage.
+- DECKHOUSE_REGISTRY_HOST - prod registry for final images.
+
 */}!}
 {!{ range $werfEnv := slice "CE" "EE" "FE" }!}
       - name: Publish release images for {!{ $werfEnv }!}
-        if: ${{ steps.filter_editions.outputs.DEPLOY_{!{ $werfEnv }!} == 'yes' }}
+        if: ${{ needs.detect_editions.outputs.DEPLOY_{!{ $werfEnv }!} == 'true' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: {!{ $werfEnv }!}
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
 
-          echo Publish {!{ $werfEnv }!} edition.
-
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${CI_COMMIT_TAG} ]] ; then
+            echo "::error title=Missed variable::CI_COMMIT_TAG is not set. Probably you try to manually deploy from branch '${CI_COMMIT_BRANCH}'? Deploy allowed for tags only."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Publish {!{ $werfEnv }!} edition".
 
           # Variables
           #   1. CE/EE/FE -> ce/ee/fe

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -117,12 +117,75 @@ jobs:
 
   # </template: git_info_job>
 
+  detect_editions:
+    name: Detect editions
+    runs-on: ubuntu-latest
+    outputs:
+      DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
+      DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}
+      DEPLOY_FE: ${{steps.detect_editions.outputs.DEPLOY_FE}}
+    steps:
+      - name: Detect editions
+        id: detect_editions
+        env:
+          EDITIONS: ${{ github.event.inputs.editions }}
+        run: |
+          echo "Input allowed editions: '${EDITIONS}'"
+
+          RESTRICTED=no
+
+          for edition in CE EE FE ; do
+            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
+              echo "  - enable deploy of ${edition} edition."
+              echo "::set-output name=DEPLOY_${edition}::true"
+              RESTRICTED=yes
+            fi
+          done
+
+          if [[ $RESTRICTED == "no" ]] ; then
+            echo "No restrictions. Enable deploy to all editions."
+            for edition in CE EE FE ; do
+              echo "::set-output name=DEPLOY_${edition}::true"
+            done
+          fi
+
+
+
+  enable_CE:
+    if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
+    name: Enable CE
+    needs:
+      - detect_editions
+    runs-on: ubuntu-latest
+    steps:
+      - run: ": Enable CE"
+
+  enable_EE:
+    if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
+    name: Enable EE
+    needs:
+      - detect_editions
+    runs-on: ubuntu-latest
+    steps:
+      - run: ": Enable EE"
+
+  enable_FE:
+    if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
+    name: Enable FE
+    needs:
+      - detect_editions
+    runs-on: ubuntu-latest
+    steps:
+      - run: ": Enable FE"
+
+
   run_deploy:
-    name: Deploy deckhouse to alpha channel
+    name: Deploy ${{needs.git_info.outputs.ci_commit_tag}} to alpha
     environment:
       name: alpha
     needs:
       - git_info
+      - detect_editions
     runs-on: [self-hosted, regular]
     steps:
 
@@ -185,52 +248,37 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      - name: Filter editions
-        id: filter_editions
-        env:
-          EDITIONS: ${{ github.event.inputs.editions }}
-        run: |
-          echo "Input allowed editions: '${EDITIONS}'"
-
-          RESTRICTED=no
-
-          for edition in CE EE FE ; do
-            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
-              echo "  - enable deploy of ${edition} edition."
-              echo "::set-output name=DEPLOY_${edition}::yes"
-              RESTRICTED=yes
-            fi
-          done
-
-          if [[ $RESTRICTED == "no" ]] ; then
-            echo "No restrictions. Enable deploy to all editions."
-            for edition in CE EE FE ; do
-              echo "::set-output name=DEPLOY_${edition}::yes"
-            done
-          fi
-
 
 
       - name: Publish release images for CE
-        if: ${{ steps.filter_editions.outputs.DEPLOY_CE == 'yes' }}
+        if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: CE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
 
-          echo Publish CE edition.
-
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${CI_COMMIT_TAG} ]] ; then
+            echo "::error title=Missed variable::CI_COMMIT_TAG is not set. Probably you try to manually deploy from branch '${CI_COMMIT_BRANCH}'? Deploy allowed for tags only."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Publish CE edition".
 
           # Variables
           #   1. CE/EE/FE -> ce/ee/fe
@@ -322,25 +370,34 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
-        if: ${{ steps.filter_editions.outputs.DEPLOY_EE == 'yes' }}
+        if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: EE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
 
-          echo Publish EE edition.
-
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${CI_COMMIT_TAG} ]] ; then
+            echo "::error title=Missed variable::CI_COMMIT_TAG is not set. Probably you try to manually deploy from branch '${CI_COMMIT_BRANCH}'? Deploy allowed for tags only."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Publish EE edition".
 
           # Variables
           #   1. CE/EE/FE -> ce/ee/fe
@@ -432,25 +489,34 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
-        if: ${{ steps.filter_editions.outputs.DEPLOY_FE == 'yes' }}
+        if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: FE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
 
-          echo Publish FE edition.
-
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${CI_COMMIT_TAG} ]] ; then
+            echo "::error title=Missed variable::CI_COMMIT_TAG is not set. Probably you try to manually deploy from branch '${CI_COMMIT_BRANCH}'? Deploy allowed for tags only."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Publish FE edition".
 
           # Variables
           #   1. CE/EE/FE -> ce/ee/fe

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -117,12 +117,75 @@ jobs:
 
   # </template: git_info_job>
 
+  detect_editions:
+    name: Detect editions
+    runs-on: ubuntu-latest
+    outputs:
+      DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
+      DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}
+      DEPLOY_FE: ${{steps.detect_editions.outputs.DEPLOY_FE}}
+    steps:
+      - name: Detect editions
+        id: detect_editions
+        env:
+          EDITIONS: ${{ github.event.inputs.editions }}
+        run: |
+          echo "Input allowed editions: '${EDITIONS}'"
+
+          RESTRICTED=no
+
+          for edition in CE EE FE ; do
+            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
+              echo "  - enable deploy of ${edition} edition."
+              echo "::set-output name=DEPLOY_${edition}::true"
+              RESTRICTED=yes
+            fi
+          done
+
+          if [[ $RESTRICTED == "no" ]] ; then
+            echo "No restrictions. Enable deploy to all editions."
+            for edition in CE EE FE ; do
+              echo "::set-output name=DEPLOY_${edition}::true"
+            done
+          fi
+
+
+
+  enable_CE:
+    if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
+    name: Enable CE
+    needs:
+      - detect_editions
+    runs-on: ubuntu-latest
+    steps:
+      - run: ": Enable CE"
+
+  enable_EE:
+    if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
+    name: Enable EE
+    needs:
+      - detect_editions
+    runs-on: ubuntu-latest
+    steps:
+      - run: ": Enable EE"
+
+  enable_FE:
+    if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
+    name: Enable FE
+    needs:
+      - detect_editions
+    runs-on: ubuntu-latest
+    steps:
+      - run: ": Enable FE"
+
+
   run_deploy:
-    name: Deploy deckhouse to beta channel
+    name: Deploy ${{needs.git_info.outputs.ci_commit_tag}} to beta
     environment:
       name: beta
     needs:
       - git_info
+      - detect_editions
     runs-on: [self-hosted, regular]
     steps:
 
@@ -185,52 +248,37 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      - name: Filter editions
-        id: filter_editions
-        env:
-          EDITIONS: ${{ github.event.inputs.editions }}
-        run: |
-          echo "Input allowed editions: '${EDITIONS}'"
-
-          RESTRICTED=no
-
-          for edition in CE EE FE ; do
-            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
-              echo "  - enable deploy of ${edition} edition."
-              echo "::set-output name=DEPLOY_${edition}::yes"
-              RESTRICTED=yes
-            fi
-          done
-
-          if [[ $RESTRICTED == "no" ]] ; then
-            echo "No restrictions. Enable deploy to all editions."
-            for edition in CE EE FE ; do
-              echo "::set-output name=DEPLOY_${edition}::yes"
-            done
-          fi
-
 
 
       - name: Publish release images for CE
-        if: ${{ steps.filter_editions.outputs.DEPLOY_CE == 'yes' }}
+        if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: CE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
 
-          echo Publish CE edition.
-
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${CI_COMMIT_TAG} ]] ; then
+            echo "::error title=Missed variable::CI_COMMIT_TAG is not set. Probably you try to manually deploy from branch '${CI_COMMIT_BRANCH}'? Deploy allowed for tags only."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Publish CE edition".
 
           # Variables
           #   1. CE/EE/FE -> ce/ee/fe
@@ -322,25 +370,34 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
-        if: ${{ steps.filter_editions.outputs.DEPLOY_EE == 'yes' }}
+        if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: EE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
 
-          echo Publish EE edition.
-
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${CI_COMMIT_TAG} ]] ; then
+            echo "::error title=Missed variable::CI_COMMIT_TAG is not set. Probably you try to manually deploy from branch '${CI_COMMIT_BRANCH}'? Deploy allowed for tags only."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Publish EE edition".
 
           # Variables
           #   1. CE/EE/FE -> ce/ee/fe
@@ -432,25 +489,34 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
-        if: ${{ steps.filter_editions.outputs.DEPLOY_FE == 'yes' }}
+        if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: FE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
 
-          echo Publish FE edition.
-
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${CI_COMMIT_TAG} ]] ; then
+            echo "::error title=Missed variable::CI_COMMIT_TAG is not set. Probably you try to manually deploy from branch '${CI_COMMIT_BRANCH}'? Deploy allowed for tags only."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Publish FE edition".
 
           # Variables
           #   1. CE/EE/FE -> ce/ee/fe

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -117,12 +117,75 @@ jobs:
 
   # </template: git_info_job>
 
+  detect_editions:
+    name: Detect editions
+    runs-on: ubuntu-latest
+    outputs:
+      DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
+      DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}
+      DEPLOY_FE: ${{steps.detect_editions.outputs.DEPLOY_FE}}
+    steps:
+      - name: Detect editions
+        id: detect_editions
+        env:
+          EDITIONS: ${{ github.event.inputs.editions }}
+        run: |
+          echo "Input allowed editions: '${EDITIONS}'"
+
+          RESTRICTED=no
+
+          for edition in CE EE FE ; do
+            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
+              echo "  - enable deploy of ${edition} edition."
+              echo "::set-output name=DEPLOY_${edition}::true"
+              RESTRICTED=yes
+            fi
+          done
+
+          if [[ $RESTRICTED == "no" ]] ; then
+            echo "No restrictions. Enable deploy to all editions."
+            for edition in CE EE FE ; do
+              echo "::set-output name=DEPLOY_${edition}::true"
+            done
+          fi
+
+
+
+  enable_CE:
+    if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
+    name: Enable CE
+    needs:
+      - detect_editions
+    runs-on: ubuntu-latest
+    steps:
+      - run: ": Enable CE"
+
+  enable_EE:
+    if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
+    name: Enable EE
+    needs:
+      - detect_editions
+    runs-on: ubuntu-latest
+    steps:
+      - run: ": Enable EE"
+
+  enable_FE:
+    if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
+    name: Enable FE
+    needs:
+      - detect_editions
+    runs-on: ubuntu-latest
+    steps:
+      - run: ": Enable FE"
+
+
   run_deploy:
-    name: Deploy deckhouse to early-access channel
+    name: Deploy ${{needs.git_info.outputs.ci_commit_tag}} to early-access
     environment:
       name: early-access
     needs:
       - git_info
+      - detect_editions
     runs-on: [self-hosted, regular]
     steps:
 
@@ -185,52 +248,37 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      - name: Filter editions
-        id: filter_editions
-        env:
-          EDITIONS: ${{ github.event.inputs.editions }}
-        run: |
-          echo "Input allowed editions: '${EDITIONS}'"
-
-          RESTRICTED=no
-
-          for edition in CE EE FE ; do
-            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
-              echo "  - enable deploy of ${edition} edition."
-              echo "::set-output name=DEPLOY_${edition}::yes"
-              RESTRICTED=yes
-            fi
-          done
-
-          if [[ $RESTRICTED == "no" ]] ; then
-            echo "No restrictions. Enable deploy to all editions."
-            for edition in CE EE FE ; do
-              echo "::set-output name=DEPLOY_${edition}::yes"
-            done
-          fi
-
 
 
       - name: Publish release images for CE
-        if: ${{ steps.filter_editions.outputs.DEPLOY_CE == 'yes' }}
+        if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: CE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
 
-          echo Publish CE edition.
-
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${CI_COMMIT_TAG} ]] ; then
+            echo "::error title=Missed variable::CI_COMMIT_TAG is not set. Probably you try to manually deploy from branch '${CI_COMMIT_BRANCH}'? Deploy allowed for tags only."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Publish CE edition".
 
           # Variables
           #   1. CE/EE/FE -> ce/ee/fe
@@ -322,25 +370,34 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
-        if: ${{ steps.filter_editions.outputs.DEPLOY_EE == 'yes' }}
+        if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: EE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
 
-          echo Publish EE edition.
-
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${CI_COMMIT_TAG} ]] ; then
+            echo "::error title=Missed variable::CI_COMMIT_TAG is not set. Probably you try to manually deploy from branch '${CI_COMMIT_BRANCH}'? Deploy allowed for tags only."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Publish EE edition".
 
           # Variables
           #   1. CE/EE/FE -> ce/ee/fe
@@ -432,25 +489,34 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
-        if: ${{ steps.filter_editions.outputs.DEPLOY_FE == 'yes' }}
+        if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: FE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
 
-          echo Publish FE edition.
-
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${CI_COMMIT_TAG} ]] ; then
+            echo "::error title=Missed variable::CI_COMMIT_TAG is not set. Probably you try to manually deploy from branch '${CI_COMMIT_BRANCH}'? Deploy allowed for tags only."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Publish FE edition".
 
           # Variables
           #   1. CE/EE/FE -> ce/ee/fe

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -117,12 +117,75 @@ jobs:
 
   # </template: git_info_job>
 
+  detect_editions:
+    name: Detect editions
+    runs-on: ubuntu-latest
+    outputs:
+      DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
+      DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}
+      DEPLOY_FE: ${{steps.detect_editions.outputs.DEPLOY_FE}}
+    steps:
+      - name: Detect editions
+        id: detect_editions
+        env:
+          EDITIONS: ${{ github.event.inputs.editions }}
+        run: |
+          echo "Input allowed editions: '${EDITIONS}'"
+
+          RESTRICTED=no
+
+          for edition in CE EE FE ; do
+            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
+              echo "  - enable deploy of ${edition} edition."
+              echo "::set-output name=DEPLOY_${edition}::true"
+              RESTRICTED=yes
+            fi
+          done
+
+          if [[ $RESTRICTED == "no" ]] ; then
+            echo "No restrictions. Enable deploy to all editions."
+            for edition in CE EE FE ; do
+              echo "::set-output name=DEPLOY_${edition}::true"
+            done
+          fi
+
+
+
+  enable_CE:
+    if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
+    name: Enable CE
+    needs:
+      - detect_editions
+    runs-on: ubuntu-latest
+    steps:
+      - run: ": Enable CE"
+
+  enable_EE:
+    if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
+    name: Enable EE
+    needs:
+      - detect_editions
+    runs-on: ubuntu-latest
+    steps:
+      - run: ": Enable EE"
+
+  enable_FE:
+    if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
+    name: Enable FE
+    needs:
+      - detect_editions
+    runs-on: ubuntu-latest
+    steps:
+      - run: ": Enable FE"
+
+
   run_deploy:
-    name: Deploy deckhouse to rock-solid channel
+    name: Deploy ${{needs.git_info.outputs.ci_commit_tag}} to rock-solid
     environment:
       name: rock-solid
     needs:
       - git_info
+      - detect_editions
     runs-on: [self-hosted, regular]
     steps:
 
@@ -185,52 +248,37 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      - name: Filter editions
-        id: filter_editions
-        env:
-          EDITIONS: ${{ github.event.inputs.editions }}
-        run: |
-          echo "Input allowed editions: '${EDITIONS}'"
-
-          RESTRICTED=no
-
-          for edition in CE EE FE ; do
-            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
-              echo "  - enable deploy of ${edition} edition."
-              echo "::set-output name=DEPLOY_${edition}::yes"
-              RESTRICTED=yes
-            fi
-          done
-
-          if [[ $RESTRICTED == "no" ]] ; then
-            echo "No restrictions. Enable deploy to all editions."
-            for edition in CE EE FE ; do
-              echo "::set-output name=DEPLOY_${edition}::yes"
-            done
-          fi
-
 
 
       - name: Publish release images for CE
-        if: ${{ steps.filter_editions.outputs.DEPLOY_CE == 'yes' }}
+        if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: CE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
 
-          echo Publish CE edition.
-
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${CI_COMMIT_TAG} ]] ; then
+            echo "::error title=Missed variable::CI_COMMIT_TAG is not set. Probably you try to manually deploy from branch '${CI_COMMIT_BRANCH}'? Deploy allowed for tags only."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Publish CE edition".
 
           # Variables
           #   1. CE/EE/FE -> ce/ee/fe
@@ -322,25 +370,34 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
-        if: ${{ steps.filter_editions.outputs.DEPLOY_EE == 'yes' }}
+        if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: EE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
 
-          echo Publish EE edition.
-
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${CI_COMMIT_TAG} ]] ; then
+            echo "::error title=Missed variable::CI_COMMIT_TAG is not set. Probably you try to manually deploy from branch '${CI_COMMIT_BRANCH}'? Deploy allowed for tags only."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Publish EE edition".
 
           # Variables
           #   1. CE/EE/FE -> ce/ee/fe
@@ -432,25 +489,34 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
-        if: ${{ steps.filter_editions.outputs.DEPLOY_FE == 'yes' }}
+        if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: FE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
 
-          echo Publish FE edition.
-
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${CI_COMMIT_TAG} ]] ; then
+            echo "::error title=Missed variable::CI_COMMIT_TAG is not set. Probably you try to manually deploy from branch '${CI_COMMIT_BRANCH}'? Deploy allowed for tags only."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Publish FE edition".
 
           # Variables
           #   1. CE/EE/FE -> ce/ee/fe

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -117,12 +117,75 @@ jobs:
 
   # </template: git_info_job>
 
+  detect_editions:
+    name: Detect editions
+    runs-on: ubuntu-latest
+    outputs:
+      DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
+      DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}
+      DEPLOY_FE: ${{steps.detect_editions.outputs.DEPLOY_FE}}
+    steps:
+      - name: Detect editions
+        id: detect_editions
+        env:
+          EDITIONS: ${{ github.event.inputs.editions }}
+        run: |
+          echo "Input allowed editions: '${EDITIONS}'"
+
+          RESTRICTED=no
+
+          for edition in CE EE FE ; do
+            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
+              echo "  - enable deploy of ${edition} edition."
+              echo "::set-output name=DEPLOY_${edition}::true"
+              RESTRICTED=yes
+            fi
+          done
+
+          if [[ $RESTRICTED == "no" ]] ; then
+            echo "No restrictions. Enable deploy to all editions."
+            for edition in CE EE FE ; do
+              echo "::set-output name=DEPLOY_${edition}::true"
+            done
+          fi
+
+
+
+  enable_CE:
+    if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
+    name: Enable CE
+    needs:
+      - detect_editions
+    runs-on: ubuntu-latest
+    steps:
+      - run: ": Enable CE"
+
+  enable_EE:
+    if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
+    name: Enable EE
+    needs:
+      - detect_editions
+    runs-on: ubuntu-latest
+    steps:
+      - run: ": Enable EE"
+
+  enable_FE:
+    if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
+    name: Enable FE
+    needs:
+      - detect_editions
+    runs-on: ubuntu-latest
+    steps:
+      - run: ": Enable FE"
+
+
   run_deploy:
-    name: Deploy deckhouse to stable channel
+    name: Deploy ${{needs.git_info.outputs.ci_commit_tag}} to stable
     environment:
       name: stable
     needs:
       - git_info
+      - detect_editions
     runs-on: [self-hosted, regular]
     steps:
 
@@ -185,52 +248,37 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      - name: Filter editions
-        id: filter_editions
-        env:
-          EDITIONS: ${{ github.event.inputs.editions }}
-        run: |
-          echo "Input allowed editions: '${EDITIONS}'"
-
-          RESTRICTED=no
-
-          for edition in CE EE FE ; do
-            if grep -i ",${edition}," <<<",${EDITIONS}," 2>/dev/null 1>&2 ; then
-              echo "  - enable deploy of ${edition} edition."
-              echo "::set-output name=DEPLOY_${edition}::yes"
-              RESTRICTED=yes
-            fi
-          done
-
-          if [[ $RESTRICTED == "no" ]] ; then
-            echo "No restrictions. Enable deploy to all editions."
-            for edition in CE EE FE ; do
-              echo "::set-output name=DEPLOY_${edition}::yes"
-            done
-          fi
-
 
 
       - name: Publish release images for CE
-        if: ${{ steps.filter_editions.outputs.DEPLOY_CE == 'yes' }}
+        if: ${{ needs.detect_editions.outputs.DEPLOY_CE == 'true' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: CE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
 
-          echo Publish CE edition.
-
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${CI_COMMIT_TAG} ]] ; then
+            echo "::error title=Missed variable::CI_COMMIT_TAG is not set. Probably you try to manually deploy from branch '${CI_COMMIT_BRANCH}'? Deploy allowed for tags only."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Publish CE edition".
 
           # Variables
           #   1. CE/EE/FE -> ce/ee/fe
@@ -322,25 +370,34 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for EE
-        if: ${{ steps.filter_editions.outputs.DEPLOY_EE == 'yes' }}
+        if: ${{ needs.detect_editions.outputs.DEPLOY_EE == 'true' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: EE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
 
-          echo Publish EE edition.
-
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${CI_COMMIT_TAG} ]] ; then
+            echo "::error title=Missed variable::CI_COMMIT_TAG is not set. Probably you try to manually deploy from branch '${CI_COMMIT_BRANCH}'? Deploy allowed for tags only."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Publish EE edition".
 
           # Variables
           #   1. CE/EE/FE -> ce/ee/fe
@@ -432,25 +489,34 @@ jobs:
           echo "  Dev: ${DEV_DESTINATION_INSTALL_IMAGE}"
           echo "Release version image: ${DECKHOUSE_DESTINATION_RELEASE_VERSION_IMAGE}"
       - name: Publish release images for FE
-        if: ${{ steps.filter_editions.outputs.DEPLOY_FE == 'yes' }}
+        if: ${{ needs.detect_editions.outputs.DEPLOY_FE == 'true' }}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           WERF_ENV: FE
         run: |
           ## Source: .gitlab/ci_templates/deploy.yml
 
-          echo Publish FE edition.
-
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${CI_COMMIT_TAG} ]] ; then
+            echo "::error title=Missed variable::CI_COMMIT_TAG is not set. Probably you try to manually deploy from branch '${CI_COMMIT_BRANCH}'? Deploy allowed for tags only."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Publish FE edition".
 
           # Variables
           #   1. CE/EE/FE -> ce/ee/fe


### PR DESCRIPTION
## Description

- Add jobs to control editions when approving deploy to environment.
- Add tag name to deploy job.
- Output errors as annotations.

## Why do we need it, and what problem does it solve?

Approvers should see what they approve.

![Pending job waiting for review](https://user-images.githubusercontent.com/1055474/158394432-9f692495-3f4f-438e-9929-2013059be037.png)



## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: feature
summary: Add jobs to control editions when approving deploy to environment
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
