### PR TITLE
[candi] Use Debian bundle as default

### DIFF
--- a/candi/bashible/bundles/debian/all/001_install_mandatory_packages.sh.tpl
+++ b/candi/bashible/bundles/debian/all/001_install_mandatory_packages.sh.tpl
@@ -18,6 +18,8 @@ KUBERNETES_DEPENDENCIES="iptables iproute2 socat util-linux mount ebtables ethto
 if bb-is-debian-version? 9 || bb-is-debian-version? 10 || bb-is-debian-version? 11; then
   SYSTEM_PACKAGES="${SYSTEM_PACKAGES} virt-what"
   KUBERNETES_DEPENDENCIES="${KUBERNETES_DEPENDENCIES} conntrack"
+else
+  bb-rp-install "virt-what:{{ .images.registrypackages.virtWhatDebian1151Deb9u1 }}" "conntrack:{{ .images.registrypackages.conntrackDebian1462 }}"
 fi
 
 bb-apt-install ${SYSTEM_PACKAGES} ${KUBERNETES_DEPENDENCIES}

--- a/candi/bashible/bundles/debian/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/debian/node-group/031_install_containerd.sh.tpl
@@ -49,6 +49,10 @@ if bb-apt-package? docker-ce || bb-apt-package? docker.io; then
   bb-flag-set reboot
 fi
 
+# set default
+desired_version={{ index .k8s .kubernetesVersion "bashible" "debian" "9" "containerd" "desiredVersion" | quote }}
+allowed_versions_pattern={{ index .k8s .kubernetesVersion "bashible" "debian" "9" "containerd" "allowedPattern" | quote }}
+
 {{- range $key, $value := index .k8s .kubernetesVersion "bashible" "debian" }}
   {{- $debianVersion := toString $key }}
   {{- if or $value.containerd.desiredVersion $value.containerd.allowedPattern }}
@@ -81,6 +85,9 @@ if [[ "$should_install_containerd" == true ]]; then
   fi
 
   bb-deckhouse-get-disruptive-update-approval
+
+# set default
+containerd_tag="{{- index $.images.registrypackages (printf "containerdDebian%sStretch" (index .k8s .kubernetesVersion "bashible" "debian" "9" "containerd" "desiredVersion" | replace "containerd.io=" "" | replace "." "" | replace "-" "")) }}"
 
 {{- $debianName := dict "9" "Stretch" "10" "Buster" "11" "Bullseye" }}
 {{- range $key, $value := index .k8s .kubernetesVersion "bashible" "debian" }}

--- a/candi/bashible/bundles/debian/node-group/031_install_docker.sh.tpl
+++ b/candi/bashible/bundles/debian/node-group/031_install_docker.sh.tpl
@@ -60,6 +60,12 @@ if bb-apt-package? containerd.io && ! bb-apt-package? docker-ce ; then
   bb-flag-set reboot
 fi
 
+# set default
+desired_version_docker={{ index .k8s .kubernetesVersion "bashible" "debian" "9" "docker" "desiredVersion" | quote }}
+allowed_versions_docker_pattern={{ index .k8s .kubernetesVersion "bashible" "debian" "9" "docker" "allowedPattern" | quote }}
+desired_version_containerd={{ index .k8s .kubernetesVersion "bashible" "debian" "9" "docker" "containerd" "desiredVersion" | quote }}
+allowed_versions_containerd_pattern={{ index .k8s .kubernetesVersion "bashible" "debian" "9" "docker" "containerd" "allowedPattern" | quote }}
+
 {{- range $key, $value := index .k8s .kubernetesVersion "bashible" "debian" }}
   {{- $debianVersion := toString $key }}
   {{- if or $value.docker.desiredVersion $value.docker.allowedPattern }}
@@ -97,6 +103,9 @@ if [[ "$should_install_containerd" == true ]]; then
 
   bb-deckhouse-get-disruptive-update-approval
 
+# set default
+containerd_tag="{{- index $.images.registrypackages (printf "containerdDebian%sStretch" (index .k8s .kubernetesVersion "bashible" "debian" "9" "docker" "containerd" "desiredVersion" | replace "containerd.io=" "" | replace "." "" | replace "-" "")) }}"
+
 {{- $debianName := dict "9" "Stretch" "10" "Buster" "11" "Bullseye" }}
 {{- range $key, $value := index .k8s .kubernetesVersion "bashible" "debian" }}
   {{- $debianVersion := toString $key }}
@@ -126,6 +135,9 @@ if [[ "$should_install_docker" == true ]]; then
   bb-deckhouse-get-disruptive-update-approval
 
   bb-flag-set new-docker-installed
