### PR TITLE
[ci] add 1.23 for e2e tests

### DIFF
--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -106,6 +106,7 @@ const kubernetesVersions = [
   '1.20',
   '1.21',
   '1.22',
+  '1.23',
 ];
 module.exports.knownKubernetesVersions = kubernetesVersions;
 

--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -20,7 +20,7 @@ $CI_COMMIT_REF_SLUG is a tag of published deckhouse images. It has a form
 
 {!{- $providerNames := slice "AWS" "Azure" "GCP" "Yandex.Cloud" "OpenStack" "vSphere" "Static" -}!}
 {!{- $criNames := slice "Docker" "Containerd" -}!}
-{!{- $kubernetesVersions := slice "1.19" "1.20" "1.21" "1.22" -}!}
+{!{- $kubernetesVersions := slice "1.19" "1.20" "1.21" "1.22" "1.23" -}!}
 
 {!{- range $providerName := $providerNames -}!}
 {!{-   $provider := $providerName | replaceAll "." "-" | toLower -}!}
@@ -65,7 +65,7 @@ on:
         description: 'A comma-separated list of cri to test. Available: Docker and Containerd.'
         required: false
       ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.19 to 1.22.'
+        description: 'A comma-separated list of versions to test. Available: from 1.19 to 1.23.'
         required: false
 env:
 {!{ tmpl.Exec "werf_envs" | strings.Indent 2 }!}

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -32,7 +32,7 @@ on:
         description: 'A comma-separated list of cri to test. Available: Docker and Containerd.'
         required: false
       ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.19 to 1.22.'
+        description: 'A comma-separated list of versions to test. Available: from 1.19 to 1.23.'
         required: false
 env:
 
@@ -200,10 +200,12 @@ jobs:
       run_docker_1_20: ${{ steps.check.outputs.run_docker_1_20 }}
       run_docker_1_21: ${{ steps.check.outputs.run_docker_1_21 }}
       run_docker_1_22: ${{ steps.check.outputs.run_docker_1_22 }}
+      run_docker_1_23: ${{ steps.check.outputs.run_docker_1_23 }}
       run_containerd_1_19: ${{ steps.check.outputs.run_containerd_1_19 }}
       run_containerd_1_20: ${{ steps.check.outputs.run_containerd_1_20 }}
       run_containerd_1_21: ${{ steps.check.outputs.run_containerd_1_21 }}
       run_containerd_1_22: ${{ steps.check.outputs.run_containerd_1_22 }}
+      run_containerd_1_23: ${{ steps.check.outputs.run_containerd_1_23 }}
     steps:
 
       # <template: checkout_step>
