### PR TITLE
[linstor] satellites: restore evicted satellites if pod exists

### DIFF
--- a/modules/031-linstor/images/piraeus-operator/patches/README.md
+++ b/modules/031-linstor/images/piraeus-operator/patches/README.md
@@ -10,3 +10,10 @@ It makes no sense for us since all the resources are deployed in single namespac
 
 Adds extra options to allow deploying with kube-rbac-proxy
 https://github.com/piraeusdatastore/piraeus-operator/pull/280
+
+## satellites: restore evicted satellites if pod exists
+
+Restore satellites for those pods we know are running. Even if the satellite
+is still offline, the initial eviction should have already triggered all the
+replacement resource creations.
+https://github.com/piraeusdatastore/piraeus-operator/pull/298

--- a/modules/031-linstor/images/piraeus-operator/patches/restore-evicted-satellites.diff
+++ b/modules/031-linstor/images/piraeus-operator/patches/restore-evicted-satellites.diff
@@ -1,0 +1,32 @@
+diff --git a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+index efd689ba..90795894 100644
+--- a/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
++++ b/pkg/controller/linstorsatelliteset/linstorsatelliteset_controller.go
+@@ -447,6 +447,12 @@ func (r *ReconcileLinstorSatelliteSet) reconcileAllNodesOnController(ctx context
+ 			continue
+ 		}
+ 
++		if pod.Status.Phase != corev1.PodRunning {
++			logger.WithField("pod", pod.Name).Debug("Pod not running.")
++
++			continue
++		}
++
+ 		// Registration can be done in parallel, so we handle per-node work in a separate go-routine
+ 		wg.Add(1)
+ 
+@@ -533,6 +539,14 @@ func (r *ReconcileLinstorSatelliteSet) reconcileSingleNodeRegistration(ctx conte
+ 		return fmt.Errorf("failed to reconcile satellite: %w", err)
+ 	}
+ 
++	if mdutil.SliceContains(lNode.Flags, linstor.FlagEvicted) {
++		// The pod exists, so there is no reason not to restore it.
++		err := linstorClient.Nodes.Restore(ctx, lNode.Name, lapi.NodeRestore{})
++		if err != nil {
++			return fmt.Errorf("node '%s' failed to restore: %w", lNode.Name, err)
++		}
++	}
++
+ 	if lNode.ConnectionStatus != lc.Online {
+ 		return &reconcileutil.TemporaryError{
+ 			Source:       fmt.Errorf("node '%s' registered, but not online (%s)", lNode.Name, lNode.ConnectionStatus),


### PR DESCRIPTION
## Description

This PR adding patch to automatically restore evicted nodes in linstor 

## Why do we need it, and what problem does it solve?

LINSTOR automatically evict the nodes from the cluster after 2 hours of unavailability.
This adds functionality to automatically recover such nodes if they came back.

## Changelog entries

```changes
section: linstor
type: fix
summary: automatically recover evicted nodes in LINSTOR
```