### PR TITLE
[user-authn] Increase authentication rate limit

### DIFF
--- a/modules/150-user-authn/templates/dex/ingress.yaml
+++ b/modules/150-user-authn/templates/dex/ingress.yaml
@@ -35,7 +35,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ include "helm_lib_module_ingress_class" . | quote }}
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-    nginx.ingress.kubernetes.io/limit-rpm: "10"
+    nginx.ingress.kubernetes.io/limit-rpm: "20"
     # Works only for ingress-controllers >=0.40. It is here to not forget to add the annotation after upgrading ingress controller.
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "2"
     # Send alert only if dex doesn't work at all (resolves issue #204).


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
The rate limit is too strict at its current state. The rate limiter permanently blocks random users from authentication for environments where all users connect to the cluster through the VPN with the same IP address.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: user-authn
type: fix
summary: Increase authentication rate limit x2
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