@@ -1683,6 +1685,379 @@ jobs:
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.22"
+        run: |
+          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          echo $WORKFLOW_URL
+
+          alertData=$(cat <<EOF
+          {
+            "labels": {
+              "severity_level": 7,
+              "trigger": "CloudLayoutTestFailed",
+              "provider": "${PROVIDER}",
+              "layout": "${LAYOUT}",
+              "cri": "${CRI}",
+              "kubernetes_version": "${KUBERNETES_VERSION}"
+            },
+            "annotations": {
+              "summary": "Cloud Layout Test failed",
+              "description": "Check Github workflow log for more information",
+              "plk_protocol_version": "1",
+              "plk_link_url/job": "${WORKFLOW_URL}",
+              "plk_link_title_en/job": "Github job run",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+            }
+          }
+          EOF
+          )
+
+          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "${alertData}"
+  # </template: e2e_run_job_template>
+
+  # <template: e2e_run_job_template>
+  run_docker_1_23:
+    name: "e2e: AWS, Docker, Kubernetes 1.23"
+    needs:
+      - check_e2e_labels
+      - git_info
+    if: needs.check_e2e_labels.outputs.run_docker_1_23 == 'true'
+    env:
+      PROVIDER: AWS
+      CRI: Docker
+      LAYOUT: WithoutNAT
+      KUBERNETES_VERSION: "1.23"
+      EVENT_LABEL: ${{ github.event.label.name }}
+    runs-on: [self-hosted, e2e-common]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_from_event_ref_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
+          fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
+      - name: Update comment on start
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'e2e: AWS, Docker, Kubernetes 1.23';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      # </template: update_comment_on_start>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
+          fi
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
+          docker pull "${IMAGE_NAME}"
+
+      - name: "Run e2e test: AWS/Docker/1.23"
+        env:
+          PROVIDER: AWS
+          CRI: Docker
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
+          LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
+        run: |
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
+            -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh run-test
+
+        # </template: e2e_run_template>
+
+      - name: Cleanup bootstrapped cluster
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          PROVIDER: AWS
+          CRI: Docker
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
+          LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
+        run: |
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
+            -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh cleanup
+
+        # </template: e2e_run_template>
+
+      - name: Save test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_output_aws_docker_1_23
+          path: |
+            testing/cloud_layouts/
+
+      - name: Cleanup temp directory
+        if: always()
+        env:
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+        run: |
+          echo "Remove temporary directory '${TMPPATH}' ..."
+          if [[ -d "${TMPPATH}" && ${#TMPPATH} > 1 ]] ; then
+            rm -rf "${TMPPATH}"
+          else
+            echo Not a directory.
+          fi
+
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'job,separate';
+            const name = 'e2e: AWS, Docker, Kubernetes 1.23';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
+
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
+      - name: Alert on fail in default branch
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        env:
+          PROVIDER: AWS
+          CRI: Docker
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
           echo $WORKFLOW_URL
@@ -3207,15 +3582,388 @@ jobs:
             -d "${alertData}"
   # </template: e2e_run_job_template>
 
+  # <template: e2e_run_job_template>
+  run_containerd_1_23:
+    name: "e2e: AWS, Containerd, Kubernetes 1.23"
+    needs:
+      - check_e2e_labels
+      - git_info
+    if: needs.check_e2e_labels.outputs.run_containerd_1_23 == 'true'
+    env:
+      PROVIDER: AWS
+      CRI: Containerd
+      LAYOUT: WithoutNAT
+      KUBERNETES_VERSION: "1.23"
+      EVENT_LABEL: ${{ github.event.label.name }}
+    runs-on: [self-hosted, e2e-common]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_from_event_ref_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
+          fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
+      - name: Update comment on start
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'e2e: AWS, Containerd, Kubernetes 1.23';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      # </template: update_comment_on_start>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
+          fi
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
+          docker pull "${IMAGE_NAME}"
+
+      - name: "Run e2e test: AWS/Containerd/1.23"
+        env:
+          PROVIDER: AWS
+          CRI: Containerd
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
+          LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
+        run: |
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
+            -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh run-test
+
+        # </template: e2e_run_template>
+
+      - name: Cleanup bootstrapped cluster
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          PROVIDER: AWS
+          CRI: Containerd
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
+          LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
+        run: |
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
+            -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh cleanup
+
+        # </template: e2e_run_template>
+
+      - name: Save test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_output_aws_containerd_1_23
+          path: |
+            testing/cloud_layouts/
+
+      - name: Cleanup temp directory
+        if: always()
+        env:
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+        run: |
+          echo "Remove temporary directory '${TMPPATH}' ..."
+          if [[ -d "${TMPPATH}" && ${#TMPPATH} > 1 ]] ; then
+            rm -rf "${TMPPATH}"
+          else
+            echo Not a directory.
+          fi
+
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'job,separate';
+            const name = 'e2e: AWS, Containerd, Kubernetes 1.23';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
+
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
+      - name: Alert on fail in default branch
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        env:
+          PROVIDER: AWS
+          CRI: Containerd
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+        run: |
+          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          echo $WORKFLOW_URL
+
+          alertData=$(cat <<EOF
+          {
+            "labels": {
+              "severity_level": 7,
+              "trigger": "CloudLayoutTestFailed",
+              "provider": "${PROVIDER}",
+              "layout": "${LAYOUT}",
+              "cri": "${CRI}",
+              "kubernetes_version": "${KUBERNETES_VERSION}"
+            },
+            "annotations": {
+              "summary": "Cloud Layout Test failed",
+              "description": "Check Github workflow log for more information",
+              "plk_protocol_version": "1",
+              "plk_link_url/job": "${WORKFLOW_URL}",
+              "plk_link_title_en/job": "Github job run",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+            }
+          }
+          EOF
+          )
+
+          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "${alertData}"
+  # </template: e2e_run_job_template>
+
 
   last_comment:
     name: Update comment on finish
-    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22"]
+    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23"]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_19":"e2e: AWS, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: AWS, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: AWS, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: AWS, Containerd, Kubernetes 1.22","run_docker_1_19":"e2e: AWS, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: AWS, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: AWS, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: AWS, Docker, Kubernetes 1.22"}
+        {"run_containerd_1_19":"e2e: AWS, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: AWS, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: AWS, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: AWS, Containerd, Kubernetes 1.22","run_containerd_1_23":"e2e: AWS, Containerd, Kubernetes 1.23","run_docker_1_19":"e2e: AWS, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: AWS, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: AWS, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: AWS, Docker, Kubernetes 1.22","run_docker_1_23":"e2e: AWS, Docker, Kubernetes 1.23"}
     steps:
 
       # <template: checkout_step>

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -32,7 +32,7 @@ on:
         description: 'A comma-separated list of cri to test. Available: Docker and Containerd.'
         required: false
       ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.19 to 1.22.'
+        description: 'A comma-separated list of versions to test. Available: from 1.19 to 1.23.'
         required: false
 env:
 
@@ -200,10 +200,12 @@ jobs:
       run_docker_1_20: ${{ steps.check.outputs.run_docker_1_20 }}
       run_docker_1_21: ${{ steps.check.outputs.run_docker_1_21 }}
       run_docker_1_22: ${{ steps.check.outputs.run_docker_1_22 }}
+      run_docker_1_23: ${{ steps.check.outputs.run_docker_1_23 }}
       run_containerd_1_19: ${{ steps.check.outputs.run_containerd_1_19 }}
       run_containerd_1_20: ${{ steps.check.outputs.run_containerd_1_20 }}
       run_containerd_1_21: ${{ steps.check.outputs.run_containerd_1_21 }}
       run_containerd_1_22: ${{ steps.check.outputs.run_containerd_1_22 }}
+      run_containerd_1_23: ${{ steps.check.outputs.run_containerd_1_23 }}
     steps:
 
       # <template: checkout_step>
@@ -1715,6 +1717,387 @@ jobs:
           CRI: Docker
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.22"
+        run: |
+          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          echo $WORKFLOW_URL
+
+          alertData=$(cat <<EOF
+          {
+            "labels": {
+              "severity_level": 7,
+              "trigger": "CloudLayoutTestFailed",
+              "provider": "${PROVIDER}",
+              "layout": "${LAYOUT}",
+              "cri": "${CRI}",
+              "kubernetes_version": "${KUBERNETES_VERSION}"
+            },
+            "annotations": {
+              "summary": "Cloud Layout Test failed",
+              "description": "Check Github workflow log for more information",
+              "plk_protocol_version": "1",
+              "plk_link_url/job": "${WORKFLOW_URL}",
+              "plk_link_title_en/job": "Github job run",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+            }
+          }
+          EOF
+          )
+
+          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "${alertData}"
+  # </template: e2e_run_job_template>
+
+  # <template: e2e_run_job_template>
+  run_docker_1_23:
+    name: "e2e: Azure, Docker, Kubernetes 1.23"
+    needs:
+      - check_e2e_labels
+      - git_info
+    if: needs.check_e2e_labels.outputs.run_docker_1_23 == 'true'
+    env:
+      PROVIDER: Azure
+      CRI: Docker
+      LAYOUT: Standard
+      KUBERNETES_VERSION: "1.23"
+      EVENT_LABEL: ${{ github.event.label.name }}
+    runs-on: [self-hosted, e2e-common]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_from_event_ref_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
+          fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
+      - name: Update comment on start
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'e2e: Azure, Docker, Kubernetes 1.23';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      # </template: update_comment_on_start>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
+          fi
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
+          docker pull "${IMAGE_NAME}"
+
+      - name: "Run e2e test: Azure/Docker/1.23"
+        env:
+          PROVIDER: Azure
+          CRI: Docker
+          LAYOUT: Standard
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
+          LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
+          LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
+          LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
+        run: |
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_AZURE_SUBSCRIPTION_ID=${LAYOUT_AZURE_SUBSCRIPTION_ID:-not_provided} \
+            -e LAYOUT_AZURE_CLIENT_ID=${LAYOUT_AZURE_CLIENT_ID:-not_provided} \
+            -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
+            -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh run-test
+
+        # </template: e2e_run_template>
+
+      - name: Cleanup bootstrapped cluster
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          PROVIDER: Azure
+          CRI: Docker
+          LAYOUT: Standard
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
+          LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
+          LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
+          LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
+        run: |
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_AZURE_SUBSCRIPTION_ID=${LAYOUT_AZURE_SUBSCRIPTION_ID:-not_provided} \
+            -e LAYOUT_AZURE_CLIENT_ID=${LAYOUT_AZURE_CLIENT_ID:-not_provided} \
+            -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
+            -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh cleanup
+
+        # </template: e2e_run_template>
+
+      - name: Save test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_output_azure_docker_1_23
+          path: |
+            testing/cloud_layouts/
+
+      - name: Cleanup temp directory
+        if: always()
+        env:
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+        run: |
+          echo "Remove temporary directory '${TMPPATH}' ..."
+          if [[ -d "${TMPPATH}" && ${#TMPPATH} > 1 ]] ; then
+            rm -rf "${TMPPATH}"
+          else
+            echo Not a directory.
+          fi
+
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Azure, Docker, Kubernetes 1.23';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
+
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
+      - name: Alert on fail in default branch
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        env:
+          PROVIDER: Azure
+          CRI: Docker
+          LAYOUT: Standard
+          KUBERNETES_VERSION: "1.23"
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
           echo $WORKFLOW_URL
@@ -3271,15 +3654,396 @@ jobs:
             -d "${alertData}"
   # </template: e2e_run_job_template>
 
+  # <template: e2e_run_job_template>
+  run_containerd_1_23:
+    name: "e2e: Azure, Containerd, Kubernetes 1.23"
+    needs:
+      - check_e2e_labels
+      - git_info
+    if: needs.check_e2e_labels.outputs.run_containerd_1_23 == 'true'
+    env:
+      PROVIDER: Azure
+      CRI: Containerd
+      LAYOUT: Standard
+      KUBERNETES_VERSION: "1.23"
+      EVENT_LABEL: ${{ github.event.label.name }}
+    runs-on: [self-hosted, e2e-common]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_from_event_ref_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
+          fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
+      - name: Update comment on start
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'e2e: Azure, Containerd, Kubernetes 1.23';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      # </template: update_comment_on_start>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
+          fi
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
+          docker pull "${IMAGE_NAME}"
+
+      - name: "Run e2e test: Azure/Containerd/1.23"
+        env:
+          PROVIDER: Azure
+          CRI: Containerd
+          LAYOUT: Standard
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
+          LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
+          LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
+          LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
+        run: |
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_AZURE_SUBSCRIPTION_ID=${LAYOUT_AZURE_SUBSCRIPTION_ID:-not_provided} \
+            -e LAYOUT_AZURE_CLIENT_ID=${LAYOUT_AZURE_CLIENT_ID:-not_provided} \
+            -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
+            -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh run-test
+
+        # </template: e2e_run_template>
+
+      - name: Cleanup bootstrapped cluster
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          PROVIDER: Azure
+          CRI: Containerd
+          LAYOUT: Standard
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
+          LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
+          LAYOUT_AZURE_CLIENT_SECRET: ${{ secrets.LAYOUT_AZURE_CLIENT_SECRET }}
+          LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
+        run: |
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_AZURE_SUBSCRIPTION_ID=${LAYOUT_AZURE_SUBSCRIPTION_ID:-not_provided} \
+            -e LAYOUT_AZURE_CLIENT_ID=${LAYOUT_AZURE_CLIENT_ID:-not_provided} \
+            -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
+            -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh cleanup
+
+        # </template: e2e_run_template>
+
+      - name: Save test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_output_azure_containerd_1_23
+          path: |
+            testing/cloud_layouts/
+
+      - name: Cleanup temp directory
+        if: always()
+        env:
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+        run: |
+          echo "Remove temporary directory '${TMPPATH}' ..."
+          if [[ -d "${TMPPATH}" && ${#TMPPATH} > 1 ]] ; then
+            rm -rf "${TMPPATH}"
+          else
+            echo Not a directory.
+          fi
+
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Azure, Containerd, Kubernetes 1.23';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
+
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
+      - name: Alert on fail in default branch
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        env:
+          PROVIDER: Azure
+          CRI: Containerd
+          LAYOUT: Standard
+          KUBERNETES_VERSION: "1.23"
+        run: |
+          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          echo $WORKFLOW_URL
+
+          alertData=$(cat <<EOF
+          {
+            "labels": {
+              "severity_level": 7,
+              "trigger": "CloudLayoutTestFailed",
+              "provider": "${PROVIDER}",
+              "layout": "${LAYOUT}",
+              "cri": "${CRI}",
+              "kubernetes_version": "${KUBERNETES_VERSION}"
+            },
+            "annotations": {
+              "summary": "Cloud Layout Test failed",
+              "description": "Check Github workflow log for more information",
+              "plk_protocol_version": "1",
+              "plk_link_url/job": "${WORKFLOW_URL}",
+              "plk_link_title_en/job": "Github job run",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+            }
+          }
+          EOF
+          )
+
+          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "${alertData}"
+  # </template: e2e_run_job_template>
+
 
   last_comment:
     name: Update comment on finish
-    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22"]
+    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23"]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_19":"e2e: Azure, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: Azure, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: Azure, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: Azure, Containerd, Kubernetes 1.22","run_docker_1_19":"e2e: Azure, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: Azure, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: Azure, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: Azure, Docker, Kubernetes 1.22"}
+        {"run_containerd_1_19":"e2e: Azure, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: Azure, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: Azure, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: Azure, Containerd, Kubernetes 1.22","run_containerd_1_23":"e2e: Azure, Containerd, Kubernetes 1.23","run_docker_1_19":"e2e: Azure, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: Azure, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: Azure, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: Azure, Docker, Kubernetes 1.22","run_docker_1_23":"e2e: Azure, Docker, Kubernetes 1.23"}
     steps:
 
       # <template: checkout_step>

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -32,7 +32,7 @@ on:
         description: 'A comma-separated list of cri to test. Available: Docker and Containerd.'
         required: false
       ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.19 to 1.22.'
+        description: 'A comma-separated list of versions to test. Available: from 1.19 to 1.23.'
         required: false
 env:
 
@@ -200,10 +200,12 @@ jobs:
       run_docker_1_20: ${{ steps.check.outputs.run_docker_1_20 }}
       run_docker_1_21: ${{ steps.check.outputs.run_docker_1_21 }}
       run_docker_1_22: ${{ steps.check.outputs.run_docker_1_22 }}
+      run_docker_1_23: ${{ steps.check.outputs.run_docker_1_23 }}
       run_containerd_1_19: ${{ steps.check.outputs.run_containerd_1_19 }}
       run_containerd_1_20: ${{ steps.check.outputs.run_containerd_1_20 }}
       run_containerd_1_21: ${{ steps.check.outputs.run_containerd_1_21 }}
       run_containerd_1_22: ${{ steps.check.outputs.run_containerd_1_22 }}
+      run_containerd_1_23: ${{ steps.check.outputs.run_containerd_1_23 }}
     steps:
 
       # <template: checkout_step>
@@ -1667,6 +1669,375 @@ jobs:
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.22"
+        run: |
+          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          echo $WORKFLOW_URL
+
+          alertData=$(cat <<EOF
+          {
+            "labels": {
+              "severity_level": 7,
+              "trigger": "CloudLayoutTestFailed",
+              "provider": "${PROVIDER}",
+              "layout": "${LAYOUT}",
+              "cri": "${CRI}",
+              "kubernetes_version": "${KUBERNETES_VERSION}"
+            },
+            "annotations": {
+              "summary": "Cloud Layout Test failed",
+              "description": "Check Github workflow log for more information",
+              "plk_protocol_version": "1",
+              "plk_link_url/job": "${WORKFLOW_URL}",
+              "plk_link_title_en/job": "Github job run",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+            }
+          }
+          EOF
+          )
+
+          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "${alertData}"
+  # </template: e2e_run_job_template>
+
+  # <template: e2e_run_job_template>
+  run_docker_1_23:
+    name: "e2e: GCP, Docker, Kubernetes 1.23"
+    needs:
+      - check_e2e_labels
+      - git_info
+    if: needs.check_e2e_labels.outputs.run_docker_1_23 == 'true'
+    env:
+      PROVIDER: GCP
+      CRI: Docker
+      LAYOUT: WithoutNAT
+      KUBERNETES_VERSION: "1.23"
+      EVENT_LABEL: ${{ github.event.label.name }}
+    runs-on: [self-hosted, e2e-common]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_from_event_ref_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
+          fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
+      - name: Update comment on start
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'e2e: GCP, Docker, Kubernetes 1.23';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      # </template: update_comment_on_start>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
+          fi
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
+          docker pull "${IMAGE_NAME}"
+
+      - name: "Run e2e test: GCP/Docker/1.23"
+        env:
+          PROVIDER: GCP
+          CRI: Docker
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
+        run: |
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh run-test
+
+        # </template: e2e_run_template>
+
+      - name: Cleanup bootstrapped cluster
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          PROVIDER: GCP
+          CRI: Docker
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
+        run: |
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh cleanup
+
+        # </template: e2e_run_template>
+
+      - name: Save test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_output_gcp_docker_1_23
+          path: |
+            testing/cloud_layouts/
+
+      - name: Cleanup temp directory
+        if: always()
+        env:
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+        run: |
+          echo "Remove temporary directory '${TMPPATH}' ..."
+          if [[ -d "${TMPPATH}" && ${#TMPPATH} > 1 ]] ; then
+            rm -rf "${TMPPATH}"
+          else
+            echo Not a directory.
+          fi
+
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'job,separate';
+            const name = 'e2e: GCP, Docker, Kubernetes 1.23';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
+
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
+      - name: Alert on fail in default branch
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        env:
+          PROVIDER: GCP
+          CRI: Docker
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
           echo $WORKFLOW_URL
@@ -3175,15 +3546,384 @@ jobs:
             -d "${alertData}"
   # </template: e2e_run_job_template>
 
+  # <template: e2e_run_job_template>
+  run_containerd_1_23:
+    name: "e2e: GCP, Containerd, Kubernetes 1.23"
+    needs:
+      - check_e2e_labels
+      - git_info
+    if: needs.check_e2e_labels.outputs.run_containerd_1_23 == 'true'
+    env:
+      PROVIDER: GCP
+      CRI: Containerd
+      LAYOUT: WithoutNAT
+      KUBERNETES_VERSION: "1.23"
+      EVENT_LABEL: ${{ github.event.label.name }}
+    runs-on: [self-hosted, e2e-common]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_from_event_ref_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
+          fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
+      - name: Update comment on start
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'e2e: GCP, Containerd, Kubernetes 1.23';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      # </template: update_comment_on_start>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
+          fi
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
+          docker pull "${IMAGE_NAME}"
+
+      - name: "Run e2e test: GCP/Containerd/1.23"
+        env:
+          PROVIDER: GCP
+          CRI: Containerd
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
+        run: |
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh run-test
+
+        # </template: e2e_run_template>
+
+      - name: Cleanup bootstrapped cluster
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          PROVIDER: GCP
+          CRI: Containerd
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
+        run: |
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh cleanup
+
+        # </template: e2e_run_template>
+
+      - name: Save test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_output_gcp_containerd_1_23
+          path: |
+            testing/cloud_layouts/
+
+      - name: Cleanup temp directory
+        if: always()
+        env:
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+        run: |
+          echo "Remove temporary directory '${TMPPATH}' ..."
+          if [[ -d "${TMPPATH}" && ${#TMPPATH} > 1 ]] ; then
+            rm -rf "${TMPPATH}"
+          else
+            echo Not a directory.
+          fi
+
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'job,separate';
+            const name = 'e2e: GCP, Containerd, Kubernetes 1.23';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
+
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
+      - name: Alert on fail in default branch
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        env:
+          PROVIDER: GCP
+          CRI: Containerd
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+        run: |
+          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          echo $WORKFLOW_URL
+
+          alertData=$(cat <<EOF
+          {
+            "labels": {
+              "severity_level": 7,
+              "trigger": "CloudLayoutTestFailed",
+              "provider": "${PROVIDER}",
+              "layout": "${LAYOUT}",
+              "cri": "${CRI}",
+              "kubernetes_version": "${KUBERNETES_VERSION}"
+            },
+            "annotations": {
+              "summary": "Cloud Layout Test failed",
+              "description": "Check Github workflow log for more information",
+              "plk_protocol_version": "1",
+              "plk_link_url/job": "${WORKFLOW_URL}",
+              "plk_link_title_en/job": "Github job run",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+            }
+          }
+          EOF
+          )
+
+          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "${alertData}"
+  # </template: e2e_run_job_template>
+
 
   last_comment:
     name: Update comment on finish
-    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22"]
+    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23"]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_19":"e2e: GCP, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: GCP, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: GCP, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: GCP, Containerd, Kubernetes 1.22","run_docker_1_19":"e2e: GCP, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: GCP, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: GCP, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: GCP, Docker, Kubernetes 1.22"}
+        {"run_containerd_1_19":"e2e: GCP, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: GCP, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: GCP, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: GCP, Containerd, Kubernetes 1.22","run_containerd_1_23":"e2e: GCP, Containerd, Kubernetes 1.23","run_docker_1_19":"e2e: GCP, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: GCP, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: GCP, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: GCP, Docker, Kubernetes 1.22","run_docker_1_23":"e2e: GCP, Docker, Kubernetes 1.23"}
     steps:
 
       # <template: checkout_step>

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -32,7 +32,7 @@ on:
         description: 'A comma-separated list of cri to test. Available: Docker and Containerd.'
         required: false
       ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.19 to 1.22.'
+        description: 'A comma-separated list of versions to test. Available: from 1.19 to 1.23.'
         required: false
 env:
 
@@ -200,10 +200,12 @@ jobs:
       run_docker_1_20: ${{ steps.check.outputs.run_docker_1_20 }}
       run_docker_1_21: ${{ steps.check.outputs.run_docker_1_21 }}
       run_docker_1_22: ${{ steps.check.outputs.run_docker_1_22 }}
+      run_docker_1_23: ${{ steps.check.outputs.run_docker_1_23 }}
       run_containerd_1_19: ${{ steps.check.outputs.run_containerd_1_19 }}
       run_containerd_1_20: ${{ steps.check.outputs.run_containerd_1_20 }}
       run_containerd_1_21: ${{ steps.check.outputs.run_containerd_1_21 }}
       run_containerd_1_22: ${{ steps.check.outputs.run_containerd_1_22 }}
+      run_containerd_1_23: ${{ steps.check.outputs.run_containerd_1_23 }}
     steps:
 
       # <template: checkout_step>
@@ -1667,6 +1669,375 @@ jobs:
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.22"
+        run: |
+          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          echo $WORKFLOW_URL
+
+          alertData=$(cat <<EOF
+          {
+            "labels": {
+              "severity_level": 7,
+              "trigger": "CloudLayoutTestFailed",
+              "provider": "${PROVIDER}",
+              "layout": "${LAYOUT}",
+              "cri": "${CRI}",
+              "kubernetes_version": "${KUBERNETES_VERSION}"
+            },
+            "annotations": {
+              "summary": "Cloud Layout Test failed",
+              "description": "Check Github workflow log for more information",
+              "plk_protocol_version": "1",
+              "plk_link_url/job": "${WORKFLOW_URL}",
+              "plk_link_title_en/job": "Github job run",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+            }
+          }
+          EOF
+          )
+
+          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "${alertData}"
+  # </template: e2e_run_job_template>
+
+  # <template: e2e_run_job_template>
+  run_docker_1_23:
+    name: "e2e: OpenStack, Docker, Kubernetes 1.23"
+    needs:
+      - check_e2e_labels
+      - git_info
+    if: needs.check_e2e_labels.outputs.run_docker_1_23 == 'true'
+    env:
+      PROVIDER: OpenStack
+      CRI: Docker
+      LAYOUT: WithoutNAT
+      KUBERNETES_VERSION: "1.23"
+      EVENT_LABEL: ${{ github.event.label.name }}
+    runs-on: [self-hosted, e2e-common]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_from_event_ref_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
+          fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
+      - name: Update comment on start
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'e2e: OpenStack, Docker, Kubernetes 1.23';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      # </template: update_comment_on_start>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
+          fi
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
+          docker pull "${IMAGE_NAME}"
+
+      - name: "Run e2e test: OpenStack/Docker/1.23"
+        env:
+          PROVIDER: OpenStack
+          CRI: Docker
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
+        run: |
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh run-test
+
+        # </template: e2e_run_template>
+
+      - name: Cleanup bootstrapped cluster
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          PROVIDER: OpenStack
+          CRI: Docker
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
+        run: |
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh cleanup
+
+        # </template: e2e_run_template>
+
+      - name: Save test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_output_openstack_docker_1_23
+          path: |
+            testing/cloud_layouts/
+
+      - name: Cleanup temp directory
+        if: always()
+        env:
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+        run: |
+          echo "Remove temporary directory '${TMPPATH}' ..."
+          if [[ -d "${TMPPATH}" && ${#TMPPATH} > 1 ]] ; then
+            rm -rf "${TMPPATH}"
+          else
+            echo Not a directory.
+          fi
+
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'job,separate';
+            const name = 'e2e: OpenStack, Docker, Kubernetes 1.23';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
+
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
+      - name: Alert on fail in default branch
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        env:
+          PROVIDER: OpenStack
+          CRI: Docker
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
           echo $WORKFLOW_URL
@@ -3175,15 +3546,384 @@ jobs:
             -d "${alertData}"
   # </template: e2e_run_job_template>
 
+  # <template: e2e_run_job_template>
+  run_containerd_1_23:
+    name: "e2e: OpenStack, Containerd, Kubernetes 1.23"
+    needs:
+      - check_e2e_labels
+      - git_info
+    if: needs.check_e2e_labels.outputs.run_containerd_1_23 == 'true'
+    env:
+      PROVIDER: OpenStack
+      CRI: Containerd
+      LAYOUT: WithoutNAT
+      KUBERNETES_VERSION: "1.23"
+      EVENT_LABEL: ${{ github.event.label.name }}
+    runs-on: [self-hosted, e2e-common]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_from_event_ref_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
+          fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
+      - name: Update comment on start
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'e2e: OpenStack, Containerd, Kubernetes 1.23';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      # </template: update_comment_on_start>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
+          fi
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
+          docker pull "${IMAGE_NAME}"
+
+      - name: "Run e2e test: OpenStack/Containerd/1.23"
+        env:
+          PROVIDER: OpenStack
+          CRI: Containerd
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
+        run: |
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh run-test
+
+        # </template: e2e_run_template>
+
+      - name: Cleanup bootstrapped cluster
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          PROVIDER: OpenStack
+          CRI: Containerd
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
+        run: |
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh cleanup
+
+        # </template: e2e_run_template>
+
+      - name: Save test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_output_openstack_containerd_1_23
+          path: |
+            testing/cloud_layouts/
+
+      - name: Cleanup temp directory
+        if: always()
+        env:
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+        run: |
+          echo "Remove temporary directory '${TMPPATH}' ..."
+          if [[ -d "${TMPPATH}" && ${#TMPPATH} > 1 ]] ; then
+            rm -rf "${TMPPATH}"
+          else
+            echo Not a directory.
+          fi
+
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'job,separate';
+            const name = 'e2e: OpenStack, Containerd, Kubernetes 1.23';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
+
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
+      - name: Alert on fail in default branch
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        env:
+          PROVIDER: OpenStack
+          CRI: Containerd
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+        run: |
+          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          echo $WORKFLOW_URL
+
+          alertData=$(cat <<EOF
+          {
+            "labels": {
+              "severity_level": 7,
+              "trigger": "CloudLayoutTestFailed",
+              "provider": "${PROVIDER}",
+              "layout": "${LAYOUT}",
+              "cri": "${CRI}",
+              "kubernetes_version": "${KUBERNETES_VERSION}"
+            },
+            "annotations": {
+              "summary": "Cloud Layout Test failed",
+              "description": "Check Github workflow log for more information",
+              "plk_protocol_version": "1",
+              "plk_link_url/job": "${WORKFLOW_URL}",
+              "plk_link_title_en/job": "Github job run",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+            }
+          }
+          EOF
+          )
+
+          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "${alertData}"
+  # </template: e2e_run_job_template>
+
 
   last_comment:
     name: Update comment on finish
-    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22"]
+    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23"]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_19":"e2e: OpenStack, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: OpenStack, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: OpenStack, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: OpenStack, Containerd, Kubernetes 1.22","run_docker_1_19":"e2e: OpenStack, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: OpenStack, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: OpenStack, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: OpenStack, Docker, Kubernetes 1.22"}
+        {"run_containerd_1_19":"e2e: OpenStack, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: OpenStack, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: OpenStack, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: OpenStack, Containerd, Kubernetes 1.22","run_containerd_1_23":"e2e: OpenStack, Containerd, Kubernetes 1.23","run_docker_1_19":"e2e: OpenStack, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: OpenStack, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: OpenStack, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: OpenStack, Docker, Kubernetes 1.22","run_docker_1_23":"e2e: OpenStack, Docker, Kubernetes 1.23"}
     steps:
 
       # <template: checkout_step>

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -32,7 +32,7 @@ on:
         description: 'A comma-separated list of cri to test. Available: Docker and Containerd.'
         required: false
       ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.19 to 1.22.'
+        description: 'A comma-separated list of versions to test. Available: from 1.19 to 1.23.'
         required: false
 env:
 
@@ -200,10 +200,12 @@ jobs:
       run_docker_1_20: ${{ steps.check.outputs.run_docker_1_20 }}
       run_docker_1_21: ${{ steps.check.outputs.run_docker_1_21 }}
       run_docker_1_22: ${{ steps.check.outputs.run_docker_1_22 }}
+      run_docker_1_23: ${{ steps.check.outputs.run_docker_1_23 }}
       run_containerd_1_19: ${{ steps.check.outputs.run_containerd_1_19 }}
       run_containerd_1_20: ${{ steps.check.outputs.run_containerd_1_20 }}
       run_containerd_1_21: ${{ steps.check.outputs.run_containerd_1_21 }}
       run_containerd_1_22: ${{ steps.check.outputs.run_containerd_1_22 }}
+      run_containerd_1_23: ${{ steps.check.outputs.run_containerd_1_23 }}
     steps:
 
       # <template: checkout_step>
@@ -1667,6 +1669,375 @@ jobs:
           CRI: Docker
           LAYOUT: Static
           KUBERNETES_VERSION: "1.22"
+        run: |
+          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          echo $WORKFLOW_URL
+
+          alertData=$(cat <<EOF
+          {
+            "labels": {
+              "severity_level": 7,
+              "trigger": "CloudLayoutTestFailed",
+              "provider": "${PROVIDER}",
+              "layout": "${LAYOUT}",
+              "cri": "${CRI}",
+              "kubernetes_version": "${KUBERNETES_VERSION}"
+            },
+            "annotations": {
+              "summary": "Cloud Layout Test failed",
+              "description": "Check Github workflow log for more information",
+              "plk_protocol_version": "1",
+              "plk_link_url/job": "${WORKFLOW_URL}",
+              "plk_link_title_en/job": "Github job run",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+            }
+          }
+          EOF
+          )
+
+          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "${alertData}"
+  # </template: e2e_run_job_template>
+
+  # <template: e2e_run_job_template>
+  run_docker_1_23:
+    name: "e2e: Static, Docker, Kubernetes 1.23"
+    needs:
+      - check_e2e_labels
+      - git_info
+    if: needs.check_e2e_labels.outputs.run_docker_1_23 == 'true'
+    env:
+      PROVIDER: Static
+      CRI: Docker
+      LAYOUT: Static
+      KUBERNETES_VERSION: "1.23"
+      EVENT_LABEL: ${{ github.event.label.name }}
+    runs-on: [self-hosted, e2e-common]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_from_event_ref_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
+          fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
+      - name: Update comment on start
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'e2e: Static, Docker, Kubernetes 1.23';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      # </template: update_comment_on_start>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
+          fi
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
+          docker pull "${IMAGE_NAME}"
+
+      - name: "Run e2e test: Static/Docker/1.23"
+        env:
+          PROVIDER: Static
+          CRI: Docker
+          LAYOUT: Static
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
+        run: |
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh run-test
+
+        # </template: e2e_run_template>
+
+      - name: Cleanup bootstrapped cluster
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          PROVIDER: Static
+          CRI: Docker
+          LAYOUT: Static
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
+        run: |
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh cleanup
+
+        # </template: e2e_run_template>
+
+      - name: Save test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_output_static_docker_1_23
+          path: |
+            testing/cloud_layouts/
+
+      - name: Cleanup temp directory
+        if: always()
+        env:
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+        run: |
+          echo "Remove temporary directory '${TMPPATH}' ..."
+          if [[ -d "${TMPPATH}" && ${#TMPPATH} > 1 ]] ; then
+            rm -rf "${TMPPATH}"
+          else
+            echo Not a directory.
+          fi
+
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Static, Docker, Kubernetes 1.23';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
+
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
+      - name: Alert on fail in default branch
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        env:
+          PROVIDER: Static
+          CRI: Docker
+          LAYOUT: Static
+          KUBERNETES_VERSION: "1.23"
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
           echo $WORKFLOW_URL
@@ -3175,15 +3546,384 @@ jobs:
             -d "${alertData}"
   # </template: e2e_run_job_template>
 
+  # <template: e2e_run_job_template>
+  run_containerd_1_23:
+    name: "e2e: Static, Containerd, Kubernetes 1.23"
+    needs:
+      - check_e2e_labels
+      - git_info
+    if: needs.check_e2e_labels.outputs.run_containerd_1_23 == 'true'
+    env:
+      PROVIDER: Static
+      CRI: Containerd
+      LAYOUT: Static
+      KUBERNETES_VERSION: "1.23"
+      EVENT_LABEL: ${{ github.event.label.name }}
+    runs-on: [self-hosted, e2e-common]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_from_event_ref_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
+          fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
+      - name: Update comment on start
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'e2e: Static, Containerd, Kubernetes 1.23';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      # </template: update_comment_on_start>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
+          fi
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
+          docker pull "${IMAGE_NAME}"
+
+      - name: "Run e2e test: Static/Containerd/1.23"
+        env:
+          PROVIDER: Static
+          CRI: Containerd
+          LAYOUT: Static
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
+        run: |
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh run-test
+
+        # </template: e2e_run_template>
+
+      - name: Cleanup bootstrapped cluster
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          PROVIDER: Static
+          CRI: Containerd
+          LAYOUT: Static
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
+        run: |
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh cleanup
+
+        # </template: e2e_run_template>
+
+      - name: Save test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_output_static_containerd_1_23
+          path: |
+            testing/cloud_layouts/
+
+      - name: Cleanup temp directory
+        if: always()
+        env:
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+        run: |
+          echo "Remove temporary directory '${TMPPATH}' ..."
+          if [[ -d "${TMPPATH}" && ${#TMPPATH} > 1 ]] ; then
+            rm -rf "${TMPPATH}"
+          else
+            echo Not a directory.
+          fi
+
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Static, Containerd, Kubernetes 1.23';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
+
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
+      - name: Alert on fail in default branch
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        env:
+          PROVIDER: Static
+          CRI: Containerd
+          LAYOUT: Static
+          KUBERNETES_VERSION: "1.23"
+        run: |
+          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          echo $WORKFLOW_URL
+
+          alertData=$(cat <<EOF
+          {
+            "labels": {
+              "severity_level": 7,
+              "trigger": "CloudLayoutTestFailed",
+              "provider": "${PROVIDER}",
+              "layout": "${LAYOUT}",
+              "cri": "${CRI}",
+              "kubernetes_version": "${KUBERNETES_VERSION}"
+            },
+            "annotations": {
+              "summary": "Cloud Layout Test failed",
+              "description": "Check Github workflow log for more information",
+              "plk_protocol_version": "1",
+              "plk_link_url/job": "${WORKFLOW_URL}",
+              "plk_link_title_en/job": "Github job run",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+            }
+          }
+          EOF
+          )
+
+          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "${alertData}"
+  # </template: e2e_run_job_template>
+
 
   last_comment:
     name: Update comment on finish
-    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22"]
+    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23"]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_19":"e2e: Static, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: Static, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: Static, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: Static, Containerd, Kubernetes 1.22","run_docker_1_19":"e2e: Static, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: Static, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: Static, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: Static, Docker, Kubernetes 1.22"}
+        {"run_containerd_1_19":"e2e: Static, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: Static, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: Static, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: Static, Containerd, Kubernetes 1.22","run_containerd_1_23":"e2e: Static, Containerd, Kubernetes 1.23","run_docker_1_19":"e2e: Static, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: Static, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: Static, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: Static, Docker, Kubernetes 1.22","run_docker_1_23":"e2e: Static, Docker, Kubernetes 1.23"}
     steps:
 
       # <template: checkout_step>

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -32,7 +32,7 @@ on:
         description: 'A comma-separated list of cri to test. Available: Docker and Containerd.'
         required: false
       ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.19 to 1.22.'
+        description: 'A comma-separated list of versions to test. Available: from 1.19 to 1.23.'
         required: false
 env:
 
@@ -200,10 +200,12 @@ jobs:
       run_docker_1_20: ${{ steps.check.outputs.run_docker_1_20 }}
       run_docker_1_21: ${{ steps.check.outputs.run_docker_1_21 }}
       run_docker_1_22: ${{ steps.check.outputs.run_docker_1_22 }}
+      run_docker_1_23: ${{ steps.check.outputs.run_docker_1_23 }}
       run_containerd_1_19: ${{ steps.check.outputs.run_containerd_1_19 }}
       run_containerd_1_20: ${{ steps.check.outputs.run_containerd_1_20 }}
       run_containerd_1_21: ${{ steps.check.outputs.run_containerd_1_21 }}
       run_containerd_1_22: ${{ steps.check.outputs.run_containerd_1_22 }}
+      run_containerd_1_23: ${{ steps.check.outputs.run_containerd_1_23 }}
     steps:
 
       # <template: checkout_step>
@@ -1683,6 +1685,379 @@ jobs:
           CRI: Docker
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.22"
+        run: |
+          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          echo $WORKFLOW_URL
+
+          alertData=$(cat <<EOF
+          {
+            "labels": {
+              "severity_level": 7,
+              "trigger": "CloudLayoutTestFailed",
+              "provider": "${PROVIDER}",
+              "layout": "${LAYOUT}",
+              "cri": "${CRI}",
+              "kubernetes_version": "${KUBERNETES_VERSION}"
+            },
+            "annotations": {
+              "summary": "Cloud Layout Test failed",
+              "description": "Check Github workflow log for more information",
+              "plk_protocol_version": "1",
+              "plk_link_url/job": "${WORKFLOW_URL}",
+              "plk_link_title_en/job": "Github job run",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+            }
+          }
+          EOF
+          )
+
+          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "${alertData}"
+  # </template: e2e_run_job_template>
+
+  # <template: e2e_run_job_template>
+  run_docker_1_23:
+    name: "e2e: vSphere, Docker, Kubernetes 1.23"
+    needs:
+      - check_e2e_labels
+      - git_info
+    if: needs.check_e2e_labels.outputs.run_docker_1_23 == 'true'
+    env:
+      PROVIDER: vSphere
+      CRI: Docker
+      LAYOUT: Standard
+      KUBERNETES_VERSION: "1.23"
+      EVENT_LABEL: ${{ github.event.label.name }}
+    runs-on: [self-hosted, e2e-vsphere]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_from_event_ref_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
+          fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
+      - name: Update comment on start
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'e2e: vSphere, Docker, Kubernetes 1.23';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      # </template: update_comment_on_start>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
+          fi
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
+          docker pull "${IMAGE_NAME}"
+
+      - name: "Run e2e test: vSphere/Docker/1.23"
+        env:
+          PROVIDER: vSphere
+          CRI: Docker
+          LAYOUT: Standard
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
+          LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
+        run: |
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
+            -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh run-test
+
+        # </template: e2e_run_template>
+
+      - name: Cleanup bootstrapped cluster
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          PROVIDER: vSphere
+          CRI: Docker
+          LAYOUT: Standard
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
+          LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
+        run: |
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
+            -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh cleanup
+
+        # </template: e2e_run_template>
+
+      - name: Save test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_output_vsphere_docker_1_23
+          path: |
+            testing/cloud_layouts/
+
+      - name: Cleanup temp directory
+        if: always()
+        env:
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+        run: |
+          echo "Remove temporary directory '${TMPPATH}' ..."
+          if [[ -d "${TMPPATH}" && ${#TMPPATH} > 1 ]] ; then
+            rm -rf "${TMPPATH}"
+          else
+            echo Not a directory.
+          fi
+
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'job,separate';
+            const name = 'e2e: vSphere, Docker, Kubernetes 1.23';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
+
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
+      - name: Alert on fail in default branch
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        env:
+          PROVIDER: vSphere
+          CRI: Docker
+          LAYOUT: Standard
+          KUBERNETES_VERSION: "1.23"
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
           echo $WORKFLOW_URL
@@ -3207,15 +3582,388 @@ jobs:
             -d "${alertData}"
   # </template: e2e_run_job_template>
 
+  # <template: e2e_run_job_template>
+  run_containerd_1_23:
+    name: "e2e: vSphere, Containerd, Kubernetes 1.23"
+    needs:
+      - check_e2e_labels
+      - git_info
+    if: needs.check_e2e_labels.outputs.run_containerd_1_23 == 'true'
+    env:
+      PROVIDER: vSphere
+      CRI: Containerd
+      LAYOUT: Standard
+      KUBERNETES_VERSION: "1.23"
+      EVENT_LABEL: ${{ github.event.label.name }}
+    runs-on: [self-hosted, e2e-vsphere]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_from_event_ref_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
+          fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
+      - name: Update comment on start
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'e2e: vSphere, Containerd, Kubernetes 1.23';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      # </template: update_comment_on_start>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
+          fi
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
+          docker pull "${IMAGE_NAME}"
+
+      - name: "Run e2e test: vSphere/Containerd/1.23"
+        env:
+          PROVIDER: vSphere
+          CRI: Containerd
+          LAYOUT: Standard
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
+          LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
+        run: |
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
+            -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh run-test
+
+        # </template: e2e_run_template>
+
+      - name: Cleanup bootstrapped cluster
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          PROVIDER: vSphere
+          CRI: Containerd
+          LAYOUT: Standard
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
+          LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
+        run: |
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
+            -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh cleanup
+
+        # </template: e2e_run_template>
+
+      - name: Save test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_output_vsphere_containerd_1_23
+          path: |
+            testing/cloud_layouts/
+
+      - name: Cleanup temp directory
+        if: always()
+        env:
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+        run: |
+          echo "Remove temporary directory '${TMPPATH}' ..."
+          if [[ -d "${TMPPATH}" && ${#TMPPATH} > 1 ]] ; then
+            rm -rf "${TMPPATH}"
+          else
+            echo Not a directory.
+          fi
+
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'job,separate';
+            const name = 'e2e: vSphere, Containerd, Kubernetes 1.23';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
+
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
+      - name: Alert on fail in default branch
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        env:
+          PROVIDER: vSphere
+          CRI: Containerd
+          LAYOUT: Standard
+          KUBERNETES_VERSION: "1.23"
+        run: |
+          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          echo $WORKFLOW_URL
+
+          alertData=$(cat <<EOF
+          {
+            "labels": {
+              "severity_level": 7,
+              "trigger": "CloudLayoutTestFailed",
+              "provider": "${PROVIDER}",
+              "layout": "${LAYOUT}",
+              "cri": "${CRI}",
+              "kubernetes_version": "${KUBERNETES_VERSION}"
+            },
+            "annotations": {
+              "summary": "Cloud Layout Test failed",
+              "description": "Check Github workflow log for more information",
+              "plk_protocol_version": "1",
+              "plk_link_url/job": "${WORKFLOW_URL}",
+              "plk_link_title_en/job": "Github job run",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+            }
+          }
+          EOF
+          )
+
+          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "${alertData}"
+  # </template: e2e_run_job_template>
+
 
   last_comment:
     name: Update comment on finish
-    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22"]
+    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23"]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_19":"e2e: vSphere, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: vSphere, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: vSphere, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: vSphere, Containerd, Kubernetes 1.22","run_docker_1_19":"e2e: vSphere, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: vSphere, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: vSphere, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: vSphere, Docker, Kubernetes 1.22"}
+        {"run_containerd_1_19":"e2e: vSphere, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: vSphere, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: vSphere, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: vSphere, Containerd, Kubernetes 1.22","run_containerd_1_23":"e2e: vSphere, Containerd, Kubernetes 1.23","run_docker_1_19":"e2e: vSphere, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: vSphere, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: vSphere, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: vSphere, Docker, Kubernetes 1.22","run_docker_1_23":"e2e: vSphere, Docker, Kubernetes 1.23"}
     steps:
 
       # <template: checkout_step>

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -32,7 +32,7 @@ on:
         description: 'A comma-separated list of cri to test. Available: Docker and Containerd.'
         required: false
       ver:
-        description: 'A comma-separated list of versions to test. Available: from 1.19 to 1.22.'
+        description: 'A comma-separated list of versions to test. Available: from 1.19 to 1.23.'
         required: false
 env:
 
@@ -200,10 +200,12 @@ jobs:
       run_docker_1_20: ${{ steps.check.outputs.run_docker_1_20 }}
       run_docker_1_21: ${{ steps.check.outputs.run_docker_1_21 }}
       run_docker_1_22: ${{ steps.check.outputs.run_docker_1_22 }}
+      run_docker_1_23: ${{ steps.check.outputs.run_docker_1_23 }}
       run_containerd_1_19: ${{ steps.check.outputs.run_containerd_1_19 }}
       run_containerd_1_20: ${{ steps.check.outputs.run_containerd_1_20 }}
       run_containerd_1_21: ${{ steps.check.outputs.run_containerd_1_21 }}
       run_containerd_1_22: ${{ steps.check.outputs.run_containerd_1_22 }}
+      run_containerd_1_23: ${{ steps.check.outputs.run_containerd_1_23 }}
     steps:
 
       # <template: checkout_step>
@@ -1699,6 +1701,383 @@ jobs:
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.22"
+        run: |
+          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          echo $WORKFLOW_URL
+
+          alertData=$(cat <<EOF
+          {
+            "labels": {
+              "severity_level": 7,
+              "trigger": "CloudLayoutTestFailed",
+              "provider": "${PROVIDER}",
+              "layout": "${LAYOUT}",
+              "cri": "${CRI}",
+              "kubernetes_version": "${KUBERNETES_VERSION}"
+            },
+            "annotations": {
+              "summary": "Cloud Layout Test failed",
+              "description": "Check Github workflow log for more information",
+              "plk_protocol_version": "1",
+              "plk_link_url/job": "${WORKFLOW_URL}",
+              "plk_link_title_en/job": "Github job run",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+            }
+          }
+          EOF
+          )
+
+          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "${alertData}"
+  # </template: e2e_run_job_template>
+
+  # <template: e2e_run_job_template>
+  run_docker_1_23:
+    name: "e2e: Yandex.Cloud, Docker, Kubernetes 1.23"
+    needs:
+      - check_e2e_labels
+      - git_info
+    if: needs.check_e2e_labels.outputs.run_docker_1_23 == 'true'
+    env:
+      PROVIDER: Yandex.Cloud
+      CRI: Docker
+      LAYOUT: WithoutNAT
+      KUBERNETES_VERSION: "1.23"
+      EVENT_LABEL: ${{ github.event.label.name }}
+    runs-on: [self-hosted, e2e-common]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_from_event_ref_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
+          fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
+      - name: Update comment on start
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'e2e: Yandex.Cloud, Docker, Kubernetes 1.23';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      # </template: update_comment_on_start>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
+          fi
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
+          docker pull "${IMAGE_NAME}"
+
+      - name: "Run e2e test: Yandex.Cloud/Docker/1.23"
+        env:
+          PROVIDER: Yandex.Cloud
+          CRI: Docker
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
+          LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
+          LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
+        run: |
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_YANDEX_CLOUD_ID=${LAYOUT_YANDEX_CLOUD_ID:-not_provided} \
+            -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
+            -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh run-test
+
+        # </template: e2e_run_template>
+
+      - name: Cleanup bootstrapped cluster
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          PROVIDER: Yandex.Cloud
+          CRI: Docker
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
+          LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
+          LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
+        run: |
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_YANDEX_CLOUD_ID=${LAYOUT_YANDEX_CLOUD_ID:-not_provided} \
+            -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
+            -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh cleanup
+
+        # </template: e2e_run_template>
+
+      - name: Save test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_output_yandex-cloud_docker_1_23
+          path: |
+            testing/cloud_layouts/
+
+      - name: Cleanup temp directory
+        if: always()
+        env:
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+        run: |
+          echo "Remove temporary directory '${TMPPATH}' ..."
+          if [[ -d "${TMPPATH}" && ${#TMPPATH} > 1 ]] ; then
+            rm -rf "${TMPPATH}"
+          else
+            echo Not a directory.
+          fi
+
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Yandex.Cloud, Docker, Kubernetes 1.23';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
+
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
+      - name: Alert on fail in default branch
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        env:
+          PROVIDER: Yandex.Cloud
+          CRI: Docker
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
           echo $WORKFLOW_URL
@@ -3239,15 +3618,392 @@ jobs:
             -d "${alertData}"
   # </template: e2e_run_job_template>
 
+  # <template: e2e_run_job_template>
+  run_containerd_1_23:
+    name: "e2e: Yandex.Cloud, Containerd, Kubernetes 1.23"
+    needs:
+      - check_e2e_labels
+      - git_info
+    if: needs.check_e2e_labels.outputs.run_containerd_1_23 == 'true'
+    env:
+      PROVIDER: Yandex.Cloud
+      CRI: Containerd
+      LAYOUT: WithoutNAT
+      KUBERNETES_VERSION: "1.23"
+      EVENT_LABEL: ${{ github.event.label.name }}
+    runs-on: [self-hosted, e2e-common]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_from_event_ref_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ github.event.inputs.pull_request_ref || github.event.ref }}
+          fetch-depth: 0
+      # </template: checkout_from_event_ref_step>
+      # <template: update_comment_on_start>
+      - name: Update comment on start
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const name = 'e2e: Yandex.Cloud, Containerd, Kubernetes 1.23';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      # </template: update_comment_on_start>
+
+      # <template: login_dev_registry_step>
+      - name: Check dev registry credentials
+        id: check_dev_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_DEV_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to dev registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_dev_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_DEV_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_dev_registry_step>
+
+      # <template: login_rw_registry_step>
+      - name: Check rw registry credentials
+        id: check_rw_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to rw registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}
+          logout: false
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_rw_registry.outputs.has_credentials != 'true' }}
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_REGISTRY_USER }}
+          password: ${{ secrets.GHCR_IO_REGISTRY_PASSWORD }}
+          logout: false
+      # </template: login_rw_registry_step>
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
+      - name: Setup
+        id: setup
+        env:
+          DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
+          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+        run: |
+          # Random delay to sparse 'update comment' steps in time.
+          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
+          echo Delay for $delay
+          sleep $delay
+
+          # Calculate unique prefix for e2e test.
+          # GITHUB_RUN_ID is a unique number for each workflow run.
+          # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
+          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=prefix::${prefix}"
+          echo "prefix=${prefix}"
+
+          # Create tmppath for test script.
+          tmppath=/mnt/cloud-layouts/layouts/${prefix}
+          if [[ -d "${tmppath}" ]] ; then
+            echo "Temporary dir already exists: ${tmppath}. ERROR!"
+            ls -la ${tmppath}
+            exit 1
+          else
+            echo "Create temporary dir for job: ${tmppath}."
+            mkdir -p "${tmppath}"
+          fi
+          echo "::set-output name=tmppath::${tmppath}"
+
+          ## Deckhouse 'install' image name
+          ## Source: ci_templates/build.yml
+
+          # Use dev-registry for Git branches.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
+          # Use rw-registry for Git tags.
+          SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
+
+          if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
+            # Use Github Container Registry for test repositories.
+            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
+          fi
+
+          IMAGE_NAME=
+          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
+          fi
+          if [[ -n $CI_COMMIT_TAG ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
+          fi
+
+          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+
+          # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
+          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
+          docker pull "${IMAGE_NAME}"
+
+      - name: "Run e2e test: Yandex.Cloud/Containerd/1.23"
+        env:
+          PROVIDER: Yandex.Cloud
+          CRI: Containerd
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
+          LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
+          LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
+        run: |
+          echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_YANDEX_CLOUD_ID=${LAYOUT_YANDEX_CLOUD_ID:-not_provided} \
+            -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
+            -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh run-test
+
+        # </template: e2e_run_template>
+
+      - name: Cleanup bootstrapped cluster
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+          PROVIDER: Yandex.Cloud
+          CRI: Containerd
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+          LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
+          LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
+          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
+          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
+          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
+          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+          PREFIX: ${{ steps.setup.outputs.prefix}}
+          INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        # <template: e2e_run_template>
+          LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
+          LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
+          LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
+        run: |
+          echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            PREFIX=${PREFIX}
+            TMPPATH=${TMPPATH}
+            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            PROVIDER=${PROVIDER}
+            CRI=${CRI}
+            LAYOUT=${LAYOUT}
+            KUBERNETES_VERSION=${KUBERNETES_VERSION}
+            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
+            JOB_STATUS=${JOB_STATUS}
+          "
+
+          docker run --rm \
+            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
+            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
+            -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
+            -e PREFIX=${PREFIX} \
+            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+            -e CRI=${CRI} \
+            -e PROVIDER=${PROVIDER:-not_provided} \
+            -e LAYOUT=${LAYOUT:-not_provided} \
+            -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
+            -e LAYOUT_YANDEX_CLOUD_ID=${LAYOUT_YANDEX_CLOUD_ID:-not_provided} \
+            -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
+            -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
+            -v $(pwd)/testing:/deckhouse/testing \
+            -v ${TMPPATH}:/tmp \
+            --user $(id -u):$(id -u) \
+            -v /etc/group:/etc/group:ro \
+            -v /etc/passwd:/etc/passwd:ro \
+            -v /etc/shadow:/etc/shadow:ro \
+            -w /deckhouse \
+          ${INSTALL_IMAGE_NAME} \
+          bash /deckhouse/testing/cloud_layouts/script.sh cleanup
+
+        # </template: e2e_run_template>
+
+      - name: Save test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_output_yandex-cloud_containerd_1_23
+          path: |
+            testing/cloud_layouts/
+
+      - name: Cleanup temp directory
+        if: always()
+        env:
+          TMPPATH: ${{ steps.setup.outputs.tmppath}}
+        run: |
+          echo "Remove temporary directory '${TMPPATH}' ..."
+          if [[ -d "${TMPPATH}" && ${#TMPPATH} > 1 ]] ; then
+            rm -rf "${TMPPATH}"
+          else
+            echo Not a directory.
+          fi
+
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'job,separate';
+            const name = 'e2e: Yandex.Cloud, Containerd, Kubernetes 1.23';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
+
+      - name: Check alerting credentials
+        id: check_alerting
+        env:
+          KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+        run: |
+          if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+
+      - name: Alert on fail in default branch
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+        env:
+          PROVIDER: Yandex.Cloud
+          CRI: Containerd
+          LAYOUT: WithoutNAT
+          KUBERNETES_VERSION: "1.23"
+        run: |
+          WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+          echo $WORKFLOW_URL
+
+          alertData=$(cat <<EOF
+          {
+            "labels": {
+              "severity_level": 7,
+              "trigger": "CloudLayoutTestFailed",
+              "provider": "${PROVIDER}",
+              "layout": "${LAYOUT}",
+              "cri": "${CRI}",
+              "kubernetes_version": "${KUBERNETES_VERSION}"
+            },
+            "annotations": {
+              "summary": "Cloud Layout Test failed",
+              "description": "Check Github workflow log for more information",
+              "plk_protocol_version": "1",
+              "plk_link_url/job": "${WORKFLOW_URL}",
+              "plk_link_title_en/job": "Github job run",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+            }
+          }
+          EOF
+          )
+
+          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "${alertData}"
+  # </template: e2e_run_job_template>
+
 
   last_comment:
     name: Update comment on finish
-    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22"]
+    needs: ["started_at","run_docker_1_19","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_containerd_1_19","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23"]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"run_containerd_1_19":"e2e: Yandex.Cloud, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: Yandex.Cloud, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: Yandex.Cloud, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: Yandex.Cloud, Containerd, Kubernetes 1.22","run_docker_1_19":"e2e: Yandex.Cloud, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: Yandex.Cloud, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: Yandex.Cloud, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: Yandex.Cloud, Docker, Kubernetes 1.22"}
+        {"run_containerd_1_19":"e2e: Yandex.Cloud, Containerd, Kubernetes 1.19","run_containerd_1_20":"e2e: Yandex.Cloud, Containerd, Kubernetes 1.20","run_containerd_1_21":"e2e: Yandex.Cloud, Containerd, Kubernetes 1.21","run_containerd_1_22":"e2e: Yandex.Cloud, Containerd, Kubernetes 1.22","run_containerd_1_23":"e2e: Yandex.Cloud, Containerd, Kubernetes 1.23","run_docker_1_19":"e2e: Yandex.Cloud, Docker, Kubernetes 1.19","run_docker_1_20":"e2e: Yandex.Cloud, Docker, Kubernetes 1.20","run_docker_1_21":"e2e: Yandex.Cloud, Docker, Kubernetes 1.21","run_docker_1_22":"e2e: Yandex.Cloud, Docker, Kubernetes 1.22","run_docker_1_23":"e2e: Yandex.Cloud, Docker, Kubernetes 1.23"}
     steps:
 
       # <template: checkout_step>


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Add CI for running e2e 1.23 kubernetes tests

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: chore
summary: Add 1.23 kubernetes e2e tests
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
