### PR TITLE
[candi] Automatically discover zone for volumes in OpenStack

### DIFF
--- a/ee/candi/cloud-providers/openstack/layouts/simple-with-internal-network/master-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/simple-with-internal-network/master-node/main.tf
@@ -14,6 +14,12 @@ locals {
   additional_tags = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalTags", {})
 }
 
+module "volume_zone" {
+  source = "../../../terraform-modules/volume-zone"
+  compute_zone = local.zone
+  region = var.providerClusterConfiguration.provider.region
+}
+
 module "master" {
   source = "../../../terraform-modules/master"
   prefix = local.prefix
@@ -29,6 +35,7 @@ module "master" {
   tags = local.tags
   zone = local.zone
   volume_type = local.volume_type
+  volume_zone = module.volume_zone.zone
 }
 
 module "kubernetes_data" {
@@ -37,7 +44,7 @@ module "kubernetes_data" {
   node_index = var.nodeIndex
   master_id = module.master.id
   volume_type = local.volume_type
-  volume_zone = local.zone
+  volume_zone = module.volume_zone.zone
   tags = local.tags
 }
 

--- a/ee/candi/cloud-providers/openstack/layouts/standard-with-no-router/master-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard-with-no-router/master-node/main.tf
@@ -18,6 +18,12 @@ module "network_security_info" {
   enabled = local.network_security
 }
 
+module "volume_zone" {
+  source = "../../../terraform-modules/volume-zone"
+  compute_zone = local.zone
+  region = var.providerClusterConfiguration.provider.region
+}
+
 module "master" {
   source = "../../../terraform-modules/master"
   prefix = local.prefix
@@ -33,6 +39,7 @@ module "master" {
   tags = local.tags
   zone = local.zone
   volume_type = local.volume_type
+  volume_zone = module.volume_zone.zone
 }
 
 module "kubernetes_data" {
@@ -41,7 +48,7 @@ module "kubernetes_data" {
   node_index = var.nodeIndex
   master_id = module.master.id
   volume_type = local.volume_type
-  volume_zone = local.zone
+  volume_zone = module.volume_zone.zone
   tags = local.tags
 }
 

--- a/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/base-infrastructure/main.tf
@@ -81,6 +81,12 @@ data "openstack_images_image_v2" "image" {
   name  = local.bastion_image_name
 }
 
+module "volume_zone" {
+  source = "../../../terraform-modules/volume-zone"
+  compute_zone = local.zone
+  region = var.providerClusterConfiguration.provider.region
+}
+
 resource "openstack_blockstorage_volume_v2" "root" {
   count       = local.bastion_instance != {} ? 1 : 0
   name        = join("-", [local.name, "root-volume"])
@@ -88,9 +94,11 @@ resource "openstack_blockstorage_volume_v2" "root" {
   image_id    = data.openstack_images_image_v2.image[0].id
   metadata    = local.metadata_tags
   volume_type = local.volume_type
+  availability_zone = module.volume_zone.zone
   lifecycle {
     ignore_changes = [
       metadata,
+      availability_zone,
     ]
   }
 }

--- a/ee/candi/cloud-providers/openstack/layouts/standard/master-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/layouts/standard/master-node/main.tf
@@ -18,6 +18,12 @@ module "network_security_info" {
   enabled = local.network_security
 }
 
+module "volume_zone" {
+  source = "../../../terraform-modules/volume-zone"
+  compute_zone = local.zone
+  region = var.providerClusterConfiguration.provider.region
+}
+
 module "master" {
   source              = "../../../terraform-modules/master"
   prefix              = local.prefix
@@ -33,6 +39,7 @@ module "master" {
   tags                = local.tags
   zone                = local.zone
   volume_type         = local.volume_type
+  volume_zone = module.volume_zone.zone
 }
 
 module "kubernetes_data" {
@@ -41,7 +48,7 @@ module "kubernetes_data" {
   node_index  = var.nodeIndex
   master_id   = module.master.id
   volume_type = local.volume_type
-  volume_zone = local.zone
+  volume_zone = module.volume_zone.zone
   tags        = local.tags
 }
 

--- a/ee/candi/cloud-providers/openstack/terraform-modules/master/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/master/main.tf
@@ -16,7 +16,7 @@ resource "openstack_blockstorage_volume_v2" "master" {
   image_id          = data.openstack_images_image_v2.master.id
   metadata          = local.metadata_tags
   volume_type       = var.volume_type
-  availability_zone = var.zone
+  availability_zone = var.volume_zone
   lifecycle {
     ignore_changes = [
       metadata,

--- a/ee/candi/cloud-providers/openstack/terraform-modules/master/variables.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/master/variables.tf
@@ -55,6 +55,10 @@ variable "volume_type" {
   type = string
 }
 
+variable "volume_zone" {
+  type = string
+}
+
 variable "zone" {
   type = string
 }

--- a/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/static-node/main.tf
@@ -11,6 +11,12 @@ module "security_groups" {
   security_group_names = local.security_group_names
 }
 
+module "volume_zone" {
+  source       = "/deckhouse/candi/cloud-providers/openstack/terraform-modules/volume-zone"
+  compute_zone = element(local.zones, var.nodeIndex)
+  region       = var.providerClusterConfiguration.provider.region
+}
+
 data "openstack_compute_availability_zones_v2" "zones" {}
 
 data "openstack_images_image_v2" "image" {
@@ -44,7 +50,7 @@ resource "openstack_blockstorage_volume_v2" "volume" {
   size              = local.root_disk_size
   image_id          = data.openstack_images_image_v2.image.id
   metadata          = local.metadata_tags
-  availability_zone = element(local.zones, var.nodeIndex)
+  availability_zone = module.volume_zone.zone
   lifecycle {
     ignore_changes = [
       metadata,

--- a/ee/candi/cloud-providers/openstack/terraform-modules/volume-zone/main.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/volume-zone/main.tf
@@ -1,0 +1,6 @@
+# Copyright 2021 Flant JSC
+# Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+
+data "openstack_blockstorage_availability_zones_v3" "zones" {
+  region = var.region
+}

--- a/ee/candi/cloud-providers/openstack/terraform-modules/volume-zone/outputs.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/volume-zone/outputs.tf
@@ -1,0 +1,6 @@
+# Copyright 2021 Flant JSC
+# Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+
+output "zone" {
+  value = contains(data.openstack_blockstorage_availability_zones_v3.zones.names, var.compute_zone) ? var.compute_zone : null
+}

--- a/ee/candi/cloud-providers/openstack/terraform-modules/volume-zone/variables.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/volume-zone/variables.tf
@@ -1,0 +1,10 @@
+# Copyright 2021 Flant JSC
+# Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+
+variable "region" {
+  type = string
+}
+
+variable "compute_zone" {
+  type = string
+}

--- a/ee/candi/cloud-providers/openstack/terraform-modules/volume-zone/versions.tf
+++ b/ee/candi/cloud-providers/openstack/terraform-modules/volume-zone/versions.tf
@@ -1,0 +1,11 @@
+# Copyright 2021 Flant JSC
+# Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+
+terraform {
+  required_providers {
+    openstack = {
+      source = "terraform-provider-openstack/openstack"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add terraform module volume-zone that helps to discover correct zone for OpenStack volumes. This module checks if provided compute zone exists for volumes. If it doesn't exist than no availability zone is set, and we assume that the default zone will be used.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Some private OpenStack clouds have different availability zones for volumes and computes.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: Automatically discover zone for volumes in OpenStack
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
