### PR TITLE
[dhctl] chore: print kube client errors

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -362,7 +362,7 @@ func WaitForReadinessNotOnNode(kubeCl *client.KubernetesClient, excludeNode stri
 		for {
 			select {
 			case <-ctx.Done():
-				return ErrTimedOut
+				return ErrTimeOut
 			default:
 				ok, err := NewLogPrinter(kubeCl).
 					WaitPodBecomeReady().
@@ -370,7 +370,7 @@ func WaitForReadinessNotOnNode(kubeCl *client.KubernetesClient, excludeNode stri
 					Print(ctx)
 
 				if err != nil {
-					if errors.Is(err, ErrTimedOut) {
+					if errors.Is(err, ErrTimeOut) {
 						return err
 					}
 					log.InfoLn(err.Error())

--- a/dhctl/pkg/kubernetes/actions/deckhouse/log.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log.go
@@ -33,10 +33,12 @@ import (
 )
 
 var (
-	ErrListPods      = errors.New("No Deckhouse pod found.")
-	ErrTimedOut      = errors.New("Time is out waiting for Deckhouse readiness.")
-	ErrRequestFailed = errors.New("Request failed. Probably pod was restarted during installation.")
-	ErrIncorrectNode = errors.New("Deckhouse on wrong node")
+	ErrPodListing     = errors.New("cannot list Deckhouse pods")
+	ErrPodNotFound    = errors.New("no Deckhouse pods found")
+	ErrTooManyPods    = errors.New("more than one Deckhouse pods found")
+	ErrTimeOut        = errors.New("timeout waiting for Deckhouse readiness")
+	ErrRequestFailed  = errors.New("request failed, probably the pod was restarted during installation")
+	ErrUnexpectedNode = errors.New("deckhouse is on unexpected node")
 )
 
 type logLine struct {
@@ -248,7 +250,7 @@ func (d *LogPrinter) checkDeckhousePodReady() (bool, error) {
 	}
 
 	if d.excludeNodeName != "" && runningPod.Spec.NodeName == d.excludeNodeName {
-		return false, ErrIncorrectNode
+		return false, ErrUnexpectedNode
 	}
 
 	ready := true
@@ -274,7 +276,7 @@ func (d *LogPrinter) Print(ctx context.Context) (bool, error) {
 	for {
 		select {
 		case <-ctx.Done():
-			return false, ErrTimedOut
+			return false, ErrTimeOut
 		default:
 			ready, err := d.checkDeckhousePodReady()
 			if err != nil {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/pod.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/pod.go
@@ -27,11 +27,15 @@ import (
 func GetPod(kubeCl *client.KubernetesClient) (*v1.Pod, error) {
 	pods, err := kubeCl.CoreV1().Pods("d8-system").List(context.TODO(), metav1.ListOptions{LabelSelector: "app=deckhouse"})
 	if err != nil {
-		return nil, ErrListPods
+		return nil, fmt.Errorf("%w: %v", ErrPodListing, err)
 	}
 
-	if len(pods.Items) != 1 {
-		return nil, ErrListPods
+	if len(pods.Items) == 0 {
+		return nil, ErrPodNotFound
+	}
+
+	if len(pods.Items) > 1 {
+		return nil, ErrTooManyPods
 	}
 
 	pod := pods.Items[0]

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/hook.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/hook.go
@@ -105,15 +105,14 @@ func (h *Hook) convergeLabelToNode(shouldExist bool) error {
 func (h *Hook) BeforeAction() (bool, error) {
 	err := log.Process(h.sourceCommandName, "Check deckhouse pod is not on converged node", func() error {
 		var pod *v1.Pod
-		err := retry.NewSilentLoop("Get deckhouse pod", 10, 3*time.Second).Run(func() error {
+		err := retry.NewSilentLoop("getting deckhouse pod", 10, 3*time.Second).Run(func() error {
 			var err error
 			pod, err = deckhouse.GetRunningPod(h.kubeCl)
-
 			return err
 		})
 
 		if err != nil {
-			return fmt.Errorf("Deckhouse pod did not get: %s", err)
+			return err
 		}
 
 		if pod.Spec.NodeName != h.nodeToConverge {


### PR DESCRIPTION
## Description

Handle errors better for kube client.

Based on #1297

## Why do we need it, and what problem does it solve?

For now, the error of the listing of deckhouse pod is muted. It makes debugging dhctl converge harder

## Changelog entries


```changes
section: dhctl
type: chore
summary: Make error handling more explicit
impact_level: low
```
