### PR TITLE
[dhctl][candi][node-manager] Remove "node.kubernetes.io/exclude-from-external-load-balancers" label from control-plane nodes

### DIFF
--- a/candi/bashible/common-steps/cluster-bootstrap/070_install_control_plane.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/070_install_control_plane.sh.tpl
@@ -21,7 +21,15 @@ kubeadm init phase certs all --config /var/lib/bashible/kubeadm/config.yaml
 kubeadm init phase kubeconfig all --config /var/lib/bashible/kubeadm/config.yaml
 kubeadm init phase etcd local --config /var/lib/bashible/kubeadm/config.yaml {{ $experimentalOption }} /var/lib/bashible/kubeadm/patches
 kubeadm init phase control-plane all --config /var/lib/bashible/kubeadm/config.yaml {{ $experimentalOption }} /var/lib/bashible/kubeadm/patches
-kubeadm init phase mark-control-plane --config /var/lib/bashible/kubeadm/config.yaml
+
+# Add necessary labels to node
+# we do not use 'kubeadm init phase mark-control-plane --config /var/lib/bashible/kubeadm/config.yaml'
+# because this phase add 'node.kubernetes.io/exclude-from-external-load-balancers' label to node
+# with this label we cannot use target load balancers to control-plane nodes
+if ! bb-kubectl --kubeconfig=/etc/kubernetes/admin.conf label node "$(hostname)" node-role.kubernetes.io/master= node-role.kubernetes.io/control-plane=; then
+  echo "Cannot mark-control-plane" 1>&2
+  exit 1
+fi
 
 # Upload pki for deckhouse
 bb-kubectl --kubeconfig=/etc/kubernetes/admin.conf -n kube-system delete secret d8-pki || true

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -216,9 +216,8 @@ func (m *MetaConfig) MasterNodeGroupManifest() map[string]interface{} {
 		},
 		"nodeTemplate": map[string]interface{}{
 			"labels": map[string]interface{}{
-				"node-role.kubernetes.io/master":                          "",
-				"node-role.kubernetes.io/control-plane":                   "",
-				"node.kubernetes.io/exclude-from-external-load-balancers": "",
+				"node-role.kubernetes.io/master":        "",
+				"node-role.kubernetes.io/control-plane": "",
 			},
 			"taints": []map[string]interface{}{
 				{

--- a/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng.go
+++ b/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng.go
@@ -24,11 +24,10 @@ package hooks
 // we will add label to nodegroup template for existing clusters
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 const (

--- a/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng.go
+++ b/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng.go
@@ -27,6 +27,11 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+
+	"github.com/deckhouse/deckhouse/go_lib/set"
 )
 
 const (
@@ -36,10 +41,47 @@ const (
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnAfterHelm: &go_hook.OrderedConfig{Order: 10},
-}, addControlPlaneRoleToMasterNodeGroup)
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                "master_nodes_with_external_lb",
+			ExecuteHookOnEvents: pointer.BoolPtr(false),
+			ApiVersion:          "v1",
+			Kind:                "Node",
+			LabelSelector: &v1.LabelSelector{
+				MatchLabels: map[string]string{
+					"node-role.kubernetes.io/master": "",
+					excludeLoadBalancerLabel:         "",
+				},
+			},
+			FilterFunc: nodeWithExternalLBLabel,
+		},
+	},
+}, relabelControlPlaneNodes)
 
