### PR TITLE
[global] Fix memory spelling for config

### DIFF
--- a/modules/300-prometheus/openapi/config-values.yaml
+++ b/modules/300-prometheus/openapi/config-values.yaml
@@ -184,7 +184,7 @@ properties:
       maxMemory:
         oneOf:
           - type: string
-            pattern: "^[0-9]+(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+            pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
           - type: number
         x-examples: ["3Mi"]
         description: |
@@ -204,7 +204,7 @@ properties:
       longtermMaxMemory:
         oneOf:
           - type: string
-            pattern: "^[0-9]+(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+            pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
           - type: number
         x-examples: ["4Mi"]
         description: |

--- a/modules/300-prometheus/openapi/values.yaml
+++ b/modules/300-prometheus/openapi/values.yaml
@@ -25,7 +25,7 @@ properties:
           maxMemory:
             oneOf:
               - type: string
-                pattern: "^[0-9]+(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
               - type: number
             x-examples: ["500Mi"]
           longtermMaxCPU:
@@ -37,7 +37,7 @@ properties:
           longtermMaxMemory:
             oneOf:
               - type: string
-                pattern: "^[0-9]+(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
               - type: number
             x-examples: ["1500Gi"]
       prometheusMain:

--- a/modules/340-monitoring-kubernetes/openapi/config-values.yaml
+++ b/modules/340-monitoring-kubernetes/openapi/config-values.yaml
@@ -63,7 +63,7 @@ properties:
         x-examples: ["3Mi"]
         oneOf:
           - type: string
-            pattern: "^[0-9]+(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+            pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
           - type: number
         description: |
           Memory requests.

--- a/modules/460-log-shipper/openapi/config-values.yaml
+++ b/modules/460-log-shipper/openapi/config-values.yaml
@@ -76,7 +76,7 @@ properties:
               max:
                 oneOf:
                   - type: string
-                    pattern: "^[0-9]+(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                    pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
                   - type: number
                 x-examples: ["32Mi", 3000]
                 description: |
@@ -85,7 +85,7 @@ properties:
               min:
                 oneOf:
                   - type: string
-                    pattern: "^[0-9]+(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                    pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
                   - type: number
                 x-examples: ["4Mi", 400]
                 description: |
@@ -111,7 +111,7 @@ properties:
           memory:
             oneOf:
               - type: string
-                pattern: "^[0-9]+(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
               - type: number
             description: |
               Memory requests.

--- a/modules/470-chrony/openapi/config-values.yaml
+++ b/modules/470-chrony/openapi/config-values.yaml
@@ -21,7 +21,7 @@ properties:
       maxMemory:
         oneOf:
           - type: string
-            pattern: "^[0-9]+(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+            pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
           - type: number
         x-examples: ["3Mi"]
         default: "10Mi"


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
We have wrong case for kilobytes selector in memory requests

## Why do we need it, and what problem does it solve?
It wouldn't work

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: global
type: fix
summary: Fix kilobyte selector for memory requests (k instead of K)
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
