### PR TITLE
[ci] fix: no second build for tag because of variable name typo

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -133,7 +133,7 @@ steps:
         IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
 
         echo "⚓️ 💫 [$(date -u)] Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
-        if [[ -n ${DECKHOUSE_REGISTRY_PATH} ]] ; then
+        if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
           # Copy stages to prod registry from dev registry.
           werf build \
             --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -481,7 +481,7 @@ jobs:
             IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
 
             echo "⚓️ 💫 [$(date -u)] Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
-            if [[ -n ${DECKHOUSE_REGISTRY_PATH} ]] ; then
+            if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
               # Copy stages to prod registry from dev registry.
               werf build \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
@@ -748,7 +748,7 @@ jobs:
             IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
 
             echo "⚓️ 💫 [$(date -u)] Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
-            if [[ -n ${DECKHOUSE_REGISTRY_PATH} ]] ; then
+            if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
               # Copy stages to prod registry from dev registry.
               werf build \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \
@@ -1015,7 +1015,7 @@ jobs:
             IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
 
             echo "⚓️ 💫 [$(date -u)] Publish images for Git tag '${CI_COMMIT_TAG}' and registry suffix '${REGISTRY_SUFFIX}' using tag '${IMAGE_TAG}' ..."
-            if [[ -n ${DECKHOUSE_REGISTRY_PATH} ]] ; then
+            if [[ -n ${DECKHOUSE_REGISTRY_HOST} ]] ; then
               # Copy stages to prod registry from dev registry.
               werf build \
                 --repo ${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX} \


### PR DESCRIPTION
## Description

Fix typo:  DECKHOUSE_REGISTRY_PATH -> DECKHOUSE_REGISTRY_HOST

## Why do we need it, and what problem does it solve?

Build for tag not run second werf build.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: fix
summary: Fix build for tags.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
