### PR TITLE
[docs] Increase maximum width of tips in openAPI schemas

### DIFF
--- a/docs/documentation/_includes/openapi-tippy.html
+++ b/docs/documentation/_includes/openapi-tippy.html
@@ -6,6 +6,7 @@ $(document).ready(function () {
     tippy('[data-tippy-content]', {
         interactive: true,
         interactiveDebounce: 75,
+        maxWidth: 400,
         theme: 'custom',
         allowHTML: true,
         arrow: false,


### PR DESCRIPTION
## Description
Increased maximum width of tears in openAPI schemas as the log parameters path didn't fit tip's maximum width.

## Changelog entries
```changes
section: docs
type: fix
summary: Increased maximum width of tears in openAPI schemas as the log parameters path didn't fit tip's maximum width.
impact_level: low
```
