### PR TITLE
[Upmeter] Add trailing dot to cluster domain resolving

### DIFF
--- a/modules/500-upmeter/images/upmeter/pkg/kubernetes/access.go
+++ b/modules/500-upmeter/images/upmeter/pkg/kubernetes/access.go
@@ -124,7 +124,7 @@ func (a *Accessor) Init(config *Config) error {
 
 	a.cloudControllerManagerNamespace = config.CloudControllerManagerNamespace
 
-	a.kubernetesDomain = "kubernetes.default.svc." + config.ClusterDomain
+	a.kubernetesDomain = "kubernetes.default.svc." + config.ClusterDomain + "." // Trailing dot to avoid domain search
 
 	return nil
 }

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/smoke_mini.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/smoke_mini.go
@@ -202,26 +202,24 @@ func (d DnsAvailable) Checker() check.Checker {
 		timeout: d.DnsTimeout,
 	}
 	return &dnsChecker{
-		domain:   d.Domain,
 		lookuper: lkp,
-		logger:   d.Logger,
+		logger:   d.Logger.WithField("domain", d.Domain),
 	}
 }
 
 type dnsChecker struct {
 	lookuper lookuper
-	domain   string
 	logger   *log.Entry
 }
 
 func (c *dnsChecker) BusyWith() string {
-	return "resolving " + c.domain
+	return "resolving"
 }
 
 func (c *dnsChecker) Check() check.Error {
 	_, err := c.lookuper.Lookup()
 	if err != nil {
-		return check.ErrFail("cannot resolve %s", c.domain)
+		return check.ErrFail("resolve: %w", err)
 	}
 	return nil
 }
@@ -258,10 +256,10 @@ func lookupAndShuffleIPs(name string, resolveTimeout time.Duration) ([]string, e
 	// lookup
 	ips, err := util.LookupIPs(name, resolveTimeout)
 	if err != nil {
-		return nil, fmt.Errorf("resolve '%s': %v", name, err)
+		return nil, fmt.Errorf("cannot resolve '%s': %v", name, err)
 	}
 	if len(ips) == 0 {
-		return nil, fmt.Errorf("resolve get 0 IPs for '%s'", name)
+		return nil, fmt.Errorf("resolved no addresses for '%s'", name)
 	}
 
 	// shuffle


### PR DESCRIPTION
## Description

Resolve cluster domain with trailing dot.

## Why do we need it, and what problem does it solve?

Lets us avoid name search latency and expose DNS queries to the internet DNS.

## Changelog entries

```changes
section: upmeter
type: fix
summary: Upmeter no longer exposes DNS queries to the Internet
```
