### PR TITLE
[cloud-provider-azure] Enable accelerated networking for new machine-controller-manager instances

### DIFF
--- a/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
@@ -159,7 +159,7 @@ apiVersions:
                   type: string
               acceleratedNetworking:
                 type: boolean
-                x-doc-default: true
+                default: false
                 description: |
                   Accelerated Networking providing up to 30Gbps in networking throughput.
       nodeGroups:

--- a/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
@@ -161,7 +161,7 @@ apiVersions:
                 type: boolean
                 default: false
                 description: |
-                  Accelerated Networking providing up to 30Gbps in networking throughput.
+                  Accelerated Networking provides up to 30Gbps in networking throughput.
       nodeGroups:
         description: |
           An array of additional NodeGroups for creating static nodes (e.g., for dedicated front nodes or gateways).

--- a/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
@@ -157,6 +157,11 @@ apiVersions:
                 type: object
                 additionalProperties:
                   type: string
+              acceleratedNetworking:
+                type: boolean
+                x-doc-default: true
+                description: |
+                  Accelerated Networking providing up to 30Gbps in networking throughput.
       nodeGroups:
         description: |
           An array of additional NodeGroups for creating static nodes (e.g., for dedicated front nodes or gateways).

--- a/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
@@ -102,6 +102,7 @@ apiVersions:
                 description: |
                   Список дополнительных тегов в формате `key: value`, которые будут назначены инстансам.
               acceleratedNetworking:
+                default: false
                 description: |
                   Accelerated Networking обеспечивает пропускную способность сети до 30 Гбит/с.
       nodeGroups:

--- a/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
@@ -101,6 +101,9 @@ apiVersions:
               additionalTags:
                 description: |
                   Список дополнительных тегов в формате `key: value`, которые будут назначены инстансам.
+              acceleratedNetworking:
+                description: |
+                  Accelerated Networking обеспечивает пропускную способность сети до 30 Гбит/с.
       nodeGroups:
         description: |
           Массив дополнительных NodeGroup для создания статичных узлов (например, для выделенных frontend-узлов или шлюзов).

--- a/candi/cloud-providers/azure/openapi/doc-ru-instance_class.yaml
+++ b/candi/cloud-providers/azure/openapi/doc-ru-instance_class.yaml
@@ -45,5 +45,8 @@ spec:
                 additionalTags:
                   description: |
                     Дополнительные теги, которые будут присвоены созданным инстансам.
+                acceleratedNetworking:
+                  description: |
+                    Accelerated Networking обеспечивает пропускную способность сети до 30 Гбит/с.
     - name: v1
       schema: *schema

--- a/candi/cloud-providers/azure/openapi/instance_class.yaml
+++ b/candi/cloud-providers/azure/openapi/instance_class.yaml
@@ -74,6 +74,11 @@ spec:
                   additionalProperties:
                     type: string
                   x-kubernetes-preserve-unknown-fields: true
+                acceleratedNetworking:
+                  type: boolean
+                  default: true
+                  description: |
+                    Accelerated Networking providing up to 30Gbps in networking throughput.
     - name: v1
       served: true
       storage: false

--- a/candi/cloud-providers/azure/openapi/instance_class.yaml
+++ b/candi/cloud-providers/azure/openapi/instance_class.yaml
@@ -77,7 +77,7 @@ spec:
                 acceleratedNetworking:
                   type: boolean
                   description: |
-                    Accelerated Networking providing up to 30Gbps in networking throughput.
+                    Accelerated Networking provides up to 30Gbps in networking throughput.
                   x-doc-default: true
     - name: v1
       served: true

--- a/candi/cloud-providers/azure/openapi/instance_class.yaml
+++ b/candi/cloud-providers/azure/openapi/instance_class.yaml
@@ -76,9 +76,9 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 acceleratedNetworking:
                   type: boolean
-                  default: true
                   description: |
                     Accelerated Networking providing up to 30Gbps in networking throughput.
+                  x-doc-default: true
     - name: v1
       served: true
       storage: false

