### PR TITLE
[candi][kube-proxy] set short hostname if itsn't and force short hostname for nodeport-bind-address.sh

### DIFF
--- a/candi/bashible/common-steps/all/001_set_short_hostname.sh.tpl
+++ b/candi/bashible/common-steps/all/001_set_short_hostname.sh.tpl
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [[ "$FIRST_BASHIBLE_RUN" == "yes" ]]; then
+if [[ "$(hostname)" != "$(hostname -s)" ]]; then
   hostnamectl set-hostname $(hostname -s)
 fi

--- a/modules/021-kube-proxy/images/init-container/nodeport-bind-address.sh
+++ b/modules/021-kube-proxy/images/init-container/nodeport-bind-address.sh
@@ -16,7 +16,7 @@
 
 set -Eeuo pipefail
 
-node_object="$(curl -sS -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -k https://127.0.0.1:6445/api/v1/nodes/$(hostname))"
+node_object="$(curl -sS -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -k https://127.0.0.1:6445/api/v1/nodes/$(hostname -s))"
 nodeport_bind_internal_ip="$(jq -re '.metadata.annotations."node.deckhouse.io/nodeport-bind-internal-ip" // true' <<< "$node_object")"
 
 internalip="$(jq -re '[.status.addresses[] | select(.type == "InternalIP").address] | (first | "\(.)/32") // ""' <<< "$node_object")"


### PR DESCRIPTION
## Description
Set short hostname if itsn't and force short hostname for kube-dns'es nodeport-bind-address.sh init-container.

## Why do we need it, and what problem does it solve?
Recently we [decided](https://fox.flant.com/sys/antiopa/-/merge_requests/2517) to set short hostname only on first bashible run due to some hostnamectl + dbus issues. But there were cases when someone changed the hostname to fqdn style, so we now set hostname short if it isn't.
Closes https://github.com/deckhouse/deckhouse/issues/1043.

## Changelog entries
```changes
section: kube-proxy
type: fix
summary: Set short hostname if itsn't and force short hostname for kube-dns'es nodeport-bind-address.sh init-container
impact_level: low
impact: kube-proxy pods will restart.
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
