### PR TITLE
[openvpn] fix sts api version in migration hook

### DIFF
--- a/ee/fe/modules/500-openvpn/hooks/easyrsa_migration.go
+++ b/ee/fe/modules/500-openvpn/hooks/easyrsa_migration.go
@@ -114,7 +114,7 @@ func migration(input *go_hook.HookInput) error {
 
 	if len(statefulsets) > 0 {
 		if migrated && statefulsets[0].(string) != "true" {
-			input.PatchCollector.Delete("v1", "StatefulSet", "d8-openvpn", "openvpn")
+			input.PatchCollector.Delete("apps/v1", "StatefulSet", "d8-openvpn", "openvpn")
 			input.LogEntry.Infof("statefulset/openvpn deleted (%t/%s)", migrated, statefulsets[0].(string))
 		}
 	}


### PR DESCRIPTION
## Description
Fixed sts api version in migration hook

## Why do we need it, and what problem does it solve?
This solves the problem of deleting the old sts in the migration hook

## Changelog entries


```changes
section: openvpn
type: fix
summary: Fixed statefulSet apiVersion in a migration hook.
```

