### PR TITLE
[deckhouse-controller] feat: update addon-operator to v1.0.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.9.0
-	github.com/flant/addon-operator v1.0.5-0.20220302103157-2ed84979179f
+	github.com/flant/addon-operator v1.0.5
 	github.com/flant/kube-client v0.0.6
 	github.com/flant/shell-operator v1.0.9-0.20220302082030-614d4cca72da
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwo
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/flant/addon-operator v1.0.5-0.20220302103157-2ed84979179f h1:GykDdQ0/5LvL6a0uo/jfZabl7JV5g/4W+DbjFiLzh/A=
-github.com/flant/addon-operator v1.0.5-0.20220302103157-2ed84979179f/go.mod h1:9tUmk+zQ8SMHE/qLEwwkejjD+6+lBZivNsXxhIiVvNg=
+github.com/flant/addon-operator v1.0.5 h1:CmwvKYXmXr0o3JEdhxEsUWPuc0PnN+QbhlyuffwqdY0=
+github.com/flant/addon-operator v1.0.5/go.mod h1:9tUmk+zQ8SMHE/qLEwwkejjD+6+lBZivNsXxhIiVvNg=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v0.0.6 h1:cHFMf7xGtJOgg+KBuPcA+7q+M7IJRSgf2pHVStv2aj0=


### PR DESCRIPTION

## Description

Changes since v1.0.4:
- fix: add flag to start scheduling 'schedule' hook before first converge done. (Merged earlier in #977)
- fix: beforeHelm hook got empty snapshots for some bindings.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

We use "beforeHelm" hooks to generate certificates if snapshots are empty. But "beforeHelm" hook got empty snapshots for bindings with `executeHookOnSynchronization: false` despite existing objects in cluster.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse-controller
type: fix
summary: Fix empty snapshots in beforeHelm hooks.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
