### PR TITLE
[cloud-provider-vsphere] Fix instanceClass.runtimeOptions.nestedHardwareVirtualization set on false does not work

### DIFF
--- a/ee/modules/030-cloud-provider-vsphere/cloud-instance-manager/machine-class.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/cloud-instance-manager/machine-class.yaml
@@ -37,7 +37,11 @@ spec:
 {{ $_ := set .nodeGroup.instanceClass "runtimeOptions" dict }}
 {{- end }}
   runtimeOptions:
-    nestedHardwareVirtualization: {{ .nodeGroup.instanceClass.runtimeOptions.nestedHardwareVirtualization | default true }}
+  {{- if hasKey .nodeGroup.instanceClass.runtimeOptions "nestedHardwareVirtualization" }}
+    nestedHardwareVirtualization: {{ .nodeGroup.instanceClass.runtimeOptions.nestedHardwareVirtualization }}
+  {{- else }}
+    nestedHardwareVirtualization: true
+  {{- end }}
     resourceAllocationInfo:
 {{- if .nodeGroup.instanceClass.runtimeOptions.cpuShares }}
       cpuShares: {{ .nodeGroup.instanceClass.runtimeOptions.cpuShares }}


### PR DESCRIPTION
## Description
Fix machineclass template.
We use `default true` on boolean value and `nestedHardwareVirtualization == true` does not work because always used default value `true` 

## Why do we need it, and what problem does it solve?
Client can not disable nested hardware virtualization for nodes controlled by machine controller manager.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-vsphere
type: fix 
summary: Client can not disable nested hardware virtualization for nodes controlled by machine controller manager.
impact_level: high
impact: |
  Nodes in node groups which instance classes are using runtimeOptions.nestedHardwareVirtualization set on false will be RECREATED by one per zone per node group.
  You can switch `nestedHardwareVirtualization` to true for prevent recreating nodes, because this flag does not work now and all nodes use nested hardware virtualization. After update, you can switch flag to false if necessary. After switch nodes in node group will be recreated by one per zone. 
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
