### PR TITLE
[node-manager] Validate NodeGroup has maxPerZone greater than minPerZone

### DIFF
--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -77,6 +77,16 @@ EOF
 }
 
 function __main__() {
+  minPerZone=$(context::jq -r '.review.request.object.spec.cloudInstances.minPerZone // 0')
+  maxPerZone=$(context::jq -r '.review.request.object.spec.cloudInstances.maxPerZone // 0')
+
+  if [[ "$maxPerZone" -lt "$minPerZone" ]]; then
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"it is forbidden to set maxPerZone lower than minPerZone for NodeGroup"}
+EOF
+    return 0
+  fi
+
   # cri.type cannot be changed if count of endpoints < 3
   if context::jq -e -r '.review.request.name == "master"' >/dev/null 2>&1; then
     defaultCRI="$(context::jq -r '.snapshots.cluster_config[0].filterResult' | base64 -d | grep "defaultCRI" | cut -d" " -f2)"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add validation that NodeGroup has maxPerZone greater than minPerZone

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
More validations less errors from clients

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Validate NodeGroup has maxPerZone greater than minPerZone
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
