### PR TITLE
[docs] Fix URL in the example in the getting started

### DIFF
--- a/docs/site/_includes/getting_started/global/step_cluster_setup.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup.html
@@ -113,7 +113,7 @@
 
   <div class="form__row">
     <label class="label" title="Specify the path prefix for Deckhouse container images">
-      The path prefix for Deckhouse container images (e.g., <code>registry.deckhouse.io/deckhouse/ce/</code> for CE).
+      The path prefix for Deckhouse container images (e.g., <code>registry.deckhouse.io/deckhouse/ce</code> for CE).
     </label>
     <input
       class="textfield"

--- a/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
@@ -113,7 +113,7 @@
 
   <div class="form__row">
     <label class="label" title="Укажите префикс имени образов контейнеров Deckhouse">
-      Префикс имени образов контейнеров Deckhouse (например, для публичных образов Deckhouse редакции CE — <code>registry.deckhouse.io/deckhouse/ce/</code>).
+      Префикс имени образов контейнеров Deckhouse (например, для публичных образов Deckhouse редакции CE — <code>registry.deckhouse.io/deckhouse/ce</code>).
     </label>
     <input
       class="textfield"


### PR DESCRIPTION
## Description
Getting started - Installing in a private environment: Remove unnecessary trailing slash in the URL of a repo.

## Changelog entries
```changes
section: docs
type: fix
summary: "Getting started - Installing in a private environment: Remove unnecessary trailing slash in the URL of a repo."
impact_level: low
```
