### PR TITLE
[user-authn] Fix namespace for DexAuthenticator openvpn adoption

### DIFF
--- a/modules/150-user-authn/hooks/dex_authenticator_adoption.go
+++ b/modules/150-user-authn/hooks/dex_authenticator_adoption.go
@@ -34,7 +34,7 @@ func addDexAuthenticatorHelmLabelsToSecret(input *go_hook.HookInput) error {
 	patchAnnotations(input, "deckhouse-web", "d8-system", "deckhouse-web")
 	patchAnnotations(input, "upmeter", "d8-upmeter", "upmeter")
 	patchAnnotations(input, "status", "d8-upmeter", "upmeter")
-	patchAnnotations(input, "openvpn", "d8-upmeter", "openvpn")
+	patchAnnotations(input, "openvpn", "d8-openvpn", "openvpn")
 	patchAnnotations(input, "istio", "d8-istio", "istio")
 
 	return nil


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix namespace for DexAuthenticator openvpn adoption

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Deckhouse is stuck on helm upgrade if module openvpn is enabled in cluster.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: user-authn
type: fix
summary: Fix namespace for DexAuthenticator openvpn adoption
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
