### PR TITLE
[snapshot-controller] Fix deployment

### DIFF
--- a/modules/045-snapshot-controller/templates/snapshot-controller/deployment.yaml
+++ b/modules/045-snapshot-controller/templates/snapshot-controller/deployment.yaml
@@ -25,7 +25,7 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "snapshot-controller" )) | nindent 2 }}
 spec:
-  {{- include "helm_lib_deployment_on_master_strategy_and_replicas_for_ha" . | nindent 2 }}
+  minAvailable: {{ include "helm_lib_is_ha_to_value" (list . 1 0) }}
   selector:
     matchLabels:
       app: snapshot-controller
@@ -38,7 +38,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "snapshot-controller")) | nindent 2 }}
 spec:
   minReadySeconds: 15
-  replicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
+  {{- include "helm_lib_deployment_on_master_strategy_and_replicas_for_ha" . | nindent 2 }}
   selector:
     matchLabels:
       app: snapshot-controller

--- a/modules/045-snapshot-controller/templates/snapshot-validation-webhook/deployment.yaml
+++ b/modules/045-snapshot-controller/templates/snapshot-validation-webhook/deployment.yaml
@@ -37,7 +37,7 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "snapshot-validation-webhook" )) | nindent 2 }}
 spec:
-  replicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
+  {{- include "helm_lib_deployment_on_master_strategy_and_replicas_for_ha" . | nindent 2 }}
   selector:
     matchLabels:
       app: snapshot-validation-webhook


### PR DESCRIPTION
## Description

Fix `replicas` and `minAvailable` for snapshot-controller

## Why do we need it, and what problem does it solve?

Manifests for snapshot-controller contain mistake it does not allow deckhouse to deploy the release:

```
{"binding":"ReloadAllModules","event.type":"OperatorStartup","level":"error","module":"snapshot-controller","msg":"ModuleRun failed in phase 'CanRunHelm'. Requeue task to retry after delay. Failed count is 38. Error: helm upgrade failed: post-upgrade hooks failed: unable to build kubernetes object for post-upgrade hook snapshot-controller/templates/snapshot-controller/deployment.yaml: error validating \"\": error validating data: [ValidationError(PodDisruptionBudget.spec): unknown field \"replicas\" in io.k8s.api.policy.v1beta1.PodDisruptionBudgetSpec, ValidationError(PodDisruptionBudget.spec): unknown field \"strategy\" in io.k8s.api.policy.v1beta1.PodDisruptionBudgetSpec]\n","operator.component":"taskRunner","queue":"main","task.id":"0ccad279-bca1-475c-a337-4395d5db2a7e","time":"2022-04-21T08:55:56Z"}
```

## Changelog entries

```changes
section: snapshot-controller
type: fix
summary: fix snapshot-controller deployment
impact_level: low
```
