### PR TITLE
[candi] add proper labels and taints on cluster bootstrap to master nodes

### DIFF
--- a/candi/bashible/common-steps/cluster-bootstrap/070_install_control_plane.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/070_install_control_plane.sh.tpl
@@ -21,13 +21,11 @@ kubeadm init phase certs all --config /var/lib/bashible/kubeadm/config.yaml
 kubeadm init phase kubeconfig all --config /var/lib/bashible/kubeadm/config.yaml
 kubeadm init phase etcd local --config /var/lib/bashible/kubeadm/config.yaml {{ $experimentalOption }} /var/lib/bashible/kubeadm/patches
 kubeadm init phase control-plane all --config /var/lib/bashible/kubeadm/config.yaml {{ $experimentalOption }} /var/lib/bashible/kubeadm/patches
-
-# Add necessary labels to node
-# we do not use 'kubeadm init phase mark-control-plane --config /var/lib/bashible/kubeadm/config.yaml'
-# because this phase add 'node.kubernetes.io/exclude-from-external-load-balancers' label to node
-# with this label we cannot use target load balancers to control-plane nodes
-if ! bb-kubectl --kubeconfig=/etc/kubernetes/admin.conf label node "$(hostname)" node-role.kubernetes.io/master= node-role.kubernetes.io/control-plane=; then
-  echo "Cannot mark-control-plane" 1>&2
+kubeadm init phase mark-control-plane --config /var/lib/bashible/kubeadm/config.yaml
+# This phase add 'node.kubernetes.io/exclude-from-external-load-balancers' label to node
+# with this label we cannot use target load balancers to control-plane nodes, so we manually remove them
+if ! bb-kubectl --kubeconfig=/etc/kubernetes/admin.conf label node "$(hostname)" node.kubernetes.io/exclude-from-external-load-balancers-; then
+  echo "Cannot remove node.kubernetes.io/exclude-from-external-load-balancers label from node" 1>&2
   exit 1
 fi
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add proper labels and taints on cluster bootstrap to master nodes.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

On previous generation of bootstrap scripts we loose some taints on master nodes.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: add proper labels and taints on cluster bootstrap to master nodes
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
