### PR TITLE
[candi] Fix docker stuck containers cleaner pattern check

### DIFF
--- a/candi/bashible/common-steps/node-group/089_setup_timer_to_run_docker_stuck_containers_cleaner.sh.tpl
+++ b/candi/bashible/common-steps/node-group/089_setup_timer_to_run_docker_stuck_containers_cleaner.sh.tpl
@@ -39,7 +39,7 @@ function echo_err() {
 }
 
 function get_stuck_containers() {
-  sed_pattern='s/^.+Container ([a-z0-9]{64}) failed to exit within [0-9]+ seconds of signal 15 - using the force.+$/\1/p'
+  sed_pattern='s/^.+Container ([a-z0-9]{64}) failed to exit within [0-9]+ seconds of signal [0-9]+ - using the force.+$/\1/p'
   journalctl --since "$log_period_minutes min ago" -u docker.service | \
     sed -nr "$sed_pattern" | \
     sort | \


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Ignore signal check because it can be 3 or 15 or some other.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This container was ignored but should have been considered stuck.
```
Mar 29 19:43:59 kube-master-1 dockerd[1848]: time="2022-03-29T19:43:59.088143054Z" level=info msg="Container 43e187a13c0a6d5e6115a578c7b853a0f883dc0b880d4b91753e4c9eaeec08e8 failed to exit within 30 seconds of signal 3 - using the force"
```

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: Fix docker stuck containers cleaner pattern check
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
