### PR TITLE
[deckhouse] fix CRD and status generation

### DIFF
--- a/modules/020-deckhouse/crds/deckhouse-release.yaml
+++ b/modules/020-deckhouse/crds/deckhouse-release.yaml
@@ -52,8 +52,7 @@ spec:
                 changelog:
                   type: object
                   description: Release's changelog for enabled modules.
-                  additionalProperties:
-                    type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 changelogLink:
                   type: string
                   description: Link to site with full changelog for this release.

--- a/modules/020-deckhouse/hooks/update_deckhouse_image.go
+++ b/modules/020-deckhouse/hooks/update_deckhouse_image.go
@@ -764,8 +764,9 @@ func deleteUpdatingCM(input *go_hook.HookInput) {
 
 func updateStatusMsg(input *go_hook.HookInput, release *deckhouseRelease, msg string) {
 	st := statusPatch{
-		Message:  msg,
-		Approved: release.StatusApproved,
+		Message:        msg,
+		Approved:       release.StatusApproved,
+		TransitionTime: time.Now().UTC(),
 	}
 	input.PatchCollector.MergePatch(st, "deckhouse.io/v1alpha1", "DeckhouseRelease", "", release.Name, object_patch.WithSubresource("/status"))
 }


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Fix deckhouse CRD and generate timestamp for CR status message

## Why do we need it, and what problem does it solve?
Need to preserve any fields in CRD

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse
type: fix 
summary: Fix DeckhouseRelease CRD
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
