### PR TITLE
[ingress-nginx] restore admission webhook

### DIFF
--- a/modules/402-ingress-nginx/templates/controller/admission.yaml
+++ b/modules/402-ingress-nginx/templates/controller/admission.yaml
@@ -21,7 +21,7 @@ webhooks:
       - apiGroups:
           - networking.k8s.io
         apiVersions:
-          - v1
+          - v1beta1
         operations:
           - CREATE
           - UPDATE
@@ -33,11 +33,12 @@ webhooks:
     timeoutSeconds: 15
     admissionReviewVersions:
       - v1
+      - v1beta1
     clientConfig:
       service:
         namespace: d8-ingress-nginx
         name: {{ $crd.name }}-admission
-        path: /networking/v1/ingresses
+        path: /networking/v1beta1/ingresses
       caBundle: {{ $context.Values.ingressNginx.internal.admissionCertificate.ca | b64enc }}
         {{- end }}
       {{- end }}


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Admission webhook was broken during the k8s 1.22 preparation

## Why do we need it, and what problem does it solve?
Ingresses could not be validated

## Changelog entries
```changes
section: ingress-nginx
type: fix
summary: Fix ingress admission webhook
```

