### PR TITLE
[Upmeter] Fix setting disabled probes

### DIFF
--- a/modules/500-upmeter/images/upmeter/cmd/upmeter/main.go
+++ b/modules/500-upmeter/images/upmeter/cmd/upmeter/main.go
@@ -54,6 +54,8 @@ func main() {
 		setupLogger(logger, loggerConfig)
 
 		logger.Info("Starting upmeter server")
+		logger.Debugf("Logger config: %v", loggerConfig)
+		logger.Debugf("Server config: %v", serverConfig)
 
 		srv := server.New(serverConfig, logger)
 		startCtx, cancelStart := context.WithCancel(context.Background())
@@ -91,6 +93,9 @@ func main() {
 	agentCommand.Action(func(c *kingpin.ParseContext) error {
 		setupLogger(logger, loggerConfig)
 		logger.Infof("Starting upmeter agent. ID=%s", util.AgentUniqueId())
+		logger.Debugf("Logger config: %v", loggerConfig)
+		logger.Debugf("Agent config: %v", agentConfig)
+		logger.Debugf("Kubernetes config: %v", agentKubeConfig)
 
 		a := agent.New(agentConfig, agentKubeConfig, logger)
 

--- a/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
+++ b/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
@@ -51,10 +51,9 @@ func parseServerArgs(cmd *kingpin.CmdClause, config *server.Config) {
 		Envar("UPMETER_ORIGINS").
 		IntVar(&config.OriginsCount)
 
-	// Disabled probes to omit from fetching
+	// Disabled probes to omit from showing by default. On the server side, it makes sense for
+	// UI only. The list of probes can be passed as a repeated command-line argument.
 	cmd.Flag("disable-probe", "Group or probe to omit by default.").
-		Envar("UPMETER_DISABLED_PROBES").
-		Default("").
 		StringsVar(&config.DisabledProbes)
 
 	// User-Agent
@@ -98,9 +97,9 @@ func parseAgentArgs(cmd *kingpin.CmdClause, config *agent.Config) {
 		Default("upmeter.db").
 		StringVar(&config.DatabasePath)
 
+	// Probes or even groups to skip for probing. The list of probes can be passed as a repeated
+	// command-line argument.
 	cmd.Flag("disable-probe", "Group or probe to disable.").
-		Envar("UPMETER_DISABLED_PROBES").
-		Default("").
 		StringsVar(&config.DisabledProbes)
 
 	// User-Agent

--- a/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
+++ b/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
@@ -52,7 +52,7 @@ func parseServerArgs(cmd *kingpin.CmdClause, config *server.Config) {
 		IntVar(&config.OriginsCount)
 
 	// Disabled probes to omit from fetching
-	cmd.Flag("disabled-probes", "The comma-separated list of groups and/or probes to disable.").
+	cmd.Flag("disable-probe", "Group or probe to omit by default.").
 		Envar("UPMETER_DISABLED_PROBES").
 		Default("").
 		StringsVar(&config.DisabledProbes)
@@ -98,7 +98,7 @@ func parseAgentArgs(cmd *kingpin.CmdClause, config *agent.Config) {
 		Default("upmeter.db").
 		StringVar(&config.DatabasePath)
 
-	cmd.Flag("disabled-probes", "The list of disabled comma-separated groups and/or probes.").
+	cmd.Flag("disable-probe", "Group or probe to disable.").
 		Envar("UPMETER_DISABLED_PROBES").
 		Default("").
 		StringsVar(&config.DisabledProbes)

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_deployment.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_deployment.go
@@ -222,7 +222,7 @@ func createDeploymentObject(agentId string) *appsv1.Deployment {
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app":           "upmeter-agent",
+						"heritage":      "upmeter",
 						agentLabelKey:   agentId,
 						"upmeter-group": "control-plane",
 						"upmeter-probe": "controller-manager",

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -116,12 +116,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          # - name: UPMETER_DISABLED_PROBES
-          #   value: '{{ .Values.upmeter.internal.disabledProbes | join "," }}'
           - name: UPMETER_CLUSTER_DOMAIN
             value: {{ .Values.global.discovery.clusterDomain | quote }}
           - name: LOG_LEVEL
-            value: "debug"
+            value: "info"
           - name: LOG_TYPE
             value: "json"
           resources:

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -83,7 +83,7 @@ spec:
             - /upmeter
             - agent
             {{- range $probeRef := .Values.upmeter.internal.disabledProbes }}
-            --disable-probe={{ $probeRef | quote}}
+            - --disable-probe={{ $probeRef | quote}}
             {{- end }}
           volumeMounts:
           - mountPath: /db

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -83,7 +83,7 @@ spec:
             - /upmeter
             - agent
             {{- range $probeRef := .Values.upmeter.internal.disabledProbes }}
-            - --disable-probe={{ $probeRef | quote}}
+            - --disable-probe={{ $probeRef }}
             {{- end }}
           volumeMounts:
           - mountPath: /db

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -120,6 +120,8 @@ spec:
           #   value: '{{ .Values.upmeter.internal.disabledProbes | join "," }}'
           - name: UPMETER_CLUSTER_DOMAIN
             value: {{ .Values.global.discovery.clusterDomain | quote }}
+          - name: LOG_LEVEL
+            value: "debug"
           - name: LOG_TYPE
             value: "json"
           resources:

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -82,6 +82,9 @@ spec:
           command:
             - /upmeter
             - agent
+            {{- range $probeRef := .Values.upmeter.internal.disabledProbes }}
+            --disable-probe={{ $probeRef | quote}}
+            {{- end }}
           volumeMounts:
           - mountPath: /db
             name: data
@@ -113,8 +116,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: UPMETER_DISABLED_PROBES
-            value: '{{ .Values.upmeter.internal.disabledProbes | join "," }}'
+          # - name: UPMETER_DISABLED_PROBES
+          #   value: '{{ .Values.upmeter.internal.disabledProbes | join "," }}'
           - name: UPMETER_CLUSTER_DOMAIN
             value: {{ .Values.global.discovery.clusterDomain | quote }}
           - name: LOG_TYPE

--- a/modules/500-upmeter/templates/upmeter/statefulset.yaml
+++ b/modules/500-upmeter/templates/upmeter/statefulset.yaml
@@ -115,7 +115,7 @@ spec:
           # - name: UPMETER_DISABLED_PROBES
             # value: '{{ .Values.upmeter.internal.disabledProbes | join "," }}'
           - name: LOG_LEVEL
-            value: "info"
+            value: "debug"
           - name: LOG_TYPE
             value: "json"
         volumeMounts:

--- a/modules/500-upmeter/templates/upmeter/statefulset.yaml
+++ b/modules/500-upmeter/templates/upmeter/statefulset.yaml
@@ -103,7 +103,7 @@ spec:
           - start
           - --origins={{ index .Values.global.discovery "clusterMasterCount" }}
           {{- range $probeRef := .Values.upmeter.internal.disabledProbes }}
-          - --disable-probe={{ $probeRef | quote}}
+          - --disable-probe={{ $probeRef }}
           {{- end }}
         env:
           - name: UPMETER_DB_PATH

--- a/modules/500-upmeter/templates/upmeter/statefulset.yaml
+++ b/modules/500-upmeter/templates/upmeter/statefulset.yaml
@@ -102,6 +102,9 @@ spec:
           - /upmeter
           - start
           - --origins={{ index .Values.global.discovery "clusterMasterCount" }}
+          {{- range $probeRef := .Values.upmeter.internal.disabledProbes }}
+          --disable-probe={{ $probeRef | quote}}
+          {{- end }}
         env:
           - name: UPMETER_DB_PATH
             value: "/db/downtime.db.sqlite"
@@ -109,8 +112,8 @@ spec:
             value: 127.0.0.1
           - name: UPMETER_LISTEN_PORT
             value: "8091"
-          - name: UPMETER_DISABLED_PROBES
-            value: '{{ .Values.upmeter.internal.disabledProbes | join "," }}'
+          # - name: UPMETER_DISABLED_PROBES
+            # value: '{{ .Values.upmeter.internal.disabledProbes | join "," }}'
           - name: LOG_LEVEL
             value: "info"
           - name: LOG_TYPE

--- a/modules/500-upmeter/templates/upmeter/statefulset.yaml
+++ b/modules/500-upmeter/templates/upmeter/statefulset.yaml
@@ -103,7 +103,7 @@ spec:
           - start
           - --origins={{ index .Values.global.discovery "clusterMasterCount" }}
           {{- range $probeRef := .Values.upmeter.internal.disabledProbes }}
-          --disable-probe={{ $probeRef | quote}}
+          - --disable-probe={{ $probeRef | quote}}
           {{- end }}
         env:
           - name: UPMETER_DB_PATH

--- a/modules/500-upmeter/templates/upmeter/statefulset.yaml
+++ b/modules/500-upmeter/templates/upmeter/statefulset.yaml
@@ -112,10 +112,8 @@ spec:
             value: 127.0.0.1
           - name: UPMETER_LISTEN_PORT
             value: "8091"
-          # - name: UPMETER_DISABLED_PROBES
-            # value: '{{ .Values.upmeter.internal.disabledProbes | join "," }}'
           - name: LOG_LEVEL
-            value: "debug"
+            value: "info"
           - name: LOG_TYPE
             value: "json"
         volumeMounts:


### PR DESCRIPTION
## Description

Move disabled probes from env variable to cmd args to correctly use kingpin library for the handling of a slice of strings.

## Why do we need it, and what problem does it solve?

Fixes ignored disabled probes when there are more than one of them

## Changelog entries

Low impact level because it is a follow-up fix after the bug was introduced

```changes
section: upmeter
type: fix
summary: Fix the application of disabled probes
impact_level: low
```
