### PR TITLE
[prometheus-metrics-adapter] remove namespace enforcing

### DIFF
--- a/modules/301-prometheus-metrics-adapter/templates/config-map.yaml
+++ b/modules/301-prometheus-metrics-adapter/templates/config-map.yaml
@@ -9,6 +9,8 @@ data:
   config.yaml: |
     externalRules:
     - seriesQuery: '{__name__=~"kube_adapter_metric_.+"}'
+      resources:
+        namespaced: false
       name:
         matches: "^kube_adapter_metric_(.+)$"
         as: "${1}"


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Fix prometheus metrics adapter external metrics

## Why do we need it, and what problem does it solve?
This behavior was broken at November by applying 0.9.1 PMA version.
By default from version 0.9.0 PMA enforces to pass namespace label to a query.
By setting `namespaced:  false` we allow PMA to accept external metrics from all namespaces.
Then, if the metrics needed by your HPA need to be selected with a specific namespace label value, you should set it directly in a HPA's label selector.
Example: 
```
  - type: External
    external:
      metric:
        name: rmq_queue_length
        selector:
          labelSelector:
            queue: my-queue
            namespace: example
```

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus-metrics-adapter
type: fix
summary:  Restore HPA external metrics behavior
impact_level: high
impact: Disable enforced namespace passing to a query. If your metric need to be selected with a specific namespace label value, you should set it directly in an HPA's label selector
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
