### PR TITLE
Chore: update changes description in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,14 +25,18 @@
 -->
 
 ```changes
-section: <kebab-case of a modules/*> | <1st level dir in the repo>
+section: <kebab-case of a module name> | <1st level dir in the repo>
 type: fix | feature | chore
-summary: <ONE LINE of what effectively changes for a user>
-impact_level: low | high* <this is an impact for users, not deckhouse>
-impact: <what to expect for users, possibly multi-line>, required if impact_level is high
+summary: <ONE-LINE of what effectively changes for a user>
+impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
+impact_level: default | high | low
 ```
 
 <!---
+`impact_level: default` adds to changelog as usual, this is the default that can be omitted
+`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
+`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores
+
 Tip for the section field:
 
   - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
@@ -52,12 +56,13 @@ Tip for the section field:
 Find changed sections:
 
 gh pr diff   $PULL_REQUEST_NUMBER   |
-  egrep "([+]{3}|[-]{3}) [ab]/" |
+  egrep "^([+]{3} b|[-]{3} a)/" |
   cut -d/ -f2- |
   sed 's#^ee/##' |
   sed 's#^fe/##' |
   sed 's#^modules/##' |
   sed 's#[0-9][0-9][0-9]-##' |
+  egrep -v 'Makefile' |       # add file exclusion here
   cut -d/ -f1 |
   sort |
   uniq


### PR DESCRIPTION
## Description

Describe `impact_level` better in PR template.

## Why do we need it, and what problem does it solve?

It is not clear when to set it.

## Changelog entries


```changes
section: ci
type: chore
summary: Better doc for `impact_level`.
impact_level: low
```
