### PR TITLE
[prometheus-metrics-adapter] Change VPA mode to 'Initial'

### DIFF
--- a/modules/301-prometheus-metrics-adapter/templates/deployment.yaml
+++ b/modules/301-prometheus-metrics-adapter/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     kind: Deployment
     name: prometheus-metrics-adapter
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "Initial"
 {{- end }}
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
## Description
Change VPA mode to 'Initial'.

## Why do we need it, and what problem does it solve?
Prometheus metrics adapter can be restarted too often

## Changelog entries
```changes
section: prometheus-metrics-adapter
type: fix
summary: Change VPA mode to 'Initial'.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
