### PR TITLE
[dhctl] Trim ending slash for imagesRepo

### DIFF
--- a/dhctl/pkg/config/load.go
+++ b/dhctl/pkg/config/load.go
@@ -50,34 +50,40 @@ func NewSchemaStore() *SchemaStore {
 		}
 	}
 
-	return newSchemaStore(paths)
+	return newOnceSchemaStore(paths)
 }
 
 func newSchemaStore(schemasDir []string) *SchemaStore {
-	once.Do(func() {
-		store = &SchemaStore{make(map[SchemaIndex]*spec.Schema)}
-		walkFunc := func(path string, info os.FileInfo, err error) error {
-			if info == nil {
-				return nil
-			}
-
-			switch info.Name() {
-			case "init_configuration.yaml", "cluster_configuration.yaml", "static_cluster_configuration.yaml", "cloud_discovery_data.yaml":
-				uploadError := store.UploadByPath(path)
-				if uploadError != nil {
-					return uploadError
-				}
-			}
-
+	st := &SchemaStore{make(map[SchemaIndex]*spec.Schema)}
+	walkFunc := func(path string, info os.FileInfo, err error) error {
+		if info == nil {
 			return nil
 		}
 
-		for _, d := range schemasDir {
-			err := filepath.Walk(d, walkFunc)
-			if err != nil {
-				panic(err)
+		switch info.Name() {
+		case "init_configuration.yaml", "cluster_configuration.yaml", "static_cluster_configuration.yaml", "cloud_discovery_data.yaml":
+			uploadError := st.UploadByPath(path)
+			if uploadError != nil {
+				return uploadError
 			}
 		}
+
+		return nil
+	}
+
+	for _, d := range schemasDir {
+		err := filepath.Walk(d, walkFunc)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return st
+}
+
+func newOnceSchemaStore(schemasDir []string) *SchemaStore {
+	once.Do(func() {
+		store = newSchemaStore(schemasDir)
 	})
 	return store
 }

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -82,6 +82,9 @@ func (m *MetaConfig) Prepare() (*MetaConfig, error) {
 			return nil, fmt.Errorf("unable to unmarshal deckhouse configuration: %v", err)
 		}
 
+		imagesRepo := strings.TrimSpace(m.DeckhouseConfig.ImagesRepo)
+		m.DeckhouseConfig.ImagesRepo = strings.TrimRight(imagesRepo, "/")
+
 		m.Registry.DockerCfg = m.DeckhouseConfig.RegistryDockerCfg
 		m.Registry.Scheme = strings.ToLower(m.DeckhouseConfig.RegistryScheme)
 		m.Registry.CA = m.DeckhouseConfig.RegistryCA

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -15,8 +15,13 @@
 package config
 
 import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
 	"testing"
+	"text/template"
 
+	"github.com/Masterminds/sprig/v3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,4 +58,109 @@ func TestGetDNSAddress(t *testing.T) {
 			require.Equal(t, testCase.result, getDNSAddress(testCase.cidr))
 		})
 	}
+}
+
+func renderTestConfig(data map[string]interface{}) string {
+	config := `
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+clusterType: Cloud
+cloud:
+  provider: Yandex
+  prefix: cluster
+podSubnetCIDR: 10.111.0.0/16
+serviceSubnetCIDR: 10.222.0.0/16
+kubernetesVersion: "1.21"
+clusterDomain: "cluster.local"
+---
+apiVersion: deckhouse.io/v1
+kind: InitConfiguration
+deckhouse:
+  devBranch: main
+  # address of the registry where the installer image is located; in this case, the default value for Deckhouse CE is set
+  imagesRepo: {{ .imagesRepo }}
+  # a special string with parameters to access Docker registry
+  registryDockerCfg: {{ .dockerCfg | b64enc }}
+  configOverrides:
+    prometheusMadisonIntegrationEnabled: false
+    global:
+      modules:
+        publicDomainTemplate: "%s.example.com"
+    nginxIngressEnabled: false
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: YandexClusterConfiguration
+layout: WithoutNAT
+masterNodeGroup:
+  replicas: 1
+  instanceClass:
+    cores: 4
+    memory: 8192
+    imageID: id
+    diskSizeGB: 50
+    externalIPAddresses:
+      - Auto
+sshPublicKey: ssh-rsa AAAA
+nodeNetworkCIDR: 10.100.0.0/21
+provider:
+  cloudID: idCloud
+  folderID: idFolder
+  serviceAccountJSON: |
+    {
+       "id": "id",
+       "service_account_id": "saID",
+       "created_at": "2020-01-01T00:00:00Z",
+       "key_algorithm": "RSA_2048",
+       "public_key": "publicKey",
+       "private_key": "privateKey"
+    }
+`
+	t := template.New("config_template").Funcs(sprig.TxtFuncMap())
+	t, err := t.Parse(config)
+	if err != nil {
+		panic(err)
+	}
+
+	var tpl bytes.Buffer
+
+	err = t.Execute(&tpl, data)
+	if err != nil {
+		panic(err)
+	}
+
+	return tpl.String()
+}
+
+func generateDockerCfg() string {
+	dockerCfgAuth := base64.StdEncoding.EncodeToString([]byte("a:b"))
+	return fmt.Sprintf(`{ "auths": { "r.example.com": { "auth": "%s" } } }`, dockerCfgAuth)
+}
+
+func TestPrepare(t *testing.T) {
+	t.Run("Registry", func(t *testing.T) {
+		dataToRender := map[string]interface{}{
+			"dockerCfg":  generateDockerCfg(),
+			"imagesRepo": "r.example.com/deckhouse/ce/",
+		}
+		configData := renderTestConfig(dataToRender)
+
+		cfg, err := ParseConfigFromData(configData)
+		require.NoError(t, err)
+
+		t.Run("Trim right slash for imagesRepo", func(t *testing.T) {
+			require.Equal(t, cfg.DeckhouseConfig.ImagesRepo, "r.example.com/deckhouse/ce")
+		})
+
+		t.Run("Correct prepare registry object", func(t *testing.T) {
+			expectedData := RegistryData{
+				Address:   "r.example.com",
+				Path:      "/deckhouse/ce",
+				Scheme:    "https",
+				CA:        "",
+				DockerCfg: "eyAiYXV0aHMiOiB7ICJyLmV4YW1wbGUuY29tIjogeyAiYXV0aCI6ICJZVHBpIiB9IH0gfQ==",
+			}
+
+			require.Equal(t, cfg.Registry, expectedData)
+		})
+	})
 }

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -115,7 +115,7 @@ provider:
        "private_key": "privateKey"
     }
 `
-	t := template.New("config_template").Funcs(sprig.TxtFuncMap())
+	t := template.New("testconfig_template").Funcs(sprig.TxtFuncMap())
 	t, err := t.Parse(config)
 	if err != nil {
 		panic(err)

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -88,7 +88,7 @@ deckhouse:
         publicDomainTemplate: "%s.example.com"
     nginxIngressEnabled: false
 ---
-apiVersion: deckhouse.io/v1alpha1
+apiVersion: deckhouse.io/v1
 kind: YandexClusterConfiguration
 layout: WithoutNAT
 masterNodeGroup:


### PR DESCRIPTION
## Description
Trim ending slash from imagesRepo.
For example, `registry.deckhouse.io/deckhouse/ce/` -> `registry.deckhouse.io/deckhouse/ce`

And add some logs for preparing MetaConfig.

## Why do we need it, and what problem does it solve?
We got incorrect images in bashible steps (`registry.deckhouse.io/deckhouse/ce/:image-for-sandbox`) and we cannot finish bootstrap.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: fix
summary: Trim ending slash for imagesRepo
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
