### PR TITLE
[openvpn] Set default value for loadbalancer object in the OpenAPI schema

### DIFF
--- a/ee/fe/modules/500-openvpn/openapi/config-values.yaml
+++ b/ee/fe/modules/500-openvpn/openapi/config-values.yaml
@@ -18,6 +18,7 @@ properties:
     type: object
     description: |
       A section of optional parameters of the `LoadBalancer` inlet.
+    default: { }
     properties:
       annotations:
         type: object

--- a/ee/fe/modules/500-openvpn/openapi/config-values.yaml
+++ b/ee/fe/modules/500-openvpn/openapi/config-values.yaml
@@ -18,7 +18,7 @@ properties:
     type: object
     description: |
       A section of optional parameters of the `LoadBalancer` inlet.
-    default: { }
+    default: {}
     properties:
       annotations:
         type: object

--- a/ee/fe/modules/500-openvpn/openapi/doc-ru-config-values.yaml
+++ b/ee/fe/modules/500-openvpn/openapi/doc-ru-config-values.yaml
@@ -11,7 +11,6 @@ properties:
   loadBalancer:
     description: |
       Секция опциональных настроек для inlet'а `LoadBalancer`.
-    default: { }
     properties:
       annotations:
         description: |

--- a/ee/fe/modules/500-openvpn/openapi/doc-ru-config-values.yaml
+++ b/ee/fe/modules/500-openvpn/openapi/doc-ru-config-values.yaml
@@ -11,6 +11,7 @@ properties:
   loadBalancer:
     description: |
       Секция опциональных настроек для inlet'а `LoadBalancer`.
+    default: { }
     properties:
       annotations:
         description: |


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Set default value for loadbalancer object in the OpenAPI schema

## Why do we need it, and what problem does it solve?
This fixes a bug in the OpenAPI schema that occurs when using the LoadBalancer inlet.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: openvpn
type: fix
summary: Set default value for loadbalancer object in the OpenAPI schema.
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
