### PR TITLE
Clarify GrafanaAdditionalDatasource type option RU

### DIFF
--- a/modules/300-prometheus/docs/FAQ_RU.md
+++ b/modules/300-prometheus/docs/FAQ_RU.md
@@ -96,7 +96,7 @@ spec:
 ### Как подключить дополнительные data source для Grafana?
 Для подключения дополнительных data source к Grafana существует специальный ресурс — `GrafanaAdditionalDatasource`.
 
-Параметры ресурса подробно описаны в [документации к Grafana](https://grafana.com/docs/grafana/latest/administration/provisioning/#example-datasource-config-file).
+Параметры ресурса подробно описаны в [документации к Grafana](https://grafana.com/docs/grafana/latest/administration/provisioning/#example-datasource-config-file). Тип ресурса, смотрите в документации по конкретному [datasource](https://grafana.com/docs/grafana/latest/datasources/).
 
 Пример:
 ```yaml


### PR DESCRIPTION
## Description
Description
Clarification in GrafanaAdditionalDatasource documentation to make it easier to find and specify the correct DataSource type


## Why do we need it, and what problem does it solve?
The documentation is not precise enough, which leads to problems when specifying the datasource type


