### PR TITLE
[monitoring-kubernetes] Removed many-to-many matching case in ebpf-exporter recording rules

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/ebpf-exporter.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/ebpf-exporter.yaml
@@ -5,9 +5,11 @@
       max by (namespace, pod) (
         label_replace(kube_pod_info, "raw_pod_id", "$1$2$3$4$5", "uid", "(.+)-(.+)-(.+)-(.+)-(.+)")
         * on (raw_pod_id) group_left
-        label_replace(
-          label_replace(ebpf_exporter_oom_kills{global_oom="0", cgroup_path=~".*slice.*"}, "raw_pod_id", "$1", "cgroup_path", ".+-pod(.+).slice"),
-          "raw_pod_id", "$1$2$3$4$5", "raw_pod_id", "(.+)_(.+)_(.+)_(.+)_(.+)"
+        max by (raw_pod_id) (
+          label_replace(
+            label_replace(ebpf_exporter_oom_kills{global_oom="0", cgroup_path=~".*slice.*"}, "raw_pod_id", "$1", "cgroup_path", ".+-pod(.+).slice"),
+              "raw_pod_id", "$1$2$3$4$5", "raw_pod_id", "(.+)_(.+)_(.+)_(.+)_(.+)"
+          )
         )
       )
   - record: oom_kills:normalized


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Removed unneeded metrics for pod level OOMs so that many-to-many matching error won't happen.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Fixed error:
```
found duplicate series for the match group {} on the right hand-side of the operation: [{__name__="ebpf_exporter_oom_kills", cgroup_path="/sys/fs/cgroup/memory/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod0391ccfb_b24a_44d3_bd23_27509e4e2830.slice/cri-containerd-9e8ce7cf657f09d15451b077a13848b0f560c7e2296ff0464f97d3ea0ef06a90.scope", container="kube-rbac-proxy", global_oom="0", instance="172.16.2.230:9434", job="ebpf-exporter", node="kube-stage-3commas-staging-spot-0256e204-7d49b-2lgdg", tier="cluster"}, 
{__name__="ebpf_exporter_oom_kills", cgroup_path="/sys/fs/cgroup/memory/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod0367bc0c_f874_4d18_ac4a_490a9418a140.slice/cri-containerd-2f9af51d0263c789f27667d440f5647576b84a8e99a4beee3fb8c18c5c6a7af7.scope", container="kube-rbac-proxy", global_oom="0", instance="172.16.2.136:9434", job="ebpf-exporter", node="kube-stage-3commas-staging-spot-0256e204-7d49b-p7kx5", tier="cluster"}];
many-to-many matching not allowed: matching labels must be unique on one side
```

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring-kubernetes
type: fix
summary: Removed many-to-many matching case in ebpf-exporter recording rules
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
