### PR TITLE
[deckhouse] use object instead of string in changelog

### DIFF
--- a/modules/020-deckhouse/crds/deckhouse-release.yaml
+++ b/modules/020-deckhouse/crds/deckhouse-release.yaml
@@ -53,7 +53,7 @@ spec:
                   type: object
                   description: Release's changelog for enabled modules.
                   additionalProperties:
-                    type: string
+                    type: object
                 changelogLink:
                   type: string
                   description: Link to site with full changelog for this release.


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Fix changelog struct

## Why do we need it, and what problem does it solve?
Changelog struct is map of objects not strings

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse
type: fix
summary: Fix DeckhouseRelease CRD
impact_level: low 
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
