### PR TITLE
[ci] fix: state is null in slash command dispatcher

### DIFF
--- a/.github/workflow_templates/dispatch-slash-command.yml
+++ b/.github/workflow_templates/dispatch-slash-command.yml
@@ -16,28 +16,37 @@ jobs:
         uses: {!{ index (ds "actions") "actions/github-script" }!}
         with:
           script: |
+            if (!context.payload.comment.body.startsWith('/')) {
+              core.notice(`Ignore regular comment.`);
+              return;
+            }
+
             // Check for release issue.
             const isReleaseIssue = context.payload.issue.labels.some((l) => l.name === 'issue/release');
             const isPrivate = context.payload.repository.private;
             const authorAssociation = context.payload.comment.author_association;
             // Check for changelog PR.
             const isPR = !!context.payload.issue.pull_request;
-            const milestoneState = context.payload.issue.milestone.state;
+            const isMilestoned = !!context.payload.issue.milestone;
+            const milestoneState = isMilestoned && context.payload.issue.milestone.state;
             const hasChangelogLabel = context.payload.issue.labels.some((l) => l.name === 'changelog');
             const hasAutoLabel = context.payload.issue.labels.some((l) => l.name === 'auto');
             core.info(`Is release issue?       ${isReleaseIssue}`)
             core.info(`Private repo?           ${isPrivate}`)
             core.info(`Author association:     ${authorAssociation}`)
             core.info(`Is PR?                  ${isPR}`)
+            core.info(`Is milestoned?          ${isMilestoned}`)
             core.info(`Milestone state:        ${milestoneState}`)
             core.info(`Has 'changelog' label?  ${hasChangelogLabel}`)
             core.info(`Has 'auto' label?       ${hasAutoLabel}`)
 
             if (isReleaseIssue && (authorAssociation === 'OWNER' || authorAssociation === 'MEMBER' || (isPrivate && authorAssociation === 'COLLABORATOR'))) {
+              core.notice(`Comment on release issue with possible slash command.`);
               return core.setOutput('trigger_for_release_issue', 'true');
             }
 
             if (isPR && milestoneState === 'open' && hasChangelogLabel && hasAutoLabel) {
+              core.notice(`Comment on changelog pull request.`);
               return core.setOutput('trigger_for_changelog', 'true');
             }
 

--- a/.github/workflows/dispatch-slash-command.yml
+++ b/.github/workflows/dispatch-slash-command.yml
@@ -20,28 +20,37 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
+            if (!context.payload.comment.body.startsWith('/')) {
+              core.notice(`Ignore regular comment.`);
+              return;
+            }
+
             // Check for release issue.
             const isReleaseIssue = context.payload.issue.labels.some((l) => l.name === 'issue/release');
             const isPrivate = context.payload.repository.private;
             const authorAssociation = context.payload.comment.author_association;
             // Check for changelog PR.
             const isPR = !!context.payload.issue.pull_request;
-            const milestoneState = context.payload.issue.milestone.state;
+            const isMilestoned = !!context.payload.issue.milestone;
+            const milestoneState = isMilestoned && context.payload.issue.milestone.state;
             const hasChangelogLabel = context.payload.issue.labels.some((l) => l.name === 'changelog');
             const hasAutoLabel = context.payload.issue.labels.some((l) => l.name === 'auto');
             core.info(`Is release issue?       ${isReleaseIssue}`)
             core.info(`Private repo?           ${isPrivate}`)
             core.info(`Author association:     ${authorAssociation}`)
             core.info(`Is PR?                  ${isPR}`)
+            core.info(`Is milestoned?          ${isMilestoned}`)
             core.info(`Milestone state:        ${milestoneState}`)
             core.info(`Has 'changelog' label?  ${hasChangelogLabel}`)
             core.info(`Has 'auto' label?       ${hasAutoLabel}`)
 
             if (isReleaseIssue && (authorAssociation === 'OWNER' || authorAssociation === 'MEMBER' || (isPrivate && authorAssociation === 'COLLABORATOR'))) {
+              core.notice(`Comment on release issue with possible slash command.`);
               return core.setOutput('trigger_for_release_issue', 'true');
             }
 
             if (isPR && milestoneState === 'open' && hasChangelogLabel && hasAutoLabel) {
+              core.notice(`Comment on changelog pull request.`);
               return core.setOutput('trigger_for_changelog', 'true');
             }
 


### PR DESCRIPTION
## Description

Fixed 'state is null' in slash command dispatcher workflow.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Workflow should not fail on regular comments.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: fix
summary: Fixed 'state is null' in slash command dispatcher workflow.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
