### PR TITLE
[cloud-provider-yandex] Change default platform to standard-v3 for new instances created by machine-controller-manager

### DIFF
--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -50,6 +50,7 @@ apiVersions:
                 description: |
                   The type of virtual machine to create.
                 type: string
+                default: standard-v2
               cores:
                 description: |
                   Amount of CPU cores to provision on a Yandex Compute Instance.

--- a/candi/cloud-providers/yandex/openapi/instance_class.yaml
+++ b/candi/cloud-providers/yandex/openapi/instance_class.yaml
@@ -63,7 +63,6 @@ spec:
                     Paltform ID. [List of available platforms...](https://cloud.yandex.com/en-ru/docs/compute/concepts/vm-platforms)
                   x-doc-default: standard-v2
                   type: string
-                  default: standard-v2
                 preemptible:
                   description: Should a provisioned Yandex Compute Instance be preemtible.
                   type: boolean

--- a/candi/cloud-providers/yandex/openapi/instance_class.yaml
+++ b/candi/cloud-providers/yandex/openapi/instance_class.yaml
@@ -63,6 +63,7 @@ spec:
                     Paltform ID. [List of available platforms...](https://cloud.yandex.com/en-ru/docs/compute/concepts/vm-platforms)
                   x-doc-default: standard-v2
                   type: string
+                  default: standard-v2
                 preemptible:
                   description: Should a provisioned Yandex Compute Instance be preemtible.
                   type: boolean

--- a/modules/030-cloud-provider-yandex/cloud-instance-manager/machine-class.checksum
+++ b/modules/030-cloud-provider-yandex/cloud-instance-manager/machine-class.checksum
@@ -1,5 +1,13 @@
 {{- $options := dict -}}
-{{- $_ := set $options "platformID" .nodeGroup.instanceClass.platformID -}}
+
+{{- $platformID := .nil }}
+{{- if hasKey .nodeGroup.instanceClass "platformID" }}
+  {{- if ne .nodeGroup.instanceClass.platformID "standard-v2" }}
+    {{- $platformID = .nodeGroup.instanceClass.platformID }}
+  {{- end }}
+{{- end }}
+
+{{- $_ := set $options "platformID" $platformID -}}
 {{- $_ := set $options "cores" .nodeGroup.instanceClass.cores -}}
 {{- if hasKey .nodeGroup.instanceClass "coreFraction" -}}
   {{- $_ := set $options "coreFraction" .nodeGroup.instanceClass.coreFraction -}}

--- a/modules/030-cloud-provider-yandex/cloud-instance-manager/machine-class.checksum
+++ b/modules/030-cloud-provider-yandex/cloud-instance-manager/machine-class.checksum
@@ -2,7 +2,7 @@
 
 {{- $platformID := .nil }}
 {{- if hasKey .nodeGroup.instanceClass "platformID" }}
-  {{- if ne .nodeGroup.instanceClass.platformID "standard-v2" }}
+  {{- if ne .nodeGroup.instanceClass.platformID "standard-v3" }}
     {{- $platformID = .nodeGroup.instanceClass.platformID }}
   {{- end }}
 {{- end }}

--- a/modules/030-cloud-provider-yandex/cloud-instance-manager/machine-class.yaml
+++ b/modules/030-cloud-provider-yandex/cloud-instance-manager/machine-class.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   regionID: {{ .Values.nodeManager.internal.cloudProvider.yandex.region }}
   zoneID: {{ .zoneName }}
-  platformID: {{ .nodeGroup.instanceClass.platformID | default "standard-v2" }}
+  platformID: {{ .nodeGroup.instanceClass.platformID | default "standard-v3" }}
   resourcesSpec:
     cores: {{ .nodeGroup.instanceClass.cores }}
     coreFraction: {{ .nodeGroup.instanceClass.coreFraction | default 100 }}

--- a/modules/030-cloud-provider-yandex/hooks/yandex_cluster_configuration_test.go
+++ b/modules/030-cloud-provider-yandex/hooks/yandex_cluster_configuration_test.go
@@ -84,6 +84,7 @@ masterNodeGroup:
     cores: 2
     imageID: test
     memory: 4096
+    platform: standard-v2
   replicas: 1
 nodeNetworkCIDR: 10.231.0.0/22
 provider:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

* New instances created by `machine-controller-manager` will use the `standard-v3` platform by default.
    * If you need to change the platform for existing instances, you have to roll out update them or just delete machines in `d8-cloud-instance-manager` namespace.
    * To change the default platform, use the `.spec.platformID` parameter in `YandexInstanceClass`.
* The master and static nodes are set to default platform `standard-v2` to be automatically added to `YandexClusterConfiguration`, which will allow us to change the default value later without any problems.
    * To change the platform, use the `.masterNodeGroup.instanceClass.platform` parameter in `YandexClusterConfiguration` and run `dhctl converge`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When setting a default value in a spec, it will be set in all YandexInstanceClass resources. This will allow us to change the default value of the platformID in the future without having to rebootstrap the cluster nodes.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-yandex
type: feature
summary: Changed default platform to standard-v3 for new instances created by machine-controller-manager.
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