--- a/candi/cloud-providers/azure/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/azure/terraform-modules/master-node/main.tf
@@ -43,7 +43,8 @@ resource "azurerm_network_interface" "master" {
   location            = data.azurerm_resource_group.kube.location
   resource_group_name = data.azurerm_resource_group.kube.name
 
-  enable_ip_forwarding = true
+  enable_ip_forwarding          = true
+  enable_accelerated_networking = local.accelerated_networking
 
   ip_configuration {
     name                          = local.prefix

--- a/candi/cloud-providers/azure/terraform-modules/master-node/variables.tf
+++ b/candi/cloud-providers/azure/terraform-modules/master-node/variables.tf
@@ -40,19 +40,20 @@ variable "clusterUUID" {
 }
 
 locals {
-  prefix             = var.clusterConfiguration.cloud.prefix
-  admin_username     = "azureuser"
-  machine_size       = var.providerClusterConfiguration.masterNodeGroup.instanceClass.machineSize
-  ssh_public_key     = var.providerClusterConfiguration.sshPublicKey
-  disk_type          = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskType", "StandardSSD_LRS")
-  disk_size_gb       = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskSizeGb", 50)
-  enable_external_ip = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "enableExternalIP", false)
-  urn                = split(":", var.providerClusterConfiguration.masterNodeGroup.instanceClass.urn)
-  image_publisher    = local.urn[0]
-  image_offer        = local.urn[1]
-  image_sku          = local.urn[2]
-  image_version      = local.urn[3]
-  actual_zones       = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(["1", "2", "3"], var.providerClusterConfiguration.zones)) : ["1", "2", "3"]
-  zones              = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", null) != null ? tolist(setintersection(local.actual_zones, var.providerClusterConfiguration.masterNodeGroup["zones"])) : local.actual_zones
-  additional_tags    = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalTags", {}))
+  prefix                 = var.clusterConfiguration.cloud.prefix
+  admin_username         = "azureuser"
+  machine_size           = var.providerClusterConfiguration.masterNodeGroup.instanceClass.machineSize
+  ssh_public_key         = var.providerClusterConfiguration.sshPublicKey
+  disk_type              = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskType", "StandardSSD_LRS")
+  disk_size_gb           = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskSizeGb", 50)
+  enable_external_ip     = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "enableExternalIP", false)
+  urn                    = split(":", var.providerClusterConfiguration.masterNodeGroup.instanceClass.urn)
+  image_publisher        = local.urn[0]
+  image_offer            = local.urn[1]
+  image_sku              = local.urn[2]
+  image_version          = local.urn[3]
+  actual_zones           = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(["1", "2", "3"], var.providerClusterConfiguration.zones)) : ["1", "2", "3"]
+  zones                  = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", null) != null ? tolist(setintersection(local.actual_zones, var.providerClusterConfiguration.masterNodeGroup["zones"])) : local.actual_zones
+  additional_tags        = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalTags", {}))
+  accelerated_networking = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "acceleratedNetworking", true)
 }

--- a/candi/cloud-providers/azure/terraform-modules/master-node/variables.tf
+++ b/candi/cloud-providers/azure/terraform-modules/master-node/variables.tf
@@ -55,5 +55,5 @@ locals {
   actual_zones           = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(["1", "2", "3"], var.providerClusterConfiguration.zones)) : ["1", "2", "3"]
   zones                  = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", null) != null ? tolist(setintersection(local.actual_zones, var.providerClusterConfiguration.masterNodeGroup["zones"])) : local.actual_zones
   additional_tags        = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalTags", {}))
-  accelerated_networking = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "acceleratedNetworking", true)
+  accelerated_networking = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "acceleratedNetworking", false)
 }

--- a/candi/cloud-providers/azure/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/azure/terraform-modules/static-node/main.tf
@@ -43,7 +43,8 @@ resource "azurerm_network_interface" "node" {
   location            = data.azurerm_resource_group.kube.location
   resource_group_name = data.azurerm_resource_group.kube.name
 
-  enable_ip_forwarding = true
+  enable_ip_forwarding          = true
+  enable_accelerated_networking = local.accelerated_networking
 
   ip_configuration {
     name                          = local.prefix

--- a/candi/cloud-providers/azure/terraform-modules/static-node/variables.tf
+++ b/candi/cloud-providers/azure/terraform-modules/static-node/variables.tf
@@ -57,5 +57,5 @@ locals {
   actual_zones           = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(["1", "2", "3"], var.providerClusterConfiguration.zones)) : ["1", "2", "3"]
   zones                  = lookup(local.node_group, "zones", null) != null ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones
   additional_tags        = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(local.node_group.instanceClass, "additionalTags", {}))
-  accelerated_networking = lookup(local.node_group.instanceClass, "acceleratedNetworking", true)
+  accelerated_networking = lookup(local.node_group.instanceClass, "acceleratedNetworking", false)
 }

