### PR TITLE
Update vSphere csi-driver and enable snapshots

### DIFF
--- a/ee/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin/Dockerfile
+++ b/ee/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_DEBIAN
 
 FROM $BASE_GOLANG_16_ALPINE as csi
 WORKDIR /src/
-RUN wget https://github.com/kubernetes-sigs/vsphere-csi-driver/archive/refs/tags/v2.4.0.tar.gz -O - | tar -xz --strip-components=1 -C /src
+RUN wget https://github.com/kubernetes-sigs/vsphere-csi-driver/archive/refs/tags/v2.5.0.tar.gz -O - | tar -xz --strip-components=1 -C /src
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o vsphere-csi cmd/vsphere-csi/main.go
 
 # support every standard Linux disk/mount utility so that CSI components won't complain

--- a/ee/modules/030-cloud-provider-vsphere/templates/csi/cm.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/templates/csi/cm.yaml
@@ -9,4 +9,5 @@ data:
   "csi-migration": "false"
   "csi-auth-check": "true"
   "online-volume-extend": "true"
+  "block-volume-snapshot": "true"
 {{- end }}

--- a/ee/modules/030-cloud-provider-vsphere/templates/csi/controller.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/templates/csi/controller.yaml
@@ -37,7 +37,6 @@
 
 {{- $csiControllerConfig := dict }}
 {{- $_ := set $csiControllerConfig "controllerImage" $csiControllerImage }}
-{{- $_ := set $csiControllerConfig "snapshotterEnabled" false }}
 {{- $_ := set $csiControllerConfig "additionalControllerArgs" (include "csi_controller_args" . | fromYamlArray) }}
 {{- $_ := set $csiControllerConfig "additionalControllerEnvs" (include "csi_controller_envs" . | fromYamlArray) }}
 {{- $_ := set $csiControllerConfig "additionalControllerVolumes" (include "csi_controller_volumes" . | fromYamlArray) }}


### PR DESCRIPTION
## Description

Update vsphere csi-driver to enable snapshots-functionality

## Why do we need it, and what problem does it solve?

Enable snapshots support for vsphere
linked issue https://github.com/deckhouse/deckhouse/pull/1068

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-vsphere
type: feature
summary: vSphere csi-driver updated to v2.5.0
impact_level: high
impact: vSphere csi-driver updated to v.2.5.0 to enable snapshots functionality
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
