### PR TITLE
[ci] fix: proper image name for e2e in test repos

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -42,9 +42,13 @@ steps:
       CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
       CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
       CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-      CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
     run: |
-      ## Source: .gitlab/ci_templates/build.yml
+      # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+      REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+      if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+        # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+        REPO_SUFFIX=
+      fi
 
       # Put tags on produced images and push to dev and release repositories.
       #
@@ -96,12 +100,14 @@ steps:
         BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
         SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
       else
-        # DECKHOUSE_REGISTRY_HOST — this is not the main repo.
-        # Build using dev-registry as a single primary repo and push to Github Container Registry.
+        # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+        # Build using dev-registry as a single primary repo and push:
+        # - branches to Dev registry to run e2e tests.
+        # - semver tags to Github Container Registry for testing release process.
         werf build \
           --parallel=true --parallel-tasks-limit=5 \
           --report-path images_tags_werf.json
-        BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+        BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
         SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
         echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
       fi
@@ -109,8 +115,8 @@ steps:
       # Publish images for Git branch.
       if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
         # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-        # Use it as image tag.
-        IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+        # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+        IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
         echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -25,23 +25,20 @@
 {!{- end }!}
 run: |
   echo "Execute '{!{ $script }!} {!{ $script_arg }!}' via 'docker run', using environment:
+    INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
     PREFIX=${PREFIX}
-    TMPPATH=${TMPPATH}
-    DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+    TMP_DIR_PATH=${TMP_DIR_PATH}
+    DEV_BRANCH=${DEV_BRANCH}
     PROVIDER=${PROVIDER}
     CRI=${CRI}
     LAYOUT=${LAYOUT}
     KUBERNETES_VERSION=${KUBERNETES_VERSION}
-    CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-    JOB_STATUS=${JOB_STATUS}
   "
 
   docker run --rm \
-    -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-    -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
     -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
     -e PREFIX=${PREFIX} \
-    -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+    -e DEV_BRANCH=${DEV_BRANCH} \
     -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
     -e CRI=${CRI} \
     -e PROVIDER=${PROVIDER:-not_provided} \
@@ -68,7 +65,7 @@ run: |
     -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
 {!{- end }!}
     -v $(pwd)/testing:/deckhouse/testing \
-    -v ${TMPPATH}:/tmp \
+    -v ${TMP_DIR_PATH}:/tmp \
     --user $(id -u):$(id -u) \
     -v /etc/group:/etc/group:ro \
     -v /etc/passwd:/etc/passwd:ro \

--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -20,7 +20,7 @@ git_info:
     ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
     ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
     ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-    ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+    ref_full: ${{ steps.git_info.outputs.ref_full }}
     github_sha: ${{ steps.git_info.outputs.github_sha }}
   # Skip the CI for automation PRs, e.g. changelog
   if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -30,22 +30,24 @@ git_info:
       uses: {!{ index (ds "actions") "actions/github-script" }!}
       with:
         script: |
-          const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+          const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-          let githubBranch = '';
-          let githubTag = '';
-          let githubSHA = '';
-          let refName = '';
-          let refSlug = '';
+          let refSlug = ''
+          let refName = ''
+          let refFull = ''
+          let githubBranch = ''
+          let githubTag = ''
+          let githubSHA = ''
           if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-            // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-            // Note: value in inputs.pull_request_ref is for pull_request_info job.
+            // Trigger: workflow_dispatch with pull_request_ref.
+            // Extract pull request number from 'refs/pull/<NUM>/merge'
+            const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+            refSlug       = `pr${prNum}`
             refName       = context.payload.inputs.ci_commit_ref_name
+            refFull       = context.payload.inputs.pull_request_ref
             githubBranch  = refName
             githubSHA     = context.payload.inputs.pull_request_sha
-            // Extract pull request number from 'refs/pull/<NUM>/merge'
-            const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-            refSlug       = `pr${prNum}`;
             core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
           } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
             // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -55,31 +57,30 @@ git_info:
 
             refSlug = `pr${context.issue.number}`;
             refName = (prRepo === targetRepo) ? prRef : refSlug;
+            refFull = `refs/pull/${context.issue.number}/head`
             githubBranch = refName
             githubSHA = context.payload.pull_request.head.sha
             core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
           } else {
-            // Events: workflow_dispatch without pull_request_ref, schedule, push...
+            // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+            // refName is 'main' or tag name, so slugification is not necessary.
+            refSlug       = GITHUB_REF_NAME
             refName       = GITHUB_REF_NAME
+            refFull       = GITHUB_REF
             githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
             githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
             githubSHA     = context.sha
-            // refName is 'main' or tag name, so slugification is not necessary.
-            refSlug       = refName
             core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
           }
 
-          core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-          core.info(`output.ci_commit_ref_name: '${refName}'`)
-          core.info(`output.ci_commit_tag:      '${githubTag}'`)
-          core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-          core.info(`output.github_sha:         '${githubSHA}'`)
-
+          core.setCommandEcho(true)
           core.setOutput('ci_commit_ref_slug', refSlug)
           core.setOutput('ci_commit_ref_name', refName)
           core.setOutput(`ci_commit_tag`, githubTag)
           core.setOutput(`ci_commit_branch`, githubBranch)
+          core.setOutput(`ref_full`, refFull)
           core.setOutput('github_sha', githubSHA)
+          core.setCommandEcho(false)
 
 # </template: git_info_job>
 {!{- end -}!}

--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -163,37 +163,36 @@ jobs:
       id: setup
       env:
         DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-        GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
         CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
         CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
         CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+        REF_FULL: ${{needs.git_info.outputs.ref_full}}
       run: |
-        # Random delay to sparse 'update comment' steps in time.
-        delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-        echo Delay for $delay
-        sleep $delay
-
         # Calculate unique prefix for e2e test.
         # GITHUB_RUN_ID is a unique number for each workflow run.
         # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-        prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-        echo "::set-output name=prefix::${prefix}"
-        echo "prefix=${prefix}"
+        # CRI value is trimmed to reduce prefix length.
+        DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
         # Create tmppath for test script.
-        tmppath=/mnt/cloud-layouts/layouts/${prefix}
-        if [[ -d "${tmppath}" ]] ; then
-          echo "Temporary dir already exists: ${tmppath}. ERROR!"
-          ls -la ${tmppath}
+        TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+        if [[ -d "${TMP_DIR_PATH}" ]] ; then
+          echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+          ls -la ${TMP_DIR_PATH}
           exit 1
         else
