### PR TITLE
[cloud-provider-vsphere] Fix handle of compatibilityFlag in Deckhouse config

### DIFF
--- a/ee/modules/030-cloud-provider-vsphere/hooks/handle_compatibility_flag.go
+++ b/ee/modules/030-cloud-provider-vsphere/hooks/handle_compatibility_flag.go
@@ -64,7 +64,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 func handleStorageClasses(input *go_hook.HookInput) error {
 	// We use `none` in internal values against empty string `` for cleaner conditions in Helm templates.
 	compatibilityFlag := "none"
-	if v, ok := input.Values.GetOk("cloudProviderVsphere.compatibilityFlag"); ok {
+	if v, ok := input.Values.GetOk("cloudProviderVsphere.storageClass.compatibilityFlag"); ok {
 		compatibilityFlag = v.String()
 	}
 	input.Values.Set("cloudProviderVsphere.internal.compatibilityFlag", compatibilityFlag)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Get correct value from config

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Compatibility mode doesn't work

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-vsphere
type: fix
summary: Fix handle of compatibilityFlag in Deckhouse config
impact_level: medium
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
