### PR TITLE
[log-shipper] Fix reloading signal

### DIFF
--- a/modules/460-log-shipper/images/vector/Dockerfile
+++ b/modules/460-log-shipper/images/vector/Dockerfile
@@ -29,7 +29,7 @@ RUN cargo build \
 FROM $BASE_DEBIAN_BULLSEYE
 RUN mkdir -p /etc/vector \
     && apt-get update \
-    && apt-get install -yq ca-certificates tzdata inotify-tools gettext \
+    && apt-get install -yq ca-certificates tzdata inotify-tools gettext procps \
     && rm -rf /var/cache/apt/archives/*
 COPY --from=build /vector/vector/target/release/vector /usr/bin/vector
 COPY reloader /usr/bin/reloader

--- a/modules/460-log-shipper/images/vector/reloader
+++ b/modules/460-log-shipper/images/vector/reloader
@@ -55,11 +55,11 @@ test_dir="/tmp/tmp_vector_conf"
 
 function reload_once() {
   if [[ ! -f "$sample_config" ]] ; then
-    log "No sample config found"
+    log "No sample config found."
     return
   fi
 
-  log "Start reloading a config"
+  log "Start reloading a config."
   vector_config=$(cat "$sample_config" | envsubst | base64 -w0)
 
   # Cleanup test directory
@@ -77,24 +77,22 @@ function reload_once() {
       if [[ -f "$dynamic_config_dir/vector.json" ]] ; then
         diff -u "$dynamic_config_dir/vector.json" "$test_dir/vector.json" || true
       fi
-
       mk_configs $dynamic_config_dir $vector_config
 
-      vector_pid=$(pidof vector)
-      if [[ "x$vector_pid" != "x" ]]; then
-        log "Reloading vector"
-        kill -SIGHUP "$vector_pid"
-      fi
+      # pkill exits with the code 1 if no process matches tgw patter,
+      # but our script will catch this error later in the main loop
+      pkill -SIGHUP vector
+      log "Vector config has been reloaded."
     else
       log "Configs are equal, doing nothing."
     fi
   else
-    log "Invalid config, skip running"
+    log "Invalid config, skip running."
   fi
 }
 
 reload_once
-log "Start watching the $sample_config file"
+log "Start watching the $sample_config file."
 while true; do
   # In case of running inside a Kubernetes Pod, inotify wait exists on every configmap change.
   inotifywait -q -e modify,create,delete,move "$sample_config" || true


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Use pkill instead of pidof.

By executing pkill reloader sends a reloading signal to every vector process, which is technically correct.

## Why do we need it, and what problem does it solve?
Closes #1427

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: log-shipper
type: fix
summary: Send reloading signal to all vector processes in a container on config change.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
