### PR TITLE
[ci] fix: detect version to suspend

### DIFF
--- a/.github/workflow_templates/suspend-channel.multi.yml
+++ b/.github/workflow_templates/suspend-channel.multi.yml
@@ -25,13 +25,16 @@ on:
     inputs:
       issue_id:
         description: 'Id of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
-        required: true
+        required: false
+      suspend_tag:
+        description: 'Set to suspend specified tag'
+        required: false
 
 env:
 {!{ tmpl.Exec "werf_envs" | strings.Indent 2 }!}
@@ -42,13 +45,44 @@ env:
 jobs:
 {!{ tmpl.Exec "git_info_job" . | strings.Indent 2 }!}
 
+  detect_version:
+    name: Detect version
+    needs:
+      - git_info
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{steps.detect_version.outputs.version}}
+    steps:
+      - name: Detect version
+        id: detect_version
+        env:
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          SUSPEND_TAG: ${{ github.event.inputs.suspend_tag }}
+        run: |
+          if [[ -n ${SUSPEND_TAG} ]] ; then
+            echo "::notice title=Suspend version::Workflow started from '${CI_COMMIT_REF_NAME}', but suspend_tag input is set. Use '${SUSPEND_REVISION}' as suspend version."
+            echo "::set-output name=version::${SUSPEND_TAG}"
+            exit 0
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            echo "::notice title=Suspend version::Workflow started from tag '${CI_COMMIT_TAG}'. Use it as suspend version."
+            echo "::set-output name=version::${CI_COMMIT_TAG}"
+            exit 0
+          fi
+
+          echo "::error title=Wrong environment::Seems you try to suspend branch '${CI_COMMIT_REF_NAME}'. Use suspend_tag input or run workflow from tag."
+          exit 1
+
+
   run_suspend:
-    name: Suspend deckhouse release on {!{ .channel }!} channel
+    name: Suspend ${{needs.detect_version.outputs.version}} on {!{ .channel }!} channel
     environment:
       name: {!{ .channel }!}
     needs:
       - git_info
-    runs-on: self-hosted
+      - detect_version
+    runs-on: [self-hosted, regular]
     steps:
 {!{ tmpl.Exec "started_at_output" . | strings.Indent 6 }!}
 {!{ tmpl.Exec "checkout_from_event_ref_step" . | strings.Indent 6 }!}
@@ -68,7 +102,7 @@ Destination registries:
       - name: Publish release images for {!{ $werfEnv }!}
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          SUSPEND_VERSION: ${{needs.detect_version.outputs.version}}
           WERF_ENV: {!{ $werfEnv }!}
           SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
@@ -97,14 +131,24 @@ Destination registries:
           }
 
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${SUSPEND_VERSION} ]] ; then
+            echo "::error title=Missed version::Suspend version not detected. Use suspend_tag input or run workflow from tag."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Suspend version '${SUSPEND_VERSION}' for {!{ $werfEnv }!} edition".
 
           # Variables
           #   1. Edition and channel.
@@ -122,17 +166,17 @@ Destination registries:
           fi
 
           #   3. Build and publish release-channel image to prod registry.
-          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
-          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
+          SUSPEND_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${SUSPEND_VERSION_IMAGE}'."
 
-          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          echo "{\"version\": \"${SUSPEND_VERSION}\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t "${RELEASE_VERSION_IMAGE}"
+          docker build . -t "${SUSPEND_VERSION_IMAGE}"
 
-          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${SUSPEND_VERSION_IMAGE}"
 
 
 {!{- end }!}

--- a/.github/workflows/suspend-alpha.yml
+++ b/.github/workflows/suspend-alpha.yml
@@ -9,13 +9,16 @@ on:
     inputs:
       issue_id:
         description: 'Id of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
-        required: true
+        required: false
+      suspend_tag:
+        description: 'Set to suspend specified tag'
+        required: false
 
 env:
 
@@ -114,13 +117,44 @@ jobs:
 
   # </template: git_info_job>
 
