### PR TITLE
[istio][kiali] jaegerURLForUsers fix

### DIFF
--- a/ee/modules/110-istio/templates/kiali/configmap.yaml
+++ b/ee/modules/110-istio/templates/kiali/configmap.yaml
@@ -35,7 +35,7 @@ data:
 {{- if and .Values.istio.tracing.enabled .Values.istio.tracing.kiali }}
       tracing:
         enabled: true
-        url: {{ .Values.istio.tracing.kiali.jaegerGRPCEndpoint }}
+        url: {{ .Values.istio.tracing.kiali.jaegerURLForUsers }}
   {{- if .Values.istio.tracing.kiali.jaegerGRPCEndpoint }}
         in_cluster_url: {{ .Values.istio.tracing.kiali.jaegerGRPCEndpoint }}
         use_grpc: true


### PR DESCRIPTION
## Description
`istio.tracing.kiali.jaegerURLForUsers` parameter bugfix.

## Why do we need it, and what problem does it solve?
The `istio.tracing.kiali.jaegerURLForUsers` didn't work due to bug.

## Changelog entries
```changes
section: istio
type: fix
summary: `istio.tracing.kiali.jaegerURLForUsers` parameter bugfix.
```
