### PR TITLE
[docs] Fix getting started

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER.liquid
+++ b/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER.liquid
@@ -4,7 +4,6 @@ Use a Docker image to install the **Deckhouse Platform**. It is necessary to tra
 {%- if page.platform_code == 'bm-private' %} Log in on the **[personal computer](step2.html#installation-process)** to the container image registry you specified in the previous step, then run:
 {%- else %} Run on the **[personal computer](step2.html#installation-process)**:{% endif %}
 
-
 {%- if revision == 'ee' %}
 {% snippetcut selector="docker-login" %}
 ```text
@@ -17,7 +16,7 @@ docker run --pull=always {% if page.platform_code == "kind" %} --network host {%
 {% else %}
 {% snippetcut selector="docker-login-ce" %}
 ```shell
-docker run --pull=always {% if page.platform_code == "kind" %} --network host {% endif %}-it -v "$PWD/config.yml:/config.yml"{% if page.platform_code == "bm-private" %} --dont-use-public-control-plane-images{% endif %}{%- if page.platform_type != 'existing' %} -v "$HOME/.ssh/:/tmp/.ssh/" \
+docker run --pull=always {% if page.platform_code == "kind" %} --network host {% endif %}-it -v "$PWD/config.yml:/config.yml"{%- if page.platform_type != 'existing' %} -v "$HOME/.ssh/:/tmp/.ssh/" \
 {% endif %}{% if page.platform_type == "existing" or page.platform_code == "kind" %} -v "$HOME/.kube/config:/kubeconfig" \
 {% endif %}{% if page.platform_type == "cloud" %} -v "$PWD/resources.yml:/resources.yml" -v "$PWD/dhctl-tmp:/tmp/dhctl" {% endif %}
 {%- if page.platform_code == "bm-private" %} <IMAGES_REPO_URI>:stable
@@ -45,6 +44,9 @@ dhctl bootstrap \
   --ssh-host=<master_ip> \
   --ssh-agent-private-keys=/tmp/.ssh/id_rsa \
   --config=/config.yml \
+{%- if page.platform_code == "bm-private" %}
+  --dont-use-public-control-plane-images \
+{%- endif %}
   --ask-become-pass
 {%- elsif page.platform_type == "cloud" %}
 dhctl bootstrap \

--- a/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
@@ -16,7 +16,7 @@ docker run --pull=always {% if page.platform_code == "kind" %} --network host {%
 {% else %}
 {% snippetcut selector="docker-login-ce" %}
 ```shell
-docker run --pull=always {% if page.platform_code == "kind" %} --network host {% endif %}-it -v "$PWD/config.yml:/config.yml"{% if page.platform_code == "bm-private" %} --dont-use-public-control-plane-images{% endif %}{%- if page.platform_type != 'existing' %} -v "$HOME/.ssh/:/tmp/.ssh/" \
+docker run --pull=always {% if page.platform_code == "kind" %} --network host {% endif %}-it -v "$PWD/config.yml:/config.yml"{%- if page.platform_type != 'existing' %} -v "$HOME/.ssh/:/tmp/.ssh/" \
 {% endif %}{% if page.platform_type == "existing" or page.platform_code == "kind" %} -v "$HOME/.kube/config:/kubeconfig" \
 {% endif %}{% if page.platform_type == "cloud" %} -v "$PWD/resources.yml:/resources.yml" -v "$PWD/dhctl-tmp:/tmp/dhctl" {% endif %}
 {%- if page.platform_code == "bm-private" %} <IMAGES_REPO_URI>:stable
@@ -44,6 +44,9 @@ dhctl bootstrap \
   --ssh-host=<master_ip> \
   --ssh-agent-private-keys=/tmp/.ssh/id_rsa \
   --config=/config.yml \
+{%- if page.platform_code == "bm-private" %}
+  --dont-use-public-control-plane-images \
+{%- endif %}
   --ask-become-pass
 {%- elsif page.platform_type == "cloud" %}
 dhctl bootstrap \


### PR DESCRIPTION
## Description
Getting started - Installing in a private environment: The `dont-use-public-control-plane-images` parameter was added to the dhctl command and was removed from the docker command.

## Why do we need it, and what problem does it solve?
It was a bug.

## Changelog entries
```changes
section: docs
type: fix
summary: Fix "Getting started - Installing in a private environment".
impact_level: low
```

