### PR TITLE
[monitoring-ping] Enable only if monitoring-kubernetes module is enabled

### DIFF
--- a/modules/340-monitoring-ping/enabled
+++ b/modules/340-monitoring-ping/enabled
@@ -19,7 +19,9 @@ source /deckhouse/shell_lib.sh
 function __main__() {
   enabled::disable_module_if_cluster_is_not_bootstraped
 
-  if values::array_has global.enabledModules "prometheus" ; then
+  # node-exporter is required for this module to work because the exporter stores metrics as a text file on a node,
+  # which then be read by a node-exporter
+  if values::array_has global.enabledModules "monitoring-kubernetes"; then
     echo "true" > $MODULE_ENABLED_RESULT
   else
     echo "false" > $MODULE_ENABLED_RESULT


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
monitroing-ping works only if we have a running node-exporter

## Why do we need it, and what problem does it solve?
Closes https://github.com/deckhouse/deckhouse/issues/1371

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring-ping
type: chore
summary: Enabled the monitoring-ping module only if the monitoring-kubernetes module is enabled.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
