### PR TITLE
[candi] Set reasonable image GC thresholds

### DIFF
--- a/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
@@ -203,8 +203,8 @@ featureGates:
   ExpandCSIVolumes: true
 fileCheckFrequency: 20s
 imageMinimumGCAge: 2m0s
-imageGCHighThresholdPercent: 50
-imageGCLowThresholdPercent: 40
+imageGCHighThresholdPercent: 85
+imageGCLowThresholdPercent: 80
 kubeAPIBurst: 50
 kubeAPIQPS: 50
 hairpinMode: promiscuous-bridge


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Parameter `evictionSoftThresholdImagefsInodesFree` is set to 10% or even smaller amount in gigabytes if node has large volume capacity. So it seems logical to run soft image GC first when there is 20% free space left and hard image GC when it is only 15% left. If GC can't free disk space, and it continues to reduce, then evictions start.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Low thresholds lead to constant launch of GC on nodes with small image fs size. And it usually leads to great amount of error events because disk space can't be reclaimed.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: Set reasonable image GC thresholds
impact_level: low
impact: Kubelet restart
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
