### PR TITLE
[deckhouse] Fix cleanup hook

### DIFF
--- a/modules/020-deckhouse/hooks/cleanup_deckhouse_releases.go
+++ b/modules/020-deckhouse/hooks/cleanup_deckhouse_releases.go
@@ -109,6 +109,7 @@ func cleanupReleases(input *go_hook.HookInput) error {
 		lastDeployed := deployedReleasesIndexes[0] // releases are reversed, that's why we have to take the first one (latest Deployed release)
 		sp := statusPatch{
 			Phase:          v1alpha1.PhaseOutdated,
+			Message:        "Outdated by cleanup hook",
 			TransitionTime: now,
 		}
 

--- a/modules/020-deckhouse/hooks/update_deckhouse_image.go
+++ b/modules/020-deckhouse/hooks/update_deckhouse_image.go
@@ -467,7 +467,7 @@ func (du *deckhouseUpdater) runReleaseDeploy(input *go_hook.HookInput, predicted
 		sp := statusPatch{
 			Phase:          v1alpha1.PhaseOutdated,
 			Approved:       currentRelease.StatusApproved,
-			Message:        "",
+			Message:        "Last Deployed release outdated",
 			TransitionTime: du.now,
 		}
 		input.PatchCollector.MergePatch(sp, "deckhouse.io/v1alpha1", "DeckhouseRelease", "", currentRelease.Name, object_patch.WithSubresource("/status"))
@@ -477,7 +477,7 @@ func (du *deckhouseUpdater) runReleaseDeploy(input *go_hook.HookInput, predicted
 		sp := statusPatch{
 			Phase:          v1alpha1.PhaseOutdated,
 			Approved:       true,
-			Message:        "",
+			Message:        "Skipped because of new patches",
 			TransitionTime: du.now,
 		}
 		for _, index := range du.skippedPatcheIndexes {


### PR DESCRIPTION
## Description
Fix hook which cleanup old Releases and also run it only at startup

## Why do we need it, and what problem does it solve?
Hook as invalid logic and sometimes in a race DeckhouseRelease can become Outdated

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse
type: fix
summary: Fix cleanup DeckhouseReleases hook
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