--- a/candi/cloud-providers/azure/terraform-modules/static-node/variables.tf
+++ b/candi/cloud-providers/azure/terraform-modules/static-node/variables.tf
@@ -39,22 +39,23 @@ variable "nodeGroupName" {
 }
 
 locals {
-  prefix             = var.clusterConfiguration.cloud.prefix
-  admin_username     = "azureuser"
-  ssh_public_key     = var.providerClusterConfiguration.sshPublicKey
-  node_groups        = lookup(var.providerClusterConfiguration, "nodeGroups", [])
-  node_group         = [for i in local.node_groups : i if i.name == var.nodeGroupName][0]
-  node_group_name    = local.node_group.name
-  machine_size       = local.node_group.instanceClass.machineSize
-  disk_type          = lookup(local.node_group.instanceClass, "diskType", "StandardSSD_LRS")
-  disk_size_gb       = lookup(local.node_group.instanceClass, "diskSizeGb", 50)
-  enable_external_ip = lookup(local.node_group.instanceClass, "enableExternalIP", false)
-  urn                = split(":", local.node_group.instanceClass.urn)
-  image_publisher    = local.urn[0]
-  image_offer        = local.urn[1]
-  image_sku          = local.urn[2]
-  image_version      = local.urn[3]
-  actual_zones       = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(["1", "2", "3"], var.providerClusterConfiguration.zones)) : ["1", "2", "3"]
-  zones              = lookup(local.node_group, "zones", null) != null ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones
-  additional_tags    = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(local.node_group.instanceClass, "additionalTags", {}))
+  prefix                 = var.clusterConfiguration.cloud.prefix
+  admin_username         = "azureuser"
+  ssh_public_key         = var.providerClusterConfiguration.sshPublicKey
+  node_groups            = lookup(var.providerClusterConfiguration, "nodeGroups", [])
+  node_group             = [for i in local.node_groups : i if i.name == var.nodeGroupName][0]
+  node_group_name        = local.node_group.name
+  machine_size           = local.node_group.instanceClass.machineSize
+  disk_type              = lookup(local.node_group.instanceClass, "diskType", "StandardSSD_LRS")
+  disk_size_gb           = lookup(local.node_group.instanceClass, "diskSizeGb", 50)
+  enable_external_ip     = lookup(local.node_group.instanceClass, "enableExternalIP", false)
+  urn                    = split(":", local.node_group.instanceClass.urn)
+  image_publisher        = local.urn[0]
+  image_offer            = local.urn[1]
+  image_sku              = local.urn[2]
+  image_version          = local.urn[3]
+  actual_zones           = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(["1", "2", "3"], var.providerClusterConfiguration.zones)) : ["1", "2", "3"]
+  zones                  = lookup(local.node_group, "zones", null) != null ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones
+  additional_tags        = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(local.node_group.instanceClass, "additionalTags", {}))
+  accelerated_networking = lookup(local.node_group.instanceClass, "acceleratedNetworking", true)
 }

--- a/modules/030-cloud-provider-azure/cloud-instance-manager/machine-class.checksum
+++ b/modules/030-cloud-provider-azure/cloud-instance-manager/machine-class.checksum
@@ -16,6 +16,12 @@
   {{- $_ := set $options "additionalTags" .nodeGroup.instanceClass.additionalTags -}}
 {{- end -}}
 
+{{- if hasKey .nodeGroup.instanceClass "acceleratedNetworking" -}}
+  {{- if ne .nodeGroup.instanceClass.acceleratedNetworking true -}}
+    {{- $_ := set $options "acceleratedNetworking" .nodeGroup.instanceClass.acceleratedNetworking -}}
+  {{- end -}}
+{{- end -}}
+
 {{- if (index .nodeGroup "manualRolloutID") -}}
   {{ $_ := set $options "manualRolloutID" (index .nodeGroup "manualRolloutID") -}}
 {{- end -}}

--- a/modules/030-cloud-provider-azure/cloud-instance-manager/machine-class.yaml
+++ b/modules/030-cloud-provider-azure/cloud-instance-manager/machine-class.yaml
@@ -44,4 +44,4 @@ spec:
             keyData: {{ .Values.nodeManager.internal.cloudProvider.azure.sshPublicKey }}
     zone: {{ .zoneName }}
     networkProfile:
-      acceleratedNetworking: {{ .nodeGroup.instanceClass.acceleratedNetworking }}
+      acceleratedNetworking: {{ .nodeGroup.instanceClass.acceleratedNetworking | default true }}

--- a/modules/030-cloud-provider-azure/cloud-instance-manager/machine-class.yaml
+++ b/modules/030-cloud-provider-azure/cloud-instance-manager/machine-class.yaml
@@ -43,3 +43,5 @@ spec:
             path: /home/azureuser/.ssh/authorized_keys
             keyData: {{ .Values.nodeManager.internal.cloudProvider.azure.sshPublicKey }}
     zone: {{ .zoneName }}
+    networkProfile:
+      acceleratedNetworking: {{ .nodeGroup.instanceClass.acceleratedNetworking }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

- Accelerated networking is enabled by default for new machine-controller-manager instances.
  - If you want your existing nodes to have accelerated networking enabled, you have to [roll out update](https://deckhouse.io/en/documentation/v1/modules/040-node-manager/faq.html#how-do-i-redeploy-ephemeral-machines-in-the-cloud-with-a-new-configuration) them or just delete.
  - To disable set `.spec.acceleratedNetworking` to `false` in AzureInstanceClass.
- The master and static nodes are set to `acceleratedNetworking=false` by default to automatically add it to AzureClusterConfiguration, which will allow us to change the default value later without any problems.
  - To enable set `.spec.acceleratedNetworking` to `true` and do `dhctl converge`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
[Accelerated networking](https://azure.microsoft.com/fr-fr/blog/maximize-your-vm-s-performance-with-accelerated-networking-now-generally-available-for-both-windows-and-linux/) is a stable feature that helps to improve performance of vm in Azure cloud.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-azure
type: feature
summary: Enable accelerated networking for new machine-controller-manager instances.
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