+  detect_version:
+    name: Detect version
+    needs:
+      - git_info
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{steps.detect_version.outputs.version}}
+    steps:
+      - name: Detect version
+        id: detect_version
+        env:
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          SUSPEND_TAG: ${{ github.event.inputs.suspend_tag }}
+        run: |
+          if [[ -n ${SUSPEND_TAG} ]] ; then
+            echo "::notice title=Suspend version::Workflow started from '${CI_COMMIT_REF_NAME}', but suspend_tag input is set. Use '${SUSPEND_REVISION}' as suspend version."
+            echo "::set-output name=version::${SUSPEND_TAG}"
+            exit 0
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            echo "::notice title=Suspend version::Workflow started from tag '${CI_COMMIT_TAG}'. Use it as suspend version."
+            echo "::set-output name=version::${CI_COMMIT_TAG}"
+            exit 0
+          fi
+
+          echo "::error title=Wrong environment::Seems you try to suspend branch '${CI_COMMIT_REF_NAME}'. Use suspend_tag input or run workflow from tag."
+          exit 1
+
+
   run_suspend:
-    name: Suspend deckhouse release on alpha channel
+    name: Suspend ${{needs.detect_version.outputs.version}} on alpha channel
     environment:
       name: alpha
     needs:
       - git_info
-    runs-on: self-hosted
+      - detect_version
+    runs-on: [self-hosted, regular]
     steps:
 
       # <template: started_at_output>
@@ -199,7 +233,7 @@ jobs:
       - name: Publish release images for CE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          SUSPEND_VERSION: ${{needs.detect_version.outputs.version}}
           WERF_ENV: CE
           SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
@@ -228,14 +262,24 @@ jobs:
           }
 
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${SUSPEND_VERSION} ]] ; then
+            echo "::error title=Missed version::Suspend version not detected. Use suspend_tag input or run workflow from tag."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Suspend version '${SUSPEND_VERSION}' for CE edition".
 
           # Variables
           #   1. Edition and channel.
@@ -253,21 +297,21 @@ jobs:
           fi
 
           #   3. Build and publish release-channel image to prod registry.
-          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
-          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
+          SUSPEND_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${SUSPEND_VERSION_IMAGE}'."
 
-          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          echo "{\"version\": \"${SUSPEND_VERSION}\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t "${RELEASE_VERSION_IMAGE}"
+          docker build . -t "${SUSPEND_VERSION_IMAGE}"
 
-          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${SUSPEND_VERSION_IMAGE}"
       - name: Publish release images for EE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          SUSPEND_VERSION: ${{needs.detect_version.outputs.version}}
           WERF_ENV: EE
           SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
@@ -296,14 +340,24 @@ jobs:
           }
 
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${SUSPEND_VERSION} ]] ; then
+            echo "::error title=Missed version::Suspend version not detected. Use suspend_tag input or run workflow from tag."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Suspend version '${SUSPEND_VERSION}' for EE edition".
 
           # Variables
           #   1. Edition and channel.
@@ -321,21 +375,21 @@ jobs:
           fi
 
           #   3. Build and publish release-channel image to prod registry.
-          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
-          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
+          SUSPEND_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${SUSPEND_VERSION_IMAGE}'."
 
-          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          echo "{\"version\": \"${SUSPEND_VERSION}\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t "${RELEASE_VERSION_IMAGE}"
+          docker build . -t "${SUSPEND_VERSION_IMAGE}"
 
-          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${SUSPEND_VERSION_IMAGE}"
       - name: Publish release images for FE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          SUSPEND_VERSION: ${{needs.detect_version.outputs.version}}
           WERF_ENV: FE
           SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
@@ -364,14 +418,24 @@ jobs:
           }
 
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${SUSPEND_VERSION} ]] ; then
+            echo "::error title=Missed version::Suspend version not detected. Use suspend_tag input or run workflow from tag."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Suspend version '${SUSPEND_VERSION}' for FE edition".
 
           # Variables
           #   1. Edition and channel.
@@ -389,17 +453,17 @@ jobs:
           fi
 
           #   3. Build and publish release-channel image to prod registry.
-          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
-          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
+          SUSPEND_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${SUSPEND_VERSION_IMAGE}'."
 
-          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          echo "{\"version\": \"${SUSPEND_VERSION}\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t "${RELEASE_VERSION_IMAGE}"
+          docker build . -t "${SUSPEND_VERSION_IMAGE}"
 
-          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${SUSPEND_VERSION_IMAGE}"
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/suspend-beta.yml
+++ b/.github/workflows/suspend-beta.yml
@@ -9,13 +9,16 @@ on:
     inputs:
       issue_id:
         description: 'Id of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
