### PR TITLE
[prometheus] Fix null pointer dereference in prometheus_disk.go hook

### DIFF
--- a/modules/300-prometheus/hooks/prometheus_disk.go
+++ b/modules/300-prometheus/hooks/prometheus_disk.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/utils/pointer"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/k8s"
@@ -104,7 +105,7 @@ func applyStorageClassFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 
 	return StorageClassFilter{
 		Name:                 sc.Name,
-		AllowVolumeExpansion: *sc.AllowVolumeExpansion && sc.Annotations["storageclass.deckhouse.io/volume-expansion-mode"] != "offline",
+		AllowVolumeExpansion: pointer.BoolPtrDerefOr(sc.AllowVolumeExpansion, false) && sc.Annotations["storageclass.deckhouse.io/volume-expansion-mode"] != "offline",
 	}, nil
 }
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixed panic when AllowVolumeExpansion is nil.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x23c3973]

goroutine 64 [running]:
github.com/deckhouse/deckhouse/modules/300-prometheus/hooks.applyStorageClassFilter(0xc000434940, 0x700, 0xc0116d6000, 0xc005d26180, 0xc0031f3100)
	/deckhouse/modules/300-prometheus/hooks/prometheus_disk.go:107 +0x113
github.com/flant/addon-operator/pkg/module_manager.NewHookConfigFromGoConfig.func1(0xc000434940, 0xc000434940, 0xc0031f3100, 0x685, 0x700)
	/go/pkg/mod/github.com/flant/addon-operator@v1.0.6-0.20220328102438-d32b26271231/pkg/module_manager/global_hook_config.go:313 +0x2f
github.com/flant/shell-operator/pkg/kube_events_manager.ApplyFilter(0x0, 0x0, 0xc001664770, 0xc000434940, 0x0, 0x0, 0x0)
	/go/pkg/mod/github.com/flant/shell-operator@v1.0.10-0.20220324171037-a48626e8b125/pkg/kube_events_manager/filter.go:38 +0x49e
github.com/flant/shell-operator/pkg/kube_events_manager.(*resourceInformer).LoadExistedObjects.func1(0xc001ca5d40, 0xc000434940, 0xc005fcdb38, 0xc005fcdb80)
	/go/pkg/mod/github.com/flant/shell-operator@v1.0.10-0.20220324171037-a48626e8b125/pkg/kube_events_manager/resource_informer.go:261 +0xc5
github.com/flant/shell-operator/pkg/kube_events_manager.(*resourceInformer).LoadExistedObjects(0xc001ca5d40, 0x0, 0x0)
	/go/pkg/mod/github.com/flant/shell-operator@v1.0.10-0.20220324171037-a48626e8b125/pkg/kube_events_manager/resource_informer.go:262 +0x5d8
github.com/flant/shell-operator/pkg/kube_events_manager.(*resourceInformer).CreateSharedInformer(0xc001ca5d40, 0x5f5e100, 0x0)
	/go/pkg/mod/github.com/flant/shell-operator@v1.0.10-0.20220324171037-a48626e8b125/pkg/kube_events_manager/resource_informer.go:180 +0xb37
github.com/flant/shell-operator/pkg/kube_events_manager.(*monitor).CreateInformersForNamespace(0xc0041ee8c0, 0x0, 0x0, 0x1f, 0x0, 0x0, 0x0, 0xc004745560)
	/go/pkg/mod/github.com/flant/shell-operator@v1.0.10-0.20220324171037-a48626e8b125/pkg/kube_events_manager/monitor.go:266 +0x282
github.com/flant/shell-operator/pkg/kube_events_manager.(*monitor).CreateInformers(0xc0041ee8c0, 0xc004f40c30, 0xc00021c000)
	/go/pkg/mod/github.com/flant/shell-operator@v1.0.10-0.20220324171037-a48626e8b125/pkg/kube_events_manager/monitor.go:123 +0x925
github.com/flant/shell-operator/pkg/kube_events_manager.(*kubeEventsManager).AddMonitor(0xc0004bd590, 0xc001b02840, 0x0, 0x45dfdd0)
	/go/pkg/mod/github.com/flant/shell-operator@v1.0.10-0.20220324171037-a48626e8b125/pkg/kube_events_manager/kube_events_manager.go:90 +0x1c4
github.com/flant/shell-operator/pkg/hook/controller.(*kubernetesBindingsController).EnableKubernetesBindings(0xc001aecec0, 0x100000000000001, 0xffffffffffffffff, 0x0, 0x1, 0x2772120)
	/go/pkg/mod/github.com/flant/shell-operator@v1.0.10-0.20220324171037-a48626e8b125/pkg/hook/controller/kubernetes_bindings_controller.go:84 +0x113
github.com/flant/shell-operator/pkg/hook/controller.(*hookController).HandleEnableKubernetesBindings(0xc001a050e0, 0xc0052ab560, 0x27, 0xc00218e978)
	/go/pkg/mod/github.com/flant/shell-operator@v1.0.10-0.20220324171037-a48626e8b125/pkg/hook/controller/hook_controller.go:170 +0x6b
github.com/flant/addon-operator/pkg/module_manager.(*moduleManager).HandleModuleEnableKubernetesBindings(0xc0009db520, 0xc000a1cbe7, 0xa, 0xc0053d6550, 0x19, 0xc0063fe870)
	/go/pkg/mod/github.com/flant/addon-operator@v1.0.6-0.20220328102438-d32b26271231/pkg/module_manager/module_manager.go:1180 +0x115
github.com/flant/addon-operator/pkg/addon-operator.(*AddonOperator).HandleModuleRun(0xc000842a00, 0x3131c18, 0xc001bb2880, 0xc005644570, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/go/pkg/mod/github.com/flant/addon-operator@v1.0.6-0.20220328102438-d32b26271231/pkg/addon-operator/operator.go:1129 +0x15cb
github.com/flant/addon-operator/pkg/addon-operator.(*AddonOperator).TaskHandler(0xc000842a00, 0x3131c18, 0xc001bb2880, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/go/pkg/mod/github.com/flant/addon-operator@v1.0.6-0.20220328102438-d32b26271231/pkg/addon-operator/operator.go:954 +0x1dee
github.com/flant/shell-operator/pkg/task/queue.(*TaskQueue).Start.func1(0xc0013c60b0)
	/go/pkg/mod/github.com/flant/shell-operator@v1.0.10-0.20220324171037-a48626e8b125/pkg/task/queue/task_queue.go:342 +0x3fc
created by github.com/flant/shell-operator/pkg/task/queue.(*TaskQueue).Start
	/go/pkg/mod/github.com/flant/shell-operator@v1.0.10-0.20220324171037-a48626e8b125/pkg/task/queue/task_queue.go:320 +0x4f
```

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: fix
summary: Fix null pointer dereference in prometheus_disk.go hook
```

