### PR TITLE
[docs] Add development mode

### DIFF
--- a/docs/documentation/Makefile
+++ b/docs/documentation/Makefile
@@ -13,6 +13,6 @@ up: network
 		werf compose up --follow --docker-compose-command-options='-d'
 
 dev: network
-		werf compose up --follow --docker-compose-command-options='-d' --dev
+		werf compose up --follow --docker-compose-command-options='-d' --dev --env development
 
 .PHONY: up dev

--- a/docs/documentation/pages/search.html
+++ b/docs/documentation/pages/search.html
@@ -7,4 +7,6 @@ toc: false
 comparable: false
 ---
 
+{%- unless jekyll.environment == "development" %}
 {% include search.html %}
+{%- endunless %}

--- a/docs/documentation/pages/search_ru.html
+++ b/docs/documentation/pages/search_ru.html
@@ -8,4 +8,6 @@ toc: false
 comparable: false
 ---
 
+{%- unless jekyll.environment == "development" %}
 {% include search.html %}
+{%- endunless %}

--- a/docs/documentation/search-index.json
+++ b/docs/documentation/search-index.json
@@ -6,6 +6,7 @@ sitemap_include: false
 ---
 
 [
+{%- unless jekyll.environment == "development" %}
 {%- assign searchedpages = site.pages | where: "searchable", true %}
 {%- for page in searchedpages %}
 {%- unless page.searchable == false %}
@@ -20,4 +21,5 @@ sitemap_include: false
 {%- unless forloop.last %},{% endunless %}
 {%- endunless %}
 {%- endfor %}
+{%- endunless %}
 ]

--- a/docs/documentation/werf-git-section.inc.yaml
+++ b/docs/documentation/werf-git-section.inc.yaml
@@ -20,7 +20,7 @@
   stageDependencies:
     setup: ['**/*']
   includePaths: ['config-values.yaml','doc-ru-config-values.yaml']
-{{- if or (eq .Env "EE") (eq .Env "FE") }}
+{{- if or (eq .Env "EE") (eq .Env "FE") (eq .Env "development") }}
 - add: /ee/modules
   to: /src/ee/modules
   owner: jekyll
@@ -57,7 +57,7 @@
   stageDependencies:
     setup: ['**/*']
 {{- end }}
-{{- if eq .Env "FE" }}
+{{- if or (eq .Env "FE") (eq .Env "development")  }}
 - add: /ee/fe/modules
   to: /src/fe/modules
   owner: jekyll

--- a/docs/documentation/werf.yaml
+++ b/docs/documentation/werf.yaml
@@ -1,4 +1,6 @@
-{{ $_ := set . "Env" "FE" }}
+{{- if ne $.Env "development" -}}
+{{- $_ := set . "Env" "FE" }}
+{{- end }}
 
 project: deckhouse-web
 configVersion: 1
@@ -115,7 +117,11 @@ ansible:
         chdir: /srv/jekyll-data/documentation/
     - shell: |
         mkdir -m 777 -p /app/_site/
+        {{- if eq $.Env "development" }}
+        JEKYLL_ENV=development jekyll build -d /app/_site/ --profile -t
+        {{- else }}
         JEKYLL_ENV=production jekyll build -d /app/_site/
+        {{- end }}
       args:
         warn: false
         executable: /bin/bash

--- a/docs/site/LOCAL_DEV.md
+++ b/docs/site/LOCAL_DEV.md
@@ -1,33 +1,51 @@
 # Running a site with the documentation locally
 
-Don't forget to clone repo firstly.
+- Don't forget to clone repo firstly.
 
-Free 80 port to bind.
+- Free 80 port to bind.
 
-Open console and start documentation container:
-```shell
-source $(trdl use werf 1.2 ea)
-cd docs/documentation
-docker network create deckhouse
-export BASE_NGINX_ALPINE=nginx:1.15.12-alpine@sha256:57a226fb6ab6823027c0704a9346a890ffb0cacde06bc19bbc234c8720673555
-export BASE_ALPINE=alpine:3.12.1@sha256:c0e9560cda118f9ec63ddefb4a173a2b2a0347082d7dff7dc14272e7841a5b5a
-export BASE_GOLANG_16_ALPINE=golang:1.16.3-alpine3.12@sha256:371dc6bf7e0c7ce112a29341b000c40d840aef1dbb4fdcb3ae5c0597e28f3061
-export BASE_JEKYLL=jekyll/jekyll:3.8@sha256:9521c8aae4739fcbc7137ead19f91841b833d671542f13e91ca40280e88d6e34 
-werf compose up --follow --docker-compose-command-options='-d'
-```
+- Install werf
 
