### PR TITLE
[linstor] fix mtab warning for mkfs commands

### DIFF
--- a/modules/031-linstor/images/linstor-csi/Dockerfile
+++ b/modules/031-linstor/images/linstor-csi/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update \
       xfsprogs \
       e2fsprogs \
  && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && ln -sf /proc/mounts /etc/mtab
+
 COPY --from=builder /linstor-csi /linstor-wait-until /
 ENTRYPOINT ["/linstor-csi"]

--- a/modules/031-linstor/images/linstor-server/Dockerfile
+++ b/modules/031-linstor/images/linstor-server/Dockerfile
@@ -178,6 +178,7 @@ RUN printf 'Package: *\nPin: release a=%s\nPin-Priority: %s\n\n' stable 700 test
  && apt-get remove -y udev \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
+ && ln -sf /proc/mounts /etc/mtab \
  && sed -i 's/udev_rules.*=.*/udev_rules=0/ ; s/udev_sync.*=.*/udev_sync=0/ ; s/obtain_device_list_from_udev.*=.*/obtain_device_list_from_udev=0/' /etc/lvm/lvm.conf \
  && sed -i '/^devices {/a global_filter = [ "r|^/dev/drbd|" ]' /etc/lvm/lvm.conf
 


### PR DESCRIPTION
## Description

upstream issue: https://github.com/piraeusdatastore/linstor-csi/pull/158

Every mkfs command reports:
```
mke2fs 1.44.5 (15-Dec-2018)\next2fs_check_if_mount: Can't check if filesystem is mounted due to missing mtab file while determining whether /dev/drbd1000 is mounted.\
```

These messages appear in csi-provisioned volumes events.

## Why do we need it, and what problem does it solve?

Better UX

## Changelog entries

```changes
section: linstor
type: fix
summary: fix mtab warning for mkfs commands
impact_level: low
```