### PR TITLE
[linstor] Enable HA mode

### DIFF
--- a/ee/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin/Dockerfile
+++ b/ee/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_DEBIAN
 
 FROM $BASE_GOLANG_16_ALPINE as csi
 WORKDIR /src/
-RUN wget https://github.com/kubernetes-sigs/vsphere-csi-driver/archive/refs/tags/v2.4.0.tar.gz -O - | tar -xz --strip-components=1 -C /src
+RUN wget https://github.com/kubernetes-sigs/vsphere-csi-driver/archive/refs/tags/v2.5.0.tar.gz -O - | tar -xz --strip-components=1 -C /src
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o vsphere-csi cmd/vsphere-csi/main.go
 
 # support every standard Linux disk/mount utility so that CSI components won't complain

--- a/ee/modules/030-cloud-provider-vsphere/templates/csi/cm.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/templates/csi/cm.yaml
@@ -9,4 +9,5 @@ data:
   "csi-migration": "false"
   "csi-auth-check": "true"
   "online-volume-extend": "true"
+  "block-volume-snapshot": "true"
 {{- end }}

--- a/ee/modules/030-cloud-provider-vsphere/templates/csi/controller.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/templates/csi/controller.yaml
@@ -37,7 +37,7 @@
 
 {{- $csiControllerConfig := dict }}
 {{- $_ := set $csiControllerConfig "controllerImage" $csiControllerImage }}
-{{- $_ := set $csiControllerConfig "snapshotterEnabled" false }}
+{{- $_ := set $csiControllerConfig "snapshotterEnabled" true }}
 {{- $_ := set $csiControllerConfig "additionalControllerArgs" (include "csi_controller_args" . | fromYamlArray) }}
 {{- $_ := set $csiControllerConfig "additionalControllerEnvs" (include "csi_controller_envs" . | fromYamlArray) }}
 {{- $_ := set $csiControllerConfig "additionalControllerVolumes" (include "csi_controller_volumes" . | fromYamlArray) }}

--- a/modules/031-linstor/template_tests/module_test.go
+++ b/modules/031-linstor/template_tests/module_test.go
@@ -33,6 +33,7 @@ func Test(t *testing.T) {
 const (
 	globalValues = `
   enabledModules: ["vertical-pod-autoscaler-crd"]
+  highAvailability: true
   modules:
     placement: {}
   discovery:

--- a/modules/031-linstor/templates/linstor-controller/linstorcontroller.yaml
+++ b/modules/031-linstor/templates/linstor-controller/linstorcontroller.yaml
@@ -36,16 +36,9 @@ spec:
             values:
             - {{ $v | quote }}
           {{- end }}
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 1
-        podAffinityTerm:
-          topologyKey: kubernetes.io/hostname
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/instance: linstor
-              app.kubernetes.io/managed-by: piraeus-operator
-              app.kubernetes.io/name: piraeus-controller
+    {{- with (index (fromYaml (include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app.kubernetes.io/instance" "linstor" "app.kubernetes.io/managed-by" "piraeus-operator" "app.kubernetes.io/name" "piraeus-controller")))) "affinity") }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
   dbConnectionURL: k8s
   #luksSecret: linstor-passphrase
   sslSecret: linstor-controller-ssl-cert
@@ -60,7 +53,7 @@ spec:
   resources:
     requests:
       {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 6 }}
-  replicas: 1
+  replicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
   additionalEnv: []
   additionalProperties:
     Autoplacer/Weights/MaxFreeSpace: "0"

--- a/modules/031-linstor/templates/linstor-csi/linstorcsidriver.yaml
+++ b/modules/031-linstor/templates/linstor-csi/linstorcsidriver.yaml
@@ -90,7 +90,7 @@ spec:
   {{- end }}
   linstorHttpsClientSecret: linstor-client-https-cert
   priorityClassName: ""
-  controllerReplicas: 1
+  controllerReplicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
   controllerEndpoint: https://linstor.d8-{{ .Chart.Name }}.svc:3371
   nodeAffinity: {}
   nodeTolerations:
@@ -106,17 +106,9 @@ spec:
             values:
             - {{ $v | quote }}
           {{- end }}
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 1
-        podAffinityTerm:
-          topologyKey: kubernetes.io/hostname
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/component: csi-controller
-              app.kubernetes.io/instance: linstor
-              app.kubernetes.io/managed-by: piraeus-operator
-              app.kubernetes.io/name: piraeus-csi
+    {{- with (index (fromYaml (include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app.kubernetes.io/component" "csi-controller" "app.kubernetes.io/instance" "linstor" "app.kubernetes.io/managed-by" "piraeus-operator" "app.kubernetes.io/name" "piraeus-csi")))) "affinity") }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
   controllerTolerations:
     {{- index (include "helm_lib_tolerations" (tuple . "master") | fromYaml) "tolerations" | toYaml | nindent 4 }}
   enableTopology: true

--- a/modules/031-linstor/templates/linstor-ha-controller/deployment.yaml
+++ b/modules/031-linstor/templates/linstor-ha-controller/deployment.yaml
@@ -38,7 +38,7 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "linstor-ha-controller" )) | nindent 2 }}
 spec:
-  replicas: 1
+  replicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
   selector:
     matchLabels:
       app: linstor-ha-controller
@@ -51,6 +51,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "linstor-ha-controller")) | nindent 6 }}
       imagePullSecrets:
         - name: deckhouse-registry
       serviceAccountName: linstor-ha-controller
@@ -124,12 +125,3 @@ spec:
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchLabels:
-                  app: linstor-ha-controller

--- a/modules/031-linstor/templates/linstor-scheduler/deployment.yaml
+++ b/modules/031-linstor/templates/linstor-scheduler/deployment.yaml
@@ -39,7 +39,7 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "linstor-scheduler" )) | nindent 2 }}
 spec:
-  replicas: 1
+  replicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
   selector:
     matchLabels:
       app: linstor-scheduler
@@ -52,6 +52,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "linstor-scheduler")) | nindent 6 }}
       imagePullSecrets:
         - name: deckhouse-registry
       containers:
@@ -138,13 +139,4 @@ spec:
           name: linstor-scheduler
         name: scheduler-config
       {{- end }}
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchLabels:
-                  app: linstor-scheduler
       serviceAccountName: linstor-scheduler

--- a/modules/031-linstor/templates/piraeus-operator/deployment.yaml
+++ b/modules/031-linstor/templates/piraeus-operator/deployment.yaml
@@ -38,7 +38,7 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "piraeus-operator" )) | nindent 2 }}
 spec:
-  replicas: 1
+  replicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
   selector:
     matchLabels:
       app: piraeus-operator
@@ -51,6 +51,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "piraeus-operator")) | nindent 6 }}
       imagePullSecrets:
       - name: deckhouse-registry
       serviceAccountName: piraeus-operator
@@ -79,12 +80,3 @@ spec:
       volumes:
       - name: backup-dir
         emptyDir: {}
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchLabels:
-                  app: piraeus-operator


### PR DESCRIPTION
## Description
This PR enables automatic HA mode for LINSTOR server and all related components

## Why do we need it, and what problem does it solve?
Better high-avability for LINSTOR installations

## Changelog entries

```changes
section: linstor
type: fix
summary: LINSTOR module now supports high-availability
impact_level: high
impact: Multimaster clusters will automatically turn LINSTOR into HA-mode
```