### PR TITLE
Revert "[cloud-provider-aws] allow ssh access to master nodes only from bastion"

### DIFF
--- a/candi/cloud-providers/aws/layouts/standard/base-infrastructure/main.tf
+++ b/candi/cloud-providers/aws/layouts/standard/base-infrastructure/main.tf
@@ -13,40 +13,25 @@
 # limitations under the License.
 
 module "vpc" {
-  source          = "../../../terraform-modules/vpc"
-  prefix          = local.prefix
+  source = "../../../terraform-modules/vpc"
+  prefix = local.prefix
   existing_vpc_id = local.existing_vpc_id
-  cidr_block      = local.vpc_network_cidr
-  tags            = local.tags
+  cidr_block = local.vpc_network_cidr
+  tags = local.tags
 }
 
 module "security-groups" {
-  source       = "../../../terraform-modules/security-groups"
-  prefix       = local.prefix
+  source = "../../../terraform-modules/security-groups"
+  prefix = local.prefix
   cluster_uuid = var.clusterUUID
-  vpc_id       = module.vpc.id
-  tags         = local.tags
-}
-
-resource "aws_security_group" "ssh-accessible" {
-  name   = "${local.prefix}-ssh-accessible"
   vpc_id = module.vpc.id
-  tags   = local.tags
-}
-
-resource "aws_security_group_rule" "allow-ssh-for-everyone" {
-  type              = "ingress"
-  from_port         = 22
-  to_port           = 22
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.ssh-accessible.id
+  tags = local.tags
 }
 
 data "aws_availability_zones" "available" {}
 
 locals {
-  az_count    = length(data.aws_availability_zones.available.names)
+  az_count = length(data.aws_availability_zones.available.names)
   subnet_cidr = lookup(var.providerClusterConfiguration, "nodeNetworkCIDR", module.vpc.cidr_block)
 }
 
@@ -58,9 +43,9 @@ resource "aws_subnet" "kube_public" {
   map_public_ip_on_launch = true
 
   tags = merge(local.tags, {
-    Name                                       = "${local.prefix}-public-${count.index}"
+    Name = "${local.prefix}-public-${count.index}"
     "kubernetes.io/cluster/${var.clusterUUID}" = "shared"
-    "kubernetes.io/cluster/${local.prefix}"    = "shared"
+    "kubernetes.io/cluster/${local.prefix}" = "shared"
   })
 }
 
@@ -72,9 +57,9 @@ resource "aws_subnet" "kube_internal" {
   map_public_ip_on_launch = false
 
   tags = merge(local.tags, {
-    Name                                       = "${local.prefix}-internal-${count.index}"
+    Name = "${local.prefix}-internal-${count.index}"
     "kubernetes.io/cluster/${var.clusterUUID}" = "shared"
-    "kubernetes.io/cluster/${local.prefix}"    = "shared"
+    "kubernetes.io/cluster/${local.prefix}" = "shared"
   })
 }
 
