### PR TITLE
[openvpn] add forgotten param effectiveStorageClass to openapi spec

### DIFF
--- a/ee/fe/modules/500-openvpn/openapi/values.yaml
+++ b/ee/fe/modules/500-openvpn/openapi/values.yaml
@@ -19,3 +19,7 @@ properties:
             type: string
       deployDexAuthenticator:
         type: boolean
+      effectiveStorageClass:
+        oneOf:
+          - type: string
+          - type: boolean


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add forgotten param effectiveStorageClass to openapi spec


## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: openvpn
type: fix
summary: Add forgotten param effectiveStorageClass to openapi spec
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
