### PR TITLE
[docs] pin kindest/node image version

### DIFF
--- a/docs/site/_includes/getting_started/kind/STEP_PREPARE.md
+++ b/docs/site/_includes/getting_started/kind/STEP_PREPARE.md
@@ -36,7 +36,7 @@ Example of creation command output:
 ```
 $ kind create cluster --image "kindest/node:v1.22.7@sha256:c195c17f2a9f6ad5bbddc9eb8bad68fa21709162aabf2b84e4a3896db05c0808" --config kind.cfg
 Creating cluster "kind" ...
- ✓ Ensuring node image (kindest/node:v1.21.1) 🖼
+ ✓ Ensuring node image (kindest/node:v1.22.7) 🖼
  ✓ Preparing nodes 📦  
  ✓ Writing configuration 📜 
  ✓ Starting control-plane 🕹️ 

--- a/docs/site/_includes/getting_started/kind/STEP_PREPARE.md
+++ b/docs/site/_includes/getting_started/kind/STEP_PREPARE.md
@@ -28,13 +28,13 @@ EOF
 Create cluster with kind:
 {% snippetcut selector="create-kind-cluster" %}
 ```shell
-kind create cluster --image "kindest/node:v1.22.7" --config kind.cfg
+kind create cluster --image "kindest/node:v1.22.7@sha256:c195c17f2a9f6ad5bbddc9eb8bad68fa21709162aabf2b84e4a3896db05c0808" --config kind.cfg
 ```
 {% endsnippetcut %}
 
 Example of creation command output:
 ```
-$ kind create cluster --image "kindest/node:v1.22.7" --config kind.cfg
+$ kind create cluster --image "kindest/node:v1.22.7@sha256:c195c17f2a9f6ad5bbddc9eb8bad68fa21709162aabf2b84e4a3896db05c0808" --config kind.cfg
 Creating cluster "kind" ...
  ✓ Ensuring node image (kindest/node:v1.21.1) 🖼
  ✓ Preparing nodes 📦  

--- a/docs/site/_includes/getting_started/kind/STEP_PREPARE.md
+++ b/docs/site/_includes/getting_started/kind/STEP_PREPARE.md
@@ -28,13 +28,13 @@ EOF
 Create cluster with kind:
 {% snippetcut selector="create-kind-cluster" %}
 ```shell
-kind create cluster --config kind.cfg
+kind create cluster --image "kindest/node:v1.22.7" --config kind.cfg
 ```
 {% endsnippetcut %}
 
 Example of creation command output:
 ```
-$ kind create cluster --config kind.cfg
+$ kind create cluster --image "kindest/node:v1.22.7" --config kind.cfg
 Creating cluster "kind" ...
  ✓ Ensuring node image (kindest/node:v1.21.1) 🖼
  ✓ Preparing nodes 📦  

--- a/docs/site/_includes/getting_started/kind/STEP_PREPARE_RU.md
+++ b/docs/site/_includes/getting_started/kind/STEP_PREPARE_RU.md
@@ -36,7 +36,7 @@ kind create cluster --image "kindest/node:v1.22.7@sha256:c195c17f2a9f6ad5bbddc9e
 ```
 $ kind create cluster --image "kindest/node:v1.22.7@sha256:c195c17f2a9f6ad5bbddc9eb8bad68fa21709162aabf2b84e4a3896db05c0808" --config kind.cfg
 Creating cluster "kind" ...
- ✓ Ensuring node image (kindest/node:v1.21.1) 🖼
+ ✓ Ensuring node image (kindest/node:v1.22.7) 🖼
  ✓ Preparing nodes 📦  
  ✓ Writing configuration 📜 
  ✓ Starting control-plane 🕹️ 

--- a/docs/site/_includes/getting_started/kind/STEP_PREPARE_RU.md
+++ b/docs/site/_includes/getting_started/kind/STEP_PREPARE_RU.md
@@ -28,13 +28,13 @@ EOF
 Создайте кластер kind:
 {% snippetcut selector="create-kind-cluster" %}
 ```shell
-kind create cluster --image "kindest/node:v1.22.7" --config kind.cfg
+kind create cluster --image "kindest/node:v1.22.7@sha256:c195c17f2a9f6ad5bbddc9eb8bad68fa21709162aabf2b84e4a3896db05c0808" --config kind.cfg
 ```
 {% endsnippetcut %}
 
 Пример вывода команды создания кластера:
 ```
-$ kind create cluster --image "kindest/node:v1.22.7" --config kind.cfg
+$ kind create cluster --image "kindest/node:v1.22.7@sha256:c195c17f2a9f6ad5bbddc9eb8bad68fa21709162aabf2b84e4a3896db05c0808" --config kind.cfg
 Creating cluster "kind" ...
  ✓ Ensuring node image (kindest/node:v1.21.1) 🖼
  ✓ Preparing nodes 📦  

--- a/docs/site/_includes/getting_started/kind/STEP_PREPARE_RU.md
+++ b/docs/site/_includes/getting_started/kind/STEP_PREPARE_RU.md
@@ -28,13 +28,13 @@ EOF
 Создайте кластер kind:
 {% snippetcut selector="create-kind-cluster" %}
 ```shell
-kind create cluster --config kind.cfg
+kind create cluster --image "kindest/node:v1.22.7" --config kind.cfg
 ```
 {% endsnippetcut %}
 
 Пример вывода команды создания кластера:
 ```
-$ kind create cluster --config kind.cfg
+$ kind create cluster --image "kindest/node:v1.22.7" --config kind.cfg
 Creating cluster "kind" ...
  ✓ Ensuring node image (kindest/node:v1.21.1) 🖼
  ✓ Preparing nodes 📦  


### PR DESCRIPTION
## Description
pin the kindest/node version for cluster

## Why do we need it, and what problem does it solve?
Deckhouse doesn't always support latest kindest/node version. I suggest pin image version for solve this problem.
<details>
  <summary>Screenshot</summary>
  
![image](https://user-images.githubusercontent.com/41015519/159720176-a4f0bcfb-d138-44c2-bbb2-3c2b0c50d5a2.png)
  
</details>

## Changelog entries
```changes
section: docs
type: fix
summary: "Pin kindest/node version"
impact_level: low
```