+
+#set default
+docker_tag="{{- index $.images.registrypackages (printf "dockerDebian%s" (index .k8s .kubernetesVersion "bashible" "debian" "9" "docker" "desiredVersion" | replace "docker-ce=" "" | replace "." "_" | replace ":" "_" | replace "~" "_" | camelcase)) }}"
 
 {{- range $key, $value := index .k8s .kubernetesVersion "bashible" "debian" }}
   {{- $debianVersion := toString $key }}

--- a/candi/bashible/bundles/debian/node-group/032_install_linux_kernel.sh.tpl
+++ b/candi/bashible/bundles/debian/node-group/032_install_linux_kernel.sh.tpl
@@ -35,6 +35,10 @@ if [ -n "$metapackages" ]; then
   bb-apt-remove $metapackages
 fi
 
+# set default
+desired_version={{ index .k8s .kubernetesVersion "bashible" "debian" "9" "kernel" "generic" "desiredVersion" | quote }}
+allowed_versions_pattern={{ index .k8s .kubernetesVersion "bashible" "debian" "9" "kernel" "generic" "allowedPattern" | quote }}
+
 {{- range $key, $value := index .k8s .kubernetesVersion "bashible" "debian" }}
   {{- $debianVersion := toString $key }}
   {{- if $value.kernel.generic }}

--- a/candi/bashible/bundles/debian/node-group/051_install_kubernetes_api_proxy.sh.tpl
+++ b/candi/bashible/bundles/debian/node-group/051_install_kubernetes_api_proxy.sh.tpl
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if bb-is-debian-version? 9 ; then
-  bb-rp-install "nginx:{{ .images.registrypackages.nginxDebian1180Stretch }}"
-fi
 if bb-is-debian-version? 10 ; then
   bb-rp-install "nginx:{{ .images.registrypackages.nginxDebian1202Buster }}"
-fi
-if bb-is-debian-version? 11 ; then
+elif bb-is-debian-version? 11 ; then
   bb-rp-install "nginx:{{ .images.registrypackages.nginxDebian1202Bullseye }}"
+else
+  bb-rp-install "nginx:{{ .images.registrypackages.nginxDebian1180Stretch }}"
 fi

--- a/candi/bashible/detect_bundle.sh
+++ b/candi/bashible/detect_bundle.sh
@@ -33,8 +33,9 @@ if [ -e /etc/os-release ]; then
       exit 1
     ;;
     *)
-      >&2 echo "ERROR: Unsupported Linux version: ${PRETTY_NAME}"
-      exit 1
+      >&2 echo "WARNING: Trying to use debian bundle as default for: ${PRETTY_NAME}"
+      echo "debian"
+      exit 0
     ;;
   esac
 fi

--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -74,7 +74,7 @@ bashible: &bashible
       kernel:
         generic:
           desiredVersion: "4.9.0-17-amd64"
-          allowedPattern: ""
+          allowedPattern: "4.9|4.15|4.19|5.4|5.10"
     '10':
       docker:
         desiredVersion: "docker-ce=5:20.10.12~3-0~debian-buster"

--- a/modules/007-registrypackages/images/conntrack-debian/scripts/install
+++ b/modules/007-registrypackages/images/conntrack-debian/scripts/install
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2021 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,22 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Avoid problems with expired ca-certificates
-bb-apt-install --force ca-certificates
-
-# Hack for old distros
-if grep -q "^mozilla\/DST_Root_CA_X3.crt$" /etc/ca-certificates.conf; then
-  sed -i "/mozilla\/DST_Root_CA_X3.crt/d" /etc/ca-certificates.conf
-  update-ca-certificates --fresh
-fi
-
-{{- if .registry.ca }}
-bb-event-on 'registry-ca-changed' '_update_ca_certificates'
-function _update_ca_certificates() {
-  update-ca-certificates
-}
-
-bb-sync-file /usr/local/share/ca-certificates/registry-ca.crt - registry-ca-changed << "EOF"
-{{ .registry.ca }}
-EOF
-{{- end }}
+set -Eeo pipefail
+dpkg -i -E conntrack_amd64.deb
+apt-mark hold conntrack

--- a/modules/007-registrypackages/images/conntrack-debian/scripts/uninstall
+++ b/modules/007-registrypackages/images/conntrack-debian/scripts/uninstall
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2021 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,22 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Avoid problems with expired ca-certificates
-bb-apt-install --force ca-certificates
-
-# Hack for old distros
-if grep -q "^mozilla\/DST_Root_CA_X3.crt$" /etc/ca-certificates.conf; then
-  sed -i "/mozilla\/DST_Root_CA_X3.crt/d" /etc/ca-certificates.conf
-  update-ca-certificates --fresh
-fi
-
-{{- if .registry.ca }}
-bb-event-on 'registry-ca-changed' '_update_ca_certificates'
-function _update_ca_certificates() {
-  update-ca-certificates
-}
-
-bb-sync-file /usr/local/share/ca-certificates/registry-ca.crt - registry-ca-changed << "EOF"
-{{ .registry.ca }}
-EOF
-{{- end }}
+set -Eeo pipefail
+apt-mark unhold conntrack
+dpkg -r conntrack

