### PR TITLE
[dhctl] Add `node.kubernetes.io/exclude-from-external-load-balancers` label on control-plane nodes

### DIFF
--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -216,8 +216,9 @@ func (m *MetaConfig) MasterNodeGroupManifest() map[string]interface{} {
 		},
 		"nodeTemplate": map[string]interface{}{
 			"labels": map[string]interface{}{
-				"node-role.kubernetes.io/master":        "",
-				"node-role.kubernetes.io/control-plane": "",
+				"node-role.kubernetes.io/master":                          "",
+				"node-role.kubernetes.io/control-plane":                   "",
+				"node.kubernetes.io/exclude-from-external-load-balancers": "",
 			},
 			"taints": []map[string]interface{}{
 				{

--- a/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng.go
+++ b/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng.go
@@ -14,8 +14,9 @@
 
 package hooks
 
-// TODO remove after 1.32 release
-// add control-plane role for all master nodes over master node group
+// TODO remove after 1.33 release
+// add control-plane role and "node.kubernetes.io/exclude-from-external-load-balancers" label
+// for all master nodes over master node group
 // At current moment, first bootstrapped master get 'control-plane' role,
 // but other master nodes don't get this role, because
 // first master bootstrapped with kubeadm (kubeadm set role to node over label), but
@@ -28,7 +29,10 @@ import (
 	"github.com/flant/shell-operator/pkg/kube/object_patch"
 )
 
-const controlPlaneRoleLabel = "node-role.kubernetes.io/control-plane"
+const (
+	controlPlaneRoleLabel    = "node-role.kubernetes.io/control-plane"
+	excludeLoadBalancerLabel = "node.kubernetes.io/exclude-from-external-load-balancers"
+)
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnAfterHelm: &go_hook.OrderedConfig{Order: 10},
@@ -39,7 +43,8 @@ func addControlPlaneRoleToMasterNodeGroup(input *go_hook.HookInput) error {
 		"spec": map[string]interface{}{
 			"nodeTemplate": map[string]interface{}{
 				"labels": map[string]interface{}{
-					"node-role.kubernetes.io/control-plane": "",
+					controlPlaneRoleLabel:    "",
+					excludeLoadBalancerLabel: "",
 				},
 			},
 		},


### PR DESCRIPTION
## Description
Add node.kubernetes.io/exclude-from-external-load-balancers label on control-plane nodes with dhctl for new clusters.
Add migration for exists clusters.

## Why do we need it, and what problem does it solve?
In kubeadm v1.21 label node.kubernetes.io/exclude-from-external-load-balancers is added to all control-plane nodes. Deckhouse clusters have this label only on the first control-plane node that was bootstrapped by dhctl.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: fix
summary: Add node.kubernetes.io/exclude-from-external-load-balancers label on control-plane nodes
impact_level: high
impact: IngressNginxController Pods with the LoadBalancer.* inlets on master nodes will be excluded from load balancing
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
