### PR TITLE
[cloud-provider] ignore default disk size for checksum calculation

### DIFF
--- a/ee/modules/030-cloud-provider-vsphere/cloud-instance-manager/machine-class.checksum
+++ b/ee/modules/030-cloud-provider-vsphere/cloud-instance-manager/machine-class.checksum
@@ -1,7 +1,15 @@
 {{- $options := dict -}}
 {{- $_ := set $options "numCPUs" .nodeGroup.instanceClass.numCPUs -}}
 {{- $_ := set $options "memory" (add .nodeGroup.instanceClass.memory (mod .nodeGroup.instanceClass.memory 4)) -}}
-{{- $_ := set $options "rootDiskSize" .nodeGroup.instanceClass.rootDiskSize -}}
+
+{{- $rootDiskSize := .nil }}
+{{- if hasKey .nodeGroup.instanceClass "rootDiskSize" }}
+  {{- if ne .nodeGroup.instanceClass.rootDiskSize 20.0 }}
+    {{- $rootDiskSize = .nodeGroup.instanceClass.rootDiskSize }}
+  {{- end }}
+{{- end }}
+
+{{- $_ := set $options "rootDiskSize" $rootDiskSize -}}
 {{- $_ := set $options "template" .nodeGroup.instanceClass.template -}}
 {{- if hasKey .nodeGroup.instanceClass "resourcePool" -}}
   {{- $_ := set $options "resourcePool" .nodeGroup.instanceClass.resourcePool -}}

--- a/modules/030-cloud-provider-aws/cloud-instance-manager/machine-class.checksum
+++ b/modules/030-cloud-provider-aws/cloud-instance-manager/machine-class.checksum
@@ -7,7 +7,9 @@
   {{- $_ := set $options "spot" .nodeGroup.instanceClass.spot -}}
 {{- end -}}
 {{- if hasKey .nodeGroup.instanceClass "diskSizeGb" -}}
-  {{- $_ := set $options "diskSizeGb" .nodeGroup.instanceClass.diskSizeGb -}}
+  {{- if ne .nodeGroup.instanceClass.diskSizeGb 20.0 -}}
+    {{- $_ := set $options "diskSizeGb" .nodeGroup.instanceClass.diskSizeGb -}}
+  {{- end -}}
 {{- end -}}
 {{- if hasKey .nodeGroup.instanceClass "diskType" -}}
   {{- $_ := set $options "diskType" .nodeGroup.instanceClass.diskType -}}

--- a/modules/030-cloud-provider-azure/cloud-instance-manager/machine-class.checksum
+++ b/modules/030-cloud-provider-azure/cloud-instance-manager/machine-class.checksum
@@ -3,7 +3,9 @@
 {{- $_ := set $options "urn" .nodeGroup.instanceClass.urn -}}
 
 {{- if hasKey .nodeGroup.instanceClass "diskSizeGb" -}}
-  {{- $_ := set $options "diskSizeGb" .nodeGroup.instanceClass.diskSize -}}
+  {{- if ne .nodeGroup.instanceClass.diskSizeGb 50.0 -}}
+    {{- $_ := set $options "diskSizeGb" .nodeGroup.instanceClass.diskSize -}}
+  {{- end }}
 {{- end -}}
 
 {{- if hasKey .nodeGroup.instanceClass "diskType" -}}

--- a/modules/030-cloud-provider-gcp/cloud-instance-manager/machine-class.checksum
+++ b/modules/030-cloud-provider-gcp/cloud-instance-manager/machine-class.checksum
@@ -3,7 +3,9 @@
 {{- $_ := set $options "machineType" .nodeGroup.instanceClass.machineType -}}
 
 {{- if hasKey .nodeGroup.instanceClass "diskSizeGb" -}}
-  {{- $_ := set $options "diskSizeGb" .nodeGroup.instanceClass.diskSizeGb -}}
+  {{- if ne .nodeGroup.instanceClass.diskSizeGb .Values.nodeManager.internal.cloudProvider.gcp.diskSizeGb -}}
+    {{- $_ := set $options "diskSizeGb" .nodeGroup.instanceClass.diskSizeGb -}}
+  {{- end }}
 {{- end -}}
 
 {{- if hasKey .nodeGroup.instanceClass "diskType" -}}

--- a/modules/030-cloud-provider-gcp/cloud-instance-manager/machine-class.checksum
+++ b/modules/030-cloud-provider-gcp/cloud-instance-manager/machine-class.checksum
@@ -3,7 +3,7 @@
 {{- $_ := set $options "machineType" .nodeGroup.instanceClass.machineType -}}
 
 {{- if hasKey .nodeGroup.instanceClass "diskSizeGb" -}}
-  {{- if ne .nodeGroup.instanceClass.diskSizeGb .Values.nodeManager.internal.cloudProvider.gcp.diskSizeGb -}}
+  {{- if ne .nodeGroup.instanceClass.diskSizeGb 50.0 -}}
     {{- $_ := set $options "diskSizeGb" .nodeGroup.instanceClass.diskSizeGb -}}
   {{- end }}
 {{- end -}}

--- a/modules/030-cloud-provider-yandex/cloud-instance-manager/machine-class.checksum
+++ b/modules/030-cloud-provider-yandex/cloud-instance-manager/machine-class.checksum
@@ -10,7 +10,9 @@
 {{- end -}}
 {{- $_ := set $options "diskType" .nodeGroup.instanceClass.diskType -}}
 {{- if hasKey .nodeGroup.instanceClass "diskSizeGB" -}}
-  {{- $_ := set $options "diskSizeGB" .nodeGroup.instanceClass.diskSizeGB -}}
+  {{- if ne .nodeGroup.instanceClass.diskSizeGB 50.0 -}}
+    {{- $_ := set $options "diskSizeGB" .nodeGroup.instanceClass.diskSizeGB -}}
+  {{- end }}
 {{- end -}}
 {{- $_ := set $options "imageID" .nodeGroup.instanceClass.imageID -}}
 {{- if hasKey .nodeGroup.instanceClass "mainSubnet" }}

--- a/modules/040-node-manager/hooks/machineclass_checksum_assign_test.go
+++ b/modules/040-node-manager/hooks/machineclass_checksum_assign_test.go
@@ -374,8 +374,8 @@ internal:
   instancePrefix: myprefix
   cloudProvider:
     type: gcp
-      gcp:
-        diskSizeGb: 50
+    gcp:
+      diskSizeGb: 50
   nodeGroups:
   - name: worker
     instanceClass: # maximum filled

--- a/modules/040-node-manager/hooks/machineclass_checksum_assign_test.go
+++ b/modules/040-node-manager/hooks/machineclass_checksum_assign_test.go
@@ -374,6 +374,8 @@ internal:
   instancePrefix: myprefix
   cloudProvider:
     type: gcp
+      gcp:
+        diskSizeGb: 50
   nodeGroups:
   - name: worker
     instanceClass: # maximum filled

--- a/modules/040-node-manager/hooks/machineclass_checksum_assign_test.go
+++ b/modules/040-node-manager/hooks/machineclass_checksum_assign_test.go
@@ -374,8 +374,6 @@ internal:
   instancePrefix: myprefix
   cloudProvider:
     type: gcp
-    gcp:
-      diskSizeGb: 50
   nodeGroups:
   - name: worker
     instanceClass: # maximum filled


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Ignore disk size when calculating checksum if disk size is equal to default size.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This is to prevent the checksum changing when specifying in the instance class a disk size equal to the default value.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider
type: fix
summary: Ignore disk size when calculating checksum if disk size is equal to default size
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
