### PR TITLE
[user-authn] Dex usage doc fix due to new default Gitlab settings

### DIFF
--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -63,7 +63,7 @@ To do this, you need to:
 * **self-hosted**: go to `Admin area` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)` and set scopes `read_user`, `openid`;
 * **cloud gitlab.com**: under the main project account, go to `User Settings` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)`; also, don't forget to set scopes `read_user`, `openid`.
 
-**Caution!** Do not enable the `Expire access tokens` for the Application because it [will break](https://github.com/dexidp/dex/issues/2316) the integration between Dex and Gitlab.
+**Caution!** Disable the `Expire access tokens` for the Application because it [will break](https://github.com/dexidp/dex/issues/2316) the integration between Dex and Gitlab.
 
 Paste the generated `Application ID` and `Secret` into the [DexProvider](cr.html#dexprovider) custom resource.
 

--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -60,8 +60,8 @@ spec:
 Create a new application in the GitLab project.
 
 To do this, you need to:
-* **self-hosted**: go to `Admin area` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)` and set scopes `read_user`, `openid`;
-* **cloud gitlab.com**: under the main project account, go to `User Settings` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)`; also, don't forget to set scopes `read_user`, `openid`.
+* **self-hosted**: go to `Admin area` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)` and set scopes `read_user`, `openid`, disable the `Expire access tokens` checkbox;
+* **cloud gitlab.com**: under the main project account, go to `User Settings` -> `Application` -> `New application` and specify the `https://dex.<modules.publicDomainTemplate>/callback` address as the `Redirect URI (Callback url)`; also, don't forget to set scopes `read_user`, `openid`, disable the `Expire access tokens` checkbox.
 
 **Caution!** Disable the `Expire access tokens` for the Application because it [will break](https://github.com/dexidp/dex/issues/2316) the integration between Dex and Gitlab.
 

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -61,8 +61,8 @@ spec:
 В GitLab проекта необходимо создать новое приложение.
 
 Для этого необходимо:
-* **self-hosted**: перейти в `Admin area` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`;
-* **cloud gitlab.com**: под главной учетной записью проекта перейти в `User Settings` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`.
+* **self-hosted**: перейти в `Admin area` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`, выключить опцию `Expire access tokens`;
+* **cloud gitlab.com**: под главной учетной записью проекта перейти в `User Settings` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`, выключить опцию `Expire access tokens`.
 
 **Внимание!** Выключите опцию `Expire access tokens` для приложения, иначе это [сломает](https://github.com/dexidp/dex/issues/2316) интеграцию между Dex и Gitlab.
 

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -64,7 +64,7 @@ spec:
 * **self-hosted**: перейти в `Admin area` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`;
 * **cloud gitlab.com**: под главной учетной записью проекта перейти в `User Settings` -> `Application` -> `New application` и в качестве `Redirect URI (Callback url)` указать адрес `https://dex.<modules.publicDomainTemplate>/callback`, scopes выбрать: `read_user`, `openid`.
 
-**Внимание!** Не включайте опцию `Expire access tokens` для приложения, потому что это [сломает](https://github.com/dexidp/dex/issues/2316) интеграцию между Dex и Gitlab.
+**Внимание!** Выключите опцию `Expire access tokens` для приложения, иначе это [сломает](https://github.com/dexidp/dex/issues/2316) интеграцию между Dex и Gitlab.
 
 Полученные `Application ID` и `Secret` необходимо указать в custom resource [DexProvider](cr.html#dexprovider).
 


### PR DESCRIPTION
## Description
Dex usage doc fix due to new default Gitlab settings.

## Why do we need it, and what problem does it solve?
The `Expire access tokens` checkbox is turned on by default in fresh Gitlab versions.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Dex usage doc fix due to new default Gitlab settings.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
