### PR TITLE
[cloud-provider-openstack] Remove default podNetworkMode from config-values

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/openapi/config-values.yaml
+++ b/ee/modules/030-cloud-provider-openstack/openapi/config-values.yaml
@@ -69,7 +69,6 @@ properties:
       type: string
   podNetworkMode:
     type: string
-    default: "DirectRoutingWithPortSecurityEnabled"
     description: |
       Sets the traffic mode for the network that the pods use to communicate with each other (usually, it is an internal network; however, there can be exceptions):
         * `DirectRouting` — means that there is a direct routing between the nodes;


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Value of `podNetworkMode` must be discovered from cloud-discovery-data and can be overwritten from Deckhouse config.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Default value broke automatic discovery that worked previously.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-openstack
type: fix
summary: Remove default podNetworkMode from config-values
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a modules/*>, like "cloud-provider-aws", "node-manager"
  - "dhctl"
  - "candi"
  - "deckhouse-controller"
  - *_lib
  - "docs", includes website changes, should always have low impact
  - "tests", should always have low impact
  - "tools", should always have low impact
  - "ci", should always have low impact
  - "global" affects all possible modules at once, discouraged if only a few of modules affected, it is better to have multiple exact changes

-->