-        required: true
+        required: false
+      suspend_tag:
+        description: 'Set to suspend specified tag'
+        required: false
 
 env:
 
@@ -114,13 +117,44 @@ jobs:
 
   # </template: git_info_job>
 
+  detect_version:
+    name: Detect version
+    needs:
+      - git_info
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{steps.detect_version.outputs.version}}
+    steps:
+      - name: Detect version
+        id: detect_version
+        env:
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          SUSPEND_TAG: ${{ github.event.inputs.suspend_tag }}
+        run: |
+          if [[ -n ${SUSPEND_TAG} ]] ; then
+            echo "::notice title=Suspend version::Workflow started from '${CI_COMMIT_REF_NAME}', but suspend_tag input is set. Use '${SUSPEND_REVISION}' as suspend version."
+            echo "::set-output name=version::${SUSPEND_TAG}"
+            exit 0
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            echo "::notice title=Suspend version::Workflow started from tag '${CI_COMMIT_TAG}'. Use it as suspend version."
+            echo "::set-output name=version::${CI_COMMIT_TAG}"
+            exit 0
+          fi
+
+          echo "::error title=Wrong environment::Seems you try to suspend branch '${CI_COMMIT_REF_NAME}'. Use suspend_tag input or run workflow from tag."
+          exit 1
+
+
   run_suspend:
-    name: Suspend deckhouse release on beta channel
+    name: Suspend ${{needs.detect_version.outputs.version}} on beta channel
     environment:
       name: beta
     needs:
       - git_info
-    runs-on: self-hosted
+      - detect_version
+    runs-on: [self-hosted, regular]
     steps:
 
       # <template: started_at_output>
@@ -199,7 +233,7 @@ jobs:
       - name: Publish release images for CE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          SUSPEND_VERSION: ${{needs.detect_version.outputs.version}}
           WERF_ENV: CE
           SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
@@ -228,14 +262,24 @@ jobs:
           }
 
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${SUSPEND_VERSION} ]] ; then
+            echo "::error title=Missed version::Suspend version not detected. Use suspend_tag input or run workflow from tag."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Suspend version '${SUSPEND_VERSION}' for CE edition".
 
           # Variables
           #   1. Edition and channel.
@@ -253,21 +297,21 @@ jobs:
           fi
 
           #   3. Build and publish release-channel image to prod registry.
-          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
-          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
+          SUSPEND_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${SUSPEND_VERSION_IMAGE}'."
 
-          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          echo "{\"version\": \"${SUSPEND_VERSION}\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t "${RELEASE_VERSION_IMAGE}"
+          docker build . -t "${SUSPEND_VERSION_IMAGE}"
 
-          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${SUSPEND_VERSION_IMAGE}"
       - name: Publish release images for EE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          SUSPEND_VERSION: ${{needs.detect_version.outputs.version}}
           WERF_ENV: EE
           SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
@@ -296,14 +340,24 @@ jobs:
           }
 
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${SUSPEND_VERSION} ]] ; then
+            echo "::error title=Missed version::Suspend version not detected. Use suspend_tag input or run workflow from tag."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Suspend version '${SUSPEND_VERSION}' for EE edition".
 
           # Variables
           #   1. Edition and channel.
@@ -321,21 +375,21 @@ jobs:
           fi
 
           #   3. Build and publish release-channel image to prod registry.
-          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
-          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
+          SUSPEND_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${SUSPEND_VERSION_IMAGE}'."
 
-          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          echo "{\"version\": \"${SUSPEND_VERSION}\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t "${RELEASE_VERSION_IMAGE}"
+          docker build . -t "${SUSPEND_VERSION_IMAGE}"
 
-          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${SUSPEND_VERSION_IMAGE}"
       - name: Publish release images for FE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          SUSPEND_VERSION: ${{needs.detect_version.outputs.version}}
           WERF_ENV: FE
           SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
@@ -364,14 +418,24 @@ jobs:
           }
 
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${SUSPEND_VERSION} ]] ; then
+            echo "::error title=Missed version::Suspend version not detected. Use suspend_tag input or run workflow from tag."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Suspend version '${SUSPEND_VERSION}' for FE edition".
 
           # Variables
           #   1. Edition and channel.
@@ -389,17 +453,17 @@ jobs:
           fi
 
           #   3. Build and publish release-channel image to prod registry.
