### PR TITLE
[ci] fix: proper image name in e2e tests for release tags

### DIFF
--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -222,7 +222,7 @@ jobs:
         if [[ -n $CI_COMMIT_TAG ]] ; then
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
           if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-            IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+            IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
           else
             echo "DECKHOUSE_REGISTRY_HOST is empty."
             exit 1
@@ -231,7 +231,9 @@ jobs:
 
         echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-        echo "Pull dev/install image."
+        # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+        echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+        echo "Pull 'dev/install' image"
         docker pull "${IMAGE_NAME}"
 
     - name: "Run e2e test: {!{ $ctx.providerName }!}/{!{ $ctx.criName }!}/{!{ $ctx.kubernetesVersion }!}"

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -365,7 +365,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -374,7 +374,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: AWS/Docker/1.19"
@@ -727,7 +729,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -736,7 +738,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: AWS/Docker/1.20"
@@ -1089,7 +1093,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1098,7 +1102,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: AWS/Docker/1.21"
@@ -1451,7 +1457,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1460,7 +1466,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: AWS/Docker/1.22"
@@ -1813,7 +1821,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1822,7 +1830,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: AWS/Containerd/1.19"
@@ -2175,7 +2185,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2184,7 +2194,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: AWS/Containerd/1.20"
@@ -2537,7 +2549,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2546,7 +2558,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: AWS/Containerd/1.21"
@@ -2899,7 +2913,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2908,7 +2922,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: AWS/Containerd/1.22"

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -365,7 +365,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -374,7 +374,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Azure/Docker/1.19"
@@ -735,7 +737,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -744,7 +746,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Azure/Docker/1.20"
@@ -1105,7 +1109,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1114,7 +1118,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Azure/Docker/1.21"
@@ -1475,7 +1481,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1484,7 +1490,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Azure/Docker/1.22"
@@ -1845,7 +1853,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1854,7 +1862,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Azure/Containerd/1.19"
@@ -2215,7 +2225,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2224,7 +2234,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Azure/Containerd/1.20"
@@ -2585,7 +2597,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2594,7 +2606,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Azure/Containerd/1.21"
@@ -2955,7 +2969,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2964,7 +2978,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Azure/Containerd/1.22"

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -365,7 +365,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -374,7 +374,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: GCP/Docker/1.19"
@@ -723,7 +725,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -732,7 +734,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: GCP/Docker/1.20"
@@ -1081,7 +1085,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1090,7 +1094,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: GCP/Docker/1.21"
@@ -1439,7 +1445,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1448,7 +1454,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: GCP/Docker/1.22"
@@ -1797,7 +1805,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1806,7 +1814,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: GCP/Containerd/1.19"
@@ -2155,7 +2165,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2164,7 +2174,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: GCP/Containerd/1.20"
@@ -2513,7 +2525,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2522,7 +2534,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: GCP/Containerd/1.21"
@@ -2871,7 +2885,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2880,7 +2894,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: GCP/Containerd/1.22"

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -365,7 +365,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -374,7 +374,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: OpenStack/Docker/1.19"
@@ -723,7 +725,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -732,7 +734,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: OpenStack/Docker/1.20"
@@ -1081,7 +1085,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1090,7 +1094,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: OpenStack/Docker/1.21"
@@ -1439,7 +1445,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1448,7 +1454,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: OpenStack/Docker/1.22"
@@ -1797,7 +1805,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1806,7 +1814,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: OpenStack/Containerd/1.19"
@@ -2155,7 +2165,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2164,7 +2174,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: OpenStack/Containerd/1.20"
@@ -2513,7 +2525,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2522,7 +2534,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: OpenStack/Containerd/1.21"
@@ -2871,7 +2885,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2880,7 +2894,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: OpenStack/Containerd/1.22"

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -365,7 +365,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -374,7 +374,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Static/Docker/1.19"
@@ -723,7 +725,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -732,7 +734,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Static/Docker/1.20"
@@ -1081,7 +1085,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1090,7 +1094,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Static/Docker/1.21"
@@ -1439,7 +1445,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1448,7 +1454,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Static/Docker/1.22"
@@ -1797,7 +1805,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1806,7 +1814,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Static/Containerd/1.19"
@@ -2155,7 +2165,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2164,7 +2174,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Static/Containerd/1.20"
@@ -2513,7 +2525,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2522,7 +2534,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Static/Containerd/1.21"
@@ -2871,7 +2885,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2880,7 +2894,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Static/Containerd/1.22"

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -365,7 +365,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -374,7 +374,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: vSphere/Docker/1.19"
@@ -727,7 +729,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -736,7 +738,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: vSphere/Docker/1.20"
@@ -1089,7 +1093,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1098,7 +1102,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: vSphere/Docker/1.21"
@@ -1451,7 +1457,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1460,7 +1466,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: vSphere/Docker/1.22"
@@ -1813,7 +1821,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1822,7 +1830,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: vSphere/Containerd/1.19"
@@ -2175,7 +2185,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2184,7 +2194,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: vSphere/Containerd/1.20"
@@ -2537,7 +2549,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2546,7 +2558,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: vSphere/Containerd/1.21"
@@ -2899,7 +2913,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2908,7 +2922,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: vSphere/Containerd/1.22"

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -365,7 +365,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -374,7 +374,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.19"
@@ -731,7 +733,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -740,7 +742,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.20"
@@ -1097,7 +1101,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1106,7 +1110,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.21"
@@ -1463,7 +1469,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1472,7 +1478,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.22"
@@ -1829,7 +1837,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -1838,7 +1846,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.19"
@@ -2195,7 +2205,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2204,7 +2214,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.20"
@@ -2561,7 +2573,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2570,7 +2582,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.21"
@@ -2927,7 +2941,7 @@ jobs:
           if [[ -n $CI_COMMIT_TAG ]] ; then
             REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
             if [[ -n "${DECKHOUSE_REGISTRY_HOST}" ]]; then
-              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${IMAGE_TAG}
+              IMAGE_NAME=${DECKHOUSE_REGISTRY_HOST}/deckhouse/${REGISTRY_SUFFIX}/install:${CI_COMMIT_TAG}
             else
               echo "DECKHOUSE_REGISTRY_HOST is empty."
               exit 1
@@ -2936,7 +2950,9 @@ jobs:
 
           echo "::set-output name=install-image-name::${IMAGE_NAME}"
 
-          echo "Pull dev/install image."
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]'
+          echo "Pull 'dev/install' image"
           docker pull "${IMAGE_NAME}"
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.22"


### PR DESCRIPTION
## Description

Proper image name in e2e tests for release tags.

## Why do we need it, and what problem does it solve?

E2e tests fail for release tags. See [run](https://github.com/deckhouse/deckhouse/runs/5598080185?check_suite_focus=true).

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: fix
summary: Proper image name in e2e tests for release tags
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
