### PR TITLE
[linstor] Update FAQ: add error case

### DIFF
--- a/modules/031-linstor/docs/FAQ.md
+++ b/modules/031-linstor/docs/FAQ.md
@@ -77,13 +77,13 @@ To configure Prometheus to use LINSTOR for storing data:
 ## Pod cannot start with the `FailedMount` error
 
 ### Pod is stuck in the `ContainerCreating` phase
-If the Pod is stuck in the `ContainerCreating` phase and you see the following errors in `kubectl describe pod`:
+If the Pod is stuck in the `ContainerCreating` phase, and you see the following errors in `kubectl describe pod`:
 
 ```
 rpc error: code = Internal desc = NodePublishVolume failed for pvc-b3e51b8a-9733-4d9a-bf34-84e0fee3168d: checking for exclusive open failed: wrong medium type, check device health
 ```
 
-It means that device is still mounted on one of the other nodes. To check it, use the following command:
+... it means that device is still mounted on one of the other nodes. To check it, use the following command:
 
 ```shell
 linstor resource list -r pvc-b3e51b8a-9733-4d9a-bf34-84e0fee3168d
@@ -99,21 +99,21 @@ An example error in `kubectl describe pod`:
 kubernetes.io/csi: attachment for pvc-be5f1991-e0f8-49e1-80c5-ad1174d10023 failed: CSINode b-node0 does not contain driver linstor.csi.linbit.com
 ```
 
-Check the status of the linstor-csi-node pods:
+Check the status of the `linstor-csi-node` Pods:
 
-```
+```shell
 kubectl get pod -n d8-linstor -l app.kubernetes.io/component=csi-node,app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-csi
 ```
 
-Most likely they are stuck in the `Init` state, waiting for the node to change its status to `Online` in LINSTOR. Check the list of nodes:
+Most likely they are stuck in the `Init` state, waiting for the node to change its status to `Online` in LINSTOR. Run the following command to check the list of nodes:
 
-```
+```shell
 linstor node list
 ```
 
 If you see any nodes in the `EVICTED` state, then they have been unavailable for 2 hours, to return them to the cluster, run:
 
-```
+```shell
 linstor node rst <name>
 ```
 

--- a/modules/031-linstor/docs/FAQ_RU.md
+++ b/modules/031-linstor/docs/FAQ_RU.md
@@ -83,7 +83,7 @@ linstor storage-pool create lvmthin node01 lvmthin linstor_data/data
 rpc error: code = Internal desc = NodePublishVolume failed for pvc-b3e51b8a-9733-4d9a-bf34-84e0fee3168d: checking for exclusive open failed: wrong medium type, check device health
 ```
 
-Значит устройство всё ещё смонтировано на одном из других узлов. Проверить это можно с помощью следующей команды:
+... значит устройство всё ещё смонтировано на одном из других узлов. Проверить это можно с помощью следующей команды:
 ```shell
 linstor resource list -r pvc-b3e51b8a-9733-4d9a-bf34-84e0fee3168d
 ```
@@ -98,21 +98,21 @@ linstor resource list -r pvc-b3e51b8a-9733-4d9a-bf34-84e0fee3168d
 kubernetes.io/csi: attachment for pvc-be5f1991-e0f8-49e1-80c5-ad1174d10023 failed: CSINode b-node0 does not contain driver linstor.csi.linbit.com
 ```
 
-Проверьте состояние подов linstor-csi-node:
+Проверьте состояние Pod'ов `linstor-csi-node`:
 
-```
+```shell
 kubectl get pod -n d8-linstor -l app.kubernetes.io/component=csi-node,app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-csi
 ```
 
-Наиболее вероятно они зависли в состоянии `Init`, оджидая пока нода сменит статус на `Online` в LINSTOR. Проверьте список нод:
+Наиболее вероятно, что они зависли в состоянии `Init`, ожидая пока узел сменит статус на `Online` в LINSTOR. Проверьте список узлов с помощью следующей команды:
 
-```
+```shell
 linstor node list
 ```
 
-Если вы видите какие-либо ноды в состоянии `EVICTED`, значит они были недоступны в течении 2х часов, чтобы вернуть их в кластер, выполните:
+Если вы видите какие-либо узлы в состоянии `EVICTED`, значит они были недоступны в течении 2‑х часов. Чтобы вернуть их в кластер, выполните:
 
-```
+```shell
 linstor node rst <name>
 ```
 

--- a/modules/031-linstor/docs/FAQ_RU.md
+++ b/modules/031-linstor/docs/FAQ_RU.md
@@ -77,7 +77,7 @@ linstor storage-pool create lvmthin node01 lvmthin linstor_data/data
 ## Pod не может запуститься из-за ошибки `FailedMount`
 
 ### Pod завис на стадии `ContainerCreating`
-Если Pod завис на стадии `ContainerCreating`, а в выводе `kubectl describe` есть ошибки вида:
+Если Pod завис на стадии `ContainerCreating`, а в выводе `kubectl describe pod` есть ошибки вида:
 
 ```
 rpc error: code = Internal desc = NodePublishVolume failed for pvc-b3e51b8a-9733-4d9a-bf34-84e0fee3168d: checking for exclusive open failed: wrong medium type, check device health
@@ -85,10 +85,36 @@ rpc error: code = Internal desc = NodePublishVolume failed for pvc-b3e51b8a-9733
 
 Значит устройство всё ещё смонтировано на одном из других узлов. Проверить это можно с помощью следующей команды:
 ```shell
-linstor r l -r pvc-b3e51b8a-9733-4d9a-bf34-84e0fee3168d
+linstor resource list -r pvc-b3e51b8a-9733-4d9a-bf34-84e0fee3168d
 ```
 
 Флаг `InUse` укажет на каком узле используется устройство.
+
+### Pod не может запуститься из-за отсутствия CSI-драйвера
+
+Пример ошибки в `kubectl describe pod`:
+
+```
+kubernetes.io/csi: attachment for pvc-be5f1991-e0f8-49e1-80c5-ad1174d10023 failed: CSINode b-node0 does not contain driver linstor.csi.linbit.com
+```
+
+Проверьте состояние подов linstor-csi-node:
+
+```
+kubectl get pod -n d8-linstor -l app.kubernetes.io/component=csi-node,app.kubernetes.io/instance=linstor,app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-csi
+```
+
+Наиболее вероятно они зависли в состоянии `Init`, оджидая пока нода сменит статус на `Online` в LINSTOR. Проверьте список нод:
+
+```
+linstor node list
+```
+
+Если вы видите какие-либо ноды в состоянии `EVICTED`, значит они были недоступны в течении 2х часов, чтобы вернуть их в кластер, выполните:
+
+```
+linstor node rst <name>
+```
 
 ### Ошибки вида `Input/output error`
 


### PR DESCRIPTION
## Description

Describe one error case from @duckhawk, when nodes were eventually evicted from the cluster due to long downtime.

## Why do we need it, and what problem does it solve?

Better UX

## Changelog entries

```changes
section: linstor
type: chore
summary: Add an error case to FAQ, when nodes were eventually evicted from the cluster
impact_level: low
```