### PR TITLE
[linstor] Add DRBD devices to blacklist on nodes

### DIFF
--- a/modules/031-linstor/templates/bashible-step.yaml
+++ b/modules/031-linstor/templates/bashible-step.yaml
@@ -21,33 +21,43 @@ spec:
     # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     # See the License for the specific language governing permissions and
     # limitations under the License.
-
+    
     # DRBD devices should not be queried by the LVM and multipath commands.
     # So we add DRBD devices into blacklist for multipath and configure
     # global_filter in lvm.conf for them
-    set -e
-
-    # multipath
-    mkdir -p /etc/multipath/conf.d
-    cat > /etc/multipath/conf.d/drbd.conf <<EOF
+    
+    bb-event-on 'bb-sync-file-changed' '_on_multipath_config_changed'
+    _on_multipath_config_changed() {
+      if systemctl is-enabled --quiet multipathd 2>/dev/null; then
+        systemctl reload multipathd
+      fi
+    }
+    
+    configure_lvm() {
+      command -V lvmconfig >/dev/null 2>&1 || return 0
+      test -f /etc/lvm/lvm.conf || return 0
+      current_global_filter=$(lvmconfig devices/global_filter 2>/dev/null || true)
+    
+      case "${current_global_filter}" in
+        '' ) new_global_filter='["r|^/dev/drbd|"]' ;;
+        */dev/drbd*) return 0 ;;
+        'global_filter="'*) new_global_filter='["r|^/dev/drbd|",'${current_global_filter#*=}] ;;
+        'global_filter=['*) new_global_filter='["r|^/dev/drbd|",'${current_global_filter#*[} ;;
+        *) echo error parsing global_filter >&2; return 1 ;;
+      esac
+    
+      lvmconfig --config "devices/global_filter=$new_global_filter" --withcomments --merge > /etc/lvm/lvm.conf.$$
+      mv /etc/lvm/lvm.conf.$$ /etc/lvm/lvm.conf
+    }
+    
+    configure_multipath() {
+      mkdir -p /etc/multipath/conf.d
+      bb-sync-file /etc/multipath/conf.d/drbd.conf - <<EOF
     blacklist {
         devnode "^drbd[0-9]+"
     }
     EOF
-    systemctl reload multipathd || true
-
-    # lvm
-    command -V lvmconfig >/dev/null 2>&1 || exit 0
-    test -f /etc/lvm/lvm.conf || exit 0
-    cur=$(lvmconfig devices/global_filter 2>/dev/null || true)
+    }
     
-    case "${cur}" in
-      '' ) new="[\"r|^/dev/drbd|\"]" ;;
-      */dev/drbd*) exit 0 ;;
-      'global_filter="'*) new="[\"r|^/dev/drbd|\",${cur#*=}]" ;;
-      'global_filter=['*) new="[\"r|^/dev/drbd|\",${cur#*[}" ;;
-      *) echo error parsing global filter >&2; exit 1 ;;
-    esac
-    
-    lvmconfig --config "devices/global_filter=$new" --withcomments --merge > /etc/lvm/lvm.conf.$$
-    mv /etc/lvm/lvm.conf.$$ /etc/lvm/lvm.conf
+    configure_lvm
+    configure_multipath

--- a/modules/031-linstor/templates/bashible-step.yaml
+++ b/modules/031-linstor/templates/bashible-step.yaml
@@ -1,0 +1,53 @@
+apiVersion: deckhouse.io/v1alpha1
+kind: NodeGroupConfiguration
+metadata:
+  name: add-drbd-to-blacklist.sh
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+spec:
+  weight: 100
+  nodeGroups: ["*"]
+  bundles: ["*"]
+  content: |
+    # Copyright 2021 Flant JSC
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+
+    # DRBD devices should not be queried by the LVM and multipath commands.
+    # So we add DRBD devices into blacklist for multipath and configure
+    # global_filter in lvm.conf for them
+    set -e
+
+    # multipath
+    mkdir -p /etc/multipath/conf.d
+    cat > /etc/multipath/conf.d/drbd.conf <<EOF
+    blacklist {
+        devnode "^drbd[0-9]+"
+    }
+    EOF
+    systemctl reload multipathd || true
+
+    # lvm
+    command -V lvmconfig >/dev/null 2>&1 || exit 0
+    test -f /etc/lvm/lvm.conf || exit 0
+    cur=$(lvmconfig devices/global_filter 2>/dev/null || true)
+    
+    case "${cur}" in
+      '' ) new="[\"r|^/dev/drbd|\"]" ;;
+      */dev/drbd*) exit 0 ;;
+      'global_filter="'*) new="[\"r|^/dev/drbd|\",${cur#*=}]" ;;
+      'global_filter=['*) new="[\"r|^/dev/drbd|\",${cur#*[}" ;;
+      *) echo error parsing global filter >&2; exit 1 ;;
+    esac
+    
+    lvmconfig --config "devices/global_filter=$new" --withcomments --merge > /etc/lvm/lvm.conf.$$
+    mv /etc/lvm/lvm.conf.$$ /etc/lvm/lvm.conf


### PR DESCRIPTION
## Description

DRBD devices should not be queried by the LVM commands, so we configure global_filter in lvm.conf

## Why do we need it, and what problem does it solve?

fixes https://github.com/deckhouse/deckhouse/issues/1067
fixes https://github.com/deckhouse/deckhouse/issues/1174
upstream issue https://github.com/piraeusdatastore/piraeus-operator/issues/182

## Changelog entries



```changes
section: linstor
type: fix
summary: Add DRBD devices to blacklist on nodes
impact_level: low
impact: DRBD devices should not be queried by LVM and multipath commands So we add DRBD devices into blacklist for multipath and configure global_filter in lvm.conf for them
```