### PR TITLE
[prometheus-metrics-adapter] Restore config file for proxy

### DIFF
--- a/modules/301-prometheus-metrics-adapter/images/prometheus-reverse-proxy/main.go
+++ b/modules/301-prometheus-metrics-adapter/images/prometheus-reverse-proxy/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -194,6 +195,10 @@ func httpProxyPass(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	listenAddr := "0.0.0.0:8000"
+
+	if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
+		logger.Fatalf("Config file %s does not exist", configPath)
+	}
 
 	initHttpTransport()
 

--- a/modules/301-prometheus-metrics-adapter/templates/deployment.yaml
+++ b/modules/301-prometheus-metrics-adapter/templates/deployment.yaml
@@ -83,6 +83,10 @@ spec:
         env:
         - name: PROMETHEUS_URL
           value: "https://trickster.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}"
+        volumeMounts:
+        - mountPath: /etc/prometheus-reverse-proxy/
+          name: prometheus-metrics-adapter-config
+          readOnly: true
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Restore VolumeMount for prometheus-metrics-adapter proxy. Also check file existence on startup and logging fatal if file is absent.

## Why do we need it, and what problem does it solve?
VolumeMount was removed during the last update. Without this file custom-metrics-handler panics on requests. But it was hidden inside logs. 

## Changelog entries


```changes
section: prometheus-metrics-adapter
type: fix
summary: Fix custom metrics workability
```

