### PR TITLE
[namespace-configurator] Ignore upmeter probe namespaces

### DIFF
--- a/ee/fe/modules/600-namespace-configurator/hooks/handler.go
+++ b/ee/fe/modules/600-namespace-configurator/hooks/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/tidwall/gjson"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -21,6 +22,19 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			Name:       "namespaces",
 			ApiVersion: "v1",
 			Kind:       "Namespace",
+			// Ignore upmeter probe fake namespaces, because upmeter deletes them immediately.
+			// They do not require any labels.
+			LabelSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "heritage",
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values: []string{
+							"upmeter",
+						},
+					},
+				},
+			},
 			FilterFunc: applyNamespaceFilter,
 		},
 	},

--- a/ee/fe/modules/600-namespace-configurator/hooks/handler_test.go
+++ b/ee/fe/modules/600-namespace-configurator/hooks/handler_test.go
@@ -176,6 +176,13 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: infra-test3
+  labels:
+    heritage: upmeter
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: prod-ns2
   annotations:
     extended-monitoring.flant.com/enabled: "true"
@@ -203,7 +210,8 @@ metadata:
 			Expect(ns.Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeTrue())
 			ns = f.KubernetesResource("Namespace", "", "prod-ns2")
 			Expect(ns.Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeTrue())
-
+			ns = f.KubernetesResource("Namespace", "", "infra-test3")
+			Expect(ns.Field(`metadata.annotations.extended-monitoring\.flant\.com/enabled`).Exists()).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Exclude namespaces by heritage labels.

## Why do we need it, and what problem does it solve?
Upmeter deletes namespaces faster than deckhouse can put labels or annotations on them.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: namespace-configurator
type: fix
summary: Exclude upmeter probe namespaces from namespace-configurator snapshots.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
