### PR TITLE
[user-authn] Fix DexAuthenticator object template for https mode OnlyInURI

### DIFF
--- a/ee/fe/modules/500-openvpn/templates/openvpn/authenticator.yaml
+++ b/ee/fe/modules/500-openvpn/templates/openvpn/authenticator.yaml
@@ -8,7 +8,9 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "dex-authenticator" "name" .Chart.Name )) | nindent 2 }}
 spec:
   applicationDomain: {{ include "helm_lib_module_public_domain" (list . "openvpn") }}
+  {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}
   applicationIngressCertificateSecretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  {{- end }}
   applicationIngressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   {{- with .Values.openvpn.auth.allowedUserGroups }}
   allowedGroups:

--- a/ee/modules/110-istio/templates/kiali/authenticator.yaml
+++ b/ee/modules/110-istio/templates/kiali/authenticator.yaml
@@ -10,7 +10,9 @@ metadata:
     dexauthenticator.deckhouse.io/allow-access-to-kubernetes: "true"
 spec:
   applicationDomain: {{ include "helm_lib_module_public_domain" (list . "istio") }}
+  {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}
   applicationIngressCertificateSecretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  {{- end }}
   applicationIngressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   sendAuthorizationHeader: true
   {{- with .Values.istio.auth.allowedUserGroups }}

--- a/modules/300-prometheus/templates/grafana/authenticator.yaml
+++ b/modules/300-prometheus/templates/grafana/authenticator.yaml
@@ -8,7 +8,9 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "dex-authenticator" "name" "grafana" )) | nindent 2 }}
 spec:
   applicationDomain: {{ include "helm_lib_module_public_domain" (list . "grafana") }}
+  {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}
   applicationIngressCertificateSecretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  {{- end }}
   applicationIngressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   signOutURL: "/logout"
   {{- with .Values.prometheus.auth.allowedUserGroups }}

--- a/modules/500-dashboard/templates/dashboard/authenticator.yaml
+++ b/modules/500-dashboard/templates/dashboard/authenticator.yaml
@@ -10,7 +10,9 @@ metadata:
     dexauthenticator.deckhouse.io/allow-access-to-kubernetes: "true"
 spec:
   applicationDomain: {{ include "helm_lib_module_public_domain" (list . "dashboard") }}
+  {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}
   applicationIngressCertificateSecretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  {{- end }}
   applicationIngressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   signOutURL: "/logout"
   sendAuthorizationHeader: true

--- a/modules/500-upmeter/templates/status/authenticator.yaml
+++ b/modules/500-upmeter/templates/status/authenticator.yaml
@@ -8,7 +8,9 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "dex-authenticator" "name" "status" )) | nindent 2 }}
 spec:
   applicationDomain: {{ include "helm_lib_module_public_domain" (list . "status") }}
+  {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}
   applicationIngressCertificateSecretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls-status") }}
+  {{- end }}
   applicationIngressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   {{- with .Values.upmeter.auth.status.allowedUserGroups }}
   allowedGroups:

--- a/modules/500-upmeter/templates/webui/authenticator.yaml
+++ b/modules/500-upmeter/templates/webui/authenticator.yaml
@@ -8,7 +8,9 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "dex-authenticator" "name" "upmeter" )) | nindent 2 }}
 spec:
   applicationDomain: {{ include "helm_lib_module_public_domain" (list . "upmeter") }}
+  {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}
   applicationIngressCertificateSecretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  {{- end }}
   applicationIngressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   {{- with .Values.upmeter.auth.webui.allowedUserGroups }}
   allowedGroups:

--- a/modules/810-deckhouse-web/openapi/values.yaml
+++ b/modules/810-deckhouse-web/openapi/values.yaml
@@ -17,6 +17,7 @@ properties:
         default: "unknown"
       deployDexAuthenticator:
         type: boolean
+        x-examples: [true, false]
       customCertificateData:
         type: object
         properties:

--- a/modules/810-deckhouse-web/templates/authenticator.yaml
+++ b/modules/810-deckhouse-web/templates/authenticator.yaml
@@ -8,7 +8,9 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "dex-authenticator" "name" "deckhouse-web" )) | nindent 2 }}
 spec:
   applicationDomain: {{ include "helm_lib_module_public_domain" (list . "deckhouse") }}
+  {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}
   applicationIngressCertificateSecretName: {{ include "helm_lib_module_https_secret_name" (list . "ingress-tls") }}
+  {{- end }}
   applicationIngressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
   {{- with .Values.deckhouseWeb.auth.allowedUserGroups }}
   allowedGroups:


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
* Add a clause to set authenticator ingress certificate secret name

## Why do we need it, and what problem does it solve?
Urgent fix

## Changelog entries

```changes
section: user-authn
type: fix
summary: Do not set ingress TLS certificate secret name if HTTPS mode is the OnlyInURI
impact_level: high
impact: Fix deploy of DexAuthenticators to clusters with the OnlyInURI HTTPS mode
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
