### PR TITLE
[chrony] Increase livenessProbe timeout

### DIFF
--- a/modules/470-chrony/templates/daemonset.yaml
+++ b/modules/470-chrony/templates/daemonset.yaml
@@ -77,7 +77,7 @@ spec:
             - tracking
           initialDelaySeconds: 30
           periodSeconds: 60
-          timeoutSeconds: 5
+          timeoutSeconds: 15
         volumeMounts:
         - name: tz-config
           mountPath: /etc/localtime
@@ -99,4 +99,3 @@ spec:
           path: /etc/timezone
       - name: chrony
         emptyDir: {}
-


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Increased `chronyc tracking` livenessProbe timeout to 15 seconds.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Sometimes chrony daemon takes longer than 5 seconds to provide tracking information, this leads to constant restarts of chrony container.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: chrony
type: fix
summary: chrony's container livenessProbe's timeout increased from 5 to 15 seconds
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