-func addControlPlaneRoleToMasterNodeGroup(input *go_hook.HookInput) error {
-	patch := map[string]interface{}{
+func nodeWithExternalLBLabel(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return obj.GetName(), nil
+}
+
+func relabelControlPlaneNodes(input *go_hook.HookInput) error {
+	// we have corner case
+	// all clusters on EarlyAccess and lower have label in NodeGroup nodeTemplate
+	// and removing label from NodeGroup nodeTemplate remove label from node
+	// BUT clusters on Stable and RockSolid do not have in NodeGroup nodeTemplate,
+	// but have on first control-plane node which bootstrapped with kubeadm
+	// we should remove label from node manually
+	nodePatch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"labels": map[string]interface{}{
+				excludeLoadBalancerLabel: nil,
+			},
+		},
+	}
+
+	for _, name := range set.NewFromSnapshot(input.Snapshots["master_nodes_with_external_lb"]).Slice() {
+		input.PatchCollector.MergePatch(nodePatch, "v1", "Node", "", name, object_patch.IgnoreMissingObject())
+	}
+
+	ngPatch := map[string]interface{}{
 		"spec": map[string]interface{}{
 			"nodeTemplate": map[string]interface{}{
 				"labels": map[string]interface{}{
@@ -50,7 +92,7 @@ func addControlPlaneRoleToMasterNodeGroup(input *go_hook.HookInput) error {
 		},
 	}
 
-	input.PatchCollector.MergePatch(patch, "deckhouse.io/v1", "NodeGroup", "", "master", object_patch.IgnoreMissingObject())
+	input.PatchCollector.MergePatch(ngPatch, "deckhouse.io/v1", "NodeGroup", "", "master", object_patch.IgnoreMissingObject())
 
 	return nil
 }

--- a/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng_test.go
+++ b/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = FDescribe("Global hooks :: migrate :: add_control_plane_role_to_master_ng_test ::", func() {
+var _ = Describe("Global hooks :: migrate :: add_control_plane_role_to_master_ng_test ::", func() {
 	f := HookExecutionConfigInit(`{}`, `{}`)
 
 	var nodeGroupResource = schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1", Resource: "nodegroups"}

--- a/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng_test.go
+++ b/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng_test.go
@@ -17,12 +17,11 @@ package hooks
 import (
 	"context"
 
-	"sigs.k8s.io/yaml"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/yaml"
 
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )

--- a/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng_test.go
+++ b/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng_test.go
@@ -21,9 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/yaml"
 
-	internal "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/v1"
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
@@ -162,17 +160,7 @@ spec:
 			masterNg := f.KubernetesResource("NodeGroup", "", "master")
 			workerNg := f.KubernetesResource("NodeGroup", "", "worker")
 
-			var masterNgExpected internal.NodeGroup
-			var masterNgInCluster internal.NodeGroup
-
-			err := yaml.Unmarshal([]byte(masterNgWithRoleAndExcludeLBLabel), &masterNgExpected)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = yaml.Unmarshal([]byte(masterNg.ToYaml()), &masterNgInCluster)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(masterNgExpected).To(Equal(masterNgInCluster))
-
+			Expect(masterNg.ToYaml()).To(MatchYAML(masterNgWithRoleAndExcludeLBLabel))
 			Expect(workerNg.ToYaml()).To(MatchYAML(workerNgYAML))
 		})
 	})

--- a/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng_test.go
+++ b/modules/040-node-manager/hooks/add_control_plane_role_to_master_ng_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = FDescribe("Global hooks :: migrate :: add_control_plane_role_to_master_ng_test ::", func() {
+var _ = Describe("Global hooks :: migrate :: add_control_plane_role_to_master_ng_test ::", func() {
 	f := HookExecutionConfigInit(`{}`, `{}`)
 
 	var nodeGroupResource = schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1", Resource: "nodegroups"}


### PR DESCRIPTION
## Description
Remove "node.kubernetes.io/exclude-from-external-load-balancers" label from control-plane nodes.

## Why do we need it, and what problem does it solve?
With this label we cannot use external load balancers with pods are scheduled to control-plane nodes.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: fix 
summary: Remove "node.kubernetes.io/exclude-from-external-load-balancers" label from control-plane nodes
impact_level: low
---
section: node-manager
type: fix 
summary: Add migration to remove "node.kubernetes.io/exclude-from-external-load-balancers" label from control-plane nodes
impact_level: hight
impact: |
  node.kubernetes.io/exclude-from-external-load-balancers label will be deleted from master node group and can not be set manually in current release.
  Without "node.kubernetes.io/exclude-from-external-load-balancers" label traffic can be directed to control plane nodes.
  In next release migration will delete and users can add it manually if it necessary.
---
section: candi
type: fix 
summary: Remove "node.kubernetes.io/exclude-from-external-load-balancers" label from control-plane nodes
impact_level: low
```



<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