-          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
-          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
+          SUSPEND_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${SUSPEND_VERSION_IMAGE}'."
 
-          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          echo "{\"version\": \"${SUSPEND_VERSION}\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t "${RELEASE_VERSION_IMAGE}"
+          docker build . -t "${SUSPEND_VERSION_IMAGE}"
 
-          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${SUSPEND_VERSION_IMAGE}"
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/suspend-early-access.yml
+++ b/.github/workflows/suspend-early-access.yml
@@ -9,13 +9,16 @@ on:
     inputs:
       issue_id:
         description: 'Id of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
-        required: true
+        required: false
+      suspend_tag:
+        description: 'Set to suspend specified tag'
+        required: false
 
 env:
 
@@ -114,13 +117,44 @@ jobs:
 
   # </template: git_info_job>
 
+  detect_version:
+    name: Detect version
+    needs:
+      - git_info
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{steps.detect_version.outputs.version}}
+    steps:
+      - name: Detect version
+        id: detect_version
+        env:
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          SUSPEND_TAG: ${{ github.event.inputs.suspend_tag }}
+        run: |
+          if [[ -n ${SUSPEND_TAG} ]] ; then
+            echo "::notice title=Suspend version::Workflow started from '${CI_COMMIT_REF_NAME}', but suspend_tag input is set. Use '${SUSPEND_REVISION}' as suspend version."
+            echo "::set-output name=version::${SUSPEND_TAG}"
+            exit 0
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            echo "::notice title=Suspend version::Workflow started from tag '${CI_COMMIT_TAG}'. Use it as suspend version."
+            echo "::set-output name=version::${CI_COMMIT_TAG}"
+            exit 0
+          fi
+
+          echo "::error title=Wrong environment::Seems you try to suspend branch '${CI_COMMIT_REF_NAME}'. Use suspend_tag input or run workflow from tag."
+          exit 1
+
+
   run_suspend:
-    name: Suspend deckhouse release on early-access channel
+    name: Suspend ${{needs.detect_version.outputs.version}} on early-access channel
     environment:
       name: early-access
     needs:
       - git_info
-    runs-on: self-hosted
+      - detect_version
+    runs-on: [self-hosted, regular]
     steps:
 
       # <template: started_at_output>
@@ -199,7 +233,7 @@ jobs:
       - name: Publish release images for CE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          SUSPEND_VERSION: ${{needs.detect_version.outputs.version}}
           WERF_ENV: CE
           SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
@@ -228,14 +262,24 @@ jobs:
           }
 
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${SUSPEND_VERSION} ]] ; then
+            echo "::error title=Missed version::Suspend version not detected. Use suspend_tag input or run workflow from tag."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Suspend version '${SUSPEND_VERSION}' for CE edition".
 
           # Variables
           #   1. Edition and channel.
@@ -253,21 +297,21 @@ jobs:
           fi
 
           #   3. Build and publish release-channel image to prod registry.
-          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
-          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
+          SUSPEND_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${SUSPEND_VERSION_IMAGE}'."
 
-          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          echo "{\"version\": \"${SUSPEND_VERSION}\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t "${RELEASE_VERSION_IMAGE}"
+          docker build . -t "${SUSPEND_VERSION_IMAGE}"
 
-          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${SUSPEND_VERSION_IMAGE}"
       - name: Publish release images for EE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          SUSPEND_VERSION: ${{needs.detect_version.outputs.version}}
           WERF_ENV: EE
           SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
@@ -296,14 +340,24 @@ jobs:
           }
 
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${SUSPEND_VERSION} ]] ; then
+            echo "::error title=Missed version::Suspend version not detected. Use suspend_tag input or run workflow from tag."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Suspend version '${SUSPEND_VERSION}' for EE edition".
 
           # Variables
           #   1. Edition and channel.
@@ -321,21 +375,21 @@ jobs:
           fi
 
           #   3. Build and publish release-channel image to prod registry.
-          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
-          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
+          SUSPEND_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${SUSPEND_VERSION_IMAGE}'."
 
-          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          echo "{\"version\": \"${SUSPEND_VERSION}\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t "${RELEASE_VERSION_IMAGE}"
+          docker build . -t "${SUSPEND_VERSION_IMAGE}"
 
-          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${SUSPEND_VERSION_IMAGE}"
       - name: Publish release images for FE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          SUSPEND_VERSION: ${{needs.detect_version.outputs.version}}
           WERF_ENV: FE
           SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
