### PR TITLE
[dashboard] upgrade from 2.2.0 to 2.5.1

### DIFF
--- a/modules/500-dashboard/images/dashboard/Dockerfile
+++ b/modules/500-dashboard/images/dashboard/Dockerfile
@@ -19,7 +19,8 @@ RUN cat /public/logout_button.js >> /public/de/de.main.44ac5dc977e4fc4e.js && \
     cat /public/logout_button.js >> /public/ko/ko.main.44ac5dc977e4fc4e.js && \
     cat /public/logout_button.js >> /public/zh-Hans/zh-Hans.main.44ac5dc977e4fc4e.js && \
     cat /public/logout_button.js >> /public/zh-Hant/zh-Hant.main.44ac5dc977e4fc4e.js && \
-    cat /public/logout_button.js >> /public/zh-Hant-HK/zh-Hant-HK.main.44ac5dc977e4fc4e.js
+    cat /public/logout_button.js >> /public/zh-Hant-HK/zh-Hant-HK.main.44ac5dc977e4fc4e.js && \
+    rm /public/logout_button.js
 
 USER nonroot
 EXPOSE 9090 8443

--- a/modules/500-dashboard/images/dashboard/Dockerfile
+++ b/modules/500-dashboard/images/dashboard/Dockerfile
@@ -1,6 +1,6 @@
 # Based on https://github.com/kubernetes/dashboard/blob/v2.2.0/aio/Dockerfile
 ARG BASE_ALPINE
-FROM kubernetesui/dashboard:v2.2.0@sha256:148991563e374c83b75e8c51bca75f512d4f006ddc791e96a91f1c7420b60bd9 as artifact
+FROM kubernetesui/dashboard:v2.5.1@sha256:6614c53fcdb9df9cb920c701c6a418e398be9b5ee147e5231ad6669fd2b76862 as artifact
 
 FROM $BASE_ALPINE
 

--- a/modules/500-dashboard/images/dashboard/Dockerfile
+++ b/modules/500-dashboard/images/dashboard/Dockerfile
@@ -1,4 +1,4 @@
-# Based on https://github.com/kubernetes/dashboard/blob/v2.2.0/aio/Dockerfile
+# Based on https://github.com/kubernetes/dashboard/blob/v2.5.1/aio/Dockerfile
 ARG BASE_ALPINE
 FROM kubernetesui/dashboard:v2.5.1@sha256:6614c53fcdb9df9cb920c701c6a418e398be9b5ee147e5231ad6669fd2b76862 as artifact
 
@@ -11,7 +11,7 @@ COPY --from=artifact /dashboard /dashboard
 
 # Inject logout button to be able to change user if token authentication is used
 ADD ./logout_button.js /public/logout_button.js
-RUN cat /public/logout_button.js >> /public/en/en.main.09bf52db2dbc808e7279.js
+RUN cat /public/logout_button.js >> /public/en/en.main.44ac5dc977e4fc4e.js
 
 USER nonroot
 EXPOSE 9090 8443

--- a/modules/500-dashboard/images/dashboard/Dockerfile
+++ b/modules/500-dashboard/images/dashboard/Dockerfile
@@ -11,15 +11,15 @@ COPY --from=artifact /dashboard /dashboard
 
 # Inject logout button to be able to change user if token authentication is used
 ADD ./logout_button.js /public/logout_button.js
-RUN cat /public/logout_button.js >> /public/de/de.main.44ac5dc977e4fc4e.js
-RUN cat /public/logout_button.js >> /public/en/en.main.44ac5dc977e4fc4e.js
-RUN cat /public/logout_button.js >> /public/es/es.main.44ac5dc977e4fc4e.js
-RUN cat /public/logout_button.js >> /public/fr/fr.main.44ac5dc977e4fc4e.js
-RUN cat /public/logout_button.js >> /public/ja/ja.main.44ac5dc977e4fc4e.js
-RUN cat /public/logout_button.js >> /public/ko/ko.main.44ac5dc977e4fc4e.js
-RUN cat /public/logout_button.js >> /public/zh-Hans/zh-Hans.main.44ac5dc977e4fc4e.js
-RUN cat /public/logout_button.js >> /public/zh-Hant/zh-Hant.main.44ac5dc977e4fc4e.js
-RUN cat /public/logout_button.js >> /public/zh-Hant-HK/zh-Hant-HK.main.44ac5dc977e4fc4e.js
+RUN cat /public/logout_button.js >> /public/de/de.main.44ac5dc977e4fc4e.js && \
+    cat /public/logout_button.js >> /public/en/en.main.44ac5dc977e4fc4e.js && \
+    cat /public/logout_button.js >> /public/es/es.main.44ac5dc977e4fc4e.js && \
+    cat /public/logout_button.js >> /public/fr/fr.main.44ac5dc977e4fc4e.js && \
+    cat /public/logout_button.js >> /public/ja/ja.main.44ac5dc977e4fc4e.js && \
+    cat /public/logout_button.js >> /public/ko/ko.main.44ac5dc977e4fc4e.js && \
+    cat /public/logout_button.js >> /public/zh-Hans/zh-Hans.main.44ac5dc977e4fc4e.js && \
+    cat /public/logout_button.js >> /public/zh-Hant/zh-Hant.main.44ac5dc977e4fc4e.js && \
+    cat /public/logout_button.js >> /public/zh-Hant-HK/zh-Hant-HK.main.44ac5dc977e4fc4e.js
 
 USER nonroot
 EXPOSE 9090 8443

--- a/modules/500-dashboard/images/dashboard/Dockerfile
+++ b/modules/500-dashboard/images/dashboard/Dockerfile
@@ -11,7 +11,15 @@ COPY --from=artifact /dashboard /dashboard
 
 # Inject logout button to be able to change user if token authentication is used
 ADD ./logout_button.js /public/logout_button.js
+RUN cat /public/logout_button.js >> /public/de/de.main.44ac5dc977e4fc4e.js
 RUN cat /public/logout_button.js >> /public/en/en.main.44ac5dc977e4fc4e.js
+RUN cat /public/logout_button.js >> /public/es/es.main.44ac5dc977e4fc4e.js
+RUN cat /public/logout_button.js >> /public/fr/fr.main.44ac5dc977e4fc4e.js
+RUN cat /public/logout_button.js >> /public/ja/ja.main.44ac5dc977e4fc4e.js
+RUN cat /public/logout_button.js >> /public/ko/ko.main.44ac5dc977e4fc4e.js
+RUN cat /public/logout_button.js >> /public/zh-Hans/zh-Hans.main.44ac5dc977e4fc4e.js
+RUN cat /public/logout_button.js >> /public/zh-Hant/zh-Hant.main.44ac5dc977e4fc4e.js
+RUN cat /public/logout_button.js >> /public/zh-Hant-HK/zh-Hant-HK.main.44ac5dc977e4fc4e.js
 
 USER nonroot
 EXPOSE 9090 8443


### PR DESCRIPTION
## Description
Dashboard upgrade from 2.2.0 to 2.5.1

## Why do we need it, and what problem does it solve?
Closes https://github.com/deckhouse/deckhouse/issues/1276.
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dashboard
type: chore
summary: Dashboard upgrade from 2.2.0 to 2.5.1
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
