### PR TITLE
[node-manager] Fix incorrect prometheus rules fo k8s 1.19.

### DIFF
--- a/helm_lib/templates/_monitoring_prometheus_rules.tpl
+++ b/helm_lib/templates/_monitoring_prometheus_rules.tpl
@@ -34,7 +34,12 @@
         {{- end }}
       {{- end }}
     {{- end }}
-    {{ $definition = $definitionStruct.Rules | toYaml }}
+
+     {{- if $definitionStruct.Rules }}
+       {{ $definition = $definitionStruct.Rules | toYaml }}
+     {{- else }}
+       {{ $definition = "[]" }}
+     {{- end }}
 
     {{- $resourceName := (regexReplaceAllLiteral "\\.(yaml|tpl)$" $path "") }}
     {{- $resourceName = ($resourceName | replace " " "-" | replace "." "-" | replace "_" "-") }}


### PR DESCRIPTION
## Description
Fix incorrect prometheus rules fo k8s 1.19.

Added tests for 'spec.groups' lenght for autoscaler and mcm prometeus rules 

## Why do we need it, and what problem does it solve?
Cluster with k8s 1.19 can not bootstrap

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Fix incorrect prometheus rules fo k8s 1.19
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