@@ -364,14 +418,24 @@ jobs:
           }
 
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${SUSPEND_VERSION} ]] ; then
+            echo "::error title=Missed version::Suspend version not detected. Use suspend_tag input or run workflow from tag."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Suspend version '${SUSPEND_VERSION}' for FE edition".
 
           # Variables
           #   1. Edition and channel.
@@ -389,17 +453,17 @@ jobs:
           fi
 
           #   3. Build and publish release-channel image to prod registry.
-          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
-          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
+          SUSPEND_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${SUSPEND_VERSION_IMAGE}'."
 
-          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          echo "{\"version\": \"${SUSPEND_VERSION}\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t "${RELEASE_VERSION_IMAGE}"
+          docker build . -t "${SUSPEND_VERSION_IMAGE}"
 
-          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${SUSPEND_VERSION_IMAGE}"
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/suspend-rock-solid.yml
+++ b/.github/workflows/suspend-rock-solid.yml
@@ -9,13 +9,16 @@ on:
     inputs:
       issue_id:
         description: 'Id of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
-        required: true
+        required: false
+      suspend_tag:
+        description: 'Set to suspend specified tag'
+        required: false
 
 env:
 
@@ -114,13 +117,44 @@ jobs:
 
   # </template: git_info_job>
 
+  detect_version:
+    name: Detect version
+    needs:
+      - git_info
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{steps.detect_version.outputs.version}}
+    steps:
+      - name: Detect version
+        id: detect_version
+        env:
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          SUSPEND_TAG: ${{ github.event.inputs.suspend_tag }}
+        run: |
+          if [[ -n ${SUSPEND_TAG} ]] ; then
+            echo "::notice title=Suspend version::Workflow started from '${CI_COMMIT_REF_NAME}', but suspend_tag input is set. Use '${SUSPEND_REVISION}' as suspend version."
+            echo "::set-output name=version::${SUSPEND_TAG}"
+            exit 0
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            echo "::notice title=Suspend version::Workflow started from tag '${CI_COMMIT_TAG}'. Use it as suspend version."
+            echo "::set-output name=version::${CI_COMMIT_TAG}"
+            exit 0
+          fi
+
+          echo "::error title=Wrong environment::Seems you try to suspend branch '${CI_COMMIT_REF_NAME}'. Use suspend_tag input or run workflow from tag."
+          exit 1
+
+
   run_suspend:
-    name: Suspend deckhouse release on rock-solid channel
+    name: Suspend ${{needs.detect_version.outputs.version}} on rock-solid channel
     environment:
       name: rock-solid
     needs:
       - git_info
-    runs-on: self-hosted
+      - detect_version
+    runs-on: [self-hosted, regular]
     steps:
 
       # <template: started_at_output>
@@ -199,7 +233,7 @@ jobs:
       - name: Publish release images for CE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          SUSPEND_VERSION: ${{needs.detect_version.outputs.version}}
           WERF_ENV: CE
           SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
@@ -228,14 +262,24 @@ jobs:
           }
 
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${SUSPEND_VERSION} ]] ; then
+            echo "::error title=Missed version::Suspend version not detected. Use suspend_tag input or run workflow from tag."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Suspend version '${SUSPEND_VERSION}' for CE edition".
 
           # Variables
           #   1. Edition and channel.
@@ -253,21 +297,21 @@ jobs:
           fi
 
           #   3. Build and publish release-channel image to prod registry.
-          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
-          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
+          SUSPEND_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${SUSPEND_VERSION_IMAGE}'."
 
-          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          echo "{\"version\": \"${SUSPEND_VERSION}\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t "${RELEASE_VERSION_IMAGE}"
+          docker build . -t "${SUSPEND_VERSION_IMAGE}"
 
-          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${SUSPEND_VERSION_IMAGE}"
       - name: Publish release images for EE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          SUSPEND_VERSION: ${{needs.detect_version.outputs.version}}
           WERF_ENV: EE
           SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
@@ -296,14 +340,24 @@ jobs:
           }
 
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${SUSPEND_VERSION} ]] ; then
+            echo "::error title=Missed version::Suspend version not detected. Use suspend_tag input or run workflow from tag."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Suspend version '${SUSPEND_VERSION}' for EE edition".
 
           # Variables
           #   1. Edition and channel.
