### PR TITLE
fix: fixing a typo in the error message

### DIFF
--- a/global-hooks/discovery/cluster_dns_address.go
+++ b/global-hooks/discovery/cluster_dns_address.go
@@ -78,7 +78,7 @@ func discoveryDNSAddress(input *go_hook.HookInput) error {
 	}
 
 	if dnsAddress == "" {
-		return fmt.Errorf("not found dns addreses")
+		return fmt.Errorf("DNS addresses not found")
 	}
 
 	input.Values.Set("global.discovery.clusterDNSAddress", dnsAddress)


### PR DESCRIPTION
## Description
"Address" has two "s" :-)