### PR TITLE
[docs] Proper display of the mandatory use of the parameter on the site

### DIFF
--- a/docs/documentation/_plugins/openapi.rb
+++ b/docs/documentation/_plugins/openapi.rb
@@ -304,7 +304,7 @@ module Jekyll
                 # object items
                 result.push('<ul>')
                 attributes['items']["properties"].sort.to_h.each do |item_key, item_value|
-                    result.push(format_schema(item_key, item_value, attributes['items'], get_hash_value(primaryLanguage,"items", "properties", item_key) , get_hash_value(fallbackLanguage,"items", "properties", item_key), fullPath))
+                    result.push(format_schema(item_key, item_value, attributes, get_hash_value(primaryLanguage,"items", "properties", item_key) , get_hash_value(fallbackLanguage,"items", "properties", item_key), fullPath))
                 end
                 result.push('</ul>')
             else


### PR DESCRIPTION
## Description
In some cases, the openAPI schema generator didn't display the mandatory use of the parameter.

## Changelog entries
```changes
section: docs
type: fix
summary: Proper display of the mandatory use of the parameter.
impact_level: low
```
