### PR TITLE
[kube-dns][sts-pods-hosts-appender-webhook] probes tcp -> http

### DIFF
--- a/modules/042-kube-dns/images/sts-pods-hosts-appender-webhook/main.go
+++ b/modules/042-kube-dns/images/sts-pods-hosts-appender-webhook/main.go
@@ -173,7 +173,6 @@ func main() {
 
 	logger.Infof("Listening on :8080")
 	err = http.ListenAndServeTLS(":8080", cfg.certFile, cfg.keyFile, whHandler)
-
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error serving webhook: %s", err)
 		os.Exit(1)

--- a/modules/042-kube-dns/images/sts-pods-hosts-appender-webhook/main.go
+++ b/modules/042-kube-dns/images/sts-pods-hosts-appender-webhook/main.go
@@ -165,14 +165,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	go func() {
-		http.HandleFunc("/healthz", httpHandlerHealthz)
-		logger.Infof("Listening /healthz on :8042")
-		http.ListenAndServe(":8042", nil)
-	}()
+	mux := http.NewServeMux()
+	mux.Handle("/", whHandler)
+	mux.HandleFunc("/healthz", httpHandlerHealthz)
 
-	logger.Infof("Listening on :8080")
-	err = http.ListenAndServeTLS(":8080", cfg.certFile, cfg.keyFile, whHandler)
+	logger.Infof("Listening on :4443")
+	err = http.ListenAndServeTLS(":4443", cfg.certFile, cfg.keyFile, mux)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error serving webhook: %s", err)
 		os.Exit(1)

--- a/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/deployment.yaml
+++ b/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/deployment.yaml
@@ -68,6 +68,7 @@ spec:
             httpGet:
               path: /healthz
               port: 4443
+              scheme: HTTPS
             periodSeconds: 1
             failureThreshold: 3
           volumeMounts:

--- a/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/deployment.yaml
+++ b/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/deployment.yaml
@@ -55,11 +55,12 @@ spec:
           - name: INIT_CONTAINER_IMAGE
             value: {{ .Values.global.modulesImages.registry }}:{{ .Values.global.modulesImages.tags.kubeDns.stsPodsHostsAppenderInitContainer }}
           ports:
-          - containerPort: 8080
+          - containerPort: 4443
           readinessProbe:
             httpGet:
               path: /healthz
-              port: 8042
+              port: 4443
+              scheme: HTTPS
             initialDelaySeconds: 5
             failureThreshold: 2
             periodSeconds: 1

--- a/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/deployment.yaml
+++ b/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/deployment.yaml
@@ -57,14 +57,16 @@ spec:
           ports:
           - containerPort: 8080
           readinessProbe:
-            tcpSocket:
-              port: 8080
+            httpGet:
+              path: /healthz
+              port: 8042
             initialDelaySeconds: 5
             failureThreshold: 2
             periodSeconds: 1
           livenessProbe:
-            tcpSocket:
-              port: 8080
+            httpGet:
+              path: /healthz
+              port: 8042
             periodSeconds: 1
             failureThreshold: 3
           volumeMounts:

--- a/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/deployment.yaml
+++ b/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8042
+              port: 4443
             periodSeconds: 1
             failureThreshold: 3
           volumeMounts:

--- a/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/service.yaml
+++ b/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/service.yaml
@@ -12,5 +12,5 @@ spec:
   ports:
   - name: https
     port: 443
-    targetPort: 8080
+    targetPort: 4443
 {{- end }}


### PR DESCRIPTION
## Description
Changed sts-pods-hosts-appender-webhook probes from tcpSocket to httpGet.

## Why do we need it, and what problem does it solve?
Fixes https://github.com/deckhouse/deckhouse/issues/1165.

## Changelog entries
```changes
section: kube-dns
type: fix
summary: Changed sts-pods-hosts-appender-webhook probes from tcpSocket to httpGet.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
