### PR TITLE
[deckhouse-controller] fix: error on 'config list' command, log level for snapshot info

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/main.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/main.go
@@ -77,6 +77,7 @@ func main() {
 			}
 
 			operator := deckhouse.DefaultDeckhouse()
+			operator.WithRuntimeConfig(runtimeConfig)
 			err := deckhouse.InitAndStart(operator)
 			if err != nil {
 				os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.9.0
-	github.com/flant/addon-operator v1.0.6-0.20220415075917-a829ed2a3d4b
+	github.com/flant/addon-operator v1.0.6-0.20220420111301-847d379e6249
 	github.com/flant/kube-client v0.0.6
 	github.com/flant/shell-operator v1.0.10-0.20220324171037-a48626e8b125
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwo
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/flant/addon-operator v1.0.6-0.20220415075917-a829ed2a3d4b h1:5fAi6DiMKScLvvQ7uTHhUI6erJcpGTYu1VneyV8yaKU=
-github.com/flant/addon-operator v1.0.6-0.20220415075917-a829ed2a3d4b/go.mod h1:FeVjg7kKnWZb9JbmOTQrUNbbGwyi18ZwW5jZSga+JOU=
+github.com/flant/addon-operator v1.0.6-0.20220420111301-847d379e6249 h1:3138zoSyxrr7QZipmX7c/sjTrlu7v2Ds9m/S5S+Nmuc=
+github.com/flant/addon-operator v1.0.6-0.20220420111301-847d379e6249/go.mod h1:FeVjg7kKnWZb9JbmOTQrUNbbGwyi18ZwW5jZSga+JOU=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v0.0.6 h1:cHFMf7xGtJOgg+KBuPcA+7q+M7IJRSgf2pHVStv2aj0=


### PR DESCRIPTION
## Description

- set runtime config dependency in operator instance (related: https://github.com/flant/addon-operator/pull/318 https://github.com/flant/shell-operator/pull/352)
- set debug log level for 'snapshot info' messages (related: https://github.com/flant/shell-operator/pull/376)

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Fix server side error on running `addon-operator config list`, reduce noise in logs.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: chore
summary: Fix error on 'config list' command, log level for snapshot info
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
