### PR TITLE
[docs] Remove ingressClassName from the site Ingress templates

### DIFF
--- a/docs/documentation/.helm/templates/20-ingress.yaml
+++ b/docs/documentation/.helm/templates/20-ingress.yaml
@@ -23,7 +23,6 @@ metadata:
     nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email
 {{- end }}
 spec:
-  ingressClassName: "nginx"
   tls:
   - hosts:
       - {{ $host }}

--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -28,7 +28,6 @@ metadata:
     nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email
 {{- end }}
 spec:
-  ingressClassName: "nginx"
   tls:
   - hosts:
       - {{ $host }}


### PR DESCRIPTION
## Description
Remove ingressClassName from the site Ingress templates

## Changelog entries
```changes
section: docs
type: chore
summary: Remove ingressClassName from the site Ingress templates
impact_level: low
```

