### PR TITLE
[monitoring] [grafana] sampleLimit increasing

### DIFF
--- a/ee/fe/modules/340-monitoring-applications/templates/service-monitors/grafana.yaml
+++ b/ee/fe/modules/340-monitoring-applications/templates/service-monitors/grafana.yaml
@@ -1,3 +1,3 @@
 {{- if .Values.monitoringApplications.internal.enabledApplicationsSummary | has "grafana" }}
-{{ include "base_application_monitor" (list . "grafana" 1000) }}
+{{ include "base_application_monitor" (list . "grafana" 1500) }}
 {{- end }}

--- a/modules/300-prometheus/templates/grafana/servicemonitor.yaml
+++ b/modules/300-prometheus/templates/grafana/servicemonitor.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main")) | nindent 2 }}
 spec:
   jobLabel: app
-  sampleLimit: 1000
+  sampleLimit: 1500
   endpoints:
   - port: https
     scheme: https


### PR DESCRIPTION
## Description
sampleLimit increasing for grafana Target.

## Why do we need it, and what problem does it solve?
There is a cluster where we've [Pushed It To The Limit](https://www.youtube.com/watch?v=3-3Yok5D3Aw) (1063 metrics).

## Changelog entries

```changes
section: monitoring
type: fix
summary: increases sampleLimit for grafana Target.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
