### PR TITLE
[extended-monitoring] Start webserver immediately for the extended-monitoring-exporter

### DIFF
--- a/ee/fe/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
+++ b/ee/fe/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
@@ -253,6 +253,7 @@ def _get_metrics():
 
 class GetHandler(BaseHTTPRequestHandler):
     _response = ""
+    _populated = False
 
     @classmethod
     def get_metrics(cls):
@@ -262,6 +263,10 @@ class GetHandler(BaseHTTPRequestHandler):
 
     @classmethod
     def loop_get_metrics(cls):
+        cls.get_metrics()
+        _populated = True
+        sleep(30)
+
         while 1:
             try:
                 cls.get_metrics()
@@ -272,7 +277,8 @@ class GetHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == "/ready":
             apis.get_api_versions()
-            self.send_response(200)
+            # Wait for the first metrics request to succeed
+            self.send_response(200 if self._populated else 400)
             self.end_headers()
             return
 
@@ -303,12 +309,11 @@ if __name__ == '__main__':
     if len(sys.argv) == 3:
         server_port = int(sys.argv[2])
 
-    # Get metrics once synchronously before starting web server
-    GetHandler.get_metrics()
     server = ThreadingHTTPServer((server_address, server_port), GetHandler)
 
     try:
         # Run metrics renew in background (daemon thread is canceled on the script exit)
+        logging.info('Starting metrics loop')
         Thread(target=GetHandler.loop_get_metrics, daemon=True).start()
 
         logging.info('Starting server')

--- a/ee/fe/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
+++ b/ee/fe/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
@@ -264,7 +264,7 @@ class GetHandler(BaseHTTPRequestHandler):
     @classmethod
     def loop_get_metrics(cls):
         cls.get_metrics()
-        _populated = True
+        cls._populated = True
         sleep(30)
 
         while 1:
@@ -278,7 +278,7 @@ class GetHandler(BaseHTTPRequestHandler):
         if self.path == "/ready":
             apis.get_api_versions()
             # Wait for the first metrics request to succeed
-            self.send_response(200 if self._populated else 400)
+            self.send_response(200 if self.__class__._populated else 400)
             self.end_headers()
             return
 

--- a/ee/fe/modules/340-extended-monitoring/templates/extended-monitoring-exporter/podmonitor.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/extended-monitoring-exporter/podmonitor.yaml
@@ -23,6 +23,9 @@ spec:
       action: labeldrop
     - sourceLabels: ["pod"]
       targetLabel: pod
+    - sourceLabels: [__meta_kubernetes_pod_ready]
+      regex: "true"
+      action: keep
   selector:
     matchLabels:
       app: extended-monitoring-exporter


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
* Start webserver immediately after running extended monitoring exporter
* Return 400 for the readiness probe requests if metrics cache is not populated

```
[2022-03-23 05:51:25,357] - Starting metrics loop
[2022-03-23 05:51:25,360] - Starting server
127.0.0.1 - - [23/Mar/2022 05:51:26] "GET /ready HTTP/1.1" 400 -
[2022-03-23 05:51:27,246] - Metrics are collected successfully. Batches quantity: 183
127.0.0.1 - - [23/Mar/2022 05:51:30] "GET /healthz HTTP/1.1" 200 -
127.0.0.1 - - [23/Mar/2022 05:51:30] "GET /ready HTTP/1.1" 200 -
127.0.0.1 - - [23/Mar/2022 05:51:40] "GET /healthz HTTP/1.1" 200 -
127.0.0.1 - - [23/Mar/2022 05:51:40] "GET /ready HTTP/1.1" 200 -
127.0.0.1 - - [23/Mar/2022 05:51:49] "GET /metrics HTTP/1.1" 200 -
127.0.0.1 - - [23/Mar/2022 05:51:50] "GET /healthz HTTP/1.1" 200 -
127.0.0.1 - - [23/Mar/2022 05:51:50] "GET /ready HTTP/1.1" 200 -
[2022-03-23 05:51:59,247] - Metrics are collected successfully. Batches quantity: 183
127.0.0.1 - - [23/Mar/2022 05:52:00] "GET /healthz HTTP/1.1" 200 -
127.0.0.1 - - [23/Mar/2022 05:52:00] "GET /ready HTTP/1.1" 200 -
```

## Why do we need it, and what problem does it solve?
Extended monitoring exporter waits for the first request to Kubernetes to populate metrics cache to be succeded before starting the webserver, because we do not want Prometheus to receive empty metrics. However, webserver also handles probe requests, e.g., readiness probe, liveness probe. If the first request is too long, Kubernetes will kill the pod because the liveness probe fails.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: extended-monitoring
type: fix
summary: Start webserver immediately for the extended-monitoring-exporter
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