-Open separate console and start site container:
-```shell
-source $(trdl use werf 1.2 ea)
-cd docs/site
-export BASE_NGINX_ALPINE=nginx:1.15.12-alpine@sha256:57a226fb6ab6823027c0704a9346a890ffb0cacde06bc19bbc234c8720673555
-export BASE_ALPINE=alpine:3.12.1@sha256:c0e9560cda118f9ec63ddefb4a173a2b2a0347082d7dff7dc14272e7841a5b5a
-export BASE_GOLANG_16_ALPINE=golang:1.16.3-alpine3.12@sha256:371dc6bf7e0c7ce112a29341b000c40d840aef1dbb4fdcb3ae5c0597e28f3061
-export BASE_JEKYLL=jekyll/jekyll:3.8@sha256:9521c8aae4739fcbc7137ead19f91841b833d671542f13e91ca40280e88d6e34 
-werf compose up --follow --docker-compose-command-options='-d'
-```
+- Open console and start documentation container with one of the following methods:
+  - Using makefile:
+    ```shell
+    cd docs/documentation
+    make up 
+    ```
 
-Open http://localhost.
+    > For development mode use `make dev` instead.
+    
+  - or using the following commands:
+    ```shell
+    cd docs/documentation
+    docker network create deckhouse
+    export BASE_NGINX_ALPINE=nginx:1.15.12-alpine@sha256:57a226fb6ab6823027c0704a9346a890ffb0cacde06bc19bbc234c8720673555
+    export BASE_ALPINE=alpine:3.12.1@sha256:c0e9560cda118f9ec63ddefb4a173a2b2a0347082d7dff7dc14272e7841a5b5a
+    export BASE_GOLANG_16_ALPINE=golang:1.16.3-alpine3.12@sha256:371dc6bf7e0c7ce112a29341b000c40d840aef1dbb4fdcb3ae5c0597e28f3061
+    export BASE_JEKYLL=jekyll/jekyll:3.8@sha256:9521c8aae4739fcbc7137ead19f91841b833d671542f13e91ca40280e88d6e34 
+    werf compose up --follow --docker-compose-command-options='-d'
+    ```
+
+- Open a separate console and start site container with one of the following methods:
+  - using makefile:
+    ```shell
+    cd docs/site
+    make up 
+    ```
+
+    > For development mode use `make dev` instead.
+
+  - or using the following commands:
+    ```shell
+    cd docs/site
+    export BASE_NGINX_ALPINE=nginx:1.15.12-alpine@sha256:57a226fb6ab6823027c0704a9346a890ffb0cacde06bc19bbc234c8720673555
+    export BASE_ALPINE=alpine:3.12.1@sha256:c0e9560cda118f9ec63ddefb4a173a2b2a0347082d7dff7dc14272e7841a5b5a
+    export BASE_GOLANG_16_ALPINE=golang:1.16.3-alpine3.12@sha256:371dc6bf7e0c7ce112a29341b000c40d840aef1dbb4fdcb3ae5c0597e28f3061
+    export BASE_JEKYLL=jekyll/jekyll:3.8@sha256:9521c8aae4739fcbc7137ead19f91841b833d671542f13e91ca40280e88d6e34 
+    werf compose up --follow --docker-compose-command-options='-d'
+    ```
+
+- Open http://localhost.
 
 Don't forget to stop documentation and site containers by running:
 ```shell


### PR DESCRIPTION
## Description
Added development mode to Jekyll in the documentation part of the site. Jekyll runs with trace and profiler In this mode.

Read docs/site/LOCAL_DEV.md for info.

## Changelog entries
```changes
section: docs
type: fix
summary: Add development mode to Jekyll in the documentation part of the site. Jekyll runs with trace and profiler In this mode.
impact_level: low
```