-          echo "Create temporary dir for job: ${tmppath}."
-          mkdir -p "${tmppath}"
+          echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+          mkdir -p "${TMP_DIR_PATH}"
         fi
-        echo "::set-output name=tmppath::${tmppath}"
 
-        ## Deckhouse 'install' image name
         ## Source: ci_templates/build.yml
+
+        # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+        REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+        if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+          # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+          REPO_SUFFIX=
+        fi
 
         # Use dev-registry for Git branches.
         BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -201,29 +200,39 @@ jobs:
         SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
         if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-          # Use Github Container Registry for test repositories.
-          BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+          # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+          # Use dev-regisry for branches and Github Container Registry for semver tags.
+          BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
           SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
         fi
 
-        IMAGE_NAME=
-        if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-          IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-          echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-        fi
-        if [[ -n $CI_COMMIT_TAG ]] ; then
-          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-          IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-          echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-        fi
+        # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+        # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+        # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+        IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-        echo "::set-output name=install-image-name::${IMAGE_NAME}"
+        INSTALL_IMAGE_NAME=
+        if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+        fi
+        if [[ -n ${CI_COMMIT_TAG} ]] ; then
+          REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+          INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+        fi
+        SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+        echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
         # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-        echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-        echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-        docker pull "${IMAGE_NAME}"
+        echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+        docker pull "${INSTALL_IMAGE_NAME}"
+
+        echo '::echo::on'
+        echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+        echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+        echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+        echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+        echo '::echo::off'
 
     - name: "Run e2e test: {!{ $ctx.providerName }!}/{!{ $ctx.criName }!}/{!{ $ctx.kubernetesVersion }!}"
       env:
@@ -233,34 +242,25 @@ jobs:
         KUBERNETES_VERSION: "{!{ $ctx.kubernetesVersion }!}"
         LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
         LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-        WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-        CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-        CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-        CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-        CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-        TMPPATH: ${{ steps.setup.outputs.tmppath}}
-        PREFIX: ${{ steps.setup.outputs.prefix}}
+        TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+        PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
         INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
 {!{- tmpl.Exec "e2e_run_template" (slice .provider "run-test") | strings.Indent 6 }!}
 
     - name: Cleanup bootstrapped cluster
       if: always()
       env:
-        JOB_STATUS: ${{ job.status }}
         PROVIDER: {!{ $ctx.providerName }!}
         CRI: {!{ $ctx.criName }!}
         LAYOUT: {!{ $ctx.layout }!}
         KUBERNETES_VERSION: "{!{ $ctx.kubernetesVersion }!}"
         LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
         LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-        WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-        CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-        CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-        CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-        CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-        TMPPATH: ${{ steps.setup.outputs.tmppath}}
-        PREFIX: ${{ steps.setup.outputs.prefix}}
+        TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+        PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
         INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+        DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
 {!{- tmpl.Exec "e2e_run_template" (slice .provider "cleanup") | strings.Indent 6 }!}
 
     - name: Save test results
@@ -287,6 +287,7 @@ jobs:
 
     - name: Check alerting credentials
       id: check_alerting
+      if: always()
       env:
         KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
       run: |

--- a/.github/workflow_templates/validation.yml
+++ b/.github/workflow_templates/validation.yml
@@ -113,7 +113,7 @@ jobs:
     name: Copyright Validation
 {!{ tmpl.Exec "validation_template" (slice $ctx "copyright") | strings.Indent 4 -}!}
 
-{!{/* Template for validation jobs. CI_COMMIT_REF_NAME and CI_PIPELINE_CREATED_AT are required for werf.yaml */}!}
+{!{/* Template for validation jobs. */}!}
 {!{ define "validation_template" }!}
 {!{- $ctx := index . 0 -}!}
 {!{- $type := index . 1 }!}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -218,7 +218,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -228,22 +228,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -253,31 +255,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 
@@ -461,9 +462,13 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
-          ## Source: .gitlab/ci_templates/build.yml
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Put tags on produced images and push to dev and release repositories.
           #
@@ -515,12 +520,14 @@ jobs:
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
           else
-            # DECKHOUSE_REGISTRY_HOST — this is not the main repo.
-            # Build using dev-registry as a single primary repo and push to Github Container Registry.
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Build using dev-registry as a single primary repo and push:
+            # - branches to Dev registry to run e2e tests.
+            # - semver tags to Github Container Registry for testing release process.
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --report-path images_tags_werf.json
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
@@ -528,8 +535,8 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+            # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
             echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -116,7 +116,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -126,22 +126,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -151,31 +153,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 
@@ -390,9 +391,13 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
-          ## Source: .gitlab/ci_templates/build.yml
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Put tags on produced images and push to dev and release repositories.
           #
@@ -444,12 +449,14 @@ jobs:
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
           else
-            # DECKHOUSE_REGISTRY_HOST — this is not the main repo.
-            # Build using dev-registry as a single primary repo and push to Github Container Registry.
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Build using dev-registry as a single primary repo and push:
+            # - branches to Dev registry to run e2e tests.
+            # - semver tags to Github Container Registry for testing release process.
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --report-path images_tags_werf.json
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
@@ -457,8 +464,8 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+            # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
             echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 
@@ -657,9 +664,13 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
-          ## Source: .gitlab/ci_templates/build.yml
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Put tags on produced images and push to dev and release repositories.
           #
@@ -711,12 +722,14 @@ jobs:
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
           else
-            # DECKHOUSE_REGISTRY_HOST — this is not the main repo.
-            # Build using dev-registry as a single primary repo and push to Github Container Registry.
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Build using dev-registry as a single primary repo and push:
+            # - branches to Dev registry to run e2e tests.
+            # - semver tags to Github Container Registry for testing release process.
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --report-path images_tags_werf.json
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
@@ -724,8 +737,8 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+            # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
             echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 
@@ -924,9 +937,13 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
         run: |
-          ## Source: .gitlab/ci_templates/build.yml
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Put tags on produced images and push to dev and release repositories.
           #
@@ -978,12 +995,14 @@ jobs:
             BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
           else
