### PR TITLE
[node-manager][dhctl] Move creating master ng to hook from dhctl

### DIFF
--- a/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
@@ -323,7 +323,7 @@ func DefineBootstrapCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 		if err != nil {
 			return err
 		}
-		if err := operations.InstallDeckhouse(kubeCl, deckhouseInstallConfig, metaConfig.MasterNodeGroupManifest()); err != nil {
+		if err := operations.InstallDeckhouse(kubeCl, deckhouseInstallConfig); err != nil {
 			return err
 		}
 

--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -72,7 +72,7 @@ func DefineBootstrapInstallDeckhouseCommand(parent *kingpin.CmdClause) *kingpin.
 				return err
 			}
 
-			return operations.InstallDeckhouse(kubeCl, installConfig, metaConfig.MasterNodeGroupManifest())
+			return operations.InstallDeckhouse(kubeCl, installConfig)
 		})
 	}
 

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -210,40 +210,6 @@ func (m *MetaConfig) ExtractMasterNodeGroupStaticSettings() map[string]interface
 	return static
 }
 
-// MasterNodeGroupManifest prepares NodeGroup custom resource for master nodes
-func (m *MetaConfig) MasterNodeGroupManifest() map[string]interface{} {
-	spec := map[string]interface{}{
-		"nodeType": "CloudPermanent",
-		"disruptions": map[string]interface{}{
-			"approvalMode": "Manual",
-		},
-		"nodeTemplate": map[string]interface{}{
-			"labels": map[string]interface{}{
-				"node-role.kubernetes.io/master":        "",
-				"node-role.kubernetes.io/control-plane": "",
-			},
-			"taints": []map[string]interface{}{
-				{
-					"key":    "node-role.kubernetes.io/master",
-					"effect": "NoSchedule",
-				},
-			},
-		},
-	}
-	if m.ClusterType == StaticClusterType {
-		spec["nodeType"] = "Static"
-	}
-
-	return map[string]interface{}{
-		"apiVersion": "deckhouse.io/v1",
-		"kind":       "NodeGroup",
-		"metadata": map[string]interface{}{
-			"name": "master",
-		},
-		"spec": spec,
-	}
-}
-
 // NodeGroupManifest prepares NodeGroup custom resource for static nodes, which were ordered by Terraform
 func (m *MetaConfig) NodeGroupManifest(terraNodeGroup TerraNodeGroupSpec) map[string]interface{} {
 	if terraNodeGroup.NodeTemplate == nil {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/log.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log.go
@@ -69,6 +69,9 @@ func isErrorLine(line *logLine) bool {
 			// We cannot skip this error in hook,
 			// because kube version needs for next installation steps
 			"Not found k8s versions",
+			// hook with creating master run immediately after deploy crd
+			// and we can get this message one time
+			"Create object: deckhouse.io/v1/NodeGroup//master: apiVersion 'deckhouse.io/v1', kind 'NodeGroup' is not supported by cluster",
 		}
 		for _, p := range badSubStrings {
 			if strings.Contains(line.Message, p) {

--- a/dhctl/pkg/operations/bootstrap.go
+++ b/dhctl/pkg/operations/bootstrap.go
@@ -221,7 +221,7 @@ func WaitForSSHConnectionOnMaster(sshClient *ssh.Client) error {
 	})
 }
 
-func InstallDeckhouse(kubeCl *client.KubernetesClient, config *deckhouse.Config, nodeGroupConfig map[string]interface{}) error {
+func InstallDeckhouse(kubeCl *client.KubernetesClient, config *deckhouse.Config) error {
 	return log.Process("bootstrap", "Install Deckhouse", func() error {
 		err := deckhouse.CreateDeckhouseManifests(kubeCl, config)
 		if err != nil {
@@ -236,13 +236,6 @@ func InstallDeckhouse(kubeCl *client.KubernetesClient, config *deckhouse.Config,
 		err = deckhouse.WaitForReadiness(kubeCl)
 		if err != nil {
 			return fmt.Errorf("deckhouse install: %v", err)
-		}
-
-		if len(config.ClusterConfig) > 0 {
-			err = converge.CreateNodeGroup(kubeCl, "master", nodeGroupConfig)
-			if err != nil {
-				return err
-			}
 		}
 
 		return nil

--- a/modules/040-node-manager/hooks/create_master_node_group.go
+++ b/modules/040-node-manager/hooks/create_master_node_group.go
@@ -1,0 +1,97 @@
+// Copyright 2022 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	"context"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	internalv1 "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/internal/v1"
+	internalschema "github.com/deckhouse/deckhouse/modules/040-node-manager/hooks/pkg/schema"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	// ensure crds hook has order 5, for creating node group we should use greater number
+	OnStartup: &go_hook.OrderedConfig{Order: 6},
+}, dependency.WithExternalDependencies(createMasterNodeGroup))
+
+var defaultMasterNodeGroup = internalv1.NodeGroup{
+	TypeMeta: metav1.TypeMeta{
+		APIVersion: "deckhouse.io/v1",
+		Kind:       "NodeGroup",
+	},
+
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "master",
+	},
+
+	Spec: internalv1.NodeGroupSpec{
+		NodeType: internalv1.NodeTypeCloudPermanent,
+		Disruptions: internalv1.Disruptions{
+			ApprovalMode: "Manual",
+		},
+
+		NodeTemplate: internalschema.NodeTemplate{
+			Labels: map[string]string{
+				"node-role.kubernetes.io/master":        "",
+				"node-role.kubernetes.io/control-plane": "",
+			},
+			Taints: []v1.Taint{
+				{
+					Key:    "node-role.kubernetes.io/master",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	},
+}
+
+func createMasterNodeGroup(input *go_hook.HookInput, dc dependency.Container) error {
+	client, err := dc.GetK8sClient()
+	if err != nil {
+		return err
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "deckhouse.io",
+		Version:  "v1",
+		Resource: "nodegroups",
+	}
+
+	_, err = client.Dynamic().Resource(gvr).Get(context.TODO(), "master", metav1.GetOptions{})
+
+	if err == nil {
+		// node group found. Nothing to do
+		return nil
+	}
+
+	if !errors.IsNotFound(err) {
+		// another error - return error. Hook will be restarted by addon-operator
+		return err
+	}
+
+	ngCopy := defaultMasterNodeGroup
+
+	input.PatchCollector.Create(&ngCopy)
+
+	return nil
+}

--- a/modules/040-node-manager/hooks/create_master_node_group.go
+++ b/modules/040-node-manager/hooks/create_master_node_group.go
@@ -27,8 +27,10 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, createMasterNodeGroup)
 
 func getDefaultMasterNg(clusterType string) (*unstructured.Unstructured, error) {
-	// do not use internal type because it has none pointer struct fields
-	// this fields not skip due marshaling and validation will be fail
+	// do not use internal type because internal type has none pointer struct fields
+	// this fields not skip due marshaling and validation will be fail on fields
+	// CRI and CloudInstances
+	// CloudInstances is incorrect field for master nodes
 	spec := map[string]interface{}{
 		"nodeType": "CloudPermanent",
 		"disruptions": map[string]interface{}{

--- a/modules/040-node-manager/hooks/create_master_node_group_test.go
+++ b/modules/040-node-manager/hooks/create_master_node_group_test.go
@@ -73,7 +73,12 @@ spec:
 `
 	)
 
-	var masterNgDefaultYAMLBBytes, err = yaml.Marshal(defaultMasterNodeGroup)
+	masterNgUnstructured, err := getDefaultMasterNg()
+	if err != nil {
+		panic(err)
+	}
+	var masterNgDefaultYAMLBBytes []byte
+	masterNgDefaultYAMLBBytes, err = yaml.Marshal(masterNgUnstructured)
 	if err != nil {
 		panic(err)
 	}

--- a/modules/040-node-manager/hooks/create_master_node_group_test.go
+++ b/modules/040-node-manager/hooks/create_master_node_group_test.go
@@ -1,0 +1,203 @@
+// Copyright 2022 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/yaml"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Global hooks :: migrate :: add_control_plane_role_to_master_ng_test ::", func() {
+	f := HookExecutionConfigInit(`{}`, `{}`)
+
+	var nodeGroupResource = schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1", Resource: "nodegroups"}
+	f.RegisterCRD(nodeGroupResource.Group, nodeGroupResource.Version, "NodeGroup", false)
+
+	const (
+		workerNgYAML = `
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: worker
+spec:
+  cloudInstances:
+    classReference:
+      kind: OpenStackInstanceClass
+      name: worker-big
+    maxPerZone: 1
+    maxSurgePerZone: 1
+    maxUnavailablePerZone: 0
+    minPerZone: 1
+  disruptions:
+    approvalMode: Automatic
+  nodeTemplate:
+    labels:
+      node.deckhouse.io/group: worker-big
+  nodeType: CloudEphemeral
+`
+		masterNgNoneDefault = `
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: master
+spec:
+  disruptions:
+    approvalMode: Manual
+  nodeTemplate:
+    annotations:
+      test-annot: test-annot
+    labels:
+      test-label: "test-label"
+      node-role.kubernetes.io/master: ""
+      node-role.kubernetes.io/control-plane: ""
+  nodeType: CloudStatic
+`
+	)
+
+	var masterNgDefaultYAMLBBytes, err = yaml.Marshal(defaultMasterNodeGroup)
+	if err != nil {
+		panic(err)
+	}
+
+	var masterNgDefaultYAML = string(masterNgDefaultYAMLBBytes)
+
+	assertCountNodeGroups := func(f *HookExecutionConfig, count int) {
+		nodeGroups, err := f.KubeClient().Dynamic().Resource(nodeGroupResource).Namespace("").List(context.TODO(), v1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(nodeGroups.Items).To(HaveLen(count))
+	}
+
+	assertDefaultMasterNodeGroupOnlyPresent := func(f *HookExecutionConfig) {
+		masterNg := f.KubernetesResource("NodeGroup", "", "master")
+		Expect(masterNg.ToYaml()).To(MatchYAML(masterNgDefaultYAML))
+
+		assertCountNodeGroups(f, 1)
+	}
+
+	Context("Cluster without node groups", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(""))
+			f.RunHook()
+		})
+
+		It("Should create default master node group only", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			assertDefaultMasterNodeGroupOnlyPresent(f)
+		})
+	})
+
+	Context("Cluster has default master node group", func() {
+		Context("only", func() {
+			BeforeEach(func() {
+				JoinKubeResourcesAndSet(f, masterNgDefaultYAML)
+
+				f.RunHook()
+			})
+
+			It("should not change master node group", func() {
+				Expect(f).To(ExecuteSuccessfully())
+
+				assertDefaultMasterNodeGroupOnlyPresent(f)
+			})
+		})
+
+		Context("with another ng", func() {
+			BeforeEach(func() {
+				JoinKubeResourcesAndSet(f, masterNgDefaultYAML, workerNgYAML)
+
+				f.RunHook()
+			})
+
+			It("should not change master node group", func() {
+				Expect(f).To(ExecuteSuccessfully())
+
+				masterNg := f.KubernetesResource("NodeGroup", "", "master")
+				Expect(masterNg.ToYaml()).To(MatchYAML(masterNgDefaultYAML))
+			})
+
+			It("should not change another node group", func() {
+				Expect(f).To(ExecuteSuccessfully())
+
+				workerNg := f.KubernetesResource("NodeGroup", "", "worker")
+				Expect(workerNg.ToYaml()).To(MatchYAML(workerNgYAML))
+			})
+
+			It("should not create another node groups", func() {
+				Expect(f).To(ExecuteSuccessfully())
+
+				assertCountNodeGroups(f, 2)
+			})
+		})
+	})
+
+	Context("Cluster has none default master node group only", func() {
+		Context("only", func() {
+			BeforeEach(func() {
+				JoinKubeResourcesAndSet(f, masterNgNoneDefault)
+
+				f.RunHook()
+			})
+
+			It("Should not change master node group", func() {
+				Expect(f).To(ExecuteSuccessfully())
+
+				masterNg := f.KubernetesResource("NodeGroup", "", "master")
+				Expect(masterNg.ToYaml()).To(MatchYAML(masterNgNoneDefault))
+			})
+
+			It("Should not create another node groups", func() {
+				Expect(f).To(ExecuteSuccessfully())
+
+				assertCountNodeGroups(f, 1)
+			})
+		})
+
+		Context("with another ng", func() {
+			BeforeEach(func() {
+				JoinKubeResourcesAndSet(f, masterNgNoneDefault, workerNgYAML)
+
+				f.RunHook()
+			})
+
+			It("should not change master node group", func() {
+				Expect(f).To(ExecuteSuccessfully())
+
+				masterNg := f.KubernetesResource("NodeGroup", "", "master")
+				Expect(masterNg.ToYaml()).To(MatchYAML(masterNgNoneDefault))
+			})
+
+			It("should not change another node group", func() {
+				Expect(f).To(ExecuteSuccessfully())
+
+				workerNg := f.KubernetesResource("NodeGroup", "", "worker")
+				Expect(workerNg.ToYaml()).To(MatchYAML(workerNgYAML))
+			})
+
+			It("should not create another node groups", func() {
+				Expect(f).To(ExecuteSuccessfully())
+
+				assertCountNodeGroups(f, 2)
+			})
+		})
+	})
+})


### PR DESCRIPTION
## Description
Move creating master ng to hook from dhctl.
In hook, if master node group exists, hook should not affect any changes in master node group.

## Why do we need it, and what problem does it solve?
Right way to creating master node group in node-manager immediately after deploy node group crd.
And we have race between creating master node group and control-plane manager. Control plane manager can redeploy kubelet config  faster than creating master node group from dhctl and we can get negative effects (can not get logs, because cert regenerated without node ip, etc...)

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: feature
summary: Add hook for creating master node group
impact_level: low
---
section: dhctl
type: feature
summary: Remove creating master node group
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
