### PR TITLE
[node-mananger] fix panic in apiserver endpoints discovery

### DIFF
--- a/go_lib/set/set_test.go
+++ b/go_lib/set/set_test.go
@@ -165,3 +165,24 @@ func Test_AddSet(t *testing.T) {
 		})
 	}
 }
+
+func Test_Delete(t *testing.T) {
+	{
+		// deletion actually works
+		s := New()
+		s.Add("")
+		s.Delete("")
+		if s.Size() > 0 {
+			t.Errorf("expected empty set")
+		}
+	}
+
+	{
+		// deletion ignores absent items
+		s := New()
+		s.Delete("")
+		if s.Size() > 0 {
+			t.Errorf("expected empty set")
+		}
+	}
+}

--- a/go_lib/set/set_test.go
+++ b/go_lib/set/set_test.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package set
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func Test_NewAndHas(t *testing.T) {
 	tests := []struct {
@@ -185,4 +189,11 @@ func Test_Delete(t *testing.T) {
 			t.Errorf("expected empty set")
 		}
 	}
+}
+
+func Test_Slice(t *testing.T) {
+	// the slice is sorted
+	s := New("x", "z", "1", "f", "a", "g", "n")
+	expected := []string{"1", "a", "f", "g", "n", "x", "z"}
+	assert.Equal(t, expected, s.Slice(), "Slice() must sort strings")
 }

--- a/modules/040-node-manager/hooks/discover_apiserver_endpoints.go
+++ b/modules/040-node-manager/hooks/discover_apiserver_endpoints.go
@@ -125,9 +125,9 @@ func handleAPIEndpoints(input *go_hook.HookInput) error {
 	for _, ep := range input.Snapshots["apiserver_endpoints"] {
 		endpointsSet.Add(ep.([]string)...)
 	}
-	endpointsSet.Delete("") // clean fauly pods
+	endpointsSet.Delete("") // clean faulty pods
 
-	endpointsList := endpointsSet.Slice()
+	endpointsList := endpointsSet.Slice() // sorted
 
 	if len(endpointsList) == 0 {
 		return errors.New("no kubernetes apiserver endpoints host:port specified")

--- a/modules/040-node-manager/hooks/discover_apiserver_endpoints.go
+++ b/modules/040-node-manager/hooks/discover_apiserver_endpoints.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"sort"
 	"strconv"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -87,7 +86,7 @@ func apiserverPodFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, e
 		}
 	}
 	if !isReady {
-		return nil, nil
+		return "", nil
 	}
 	return fmt.Sprintf("%s:%d", pod.Status.PodIP, apiserverPort), nil
 }
@@ -126,10 +125,9 @@ func handleAPIEndpoints(input *go_hook.HookInput) error {
 	for _, ep := range input.Snapshots["apiserver_endpoints"] {
 		endpointsSet.Add(ep.([]string)...)
 	}
+	endpointsSet.Delete("") // clean fauly pods
 
 	endpointsList := endpointsSet.Slice()
-
-	sort.Strings(endpointsList)
 
 	if len(endpointsList) == 0 {
 		return errors.New("no kubernetes apiserver endpoints host:port specified")


### PR DESCRIPTION
## Description

Fix panic when we get nil instead of a string

## Why do we need it, and what problem does it solve?

When pod is nt ready, the hooks panics and blocks deckhouse main queue

## Changelog entries


```changes
section: node-manager
type: fix
summary: Fix panic
impact_level: low
```
