### PR TITLE
[node-manager] fixup configurable kubelet log rotation

### DIFF
--- a/modules/040-node-manager/hooks/internal/v1/nodegroup.go
+++ b/modules/040-node-manager/hooks/internal/v1/nodegroup.go
@@ -253,10 +253,18 @@ type Kubelet struct {
 	// Directory path for managing kubelet files (volume mounts,etc).
 	// Default: '/var/lib/kubelet'
 	RootDir string `json:"rootDir,omitempty"`
+
+	// Maximum log file size before it is rotated.
+	// Default: '50Mi'
+	ContainerLogMaxSize string `json:"containerLogMaxSize,omitempty"`
+
+	// How many rotated log files to store before deleting them.
+	// Default: '4'
+	ContainerLogMaxFiles int `json:"containerLogMaxFiles,omitempty"`
 }
 
 func (k Kubelet) IsEmpty() bool {
-	return k.MaxPods == nil && k.RootDir == ""
+	return k.MaxPods == nil && k.RootDir == "" && k.ContainerLogMaxSize == "" && k.ContainerLogMaxFiles == 0
 }
 
 type NodeGroupStatus struct {

--- a/modules/040-node-manager/hooks/internal/v1alpha2/nodegroup.go
+++ b/modules/040-node-manager/hooks/internal/v1alpha2/nodegroup.go
@@ -232,10 +232,18 @@ type Kubelet struct {
 	// Directory path for managing kubelet files (volume mounts,etc).
 	// Default: '/var/lib/kubelet'
 	RootDir string `json:"rootDir,omitempty"`
+
+	// Maximum log file size before it is rotated.
+	// Default: '50Mi'
+	ContainerLogMaxSize string `json:"containerLogMaxSize,omitempty"`
+
+	// How many rotated log files to store before deleting them.
+	// Default: '4'
+	ContainerLogMaxFiles int `json:"containerLogMaxFiles,omitempty"`
 }
 
 func (k Kubelet) IsEmpty() bool {
-	return k.MaxPods == nil && k.RootDir == ""
+	return k.MaxPods == nil && k.RootDir == "" && k.ContainerLogMaxSize == "" && k.ContainerLogMaxFiles == 0
 }
 
 type NodeGroupStatus struct {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixup configurable kubelet log rotation.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When we set kubelet.containerLogMaxSize or kubelet.containerLogMaxFiles in nodeGroup, these settings were not applied to nodes.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Fixup configurable kubelet log rotation.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