@@ -95,7 +80,7 @@ resource "aws_internet_gateway" "kube" {
 }
 
 resource "aws_nat_gateway" "kube" {
-  subnet_id     = aws_subnet.kube_public[0].id
+  subnet_id = aws_subnet.kube_public[0].id
   allocation_id = aws_eip.natgw.id
 
   tags = merge(local.tags, {
@@ -107,9 +92,9 @@ resource "aws_route_table" "kube_internal" {
   vpc_id = module.vpc.id
 
   tags = merge(local.tags, {
-    Name                                       = "${local.prefix}-internal"
+    Name = "${local.prefix}-internal"
     "kubernetes.io/cluster/${var.clusterUUID}" = "shared"
-    "kubernetes.io/cluster/${local.prefix}"    = "shared"
+    "kubernetes.io/cluster/${local.prefix}" = "shared"
   })
 }
 
@@ -195,7 +180,7 @@ resource "aws_iam_instance_profile" "node" {
 }
 
 resource "aws_key_pair" "ssh" {
-  key_name   = local.prefix
+  key_name = local.prefix
   public_key = var.providerClusterConfiguration.sshPublicKey
 
   tags = merge(local.tags, {

--- a/candi/cloud-providers/aws/layouts/without-nat/base-infrastructure/main.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/base-infrastructure/main.tf
@@ -13,40 +13,25 @@
 # limitations under the License.
 
 module "vpc" {
-  source          = "../../../terraform-modules/vpc"
-  prefix          = local.prefix
+  source = "../../../terraform-modules/vpc"
+  prefix = local.prefix
   existing_vpc_id = local.existing_vpc_id
-  cidr_block      = local.vpc_network_cidr
-  tags            = local.tags
+  cidr_block = local.vpc_network_cidr
+  tags = local.tags
 }
 
 module "security-groups" {
-  source       = "../../../terraform-modules/security-groups"
-  prefix       = local.prefix
+  source = "../../../terraform-modules/security-groups"
+  prefix = local.prefix
   cluster_uuid = var.clusterUUID
-  vpc_id       = module.vpc.id
-  tags         = local.tags
-}
-
-resource "aws_security_group" "ssh-accessible" {
-  name   = "${local.prefix}-ssh-accessible"
   vpc_id = module.vpc.id
-  tags   = local.tags
-}
-
-resource "aws_security_group_rule" "allow-ssh-for-everyone" {
-  type              = "ingress"
-  from_port         = 22
-  to_port           = 22
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.ssh-accessible.id
+  tags = local.tags
 }
 
 data "aws_availability_zones" "available" {}
 
 locals {
-  az_count    = length(data.aws_availability_zones.available.names)
+  az_count = length(data.aws_availability_zones.available.names)
   subnet_cidr = lookup(var.providerClusterConfiguration, "nodeNetworkCIDR", module.vpc.cidr_block)
 }
 
@@ -58,9 +43,9 @@ resource "aws_subnet" "kube_public" {
   map_public_ip_on_launch = true
 
   tags = merge(local.tags, {
-    Name                                       = "${local.prefix}-public-${count.index}"
+    Name = "${local.prefix}-public-${count.index}"
     "kubernetes.io/cluster/${var.clusterUUID}" = "shared"
-    "kubernetes.io/cluster/${local.prefix}"    = "shared"
+    "kubernetes.io/cluster/${local.prefix}" = "shared"
   })
 }
 
@@ -76,9 +61,9 @@ resource "aws_route_table" "kube_public" {
   vpc_id = module.vpc.id
 
   tags = merge(local.tags, {
-    Name                                       = "${local.prefix}-public"
+    Name = "${local.prefix}-public"
     "kubernetes.io/cluster/${var.clusterUUID}" = "shared"
-    "kubernetes.io/cluster/${local.prefix}"    = "shared"
+    "kubernetes.io/cluster/${local.prefix}" = "shared"
   })
 }
 
@@ -144,7 +129,7 @@ resource "aws_iam_instance_profile" "node" {
 }
 
 resource "aws_key_pair" "ssh" {
-  key_name   = local.prefix
+  key_name = local.prefix
   public_key = var.providerClusterConfiguration.sshPublicKey
 
   tags = merge(local.tags, {

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/main.tf
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 resource "aws_security_group" "node" {
-  name   = "${var.prefix}-node"
-  vpc_id = var.vpc_id
+  name        = "${var.prefix}-node"
+  vpc_id      = var.vpc_id
 
   egress {
     from_port   = 0
@@ -25,7 +25,7 @@ resource "aws_security_group" "node" {
 
   tags = merge(var.tags, {
     "kubernetes.io/cluster/${var.cluster_uuid}" = "shared"
-    "kubernetes.io/cluster/${var.prefix}"       = "shared"
+    "kubernetes.io/cluster/${var.prefix}" = "shared"
   })
 }
 
@@ -48,27 +48,27 @@ resource "aws_security_group_rule" "node-to-node" {
 }
 
 resource "aws_security_group_rule" "to-node-icmp" {
-  type              = "ingress"
-  from_port         = -1
-  to_port           = -1
-  protocol          = "icmp"
-  cidr_blocks       = ["0.0.0.0/0"]
+  type = "ingress"
+  from_port = -1
+  to_port = -1
+  protocol = "icmp"
+  cidr_blocks = ["0.0.0.0/0"]
   security_group_id = aws_security_group.node.id
 }
 
 resource "aws_security_group" "loadbalancer" {
-  name   = "${var.prefix}-loadbalancer"
+  name = "${var.prefix}-loadbalancer"
   vpc_id = var.vpc_id
-  tags   = var.tags
+  tags = var.tags
 }
 
 resource "aws_security_group_rule" "allow-all-incoming-traffic-to-loadbalancer" {
-  type              = "ingress"
-  protocol          = "-1"
-  from_port         = 0
-  to_port           = 65535
-  security_group_id = aws_security_group.loadbalancer.id
-  cidr_blocks       = ["0.0.0.0/0"]
+  type                     = "ingress"
+  protocol                 = "-1"
+  from_port                = 0
+  to_port                  = 65535
+  security_group_id        = aws_security_group.loadbalancer.id
+  cidr_blocks              = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "allow-all-outgoing-traffic-to-nodes" {
@@ -78,4 +78,19 @@ resource "aws_security_group_rule" "allow-all-outgoing-traffic-to-nodes" {
   to_port                  = 65535
   security_group_id        = aws_security_group.loadbalancer.id
   source_security_group_id = aws_security_group.node.id
+}
+
+resource "aws_security_group" "ssh-accessible" {
+  name        = "${var.prefix}-ssh-accessible"
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_security_group_rule" "allow-ssh-for-everyone" {
+  type = "ingress"
+  from_port = 22
+  to_port = 22
+  protocol = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.ssh-accessible.id
 }

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/outputs.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/outputs.tf
@@ -23,3 +23,7 @@ output "load_balancer_security_group" {
 output "security_group_id_node" {
   value = aws_security_group.node.id
 }
+
+output "security_group_id_ssh_accessible" {
+  value = aws_security_group.ssh-accessible.id
+}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Reverts deckhouse/deckhouse#1217.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
[PR #1217](deckhouse/deckhouse#1217) breaks terraform state and manual operations required, so auto converge doesn't work. Further work will be done in https://github.com/deckhouse/deckhouse/pull/1301.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-aws
type: fix
summary: Allow ssh access to master nodes only from bastion for with-nat layout
impact_level: low
```