### PR TITLE
[upmeter] use timeout in insecure client

### DIFF
--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/http.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/http.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"d8.io/upmeter/pkg/check"
 	"d8.io/upmeter/pkg/util"
@@ -104,9 +105,13 @@ func doRequest(client *http.Client, req *http.Request) ([]byte, check.Error) {
 	return body, nil
 }
 
-// Insecure transport is useful when kube-rbac-proxy generates self-signed certificates, causing cert validation error
-var insecureClient = &http.Client{
-	Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	},
+// newInsecureClient creates http.Client omitting TLS verificaton. Useful for accessing APIs via
+// kube-rbac-proxy which has self-signed certificates.
+func newInsecureClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+		Timeout: timeout,
+	}
 }

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/prometheus.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/prometheus.go
@@ -40,7 +40,7 @@ func (c PrometheusApiAvailable) Checker() check.Checker {
 		endpoint: c.Endpoint,
 		access:   c.Access,
 	}
-	checker := newHTTPChecker(insecureClient, verifier)
+	checker := newHTTPChecker(newInsecureClient(3*c.Timeout), verifier)
 	return withTimeout(checker, c.Timeout)
 }
 
@@ -100,9 +100,7 @@ func (c MetricPresentInPrometheus) Checker() check.Checker {
 		access:   c.Access,
 		endpoint: addMetricQuery(c.Endpoint, c.Metric),
 	}
-
-	checker := newHTTPChecker(insecureClient, verifier)
-
+	checker := newHTTPChecker(newInsecureClient(3*c.Timeout), verifier)
 	return withTimeout(checker, c.Timeout)
 }
 

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/prometheus_metrics_adapter.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/prometheus_metrics_adapter.go
@@ -38,7 +38,7 @@ func (c MetricsAdapterApiAvailable) Checker() check.Checker {
 		endpoint:     c.Endpoint,
 		kubeAccessor: c.Access,
 	}
-	checker := newHTTPChecker(insecureClient, verifier)
+	checker := newHTTPChecker(newInsecureClient(3*c.Timeout), verifier)
 	return withTimeout(checker, c.Timeout)
 }
 


### PR DESCRIPTION
## Description

Use timeout in insecure HTTP client in agent.

## Why do we need it, and what problem does it solve?

Probe checks won't be able to stuck indefinitely.

## Changelog entries

```changes
section: upmeter
type: fix
summary: Use finite timeout in agent insecure HTTP client
```
