### PR TITLE
[deckhouse] disable release event

### DIFF
--- a/modules/020-deckhouse/hooks/update_deckhouse_image.go
+++ b/modules/020-deckhouse/hooks/update_deckhouse_image.go
@@ -77,6 +77,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			Name:                         "releases",
 			ApiVersion:                   "deckhouse.io/v1alpha1",
 			Kind:                         "DeckhouseRelease",
+			ExecuteHookOnEvents:          pointer.BoolPtr(false),
 			ExecuteHookOnSynchronization: pointer.BoolPtr(false),
 			FilterFunc:                   filterDeckhouseRelease,
 		},

--- a/modules/020-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/020-deckhouse/hooks/update_deckhouse_image_test.go
@@ -160,8 +160,8 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 		Context("After setting manual approve", func() {
 			BeforeEach(func() {
 				f.KubeStateSet("")
-				cc := f.KubeStateSet(deckhouseDeployment + deckhouseReadyPod + manualApprovedReleases)
-				f.BindingContexts.Set(cc)
+				f.KubeStateSet(deckhouseDeployment + deckhouseReadyPod + manualApprovedReleases)
+				f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
 				f.RunHook()
 			})
 			It("Must upgrade deckhouse", func() {
@@ -174,8 +174,8 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 		Context("Auto deploy Patch release in Manual mode", func() {
 			BeforeEach(func() {
 				f.KubeStateSet("")
-				cc := f.KubeStateSet(deckhouseDeployment + deckhouseReadyPod + deckhouseReleases + deckhousePatchRelease)
-				f.BindingContexts.Set(cc)
+				f.KubeStateSet(deckhouseDeployment + deckhouseReadyPod + deckhouseReleases + deckhousePatchRelease)
+				f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
 				f.RunHook()
 			})
 			It("Must upgrade deckhouse", func() {


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Disable reaction on release events

## Why do we need it, and what problem does it solve?
We run hook every 15 seconds. I don't think we need this reaction which can lead to some artifacts

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse
type: fix
summary: disable hook reaction on DeckhouseRelease events
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
