### PR TITLE
[extended-monitoring] Kubernetes 1.19 compatibility fix

### DIFF
--- a/ee/fe/modules/340-extended-monitoring/templates/extended-monitoring-exporter/rbac-for-us.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/extended-monitoring-exporter/rbac-for-us.yaml
@@ -22,6 +22,7 @@ rules:
   - watch
   - get
 - apiGroups:
+  - extensions
   - networking.k8s.io
   resources:
   - ingresses


### PR DESCRIPTION
## Description
Old Ingress group "extensions" support for extended-monitoring-exporter in old Kubernetes clusters.

## Why do we need it, and what problem does it solve?
There still are working Kuberneteses 1.19 and exporter was incompatible.

## Changelog entries

```changes
section: extended-monitoring
type: fix
summary: Old Ingress group "extensions" support for extended-monitoring-exporter in old Kubernetes clusters.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
