### PR TITLE
[tests] feat: support x-required-for-helm, add x-test-focus

### DIFF
--- a/modules/301-prometheus-metrics-adapter/openapi/openapi-case-tests.yaml
+++ b/modules/301-prometheus-metrics-adapter/openapi/openapi-case-tests.yaml
@@ -73,45 +73,32 @@ negative:
 # next case don't work because deckhouse testes not support x-required-for-helm
 # need to fix it and uncomment cases after fix
 
-##  # does not have internal pma tls
-#  - internal:
-#      prometheusAPIClientTLS:
-#        certificate: cert
-#        key: key
-#      customMetrics:
-#        daemonset: { }
-#        deployment: { }
-#        ingress: { }
-#        namespace: { }
-#        pod: { }
-#        service: { }
-#        statefulset: { }
-#
-#  # does not have prom client tls object
-#  - internal:
-#      adapterPem: cert
-#      adapterCA: cert
-#      adapterKey: key
-#      customMetrics:
-#        daemonset: { }
-#        deployment: { }
-#        ingress: { }
-#        namespace: { }
-#        pod: { }
-#        service: { }
-#        statefulset: { }
-#
-#  # does not have prom client tls
-#  - internal:
-#      adapterPem: cert
-#      adapterCA: cert
-#      adapterKey: key
-#      prometheusAPIClientTLS: { }
-#      customMetrics:
-#        daemonset: { }
-#        deployment: { }
-#        ingress: { }
-#        namespace: { }
-#        pod: { }
-#        service: { }
-#        statefulset: { }
+  # Cases with absent keys required for Helm.
+  helmValues:
+  # No requried fields.
+  - internal:
+      customMetrics:
+        daemonset: { }
+        deployment: { }
+        ingress: { }
+        namespace: { }
+        pod: { }
+        service: { }
+        statefulset: { }
+
+  # No required adapterKey.
+  - internal:
+      adapterPem: cert
+      adapterCA: cert
+      customMetrics:
+        daemonset: { }
+        deployment: { }
+        ingress: { }
+        namespace: { }
+        pod: { }
+        service: { }
+        statefulset: { }
+
+  # Only one required field.
+  - internal:
+      adapterKey: key


### PR DESCRIPTION
## Description

- Use "helmValues" in positive or negative cases if values.yaml to test effect of x-required-from.
- Use "x-test-focus: true" to run only specific cases.

## TODO

1. Delete `modules/000-prom-test` before merging.
1. Documentation validation failed because of this example module.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Fix #186
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: tests
type: feature
summary: Support x-required-for-helm, add x-test-focus
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