--- a/modules/007-registrypackages/images/conntrack-debian/werf.inc.yaml
+++ b/modules/007-registrypackages/images/conntrack-debian/werf.inc.yaml
@@ -1,0 +1,28 @@
+{{- $version := "1.4.6-2" }}
+{{- $image_version := $version | replace "." "-" }}
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
+from: {{ env "BASE_SCRATCH" }}
+import:
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+  add: /
+  to: /
+  includePaths:
+  - conntrack_amd64.deb
+  - install
+  - uninstall
+  before: setup
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+from: {{ env "BASE_ALPINE" }}
+git:
+  - add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+    to: /
+    stageDependencies:
+      setup:
+      - '**/*'
+shell:
+  beforeInstall:
+  - apk add --no-cache curl
+  setup:
+  - curl -sL "http://ftp.debian.org/debian/pool/main/c/conntrack-tools/conntrack_{{ $version }}_amd64.deb" --output /conntrack_amd64.deb

--- a/modules/007-registrypackages/images/virt-what-debian/scripts/install
+++ b/modules/007-registrypackages/images/virt-what-debian/scripts/install
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2021 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,23 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Avoid problems with expired ca-certificates
-bb-apt-install --force ca-certificates
-
-# Hack for old distros
-if grep -q "^mozilla\/DST_Root_CA_X3.crt$" /etc/ca-certificates.conf; then
-  sed -i "/mozilla\/DST_Root_CA_X3.crt/d" /etc/ca-certificates.conf
-  update-ca-certificates --fresh
-fi
-
-{{- if .registry.ca }}
-bb-event-on 'registry-ca-changed' '_update_ca_certificates'
-function _update_ca_certificates() {
-  update-ca-certificates
-}
-
-bb-sync-file /usr/local/share/ca-certificates/registry-ca.crt - registry-ca-changed << "EOF"
-{{ .registry.ca }}
-EOF
-{{- end }}
+set -Eeo pipefail
+dpkg -i -E virt-what_amd64.deb
+apt-mark hold virt-what

--- a/modules/007-registrypackages/images/virt-what-debian/scripts/uninstall
+++ b/modules/007-registrypackages/images/virt-what-debian/scripts/uninstall
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2021 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,22 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Avoid problems with expired ca-certificates
-bb-apt-install --force ca-certificates
-
-# Hack for old distros
-if grep -q "^mozilla\/DST_Root_CA_X3.crt$" /etc/ca-certificates.conf; then
-  sed -i "/mozilla\/DST_Root_CA_X3.crt/d" /etc/ca-certificates.conf
-  update-ca-certificates --fresh
-fi
-
-{{- if .registry.ca }}
-bb-event-on 'registry-ca-changed' '_update_ca_certificates'
-function _update_ca_certificates() {
-  update-ca-certificates
-}
-
-bb-sync-file /usr/local/share/ca-certificates/registry-ca.crt - registry-ca-changed << "EOF"
-{{ .registry.ca }}
-EOF
-{{- end }}
+set -Eeo pipefail
+apt-mark unhold virt-what
+dpkg -r virt-what

--- a/modules/007-registrypackages/images/virt-what-debian/werf.inc.yaml
+++ b/modules/007-registrypackages/images/virt-what-debian/werf.inc.yaml
@@ -1,0 +1,29 @@
+{{- $version := "1.15-1+deb9u1" }}
+{{- $image_version := $version | replace "." "-" | replace "+" "-" }}
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
+from: {{ env "BASE_SCRATCH" }}
+import:
+- artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+  add: /
+  to: /
+  includePaths:
+  - virt-what_amd64.deb
+  - install
+  - uninstall
+  before: setup
+---
+artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
+from: {{ env "BASE_ALPINE" }}
+git:
+  - add: /modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+    to: /
+    stageDependencies:
+      setup:
+      - '**/*'
+shell:
+  beforeInstall:
+  - apk add --no-cache curl
+  setup:
+  - curl -sL "http://ftp.debian.org/debian/pool/main/v/virt-what/virt-what_{{ $version }}_amd64.deb" --output /virt-what_amd64.deb
+


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Debian is the default bundle now. If we can't discover distro then we try bootstrap up it as Debian 9.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Support of distros based on Debian.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: feature
summary: Use Debian bundle as default
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