@@ -321,21 +375,21 @@ jobs:
           fi
 
           #   3. Build and publish release-channel image to prod registry.
-          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
-          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
+          SUSPEND_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${SUSPEND_VERSION_IMAGE}'."
 
-          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          echo "{\"version\": \"${SUSPEND_VERSION}\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t "${RELEASE_VERSION_IMAGE}"
+          docker build . -t "${SUSPEND_VERSION_IMAGE}"
 
-          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${SUSPEND_VERSION_IMAGE}"
       - name: Publish release images for FE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          SUSPEND_VERSION: ${{needs.detect_version.outputs.version}}
           WERF_ENV: FE
           SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
@@ -364,14 +418,24 @@ jobs:
           }
 
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${SUSPEND_VERSION} ]] ; then
+            echo "::error title=Missed version::Suspend version not detected. Use suspend_tag input or run workflow from tag."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Suspend version '${SUSPEND_VERSION}' for FE edition".
 
           # Variables
           #   1. Edition and channel.
@@ -389,17 +453,17 @@ jobs:
           fi
 
           #   3. Build and publish release-channel image to prod registry.
-          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
-          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
+          SUSPEND_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${SUSPEND_VERSION_IMAGE}'."
 
-          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          echo "{\"version\": \"${SUSPEND_VERSION}\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t "${RELEASE_VERSION_IMAGE}"
+          docker build . -t "${SUSPEND_VERSION_IMAGE}"
 
-          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${SUSPEND_VERSION_IMAGE}"
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/suspend-stable.yml
+++ b/.github/workflows/suspend-stable.yml
@@ -9,13 +9,16 @@ on:
     inputs:
       issue_id:
         description: 'Id of issue where label was set'
-        required: true
+        required: false
       issue_number:
         description: 'Number of issue where label was set'
-        required: true
+        required: false
       comment_id:
         description: 'Id of comment in issue where to put workflow run status'
-        required: true
+        required: false
+      suspend_tag:
+        description: 'Set to suspend specified tag'
+        required: false
 
 env:
 
@@ -114,13 +117,44 @@ jobs:
 
   # </template: git_info_job>
 
+  detect_version:
+    name: Detect version
+    needs:
+      - git_info
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{steps.detect_version.outputs.version}}
+    steps:
+      - name: Detect version
+        id: detect_version
+        env:
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          SUSPEND_TAG: ${{ github.event.inputs.suspend_tag }}
+        run: |
+          if [[ -n ${SUSPEND_TAG} ]] ; then
+            echo "::notice title=Suspend version::Workflow started from '${CI_COMMIT_REF_NAME}', but suspend_tag input is set. Use '${SUSPEND_REVISION}' as suspend version."
+            echo "::set-output name=version::${SUSPEND_TAG}"
+            exit 0
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            echo "::notice title=Suspend version::Workflow started from tag '${CI_COMMIT_TAG}'. Use it as suspend version."
+            echo "::set-output name=version::${CI_COMMIT_TAG}"
+            exit 0
+          fi
+
+          echo "::error title=Wrong environment::Seems you try to suspend branch '${CI_COMMIT_REF_NAME}'. Use suspend_tag input or run workflow from tag."
+          exit 1
+
+
   run_suspend:
-    name: Suspend deckhouse release on stable channel
+    name: Suspend ${{needs.detect_version.outputs.version}} on stable channel
     environment:
       name: stable
     needs:
       - git_info
-    runs-on: self-hosted
+      - detect_version
+    runs-on: [self-hosted, regular]
     steps:
 
       # <template: started_at_output>
@@ -199,7 +233,7 @@ jobs:
       - name: Publish release images for CE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          SUSPEND_VERSION: ${{needs.detect_version.outputs.version}}
           WERF_ENV: CE
           SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
@@ -228,14 +262,24 @@ jobs:
           }
 
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${SUSPEND_VERSION} ]] ; then
+            echo "::error title=Missed version::Suspend version not detected. Use suspend_tag input or run workflow from tag."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Suspend version '${SUSPEND_VERSION}' for CE edition".
 
           # Variables
           #   1. Edition and channel.
@@ -253,21 +297,21 @@ jobs:
           fi
 
           #   3. Build and publish release-channel image to prod registry.
-          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
-          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
+          SUSPEND_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${SUSPEND_VERSION_IMAGE}'."
 
