### PR TITLE
[istio] dex authn hook fix

### DIFF
--- a/ee/modules/110-istio/hooks/external_auth.go
+++ b/ee/modules/110-istio/hooks/external_auth.go
@@ -13,7 +13,7 @@ var _ = external_auth.RegisterHook(external_auth.Settings{
 	ExternalAuthPath:            "istio.auth.externalAuthentication",
 	DexAuthenticatorEnabledPath: "istio.internal.deployDexAuthenticator",
 	DexExternalAuth: external_auth.ExternalAuth{
-		AuthURL:       "https://istio-dex-authenticator.d8-dashboard.svc.%CLUSTER_DOMAIN%/dex-authenticator/auth",
+		AuthURL:       "https://istio-dex-authenticator.d8-istio.svc.%CLUSTER_DOMAIN%/dex-authenticator/auth",
 		AuthSignInURL: "https://$host/dex-authenticator/sign_in",
 	},
 })


### PR DESCRIPTION
## Description
AuthURL fix in external_auth.go hook.

## Why do we need it, and what problem does it solve?
There was wrong namespace for AuthURL in external_auth.go hook.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries

```changes
section: istio
type: fix
summary: AuthURL fix in external_auth.go hook.
```

