### PR TITLE
[docs] Cloud Provider page headers and OpenStack names

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -185,7 +185,7 @@ entries:
                     ru: Примеры
                     en: Usage
                   url: /modules/030-cloud-provider-azure/usage.html
-            - title: Openstack
+            - title: OpenStack
               versionType: ee
               folders:
                 - title:

--- a/ee/candi/cloud-providers/openstack/docs/CLUSTER_CONFIGURATION.md
+++ b/ee/candi/cloud-providers/openstack/docs/CLUSTER_CONFIGURATION.md
@@ -1,5 +1,5 @@
 ---
-title: "Cloud provider — Openstack: provider configuration"
+title: "Cloud provider — OpenStack: provider configuration"
 ---
 
 <!-- SCHEMA -->

--- a/ee/candi/cloud-providers/openstack/docs/CLUSTER_CONFIGURATION_RU.md
+++ b/ee/candi/cloud-providers/openstack/docs/CLUSTER_CONFIGURATION_RU.md
@@ -1,5 +1,5 @@
 ---
-title: "Cloud provider — Openstack: настройки провайдера"
+title: "Cloud provider — OpenStack: настройки провайдера"
 ---
 
 <!-- SCHEMA -->

--- a/ee/candi/cloud-providers/openstack/docs/ENVIRONMENT.md
+++ b/ee/candi/cloud-providers/openstack/docs/ENVIRONMENT.md
@@ -1,5 +1,5 @@
 ---
-title: "Cloud provider — Openstack: Preparing environment"
+title: "Cloud provider — OpenStack: Preparing environment"
 ---
 
 To manage resources in an OpenStack cloud, Deckhouse connects to the OpenStack API. The user credentials required to connect to the OpenStack API are located in the openrc file (OpenStack RC file).

--- a/ee/candi/cloud-providers/openstack/docs/ENVIRONMENT_RU.md
+++ b/ee/candi/cloud-providers/openstack/docs/ENVIRONMENT_RU.md
@@ -1,5 +1,5 @@
 ---
-title: "Cloud provider — Openstack: подготовка окружения"
+title: "Cloud provider — OpenStack: подготовка окружения"
 ---
 
 Для того чтобы Deckhouse мог управлять ресурсами в облаке OpenStack, ему необходимо подключиться к OpenStack API. 

--- a/ee/candi/cloud-providers/openstack/docs/LAYOUTS.md
+++ b/ee/candi/cloud-providers/openstack/docs/LAYOUTS.md
@@ -1,5 +1,5 @@
 ---
-title: "Cloud provider - Openstack: Layouts"
+title: "Cloud provider - OpenStack: Layouts"
 ---
 
 Four layouts are supported. Below is more information about each of them.

--- a/ee/modules/030-cloud-provider-openstack/docs/README.md
+++ b/ee/modules/030-cloud-provider-openstack/docs/README.md
@@ -2,7 +2,7 @@
 title: "Cloud provider — OpenStack"
 ---
 
-The `cloud-provider-openstack` module is responsible for interacting with the [OpenStack-based](https://www.openstack.org/) cloud resources. It allows the [node manager](../../modules/040-node-manager/) module to use Openstack resources for provisioning nodes for the specified [node group](../../modules/040-node-manager/cr.html#nodegroup) (a group of nodes that are acted upon as if they were a single entity).
+The `cloud-provider-openstack` module is responsible for interacting with the [OpenStack-based](https://www.openstack.org/) cloud resources. It allows the [node manager](../../modules/040-node-manager/) module to use OpenStack resources for provisioning nodes for the specified [node group](../../modules/040-node-manager/cr.html#nodegroup) (a group of nodes that are acted upon as if they were a single entity).
 
 The `cloud-provider-openstack` module:
 - Manages OpenStack resources using the `cloud-controller-manager` (CCM) module:

--- a/ee/modules/030-cloud-provider-openstack/docs/README_RU.md
+++ b/ee/modules/030-cloud-provider-openstack/docs/README_RU.md
@@ -2,7 +2,7 @@
 title: "Cloud provider — OpenStack"
 ---
 
-Взаимодействие с облачными ресурсами провайдеров на базе [OpenStack](https://www.openstack.org/) осуществляется с помощью модуля `cloud-provider-openstack`. Он предоставляет возможность модулю [управления узлами](../../modules/040-node-manager/) использовать ресурсы Openstack при заказе узлов для описанной [группы узлов](../../modules/040-node-manager/cr.html#nodegroup).
+Взаимодействие с облачными ресурсами провайдеров на базе [OpenStack](https://www.openstack.org/) осуществляется с помощью модуля `cloud-provider-openstack`. Он предоставляет возможность модулю [управления узлами](../../modules/040-node-manager/) использовать ресурсы OpenStack при заказе узлов для описанной [группы узлов](../../modules/040-node-manager/cr.html#nodegroup).
 
 Функционал модуля `cloud-provider-openstack`:
 - Управляет ресурсами OpenStack с помощью модуля `cloud-controller-manager`:

--- a/modules/030-cloud-provider-azure/docs/CR.md
+++ b/modules/030-cloud-provider-azure/docs/CR.md
@@ -1,5 +1,5 @@
 ---
-title: "Cloud provider — Azure: custom resource"
+title: "Cloud provider — Azure: Custom Resources"
 ---
 
 <!-- SCHEMA -->

--- a/modules/030-cloud-provider-azure/docs/CR_RU.md
+++ b/modules/030-cloud-provider-azure/docs/CR_RU.md
@@ -1,5 +1,5 @@
 ---
-title: "Cloud provider — Azure: custom resource"
+title: "Cloud provider — Azure: Custom Resources"
 ---
 
 <!-- SCHEMA -->

--- a/modules/030-cloud-provider-gcp/docs/CR.md
+++ b/modules/030-cloud-provider-gcp/docs/CR.md
@@ -1,5 +1,5 @@
 ---
-title: "Cloud provider — GCP: custom resource"
+title: "Cloud provider — GCP: Custom Resources"
 ---
 
 <!-- SCHEMA -->

--- a/modules/030-cloud-provider-gcp/docs/CR_RU.md
+++ b/modules/030-cloud-provider-gcp/docs/CR_RU.md
@@ -1,5 +1,5 @@
 ---
-title: "Cloud provider — GCP: custom resource"
+title: "Cloud provider — GCP: Custom Resources"
 ---
 
 <!-- SCHEMA -->

--- a/modules/030-cloud-provider-yandex/docs/CR.md
+++ b/modules/030-cloud-provider-yandex/docs/CR.md
@@ -1,5 +1,5 @@
 ---
-title: "Cloud provider — Yandex.Cloud: Custom Resource"
+title: "Cloud provider — Yandex.Cloud: Custom Resources"
 ---
 
 <!-- SCHEMA -->

--- a/modules/030-cloud-provider-yandex/docs/CR_RU.md
+++ b/modules/030-cloud-provider-yandex/docs/CR_RU.md
@@ -1,5 +1,5 @@
 ---
-title: "Cloud provider — Yandex.Cloud: Custom Resource"
+title: "Cloud provider — Yandex.Cloud: Custom Resources"
 ---
 
 <!-- SCHEMA -->


### PR DESCRIPTION
## Description

Fixing of the "Cloud Provider" pages headers and OpenStack names.

## Changelog entries

```changes
section: docs
type: fix
summary: "Fix "Cloud Provider" page headers and OpenStack names"
impact_level: low
```