### PR TITLE
[ci] fix: support closed PRs in pull_request_info_job

### DIFF
--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -121,6 +121,7 @@ pull_request_info:
           const response = await github.rest.pulls.list({
             owner: context.repo.owner,
             repo: context.repo.repo,
+            state: 'all',
             head: head_label
           });
           if (response.status != 200) {

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -114,6 +114,7 @@ jobs:
             const response = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
+              state: 'all',
               head: head_label
             });
             if (response.status != 200) {

--- a/.github/workflows/on-pull-request-labeled.yml
+++ b/.github/workflows/on-pull-request-labeled.yml
@@ -43,6 +43,7 @@ jobs:
             const response = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
+              state: 'all',
               head: head_label
             });
             if (response.status != 200) {

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -87,6 +87,7 @@ jobs:
             const response = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
+              state: 'all',
               head: head_label
             });
             if (response.status != 200) {


### PR DESCRIPTION
## Description

Add `state: "all"` to pull request filter, it is [default to "open"](https://docs.github.com/en/rest/reference/pulls#list-pull-requests).

## Why do we need it, and what problem does it solve?

Prevent failing on unlabel closed pull requests.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: chore
summary: Prevent failing on unlabel closed pull requests.
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
