### PR TITLE
[user-authn] Do not wait for deleting publish API secret

### DIFF
--- a/modules/150-user-authn/hooks/discover_publish_api_cert.go
+++ b/modules/150-user-authn/hooks/discover_publish_api_cert.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -104,7 +105,7 @@ func discoverPublishAPICA(input *go_hook.HookInput) error {
 			continue
 		}
 
-		input.PatchCollector.Delete("v1", "Secret", "d8-user-authn", name)
+		input.PatchCollector.Delete("v1", "Secret", "d8-user-authn", name, object_patch.InBackground())
 	}
 
 	if len(cert) > 0 {


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
Closes https://github.com/deckhouse/deckhouse/issues/1045

## Changelog entries

```changes
section: user-authn
type: fix
summary: Do not wait for deleting publish API secret
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
