### PR TITLE
[ingress-nginx] VHost Detail: select all locations by default

### DIFF
--- a/modules/402-ingress-nginx/monitoring/grafana-dashboards/ingress-nginx/vhost/vhost_detail.json
+++ b/modules/402-ingress-nginx/monitoring/grafana-dashboards/ingress-nginx/vhost/vhost_detail.json
@@ -10013,9 +10013,8 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": false,
-          "text": "grafana.sandbox.n-mitrofanov.hf.flant.com",
-          "value": "grafana.sandbox.n-mitrofanov.hf.flant.com"
+          "text": "example.com",
+          "value": "example.com"
         },
         "datasource": "$ds_prometheus",
         "definition": "",
@@ -10045,10 +10044,10 @@
         "current": {
           "selected": true,
           "text": [
-            "/"
+            "All"
           ],
           "value": [
-            "/"
+            "$__all"
           ]
         },
         "datasource": "$ds_prometheus",


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
Closes https://github.com/deckhouse/deckhouse/issues/754?utm=ford_plain-number-sign

## Changelog entries
```changes
section: ingress-nginx
type: fix
summary: Make the VHost Detail dashboard show all locations by default
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
