### PR TITLE
[cloud-provider-vsphere] setting default values in hybrid mode

### DIFF
--- a/ee/candi/cloud-providers/vsphere/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vsphere/openapi/cluster_configuration.yaml
@@ -252,12 +252,12 @@ apiVersions:
         type: string
         description: |
           The name of the tag category used to identify the region (vSphere Datacenter).
-        x-doc-default: "k8s-region"
+        default: "k8s-region"
       zoneTagCategory:
         type: string
         description: |
           The name of the tag category used to identify the zone (vSphere Cluster).
-        x-doc-default: "k8s-zone"
+        default: "k8s-zone"
       disableTimesync:
         type: boolean
         description: |

--- a/ee/modules/030-cloud-provider-vsphere/hooks/vsphere_cluster_configuration_test.go
+++ b/ee/modules/030-cloud-provider-vsphere/hooks/vsphere_cluster_configuration_test.go
@@ -43,6 +43,22 @@ cloudProviderVsphere:
   region: override
   zones: [override1, override2]
 `
+		filledValuesWithoutSomeFields = `
+global:
+  discovery: {}
+cloudProviderVsphere:
+  internal: {}
+  host: override
+  username: override
+  password: override
+  insecure: true
+  internalNetworkNames: [override1, override2]
+  externalNetworkNames: [override1, override2]
+  disableTimesync: false
+  vmFolderPath: override
+  sshKeys: [override1, override2]
+  region: override
+`
 		filledValuesWithNSXT = filledValues + `
   nsxt:
     defaultIpPoolName: pool1
@@ -174,6 +190,27 @@ zoneTagCategory: override
 zones:
 - override1
 - override2
+`
+		stateAClusterConfiguration4 = `
+disableTimesync: false
+externalNetworkNames:
+- override1
+- override2
+internalNetworkNames:
+- override1
+- override2
+provider:
+  insecure: true
+  password: override
+  server: override
+  username: override
+region: override
+regionTagCategory: k8s-region
+sshPublicKey: override1
+vmFolderPath: override
+zoneTagCategory: k8s-zone
+zones:
+- test
 `
 		nsxt = `
 nsxt:
@@ -345,6 +382,31 @@ data: {}
 			Expect(c).To(ExecuteSuccessfully())
 			Expect(c.ValuesGet("cloudProviderVsphere.internal.providerClusterConfiguration").String()).To(MatchYAML(stateAClusterConfiguration3 + nsxt))
 			Expect(c.ValuesGet("cloudProviderVsphere.internal.providerDiscoveryData").String()).To(MatchJSON(stateACloudDiscoveryData))
+		})
+	})
+
+	d := HookExecutionConfigInit(filledValuesWithoutSomeFields, `{}`)
+	Context("Cluster with module configuration without zones, with empty secret", func() {
+		BeforeEach(func() {
+			d.BindingContexts.Set(d.KubeStateSet(emptyProviderClusterConfigurationState))
+			d.RunHook()
+		})
+
+		It("Should fail", func() {
+			Expect(d).To(Not(ExecuteSuccessfully()))
+		})
+	})
+	Context("Cluster with module configuration with zones, but without zoneTagCategory and regionTagCategory, with empty secret", func() {
+		BeforeEach(func() {
+			d.BindingContexts.Set(d.KubeStateSet(emptyProviderClusterConfigurationState))
+			d.ValuesSet("cloudProviderVsphere.zones", []string{"test"})
+			d.RunHook()
+		})
+
+		It("Should fill values from module configuration", func() {
+			Expect(d).To(ExecuteSuccessfully())
+			Expect(d.ValuesGet("cloudProviderVsphere.internal.providerClusterConfiguration").String()).To(MatchYAML(stateAClusterConfiguration4))
+			Expect(d.ValuesGet("cloudProviderVsphere.internal.providerDiscoveryData").String()).To(MatchJSON("{}"))
 		})
 	})
 })


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
1. If `zoneTagCategory` is not set, set to default `k8s-zone`.
2. If `regionTagCategory` is not set, set to default `k8s-region`.
3. Error if `zones` is not set in module config in Hybrid cluster mode.

## Why do we need it, and what problem does it solve?
<!---

  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Module config values for cloud-provider-vpshere module overrides values from secret `d8-provider-cluster-configuration`.
But in hybrid mode, we cannot have secret, and defaults from secret do not work. So we need to check additionally config values from module and use defaults if they are not set.
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-vsphere
type: fix
summary: setting default values in hybrid mode.
impact_level: low
```

<!---
Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "([+]{3}|[-]{3}) [ab]/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
