### PR TITLE
Revert "[docs] Fix openAPI schema generator (#1272)"

### DIFF
--- a/docs/documentation/_plugins/openapi.rb
+++ b/docs/documentation/_plugins/openapi.rb
@@ -306,7 +306,7 @@ module Jekyll
                 # object items
                 result.push('<ul>')
                 attributes['items']["properties"].sort.to_h.each do |item_key, item_value|
-                    result.push(format_schema(item_key, item_value, attributes, get_hash_value(primaryLanguage,"items", "properties", item_key) , get_hash_value(fallbackLanguage,"items", "properties", item_key), fullPath))
+                    result.push(format_schema(item_key, item_value, attributes['items'], get_hash_value(primaryLanguage,"items", "properties", item_key) , get_hash_value(fallbackLanguage,"items", "properties", item_key), fullPath))
                 end
                 result.push('</ul>')
             else


### PR DESCRIPTION
## Description

This reverts commit 3ec2847b0bc7c7ba6190c1ecef73aa25c98d8943 (#1272).


## Why do we need it, and what problem does it solve?
Changes in #1272 were wrong.

## Changelog entries
```changes
section: docs
type: fix
summary: Revert OpenAPI generator changes.
impact_level: low
```
