### PR TITLE
[node-group] minPerZone = 0 while maxPerZone > 0 validation

### DIFF
--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -87,6 +87,13 @@ EOF
     return 0
   fi
 
+  if [[ "$minPerZone" -eq 0 && "$maxPerZone" -gt 0 ]]; then
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"it is forbidden to set minPerZone to zero while maxPerZone is greater than zero"}
+EOF
+    return 0
+  fi
+
   # cri.type cannot be changed if count of endpoints < 3
   if context::jq -e -r '.review.request.name == "master"' >/dev/null 2>&1; then
     defaultCRI="$(context::jq -r '.snapshots.cluster_config[0].filterResult' | base64 -d | grep "defaultCRI" | cut -d" " -f2)"


### PR DESCRIPTION
## Description
NodeGroup validation to forbid minPerZone = 0 while maxPerZone > 0.

(I am not sure it is a relevant solution, there could be NG without nodes but they must autoscale after deploying some Pod with appropriate nodeSelector).

## Why do we need it, and what problem does it solve?
 Closes #1241.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-group
type: feature
summary: NodeGroup validation to forbid minPerZone = 0 while maxPerZone > 0
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
