### PR TITLE
[deckhouse] fix changelog build during DeckhouseRelease

### DIFF
--- a/modules/020-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/020-deckhouse/hooks/check_deckhouse_release.go
@@ -290,7 +290,10 @@ func (dcr *DeckhouseReleaseChecker) fetchReleaseMetadata(image v1.Image) (releas
 		var changelog map[string]interface{}
 		err = yaml.NewDecoder(rr.changelogReader).Decode(&changelog)
 		if err != nil {
-			return meta, err
+			// if changelog build failed - warn about it but don't fail the release
+			dcr.logger.Warnf("Unmarshal CHANGELOG yaml failed: %s", err)
+			meta.Changelog = make(map[string]interface{})
+			return meta, nil
 		}
 		meta.Changelog = changelog
 	}


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Suppress error on changelog unmarshaling error

## Why do we need it, and what problem does it solve?
If changelog yaml has some lint errors - release hook will fail

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse
type: fix
summary: Warn on failed changelog build
impact_level: low 
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