-            # DECKHOUSE_REGISTRY_HOST — this is not the main repo.
-            # Build using dev-registry as a single primary repo and push to Github Container Registry.
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Build using dev-registry as a single primary repo and push:
+            # - branches to Dev registry to run e2e tests.
+            # - semver tags to Github Container Registry for testing release process.
             werf build \
               --parallel=true --parallel-tasks-limit=5 \
               --report-path images_tags_werf.json
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
             echo "⚓️ 🧪 [$(date -u)] DECKHOUSE_REGISTRY_HOST is empty. Publish to Github Container Registry '${PROD_REGISTRY_PATH}'"
           fi
@@ -991,8 +1010,8 @@ jobs:
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
             # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            # Use it as image tag.
-            IMAGE_TAG=${CI_COMMIT_REF_SLUG}
+            # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+            IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
             echo "⚓️ 💫 [$(date -u)] Publish images to dev-registry for branch '${CI_COMMIT_BRANCH}' and edition '${WERF_ENV}' using tag '${IMAGE_TAG}' ..."
 

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -54,7 +54,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -64,22 +64,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -89,31 +91,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -54,7 +54,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -64,22 +64,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -89,31 +91,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -54,7 +54,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -64,22 +64,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -89,31 +91,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -54,7 +54,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -64,22 +64,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -89,31 +91,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -54,7 +54,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -64,22 +64,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -89,31 +91,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 

--- a/.github/workflows/deploy-web-stage.yml
+++ b/.github/workflows/deploy-web-stage.yml
@@ -111,7 +111,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -121,22 +121,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -146,31 +148,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 

--- a/.github/workflows/deploy-web-test.yml
+++ b/.github/workflows/deploy-web-test.yml
@@ -111,7 +111,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -121,22 +121,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -146,31 +148,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -127,7 +127,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -137,22 +137,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -162,31 +164,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 
@@ -323,37 +324,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -361,29 +361,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: AWS/Docker/1.19"
         env:
@@ -393,36 +403,29 @@ jobs:
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -431,7 +434,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -445,43 +448,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -490,7 +485,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -554,6 +549,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -696,37 +692,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -734,29 +729,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: AWS/Docker/1.20"
         env:
@@ -766,36 +771,29 @@ jobs:
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -804,7 +802,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -818,43 +816,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -863,7 +853,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -927,6 +917,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1069,37 +1060,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1107,29 +1097,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: AWS/Docker/1.21"
         env:
@@ -1139,36 +1139,29 @@ jobs:
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1177,7 +1170,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1191,43 +1184,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1236,7 +1221,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1300,6 +1285,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1442,37 +1428,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1480,29 +1465,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: AWS/Docker/1.22"
         env:
@@ -1512,36 +1507,29 @@ jobs:
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1550,7 +1538,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1564,43 +1552,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1609,7 +1589,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1673,6 +1653,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1815,37 +1796,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1853,29 +1833,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: AWS/Docker/1.23"
         env:
@@ -1885,36 +1875,29 @@ jobs:
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1923,7 +1906,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1937,43 +1920,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1982,7 +1957,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2046,6 +2021,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2188,37 +2164,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2226,29 +2201,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: AWS/Containerd/1.19"
         env:
@@ -2258,36 +2243,29 @@ jobs:
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2296,7 +2274,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2310,43 +2288,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2355,7 +2325,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2419,6 +2389,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2561,37 +2532,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2599,29 +2569,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: AWS/Containerd/1.20"
         env:
@@ -2631,36 +2611,29 @@ jobs:
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2669,7 +2642,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2683,43 +2656,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2728,7 +2693,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2792,6 +2757,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2934,37 +2900,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2972,29 +2937,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: AWS/Containerd/1.21"
         env:
@@ -3004,36 +2979,29 @@ jobs:
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3042,7 +3010,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3056,43 +3024,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3101,7 +3061,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3165,6 +3125,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -3307,37 +3268,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -3345,29 +3305,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: AWS/Containerd/1.22"
         env:
@@ -3377,36 +3347,29 @@ jobs:
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3415,7 +3378,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3429,43 +3392,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3474,7 +3429,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3538,6 +3493,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -3680,37 +3636,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -3718,29 +3673,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: AWS/Containerd/1.23"
         env:
