### PR TITLE
chore: update shell-operator, set debug level for snapshot info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.9.0
-	github.com/flant/addon-operator v1.0.5
+	github.com/flant/addon-operator v1.0.6-0.20220324172214-023b896ccf0d
 	github.com/flant/kube-client v0.0.6
-	github.com/flant/shell-operator v1.0.9-0.20220302082030-614d4cca72da
+	github.com/flant/shell-operator v1.0.10-0.20220324171037-a48626e8b125
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/spec v0.19.8

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwo
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/flant/addon-operator v1.0.5 h1:CmwvKYXmXr0o3JEdhxEsUWPuc0PnN+QbhlyuffwqdY0=
-github.com/flant/addon-operator v1.0.5/go.mod h1:9tUmk+zQ8SMHE/qLEwwkejjD+6+lBZivNsXxhIiVvNg=
+github.com/flant/addon-operator v1.0.6-0.20220324172214-023b896ccf0d h1:vh6WBz7neXWG97IHIpjNB/50Gk05bNVvcB1C8fIF4Ls=
+github.com/flant/addon-operator v1.0.6-0.20220324172214-023b896ccf0d/go.mod h1:FeVjg7kKnWZb9JbmOTQrUNbbGwyi18ZwW5jZSga+JOU=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v0.0.6 h1:cHFMf7xGtJOgg+KBuPcA+7q+M7IJRSgf2pHVStv2aj0=
@@ -263,8 +263,8 @@ github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a h1:PlStPekqPtTSWD
 github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
 github.com/flant/logboek v0.3.4 h1://0FHwS7hoLHTz7H+JlLheKlu298edC+qV61ca9OJBQ=
 github.com/flant/logboek v0.3.4/go.mod h1:/vKAVARjAIs2OlxxDRn7SvltNVcWMb1Ifo23kCDJZco=
-github.com/flant/shell-operator v1.0.9-0.20220302082030-614d4cca72da h1:DPVDviZzDUWP3OSXB2I/Ttxu1K4fosxmDA3uHMTgcr8=
-github.com/flant/shell-operator v1.0.9-0.20220302082030-614d4cca72da/go.mod h1:bHcTpRq0k0c/kaVQl6sODi/Nz8mqmtmMk9ff9dxrpN4=
+github.com/flant/shell-operator v1.0.10-0.20220324171037-a48626e8b125 h1:XaPqZE2PtFC0DQFHMX2w84SP+bAD3tYpRbFmOZVYMQk=
+github.com/flant/shell-operator v1.0.10-0.20220324171037-a48626e8b125/go.mod h1:bHcTpRq0k0c/kaVQl6sODi/Nz8mqmtmMk9ff9dxrpN4=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=


### PR DESCRIPTION

## Description

- https://github.com/flant/shell-operator/pull/376
- https://github.com/flant/addon-operator/pull/310

## Why do we need it, and what problem does it solve?

Too much log messages on new releases.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: global
type: fix
summary: Set debug level for snapshot info messages
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
