### PR TITLE
[Prometheus] Add bigger sample limit to Grafana service

### DIFF
--- a/modules/300-prometheus/templates/grafana/service.yaml
+++ b/modules/300-prometheus/templates/grafana/service.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     prometheus.deckhouse.io/port: "8443"
     prometheus.deckhouse.io/tls: "true"
+    prometheus.deckhouse.io/sample-limit: "5000"
 spec:
   type: ClusterIP
   clusterIP: None

--- a/modules/300-prometheus/templates/grafana/servicemonitor.yaml
+++ b/modules/300-prometheus/templates/grafana/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main")) | nindent 2 }}
 spec:
   jobLabel: app
-  sampleLimit: 1000
+  sampleLimit: 5000
   endpoints:
   - port: https
     scheme: https


### PR DESCRIPTION
## Description

Add bigger sample limit to Grafana service

## Why do we need it, and what problem does it solve?

The number of Grafana metrics grows with time and can exceed the default limit of 1000.

## Changelog entries

```changes
section: prometheus
type: fix 
summary: Set Grafana sample limit to 5000
```
