### PR TITLE
[candi] fix startup config in kubernetes api proxy configuration script

### DIFF
--- a/candi/bashible/common-steps/node-group/052_configure_kubernetes_api_proxy.sh.tpl
+++ b/candi/bashible/common-steps/node-group/052_configure_kubernetes_api_proxy.sh.tpl
@@ -54,7 +54,7 @@ stream {
 }
 EOF
 
-if [[ ! -f /etc/kubernetes/kubernetes-api-proxy/nginx_new.conf ]]; then
+if [[ ! -f /etc/kubernetes/kubernetes-api-proxy/nginx.conf ]]; then
   cp /etc/kubernetes/kubernetes-api-proxy/nginx_new.conf /etc/kubernetes/kubernetes-api-proxy/nginx.conf
 fi
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Copy /etc/kubernetes/kubernetes-api-proxy/nginx.conf file from etc/kubernetes/kubernetes-api-proxy/nginx_new.conf if etc/kubernetes/kubernetes-api-proxy/nginx.conf is absent.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When kubernetes-api-proxy starts for first time, it needs /etc/kubernetes/kubernetes-api-proxy/nginx.conf file. But file is absent.
This PR  fixes this in kubernetes-api-proxy configuration script.
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: fix startup config in kubernetes api proxy configuration script
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
