### PR TITLE
[prometheus] Alerts with no namespace go to clusters

### DIFF
--- a/ee/modules/600-flant-integration/templates/madison/additional-alert-relable-config.yaml
+++ b/ee/modules/600-flant-integration/templates/madison/additional-alert-relable-config.yaml
@@ -1,6 +1,10 @@
 {{- define "additional_relable_config_tier" }}
 - source_labels: [namespace]
-  regex: "d8-.+|kube-system|kube-nginx-ingress.*|kube-prometheus|None"
+  regex: "d8-.+|kube-system|None"
+  target_label: tier
+  replacement: cluster
+- source_labels: [namespace, tier]
+  regex: "^;$"
   target_label: tier
   replacement: cluster
 - source_labels: [tier]


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
As for now, all global problems are marked as application-level issues, which is not accurate. For example, alerts about node-local-dns pods being unavailable are application-level now.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: flant-integration
type: fix
summary: Set the tier = cluster label for alerts without the namespace label
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
