### PR TITLE
[control-plane-manager] Add list from all namespaces to audit log by default

### DIFF
--- a/modules/040-control-plane-manager/hooks/audit_policy.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy.go
@@ -215,6 +215,17 @@ func appendBasicPolicyRules(policy *audit.Policy) {
 		}
 		policy.Rules = append(policy.Rules, rule)
 	}
+	// Collect all LIST operations for all namespaces since they consume a lot of
+	// apiserver memory sometimes and are a mean to debug OOMs.
+	{
+		rule := audit.PolicyRule{
+			Level:      audit.LevelMetadata,
+			Verbs:      []string{"list"},
+			Namespaces: []string{}, // every namespace
+			// no stage omitted, since apiserver might crash with OOM before it responds, and we want to catch it
+		}
+		policy.Rules = append(policy.Rules, rule)
+	}
 }
 
 func appendAdditionalPolicyRules(policy *audit.Policy, data *[]byte) error {

--- a/modules/040-control-plane-manager/hooks/audit_policy_test.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy_test.go
@@ -168,17 +168,22 @@ rules:
 			var policy audit.Policy
 			_ = yaml.UnmarshalStrict(data, &policy)
 
-			// All rules, except last two are dropping rules.
-			for i := 0; i < len(policy.Rules)-2; i++ {
+			// All rules, except last three are dropping rules.
+			for i := 0; i < len(policy.Rules)-3; i++ {
 				Expect(policy.Rules[i].Level).To(Equal(audit.LevelNone))
 			}
 
-			saRule := policy.Rules[len(policy.Rules)-2]
+			saRule := policy.Rules[len(policy.Rules)-3]
 			Expect(saRule.Level).To(Equal(audit.LevelMetadata))
 			Expect(saRule.Users).To(Equal(auditPolicyBasicServiceAccounts))
-			namespaceRule := policy.Rules[len(policy.Rules)-1]
+
+			namespaceRule := policy.Rules[len(policy.Rules)-2]
 			Expect(namespaceRule.Level).To(Equal(audit.LevelMetadata))
 			Expect(namespaceRule.Namespaces).To(Equal(auditPolicyBasicNamespaces))
+
+			listRule := policy.Rules[len(policy.Rules)-1]
+			Expect(listRule.Level).To(Equal(audit.LevelMetadata))
+			Expect(listRule.Namespaces).To(Equal([]string{}) )
 		})
 	})
 })

--- a/modules/040-control-plane-manager/hooks/audit_policy_test.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy_test.go
@@ -183,7 +183,7 @@ rules:
 
 			listRule := policy.Rules[len(policy.Rules)-1]
 			Expect(listRule.Level).To(Equal(audit.LevelMetadata))
-			Expect(listRule.Namespaces).To(Equal([]string{}) )
+			Expect(listRule.Namespaces).To(BeEmpty())
 		})
 	})
 })


### PR DESCRIPTION
## Description

Add listing object from all namespaces to default audit policy.

## Why do we need it, and what problem does it solve?

Helps debugging kube-apiserver OOMs caused by list operations.

## Changelog entries

```changes
section: control-plane-manager
type: feature
summary: Add listing object from all namespaces to default audit policy.
impact_level: low
```
