### PR TITLE
[prometheus] Show instant values on Grafana home dashboard

### DIFF
--- a/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
+++ b/modules/300-prometheus/images/grafana/grafana_home_dashboard.json
@@ -367,6 +367,7 @@
         {
           "exemplar": true,
           "expr": "sum by (version, edition) (deckhouse_build_info{job=\"deckhouse\"})",
+          "instant": true,
           "interval": "",
           "legendFormat": "{{ version }} {{ edition }}",
           "refId": "A"
@@ -426,6 +427,7 @@
         {
           "exemplar": true,
           "expr": "sum by (git_version) (kubernetes_build_info{job=\"kube-apiserver\"})",
+          "instant": true,
           "interval": "",
           "legendFormat": "{{ git_version }}",
           "refId": "A"
@@ -511,6 +513,7 @@
         {
           "exemplar": true,
           "expr": "sum by (container_runtime_version) (kube_node_info)",
+          "instant": true,
           "interval": "",
           "legendFormat": "{{ container_runtime_version }}",
           "refId": "A"


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
It may puzzle a user if there is more than one version of Deckhouse/Kubernetes control plane in a cluster.

## Changelog entries


```changes
section: prometheus
type: fix
summary: Do not show more than one value on home Grafana dashboard stat panels
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
