### PR TITLE
[Upmeter] Add user-agents to http requests

### DIFF
--- a/modules/500-upmeter/images/upmeter/.golangci.yaml
+++ b/modules/500-upmeter/images/upmeter/.golangci.yaml
@@ -9,7 +9,10 @@ issues:
 
 linters-settings:
   gci:
-    local-prefixes: d8.io/upmeter
+    sections:
+      - standard
+      - default
+      - prefix(d8.io/upmeter)
   goimports:
     local-prefixes: d8.io/upmeter
   golint:
@@ -32,4 +35,3 @@ linters:
     - misspell
     - sqlclosecheck
     - unparam
-

--- a/modules/500-upmeter/images/upmeter/Makefile
+++ b/modules/500-upmeter/images/upmeter/Makefile
@@ -1,6 +1,7 @@
-GO_VERSION=1.16.3
-GOLANGCI_LINT_VERSION=1.39.0
-GOFUMPT_VERSION=0.1.1
+# https://github.com/golangci/golangci-lint
+GOLANGCI_LINT_VERSION=1.45.2
+# https://github.com/mvdan/gofumpt
+GOFUMPT_VERSION=0.3.1
 GOARCH=amd64
 UNAME=$(shell uname -s)
 

--- a/modules/500-upmeter/images/upmeter/pkg/agent/sender/client.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/sender/client.go
@@ -25,8 +25,9 @@ import (
 	"net/http"
 	"time"
 
-	"d8.io/upmeter/pkg/util"
 	log "github.com/sirupsen/logrus"
+
+	"d8.io/upmeter/pkg/util"
 )
 
 type Client struct {

--- a/modules/500-upmeter/images/upmeter/pkg/agent/sender/client.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/sender/client.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"time"
 
+	"d8.io/upmeter/pkg/util"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -66,6 +67,8 @@ func (c *Client) Send(reqBody []byte) error {
 		return fmt.Errorf("cannot create POST request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", util.AgentUserAgent)
+
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("did not send to upmeter: %v", err)

--- a/modules/500-upmeter/images/upmeter/pkg/check/series_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/check/series_test.go
@@ -176,7 +176,6 @@ func Test_StatusSeries_Merge(t *testing.T) {
 		args      args
 		wantStats Stats
 	}{
-
 		{
 			name:    "nodata 0/0 + 0/0",
 			wantErr: false,

--- a/modules/500-upmeter/images/upmeter/pkg/db/connect.go
+++ b/modules/500-upmeter/images/upmeter/pkg/db/connect.go
@@ -17,8 +17,6 @@ limitations under the License.
 package db
 
 import (
-
-	// sqlite3 driver
 	_ "github.com/mattn/go-sqlite3"
 
 	dbcontext "d8.io/upmeter/pkg/db/context"

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/http.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/http.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 
 	"d8.io/upmeter/pkg/check"
+	"d8.io/upmeter/pkg/util"
 )
 
 // httpChecker implements the checker for HTTP endpoints
@@ -76,6 +77,7 @@ func newGetRequest(endpoint, authToken string) (*http.Request, check.Error) {
 		return nil, check.ErrUnknown("cannot create request: %s", err)
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
+	req.Header.Set("User-Agent", util.AgentUserAgent)
 
 	return req, nil
 }

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/smoke_mini.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/smoke_mini.go
@@ -30,6 +30,7 @@ import (
 
 	"d8.io/upmeter/pkg/check"
 	"d8.io/upmeter/pkg/probe/util"
+	uutil "d8.io/upmeter/pkg/util"
 )
 
 // SmokeMiniAvailable is a checker constructor and configurator
@@ -170,6 +171,7 @@ func (c *smokeMiniChecker) request(ctx context.Context, ip string) error {
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, u.String(), nil)
+	req.Header.Set("User-Agent", uutil.AgentUserAgent)
 	if err != nil {
 		return err
 	}

--- a/modules/500-upmeter/images/upmeter/pkg/server/remotewrite/syncer.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/remotewrite/syncer.go
@@ -29,6 +29,7 @@ import (
 	"d8.io/upmeter/pkg/check"
 	v1 "d8.io/upmeter/pkg/crd/v1"
 	"d8.io/upmeter/pkg/db/dao"
+	"d8.io/upmeter/pkg/util"
 )
 
 var ErrSkip = fmt.Errorf("skip export")
@@ -218,6 +219,9 @@ func newExportConfig(rw *v1.RemoteWrite) exportingConfig {
 			Endpoint:    rw.Spec.Config.Endpoint,
 			BasicAuth:   rw.Spec.Config.BasicAuth,
 			BearerToken: rw.Spec.Config.BearerToken,
+			Headers: map[string]string{
+				"User-Agent": util.ServerUserAgent,
+			},
 		},
 		slotSize: time.Duration(rw.Spec.IntervalSeconds) * time.Second,
 		labels:   labels,

--- a/modules/500-upmeter/images/upmeter/pkg/server/server.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/server.go
@@ -36,6 +36,8 @@ import (
 	"d8.io/upmeter/pkg/server/remotewrite"
 )
 
+const UserAgent = "Upmeter/1.0"
+
 // server initializes all dependencies:
 // - kubernetes client
 // - crd monitor

--- a/modules/500-upmeter/images/upmeter/pkg/server/server.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/server.go
@@ -36,8 +36,6 @@ import (
 	"d8.io/upmeter/pkg/server/remotewrite"
 )
 
-const UserAgent = "Upmeter/1.0"
-
 // server initializes all dependencies:
 // - kubernetes client
 // - crd monitor

--- a/modules/500-upmeter/images/upmeter/pkg/util/env.go
+++ b/modules/500-upmeter/images/upmeter/pkg/util/env.go
@@ -21,6 +21,11 @@ import (
 	"strconv"
 )
 
+const (
+	AgentUserAgent  = "UpmeterAgent/1.0"
+	ServerUserAgent = "Upmeter/1.0"
+)
+
 func GetenvInt64(name string) int {
 	s := os.Getenv(name)
 	if s == "" || s == "0" {
@@ -33,6 +38,3 @@ func GetenvInt64(name string) int {
 	}
 	return n
 }
-
-const AgentUserAgent = "UpmeterAgent/1.0"
-const ServerUserAgent = "Upmeter/1.0"

--- a/modules/500-upmeter/images/upmeter/pkg/util/env.go
+++ b/modules/500-upmeter/images/upmeter/pkg/util/env.go
@@ -33,3 +33,6 @@ func GetenvInt64(name string) int {
 	}
 	return n
 }
+
+const AgentUserAgent = "UpmeterAgent/1.0"
+const ServerUserAgent = "Upmeter/1.0"


### PR DESCRIPTION
## Description

Specify User-Agent in all HTTP requests

## Why do we need it, and what problem does it solve?

Makes it easier to track Upmeter in logs, makes it distinguishable from "Go-http-client/2.0"

## Changelog entries

```changes
section: upmeter
type: chore
summary: Add User-Agent header to all requests
```
