### PR TITLE
revert: Update vsphere csi-driver and enable snapshots

### DIFF
--- a/ee/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin/Dockerfile
+++ b/ee/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_DEBIAN
 
 FROM $BASE_GOLANG_16_ALPINE as csi
 WORKDIR /src/
-RUN wget https://github.com/kubernetes-sigs/vsphere-csi-driver/archive/refs/tags/v2.5.0.tar.gz -O - | tar -xz --strip-components=1 -C /src
+RUN wget https://github.com/kubernetes-sigs/vsphere-csi-driver/archive/refs/tags/v2.4.0.tar.gz -O - | tar -xz --strip-components=1 -C /src
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o vsphere-csi cmd/vsphere-csi/main.go
 
 # support every standard Linux disk/mount utility so that CSI components won't complain

--- a/ee/modules/030-cloud-provider-vsphere/templates/csi/cm.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/templates/csi/cm.yaml
@@ -9,5 +9,4 @@ data:
   "csi-migration": "false"
   "csi-auth-check": "true"
   "online-volume-extend": "true"
-  "block-volume-snapshot": "true"
 {{- end }}

--- a/ee/modules/030-cloud-provider-vsphere/templates/csi/controller.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/templates/csi/controller.yaml
@@ -37,7 +37,7 @@
 
 {{- $csiControllerConfig := dict }}
 {{- $_ := set $csiControllerConfig "controllerImage" $csiControllerImage }}
-{{- $_ := set $csiControllerConfig "snapshotterEnabled" true }}
+{{- $_ := set $csiControllerConfig "snapshotterEnabled" false }}
 {{- $_ := set $csiControllerConfig "additionalControllerArgs" (include "csi_controller_args" . | fromYamlArray) }}
 {{- $_ := set $csiControllerConfig "additionalControllerEnvs" (include "csi_controller_envs" . | fromYamlArray) }}
 {{- $_ := set $csiControllerConfig "additionalControllerVolumes" (include "csi_controller_volumes" . | fromYamlArray) }}


### PR DESCRIPTION
## Description

This PR reverts last update of vSphere csi-driver as it is not properly tested yet

## Why do we need it, and what problem does it solve?

By an accident the changes of https://github.com/deckhouse/deckhouse/pull/1121 were merged from with https://github.com/deckhouse/deckhouse/pull/1147 we need to finish e2e tests before merging this.