@@ -3750,36 +3715,29 @@ jobs:
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3788,7 +3746,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3802,43 +3760,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: AWS
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AWS_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_ACCESS_KEY }}
           LAYOUT_AWS_SECRET_ACCESS_KEY: ${{ secrets.LAYOUT_AWS_SECRET_ACCESS_KEY }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3847,7 +3797,7 @@ jobs:
             -e LAYOUT_AWS_ACCESS_KEY=${LAYOUT_AWS_ACCESS_KEY:-not_provided} \
             -e LAYOUT_AWS_SECRET_ACCESS_KEY=${LAYOUT_AWS_SECRET_ACCESS_KEY:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3911,6 +3861,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -127,7 +127,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -137,22 +137,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -162,31 +164,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 
@@ -323,37 +324,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -361,29 +361,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Azure/Docker/1.19"
         env:
@@ -393,14 +403,10 @@ jobs:
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -408,23 +414,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -435,7 +438,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -449,21 +452,16 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
           CRI: Docker
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -471,23 +469,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -498,7 +493,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -562,6 +557,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -704,37 +700,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -742,29 +737,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Azure/Docker/1.20"
         env:
@@ -774,14 +779,10 @@ jobs:
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -789,23 +790,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -816,7 +814,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -830,21 +828,16 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
           CRI: Docker
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -852,23 +845,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -879,7 +869,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -943,6 +933,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1085,37 +1076,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1123,29 +1113,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Azure/Docker/1.21"
         env:
@@ -1155,14 +1155,10 @@ jobs:
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -1170,23 +1166,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1197,7 +1190,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1211,21 +1204,16 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
           CRI: Docker
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -1233,23 +1221,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1260,7 +1245,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1324,6 +1309,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1466,37 +1452,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1504,29 +1489,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Azure/Docker/1.22"
         env:
@@ -1536,14 +1531,10 @@ jobs:
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -1551,23 +1542,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1578,7 +1566,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1592,21 +1580,16 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
           CRI: Docker
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -1614,23 +1597,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1641,7 +1621,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1705,6 +1685,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1847,37 +1828,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1885,29 +1865,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Azure/Docker/1.23"
         env:
@@ -1917,14 +1907,10 @@ jobs:
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -1932,23 +1918,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1959,7 +1942,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1973,21 +1956,16 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
           CRI: Docker
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -1995,23 +1973,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2022,7 +1997,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2086,6 +2061,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2228,37 +2204,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2266,29 +2241,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Azure/Containerd/1.19"
         env:
@@ -2298,14 +2283,10 @@ jobs:
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -2313,23 +2294,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2340,7 +2318,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2354,21 +2332,16 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -2376,23 +2349,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2403,7 +2373,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2467,6 +2437,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2609,37 +2580,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2647,29 +2617,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Azure/Containerd/1.20"
         env:
@@ -2679,14 +2659,10 @@ jobs:
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -2694,23 +2670,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2721,7 +2694,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2735,21 +2708,16 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -2757,23 +2725,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2784,7 +2749,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2848,6 +2813,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2990,37 +2956,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -3028,29 +2993,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Azure/Containerd/1.21"
         env:
@@ -3060,14 +3035,10 @@ jobs:
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -3075,23 +3046,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3102,7 +3070,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3116,21 +3084,16 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -3138,23 +3101,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3165,7 +3125,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3229,6 +3189,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -3371,37 +3332,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -3409,29 +3369,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Azure/Containerd/1.22"
         env:
@@ -3441,14 +3411,10 @@ jobs:
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -3456,23 +3422,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3483,7 +3446,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3497,21 +3460,16 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -3519,23 +3477,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3546,7 +3501,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3610,6 +3565,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -3752,37 +3708,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -3790,29 +3745,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Azure/Containerd/1.23"
         env:
@@ -3822,14 +3787,10 @@ jobs:
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -3837,23 +3798,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3864,7 +3822,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3878,21 +3836,16 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Azure
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_AZURE_SUBSCRIPTION_ID: ${{ secrets.LAYOUT_AZURE_SUBSCRIPTION_ID }}
           LAYOUT_AZURE_CLIENT_ID: ${{ secrets.LAYOUT_AZURE_CLIENT_ID }}
@@ -3900,23 +3853,20 @@ jobs:
           LAYOUT_AZURE_TENANT_ID: ${{ secrets.LAYOUT_AZURE_TENANT_ID }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3927,7 +3877,7 @@ jobs:
             -e LAYOUT_AZURE_CLIENT_SECRET=${LAYOUT_AZURE_CLIENT_SECRET:-not_provided} \
             -e LAYOUT_AZURE_TENANT_ID=${LAYOUT_AZURE_TENANT_ID:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3991,6 +3941,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -127,7 +127,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -137,22 +137,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -162,31 +164,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 
@@ -323,37 +324,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -361,29 +361,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: GCP/Docker/1.19"
         env:
@@ -393,35 +403,28 @@ jobs:
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -429,7 +432,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -443,42 +446,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -486,7 +481,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -550,6 +545,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -692,37 +688,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -730,29 +725,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: GCP/Docker/1.20"
         env:
@@ -762,35 +767,28 @@ jobs:
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -798,7 +796,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -812,42 +810,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -855,7 +845,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -919,6 +909,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1061,37 +1052,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1099,29 +1089,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: GCP/Docker/1.21"
         env:
@@ -1131,35 +1131,28 @@ jobs:
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1167,7 +1160,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1181,42 +1174,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1224,7 +1209,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1288,6 +1273,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1430,37 +1416,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1468,29 +1453,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: GCP/Docker/1.22"
         env:
@@ -1500,35 +1495,28 @@ jobs:
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1536,7 +1524,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1550,42 +1538,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1593,7 +1573,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1657,6 +1637,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1799,37 +1780,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1837,29 +1817,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: GCP/Docker/1.23"
         env:
@@ -1869,35 +1859,28 @@ jobs:
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1905,7 +1888,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1919,42 +1902,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1962,7 +1937,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2026,6 +2001,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2168,37 +2144,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2206,29 +2181,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: GCP/Containerd/1.19"
         env:
@@ -2238,35 +2223,28 @@ jobs:
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2274,7 +2252,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2288,42 +2266,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2331,7 +2301,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2395,6 +2365,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2537,37 +2508,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2575,29 +2545,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: GCP/Containerd/1.20"
         env:
@@ -2607,35 +2587,28 @@ jobs:
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2643,7 +2616,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2657,42 +2630,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2700,7 +2665,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2764,6 +2729,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2906,37 +2872,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2944,29 +2909,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: GCP/Containerd/1.21"
         env:
@@ -2976,35 +2951,28 @@ jobs:
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3012,7 +2980,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3026,42 +2994,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3069,7 +3029,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3133,6 +3093,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -3275,37 +3236,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -3313,29 +3273,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: GCP/Containerd/1.22"
         env:
@@ -3345,35 +3315,28 @@ jobs:
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3381,7 +3344,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3395,42 +3358,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3438,7 +3393,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3502,6 +3457,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -3644,37 +3600,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -3682,29 +3637,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: GCP/Containerd/1.23"
         env:
@@ -3714,35 +3679,28 @@ jobs:
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3750,7 +3708,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3764,42 +3722,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: GCP
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON: ${{ secrets.LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3807,7 +3757,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON=${LAYOUT_GCP_SERVICE_ACCOUT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3871,6 +3821,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -127,7 +127,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -137,22 +137,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -162,31 +164,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 
@@ -323,37 +324,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -361,29 +361,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Docker/1.19"
         env:
@@ -393,35 +403,28 @@ jobs:
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -429,7 +432,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -443,42 +446,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -486,7 +481,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -550,6 +545,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -692,37 +688,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -730,29 +725,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Docker/1.20"
         env:
@@ -762,35 +767,28 @@ jobs:
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -798,7 +796,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -812,42 +810,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -855,7 +845,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -919,6 +909,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1061,37 +1052,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1099,29 +1089,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Docker/1.21"
         env:
@@ -1131,35 +1131,28 @@ jobs:
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1167,7 +1160,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1181,42 +1174,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1224,7 +1209,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1288,6 +1273,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1430,37 +1416,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1468,29 +1453,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Docker/1.22"
         env:
@@ -1500,35 +1495,28 @@ jobs:
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1536,7 +1524,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1550,42 +1538,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1593,7 +1573,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1657,6 +1637,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1799,37 +1780,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1837,29 +1817,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Docker/1.23"
         env:
@@ -1869,35 +1859,28 @@ jobs:
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1905,7 +1888,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1919,42 +1902,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1962,7 +1937,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2026,6 +2001,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2168,37 +2144,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2206,29 +2181,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Containerd/1.19"
         env:
@@ -2238,35 +2223,28 @@ jobs:
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2274,7 +2252,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2288,42 +2266,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2331,7 +2301,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2395,6 +2365,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2537,37 +2508,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2575,29 +2545,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Containerd/1.20"
         env:
@@ -2607,35 +2587,28 @@ jobs:
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2643,7 +2616,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2657,42 +2630,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2700,7 +2665,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2764,6 +2729,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2906,37 +2872,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2944,29 +2909,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Containerd/1.21"
         env:
@@ -2976,35 +2951,28 @@ jobs:
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3012,7 +2980,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3026,42 +2994,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3069,7 +3029,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3133,6 +3093,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -3275,37 +3236,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -3313,29 +3273,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Containerd/1.22"
         env:
@@ -3345,35 +3315,28 @@ jobs:
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3381,7 +3344,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3395,42 +3358,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3438,7 +3393,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3502,6 +3457,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -3644,37 +3600,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -3682,29 +3637,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Containerd/1.23"
         env:
@@ -3714,35 +3679,28 @@ jobs:
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3750,7 +3708,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3764,42 +3722,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: OpenStack
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3807,7 +3757,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3871,6 +3821,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -127,7 +127,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -137,22 +137,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -162,31 +164,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 
@@ -323,37 +324,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -361,29 +361,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Static/Docker/1.19"
         env:
@@ -393,35 +403,28 @@ jobs:
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -429,7 +432,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -443,42 +446,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
           CRI: Docker
           LAYOUT: Static
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -486,7 +481,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -550,6 +545,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -692,37 +688,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -730,29 +725,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Static/Docker/1.20"
         env:
@@ -762,35 +767,28 @@ jobs:
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -798,7 +796,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -812,42 +810,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
           CRI: Docker
           LAYOUT: Static
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -855,7 +845,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -919,6 +909,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1061,37 +1052,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1099,29 +1089,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Static/Docker/1.21"
         env:
@@ -1131,35 +1131,28 @@ jobs:
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1167,7 +1160,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1181,42 +1174,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
           CRI: Docker
           LAYOUT: Static
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1224,7 +1209,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1288,6 +1273,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1430,37 +1416,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1468,29 +1453,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Static/Docker/1.22"
         env:
@@ -1500,35 +1495,28 @@ jobs:
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1536,7 +1524,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1550,42 +1538,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
           CRI: Docker
           LAYOUT: Static
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1593,7 +1573,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1657,6 +1637,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1799,37 +1780,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1837,29 +1817,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Static/Docker/1.23"
         env:
@@ -1869,35 +1859,28 @@ jobs:
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1905,7 +1888,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1919,42 +1902,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
           CRI: Docker
           LAYOUT: Static
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1962,7 +1937,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2026,6 +2001,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2168,37 +2144,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2206,29 +2181,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Static/Containerd/1.19"
         env:
@@ -2238,35 +2223,28 @@ jobs:
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2274,7 +2252,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2288,42 +2266,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
           CRI: Containerd
           LAYOUT: Static
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2331,7 +2301,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2395,6 +2365,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2537,37 +2508,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2575,29 +2545,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Static/Containerd/1.20"
         env:
@@ -2607,35 +2587,28 @@ jobs:
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2643,7 +2616,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2657,42 +2630,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
           CRI: Containerd
           LAYOUT: Static
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2700,7 +2665,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2764,6 +2729,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2906,37 +2872,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2944,29 +2909,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Static/Containerd/1.21"
         env:
@@ -2976,35 +2951,28 @@ jobs:
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3012,7 +2980,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3026,42 +2994,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
           CRI: Containerd
           LAYOUT: Static
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3069,7 +3029,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3133,6 +3093,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -3275,37 +3236,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -3313,29 +3273,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Static/Containerd/1.22"
         env:
@@ -3345,35 +3315,28 @@ jobs:
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3381,7 +3344,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3395,42 +3358,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
           CRI: Containerd
           LAYOUT: Static
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3438,7 +3393,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3502,6 +3457,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -3644,37 +3600,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -3682,29 +3637,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Static/Containerd/1.23"
         env:
@@ -3714,35 +3679,28 @@ jobs:
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3750,7 +3708,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3764,42 +3722,34 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Static
           CRI: Containerd
           LAYOUT: Static
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_OS_PASSWORD: ${{ secrets.LAYOUT_OS_PASSWORD }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3807,7 +3757,7 @@ jobs:
             -e SSH_KEY=${LAYOUT_SSH_KEY:-not_provided} \
             -e LAYOUT_OS_PASSWORD=${LAYOUT_OS_PASSWORD:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3871,6 +3821,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -127,7 +127,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -137,22 +137,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -162,31 +164,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 
@@ -323,37 +324,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -361,29 +361,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Docker/1.19"
         env:
@@ -393,36 +403,29 @@ jobs:
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -431,7 +434,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -445,43 +448,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
           CRI: Docker
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -490,7 +485,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -554,6 +549,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -696,37 +692,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -734,29 +729,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Docker/1.20"
         env:
@@ -766,36 +771,29 @@ jobs:
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -804,7 +802,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -818,43 +816,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
           CRI: Docker
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -863,7 +853,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -927,6 +917,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1069,37 +1060,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1107,29 +1097,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Docker/1.21"
         env:
@@ -1139,36 +1139,29 @@ jobs:
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1177,7 +1170,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1191,43 +1184,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
           CRI: Docker
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1236,7 +1221,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1300,6 +1285,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1442,37 +1428,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1480,29 +1465,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Docker/1.22"
         env:
@@ -1512,36 +1507,29 @@ jobs:
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1550,7 +1538,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1564,43 +1552,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
           CRI: Docker
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1609,7 +1589,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1673,6 +1653,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1815,37 +1796,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1853,29 +1833,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Docker/1.23"
         env:
@@ -1885,36 +1875,29 @@ jobs:
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1923,7 +1906,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1937,43 +1920,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
           CRI: Docker
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1982,7 +1957,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2046,6 +2021,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2188,37 +2164,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2226,29 +2201,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Containerd/1.19"
         env:
@@ -2258,36 +2243,29 @@ jobs:
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2296,7 +2274,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2310,43 +2288,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2355,7 +2325,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2419,6 +2389,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2561,37 +2532,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2599,29 +2569,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Containerd/1.20"
         env:
@@ -2631,36 +2611,29 @@ jobs:
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2669,7 +2642,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2683,43 +2656,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2728,7 +2693,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2792,6 +2757,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2934,37 +2900,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2972,29 +2937,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Containerd/1.21"
         env:
@@ -3004,36 +2979,29 @@ jobs:
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3042,7 +3010,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3056,43 +3024,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3101,7 +3061,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3165,6 +3125,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -3307,37 +3268,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -3345,29 +3305,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Containerd/1.22"
         env:
@@ -3377,36 +3347,29 @@ jobs:
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3415,7 +3378,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3429,43 +3392,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3474,7 +3429,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3538,6 +3493,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -3680,37 +3636,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -3718,29 +3673,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Containerd/1.23"
         env:
@@ -3750,36 +3715,29 @@ jobs:
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3788,7 +3746,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3802,43 +3760,35 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: vSphere
           CRI: Containerd
           LAYOUT: Standard
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_VSPHERE_PASSWORD: ${{ secrets.LAYOUT_VSPHERE_PASSWORD }}
           LAYOUT_VSPHERE_BASE_DOMAIN: ${{ secrets.LAYOUT_VSPHERE_BASE_DOMAIN }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3847,7 +3797,7 @@ jobs:
             -e LAYOUT_VSPHERE_PASSWORD=${LAYOUT_VSPHERE_PASSWORD:-not_provided} \
             -e LAYOUT_VSPHERE_BASE_DOMAIN=${LAYOUT_VSPHERE_BASE_DOMAIN:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3911,6 +3861,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -127,7 +127,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -137,22 +137,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -162,31 +164,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 
@@ -323,37 +324,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -361,29 +361,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.19"
         env:
@@ -393,37 +403,30 @@ jobs:
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -433,7 +436,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -447,44 +450,36 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -494,7 +489,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -558,6 +553,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -700,37 +696,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -738,29 +733,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.20"
         env:
@@ -770,37 +775,30 @@ jobs:
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -810,7 +808,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -824,44 +822,36 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -871,7 +861,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -935,6 +925,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1077,37 +1068,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1115,29 +1105,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.21"
         env:
@@ -1147,37 +1147,30 @@ jobs:
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1187,7 +1180,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1201,44 +1194,36 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1248,7 +1233,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1312,6 +1297,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1454,37 +1440,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1492,29 +1477,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.22"
         env:
@@ -1524,37 +1519,30 @@ jobs:
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1564,7 +1552,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1578,44 +1566,36 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1625,7 +1605,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1689,6 +1669,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -1831,37 +1812,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -1869,29 +1849,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.23"
         env:
@@ -1901,37 +1891,30 @@ jobs:
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -1941,7 +1924,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -1955,44 +1938,36 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
           CRI: Docker
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2002,7 +1977,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2066,6 +2041,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2208,37 +2184,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2246,29 +2221,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.19"
         env:
@@ -2278,37 +2263,30 @@ jobs:
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2318,7 +2296,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2332,44 +2310,36 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.19"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2379,7 +2349,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2443,6 +2413,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2585,37 +2556,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -2623,29 +2593,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.20"
         env:
@@ -2655,37 +2635,30 @@ jobs:
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2695,7 +2668,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2709,44 +2682,36 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.20"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -2756,7 +2721,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -2820,6 +2785,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -2962,37 +2928,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -3000,29 +2965,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.21"
         env:
@@ -3032,37 +3007,30 @@ jobs:
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3072,7 +3040,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3086,44 +3054,36 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.21"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3133,7 +3093,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3197,6 +3157,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -3339,37 +3300,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -3377,29 +3337,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.22"
         env:
@@ -3409,37 +3379,30 @@ jobs:
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3449,7 +3412,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3463,44 +3426,36 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.22"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3510,7 +3465,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3574,6 +3529,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
@@ -3716,37 +3672,36 @@ jobs:
         id: setup
         env:
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
-          GITHUB_SHA: ${{needs.git_info.outputs.github_sha}}
           CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
+          REF_FULL: ${{needs.git_info.outputs.ref_full}}
         run: |
-          # Random delay to sparse 'update comment' steps in time.
-          delay=$[ $RANDOM % 5 ].$[ ( $RANDOM % 4 ) * 250 ]
-          echo Delay for $delay
-          sleep $delay
-
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          prefix=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=prefix::${prefix}"
-          echo "prefix=${prefix}"
+          # CRI value is trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
-          tmppath=/mnt/cloud-layouts/layouts/${prefix}
-          if [[ -d "${tmppath}" ]] ; then
-            echo "Temporary dir already exists: ${tmppath}. ERROR!"
-            ls -la ${tmppath}
+          TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
+          if [[ -d "${TMP_DIR_PATH}" ]] ; then
+            echo "Temporary dir already exists: ${TMP_DIR_PATH}. ERROR!"
+            ls -la ${TMP_DIR_PATH}
             exit 1
           else
-            echo "Create temporary dir for job: ${tmppath}."
-            mkdir -p "${tmppath}"
+            echo "Create temporary dir for job: ${TMP_DIR_PATH}."
+            mkdir -p "${TMP_DIR_PATH}"
           fi
-          echo "::set-output name=tmppath::${tmppath}"
 
-          ## Deckhouse 'install' image name
           ## Source: ci_templates/build.yml
+
+          # Extract REPO_SUFFIX from repository name: trim prefix 'deckhouse/deckhouse-'.
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            # REPO_SUFFIX should be empty for main repo 'deckhouse/deckhouse'.
+            REPO_SUFFIX=
+          fi
 
           # Use dev-registry for Git branches.
           BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
@@ -3754,29 +3709,39 @@ jobs:
           SEMVER_REGISTRY_PATH="${DECKHOUSE_REGISTRY_HOST}/deckhouse"
 
           if [[ -z ${DECKHOUSE_REGISTRY_HOST:-} ]] ; then
-            # Use Github Container Registry for test repositories.
-            BRANCH_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}/dev"
+            # DECKHOUSE_REGISTRY_HOST is empty, so this repo is not the main repo.
+            # Use dev-regisry for branches and Github Container Registry for semver tags.
+            BRANCH_REGISTRY_PATH="${DEV_REGISTRY_PATH}"
             SEMVER_REGISTRY_PATH="${GHA_TEST_REGISTRY_PATH}"
           fi
 
-          IMAGE_NAME=
-          if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
-            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
-            IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git branch ${CI_COMMIT_BRANCH}"
-          fi
-          if [[ -n $CI_COMMIT_TAG ]] ; then
-            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
-            IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
-            echo "Deckhouse Deployment will use image ${IMAGE_NAME} to test Git tag ${CI_COMMIT_TAG}"
-          fi
+          # Prepare image tag for deploy/deckhouse (DEV_BRANCH option in testing/cloud_layouts/script.sh).
+          # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+          # Use it as image tag. Add suffix to not overlap with PRs in main repo.
+          IMAGE_TAG=${CI_COMMIT_REF_SLUG}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          echo "::set-output name=install-image-name::${IMAGE_NAME}"
+          INSTALL_IMAGE_NAME=
+          if [[ -n ${CI_COMMIT_BRANCH} ]]; then
+            # CI_COMMIT_REF_SLUG is a 'prNUM' for dev branches or 'main' for default branch.
+            INSTALL_IMAGE_NAME=${BRANCH_REGISTRY_PATH}/install:${IMAGE_TAG}
+          fi
+          if [[ -n ${CI_COMMIT_TAG} ]] ; then
+            REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]') # CE/EE/FE -> ce/ee/fe
+            INSTALL_IMAGE_NAME=${SEMVER_REGISTRY_PATH}/${REGISTRY_SUFFIX}/install:${CI_COMMIT_REF_SLUG}
+          fi
+          SAFE_IMAGE_NAME=$(echo ${INSTALL_IMAGE_NAME} | tr '[:lower:]' '[:upper:]')
+          echo "Deckhouse Deployment will use install image ${SAFE_IMAGE_NAME} to test Git ref ${REF_FULL}"
 
           # Print image name in uppercase to prevent hiding non-secret registry host stored in secret.
-          echo "Name: ${IMAGE_NAME}" | tr '[:lower:]' '[:upper:]'
-          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${IMAGE_NAME}'."
-          docker pull "${IMAGE_NAME}"
+          echo "⚓️ [$(date -u)] Pull 'dev/install' image '${SAFE_IMAGE_NAME}'."
+          docker pull "${INSTALL_IMAGE_NAME}"
+
+          echo '::echo::on'
+          echo "::set-output name=tmp-dir-path::${TMP_DIR_PATH}"
+          echo "::set-output name=dhctl-prefix::${DHCTL_PREFIX}"
+          echo "::set-output name=install-image-name::${INSTALL_IMAGE_NAME}"
+          echo "::set-output name=deckhouse-image-tag::${IMAGE_TAG}"
+          echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.23"
         env:
@@ -3786,37 +3751,30 @@ jobs:
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh run-test' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3826,7 +3784,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3840,44 +3798,36 @@ jobs:
       - name: Cleanup bootstrapped cluster
         if: always()
         env:
-          JOB_STATUS: ${{ job.status }}
           PROVIDER: Yandex.Cloud
           CRI: Containerd
           LAYOUT: WithoutNAT
           KUBERNETES_VERSION: "1.23"
           LAYOUT_DECKHOUSE_DOCKERCFG: ${{ secrets.LAYOUT_DECKHOUSE_DOCKERCFG }}
           LAYOUT_SSH_KEY: ${{ secrets.LAYOUT_SSH_KEY}}
-          WERF_REPO: ${{env.DEV_REGISTRY_PATH}}
-          CI_COMMIT_TAG: ${{needs.git_info.outputs.ci_commit_tag}}
-          CI_COMMIT_REF_NAME: ${{needs.git_info.outputs.ci_commit_ref_name}}
-          CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
-          CI_PIPELINE_CREATED_AT: ${{needs.git_info.outputs.ci_pipeline_created_at}}
-          TMPPATH: ${{ steps.setup.outputs.tmppath}}
-          PREFIX: ${{ steps.setup.outputs.prefix}}
+          TMP_DIR_PATH: ${{ steps.setup.outputs.tmp-dir-path}}
+          PREFIX: ${{ steps.setup.outputs.dhctl-prefix}}
           INSTALL_IMAGE_NAME: ${{ steps.setup.outputs.install-image-name }}
+          DEV_BRANCH: ${{ steps.setup.outputs.deckhouse-image-tag }}
         # <template: e2e_run_template>
           LAYOUT_YANDEX_CLOUD_ID: ${{ secrets.LAYOUT_YANDEX_CLOUD_ID }}
           LAYOUT_YANDEX_FOLDER_ID: ${{ secrets.LAYOUT_YANDEX_FOLDER_ID }}
           LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON }}
         run: |
           echo "Execute 'script.sh cleanup' via 'docker run', using environment:
+            INSTALL_IMAGE_NAME=${INSTALL_IMAGE_NAME}
             PREFIX=${PREFIX}
-            TMPPATH=${TMPPATH}
-            DEV_BRANCH=${CI_COMMIT_REF_SLUG}
+            TMP_DIR_PATH=${TMP_DIR_PATH}
+            DEV_BRANCH=${DEV_BRANCH}
             PROVIDER=${PROVIDER}
             CRI=${CRI}
             LAYOUT=${LAYOUT}
             KUBERNETES_VERSION=${KUBERNETES_VERSION}
-            CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY}
-            JOB_STATUS=${JOB_STATUS}
           "
 
           docker run --rm \
-            -e CLOUD_TESTS_RUN_BOOTSTRAP_ONLY=${CLOUD_TESTS_RUN_BOOTSTRAP_ONLY} \
-            -e CLOUD_TESTS_RUN_ACTION=${CLOUD_TESTS_RUN_ACTION} \
             -e DECKHOUSE_DOCKERCFG=${LAYOUT_DECKHOUSE_DOCKERCFG} \
             -e PREFIX=${PREFIX} \
-            -e DEV_BRANCH=${CI_COMMIT_REF_SLUG} \
+            -e DEV_BRANCH=${DEV_BRANCH} \
             -e KUBERNETES_VERSION=${KUBERNETES_VERSION} \
             -e CRI=${CRI} \
             -e PROVIDER=${PROVIDER:-not_provided} \
@@ -3887,7 +3837,7 @@ jobs:
             -e LAYOUT_YANDEX_FOLDER_ID=${LAYOUT_YANDEX_FOLDER_ID:-not_provided} \
             -e LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON=${LAYOUT_YANDEX_SERVICE_ACCOUNT_KEY_JSON:-not_provided} \
             -v $(pwd)/testing:/deckhouse/testing \
-            -v ${TMPPATH}:/tmp \
+            -v ${TMP_DIR_PATH}:/tmp \
             --user $(id -u):$(id -u) \
             -v /etc/group:/etc/group:ro \
             -v /etc/passwd:/etc/passwd:ro \
@@ -3951,6 +3901,7 @@ jobs:
 
       - name: Check alerting credentials
         id: check_alerting
+        if: always()
         env:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |

--- a/.github/workflows/schedule-cleanup.yml
+++ b/.github/workflows/schedule-cleanup.yml
@@ -91,7 +91,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -101,22 +101,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -126,31 +128,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 

--- a/.github/workflows/suspend-alpha.yml
+++ b/.github/workflows/suspend-alpha.yml
@@ -54,7 +54,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -64,22 +64,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -89,31 +91,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 

--- a/.github/workflows/suspend-beta.yml
+++ b/.github/workflows/suspend-beta.yml
@@ -54,7 +54,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -64,22 +64,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -89,31 +91,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 

--- a/.github/workflows/suspend-early-access.yml
+++ b/.github/workflows/suspend-early-access.yml
@@ -54,7 +54,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -64,22 +64,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -89,31 +91,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 

--- a/.github/workflows/suspend-rock-solid.yml
+++ b/.github/workflows/suspend-rock-solid.yml
@@ -54,7 +54,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -64,22 +64,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -89,31 +91,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 

--- a/.github/workflows/suspend-stable.yml
+++ b/.github/workflows/suspend-stable.yml
@@ -54,7 +54,7 @@ jobs:
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
       ci_commit_ref_name: ${{ steps.git_info.outputs.ci_commit_ref_name }}
       ci_commit_ref_slug: ${{ steps.git_info.outputs.ci_commit_ref_slug }}
-      ci_pipeline_created_at: ${{ steps.git_info.outputs.ci_pipeline_created_at }}
+      ref_full: ${{ steps.git_info.outputs.ref_full }}
       github_sha: ${{ steps.git_info.outputs.github_sha }}
     # Skip the CI for automation PRs, e.g. changelog
     if: ${{ github.event.pull_request.user.login != 'deckhouse-BOaTswain' }}
@@ -64,22 +64,24 @@ jobs:
         uses: actions/github-script@v5.0.0
         with:
           script: |
-            const { GITHUB_REF_TYPE, GITHUB_REF_NAME } = process.env
+            const { GITHUB_REF_TYPE, GITHUB_REF_NAME, GITHUB_REF } = process.env
 
-            let githubBranch = '';
-            let githubTag = '';
-            let githubSHA = '';
-            let refName = '';
-            let refSlug = '';
+            let refSlug = ''
+            let refName = ''
+            let refFull = ''
+            let githubBranch = ''
+            let githubTag = ''
+            let githubSHA = ''
             if (context.eventName === "workflow_dispatch" && context.payload.inputs && context.payload.inputs.pull_request_ref) {
-              // workflow_dispatch run for pull request should have input 'pull_request_ref'.
-              // Note: value in inputs.pull_request_ref is for pull_request_info job.
+              // Trigger: workflow_dispatch with pull_request_ref.
+              // Extract pull request number from 'refs/pull/<NUM>/merge'
+              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '')
+
+              refSlug       = `pr${prNum}`
               refName       = context.payload.inputs.ci_commit_ref_name
+              refFull       = context.payload.inputs.pull_request_ref
               githubBranch  = refName
               githubSHA     = context.payload.inputs.pull_request_sha
-              // Extract pull request number from 'refs/pull/<NUM>/merge'
-              const prNum   = context.payload.inputs.pull_request_ref.replace('refs/pull/', '').replace('/merge', '').replace('/head', '');
-              refSlug       = `pr${prNum}`;
               core.info(`workflow_dispatch event: set git info from inputs. inputs: ${JSON.stringify(context.payload.inputs)}`)
             } else if (context.eventName === "pull_request" || context.eventName === "pull_request_target" ) {
               // For PRs from forks, tag images with `prXXX` to avoid clashes between branches.
@@ -89,31 +91,30 @@ jobs:
 
               refSlug = `pr${context.issue.number}`;
               refName = (prRepo === targetRepo) ? prRef : refSlug;
+              refFull = `refs/pull/${context.issue.number}/head`
               githubBranch = refName
               githubSHA = context.payload.pull_request.head.sha
               core.info(`pull request event: set git info from pull_request.head. pr:${prRepo}:${prRef} target:${targetRepo}:${context.ref}`)
             } else {
-              // Events: workflow_dispatch without pull_request_ref, schedule, push...
+              // Other triggers: workflow_dispatch without pull_request_ref, schedule, push...
+              // refName is 'main' or tag name, so slugification is not necessary.
+              refSlug       = GITHUB_REF_NAME
               refName       = GITHUB_REF_NAME
+              refFull       = GITHUB_REF
               githubTag     = GITHUB_REF_TYPE == "tag"    ? refName : ""
               githubBranch  = GITHUB_REF_TYPE == "branch" ? refName : ""
               githubSHA     = context.sha
-              // refName is 'main' or tag name, so slugification is not necessary.
-              refSlug       = refName
               core.info(`${context.eventName} event: set git info from context: ${JSON.stringify({GITHUB_REF_NAME, GITHUB_REF_TYPE, sha: context.sha })}`)
             }
 
-            core.info(`output.ci_commit_ref_slug: '${refSlug}'`)
-            core.info(`output.ci_commit_ref_name: '${refName}'`)
-            core.info(`output.ci_commit_tag:      '${githubTag}'`)
-            core.info(`output.ci_commit_branch:   '${githubBranch}'`)
-            core.info(`output.github_sha:         '${githubSHA}'`)
-
+            core.setCommandEcho(true)
             core.setOutput('ci_commit_ref_slug', refSlug)
             core.setOutput('ci_commit_ref_name', refName)
             core.setOutput(`ci_commit_tag`, githubTag)
             core.setOutput(`ci_commit_branch`, githubBranch)
+            core.setOutput(`ref_full`, refFull)
             core.setOutput('github_sha', githubSHA)
+            core.setCommandEcho(false)
 
   # </template: git_info_job>
 

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -547,6 +547,7 @@ function main() {
     exit 2
   fi
 
+
   exitCode=0
   case "${1}" in
     run-test)


### PR DESCRIPTION
## Description

Dhctl doesn't support different repos for deckhouse image and module images. Use dev-registry and tag suffixes for e2e tests in test repositories as a workaround.

Chore: finally remove CI_PIPELINE_CREATED_AT.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

We need to run e2e tests in test repositories.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: fix
summary: Fix image name for running e2e tests in test repositories
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