-          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          echo "{\"version\": \"${SUSPEND_VERSION}\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t "${RELEASE_VERSION_IMAGE}"
+          docker build . -t "${SUSPEND_VERSION_IMAGE}"
 
-          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${SUSPEND_VERSION_IMAGE}"
       - name: Publish release images for EE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          SUSPEND_VERSION: ${{needs.detect_version.outputs.version}}
           WERF_ENV: EE
           SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
@@ -296,14 +340,24 @@ jobs:
           }
 
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${SUSPEND_VERSION} ]] ; then
+            echo "::error title=Missed version::Suspend version not detected. Use suspend_tag input or run workflow from tag."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Suspend version '${SUSPEND_VERSION}' for EE edition".
 
           # Variables
           #   1. Edition and channel.
@@ -321,21 +375,21 @@ jobs:
           fi
 
           #   3. Build and publish release-channel image to prod registry.
-          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
-          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
+          SUSPEND_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${SUSPEND_VERSION_IMAGE}'."
 
-          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          echo "{\"version\": \"${SUSPEND_VERSION}\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t "${RELEASE_VERSION_IMAGE}"
+          docker build . -t "${SUSPEND_VERSION_IMAGE}"
 
-          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${SUSPEND_VERSION_IMAGE}"
       - name: Publish release images for FE
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          SUSPEND_VERSION: ${{needs.detect_version.outputs.version}}
           WERF_ENV: FE
           SKIP_PUSH_FOR_SUSPEND: ${{secrets.SKIP_PUSH_FOR_SUSPEND}}
         run: |
@@ -364,14 +418,24 @@ jobs:
           }
 
           # Some precautions.
-          if [[ -z $DEV_REGISTRY_PATH ]] ; then
-            echo "DEV_REGISTRY_PATH is not set!"
+          shouldExit1=
+          if [[ -z ${DEV_REGISTRY_PATH} ]] ; then
+            echo "::error title=Missed variable::DEV_REGISTRY_PATH is not set. Define destination registry in secrets."
+            shouldExit1=yes
+          fi
+          if [[ -z ${WERF_ENV} ]] ; then
+            echo "::error title=Missed variable::WERF_ENV is not set. Cannot deploy unknown edition, only ce, ee and fe are allowed in inputs."
+            shouldExit1=yes
+          fi
+          if [[ -z ${SUSPEND_VERSION} ]] ; then
+            echo "::error title=Missed version::Suspend version not detected. Use suspend_tag input or run workflow from tag."
+            shouldExit1=yes
+          fi
+          if [[ -n ${shouldExit1} ]] ; then
             exit 1
           fi
-          if [[ -z $WERF_ENV ]] ; then
-            echo "WERF_ENV is not set!"
-            exit 1
-          fi
+
+          echo "Suspend version '${SUSPEND_VERSION}' for FE edition".
 
           # Variables
           #   1. Edition and channel.
@@ -389,17 +453,17 @@ jobs:
           fi
 
           #   3. Build and publish release-channel image to prod registry.
-          RELEASE_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
-          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${RELEASE_VERSION_IMAGE}'."
+          SUSPEND_VERSION_IMAGE=${DST_REGISTRY_PATH}/${REGISTRY_SUFFIX}/release-channel:${RELEASE_CHANNEL}
+          echo "⚓️ 🛠 [$(date -u)] Build 'release-channel suspend' image as '${SUSPEND_VERSION_IMAGE}'."
 
-          echo "{\"version\": \"$CI_COMMIT_REF_NAME\", \"suspend\": true}" > version.json
+          echo "{\"version\": \"${SUSPEND_VERSION}\", \"suspend\": true}" > version.json
           cat <<EOF >Dockerfile
           FROM spotify/scratch
           COPY version.json version.json
           EOF
-          docker build . -t "${RELEASE_VERSION_IMAGE}"
+          docker build . -t "${SUSPEND_VERSION_IMAGE}"
 
-          push_rmi 'release-channel suspend' "${RELEASE_VERSION_IMAGE}"
+          push_rmi 'release-channel suspend' "${SUSPEND_VERSION_IMAGE}"
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish


### PR DESCRIPTION
## Description

- Put version into job name for easy approvement.
- Add suspend_tag input to suspend any version manually.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Fix problems in suspend workflow after failed suspend for v1.31.0.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: fix
summary: Fix suspend forkflow
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
