### PR TITLE
[prometheus] handle custom alertmanager path

### DIFF
--- a/modules/300-prometheus/templates/alertmanager/additional-configs-secret.yaml
+++ b/modules/300-prometheus/templates/alertmanager/additional-configs-secret.yaml
@@ -5,6 +5,7 @@
   static_configs:
     - targets:
         - {{ $spec.target }}
+  path_prefix: {{ $spec.path }}
   {{- if $spec.basicAuth }}
   basic_auth:
     username: {{ $spec.basicAuth.username }}


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Handle path prefix in CustomAlertmanager CR

## Why do we need it, and what problem does it solve?
Path prefix was forgotten in templates

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: fix
summary: Handle path prefix for CustomAlertmanager
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
