### PR TITLE
[ci] fix: --user option for proper permission on generated files

### DIFF
--- a/.github/render-workflows.sh
+++ b/.github/render-workflows.sh
@@ -38,6 +38,7 @@ cat <<'SCRIPT_END' | docker run -i --rm \
   -v $(pwd)/ci_templates:/in/ci_templates \
   -v $(pwd)/workflow_templates:/in/workflow_templates \
   -v $(pwd)/workflows:/out/workflows \
+  --user ${UID}:${GID} \
   --entrypoint=ash \
   hairyhenderson/gomplate:v3.10.0-alpine - || dockerExit=1
 


### PR DESCRIPTION
## Description

Add --user option for proper permission on generated workflows.

## Why do we need it, and what problem does it solve?

Prevent "file is readonly" warnings for Linux users.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: chore
summary: Add --user option for proper permission on generated files on Linux
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
