### PR TITLE
[log-shipper] Migrate deprecated elasticsearch fields

### DIFF
--- a/modules/460-log-shipper/hooks/internal/vector/config/testdata/config_3.json
+++ b/modules/460-log-shipper/hooks/internal/vector/config/testdata/config_3.json
@@ -32,9 +32,12 @@
         "verify_hostname": true
       },
       "compression": "gzip",
-      "index": "{{ kubernetes.namespace }}-%F",
+      "bulk": {
+        "action": "index",
+        "index": "{{ kubernetes.namespace }}-%F"
+      },
       "pipeline": "test-pipe",
-      "bulk_action": "index"
+      "mode": "bulk"
     }
   }
 }

--- a/modules/460-log-shipper/hooks/internal/vector/model/destination.go
+++ b/modules/460-log-shipper/hooks/internal/vector/model/destination.go
@@ -173,7 +173,9 @@ func NewLokiDestination(name string, cspec v1alpha1.ClusterLogDestinationSpec) i
 func NewElasticsearchDestination(name string, cspec v1alpha1.ClusterLogDestinationSpec) impl.LogDestination {
 	spec := cspec.Elasticsearch
 	var ESBatch batch
-	var BulkAction string = "index"
+
+	bulkAction := "index"
+	mode := "bulk"
 
 	common := commonDestinationSettings{
 		Name: "d8_cluster_sink_" + name,
@@ -257,7 +259,8 @@ func NewElasticsearchDestination(name string, cspec v1alpha1.ClusterLogDestinati
 	}
 
 	if spec.DataStreamEnabled {
-		BulkAction = "create"
+		mode = "data_stream"
+		bulkAction = "create"
 	}
 
 	return &elasticsearchDestination{
@@ -269,12 +272,13 @@ func NewElasticsearchDestination(name string, cspec v1alpha1.ClusterLogDestinati
 		Batch:                     ESBatch,
 		Endpoint:                  spec.Endpoint,
 		Compression:               "gzip",
-		Index:                     spec.Index,
-		Pipeline:                  spec.Pipeline,
-		BulkAction:                BulkAction,
-		DocType:                   spec.DocType,
-		// We do not neet this field for vector 0.14
-		//Mode:                      "normal",
+		Bulk: ElasticsearchBulk{
+			Action: bulkAction,
+			Index:  spec.Index,
+		},
+		Pipeline: spec.Pipeline,
+		DocType:  spec.DocType,
+		Mode:     mode,
 	}
 }
 

--- a/modules/460-log-shipper/hooks/internal/vector/model/model.go
+++ b/modules/460-log-shipper/hooks/internal/vector/model/model.go
@@ -189,15 +189,18 @@ type elasticsearchDestination struct {
 
 	Compression string `json:"compression,omitempty"`
 
-	Index string `json:"index,omitempty"`
+	Bulk ElasticsearchBulk `json:"bulk,omitempty"`
 
 	Pipeline string `json:"pipeline,omitempty"`
-
-	BulkAction string `json:"bulk_action,omitempty"`
 
 	Mode string `json:"mode,omitempty"`
 
 	DocType string `json:"doc_type,omitempty"`
+}
+
+type ElasticsearchBulk struct {
+	Action string `json:"action,omitempty"`
+	Index  string `json:"index,omitempty"`
 }
 
 type logstashDestination struct {

--- a/modules/460-log-shipper/hooks/testdata/es-5x.json
+++ b/modules/460-log-shipper/hooks/testdata/es-5x.json
@@ -133,9 +133,12 @@
         "verify_hostname": false
       },
       "compression": "gzip",
-      "index": "logs-%F",
+      "bulk": {
+        "action": "index",
+        "index": "logs-%F"
+      },
       "pipeline": "testpipe",
-      "bulk_action": "index",
+      "mode": "bulk",
       "doc_type": "_doc"
     }
   }

--- a/modules/460-log-shipper/hooks/testdata/multiline.json
+++ b/modules/460-log-shipper/hooks/testdata/multiline.json
@@ -105,9 +105,12 @@
         "verify_hostname": false
       },
       "compression": "gzip",
-      "index": "logs-%F",
+      "bulk": {
+        "action": "index",
+        "index": "logs-%F"
+      },
       "pipeline": "testpipe",
-      "bulk_action": "index"
+      "mode": "bulk"
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/multiple-dests.json
+++ b/modules/460-log-shipper/hooks/testdata/multiple-dests.json
@@ -308,8 +308,11 @@
         "verify_hostname": false
       },
       "compression": "gzip",
-      "index": "logs-%F",
-      "bulk_action": "index"
+      "bulk": {
+        "action": "index",
+        "index": "logs-%F"
+      },
+      "mode": "bulk"
     },
     "d8_cluster_sink_test-logstash-dest": {
       "type": "socket",

--- a/modules/460-log-shipper/hooks/testdata/namespaced-source.json
+++ b/modules/460-log-shipper/hooks/testdata/namespaced-source.json
@@ -227,8 +227,11 @@
         "timeout_secs": 1
       },
       "compression": "gzip",
-      "index": "logs-%F",
-      "bulk_action": "index"
+      "bulk": {
+        "action": "index",
+        "index": "logs-%F"
+      },
+      "mode": "bulk"
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/one-dest.json
+++ b/modules/460-log-shipper/hooks/testdata/one-dest.json
@@ -108,8 +108,11 @@
         "verify_hostname": false
       },
       "compression": "gzip",
-      "index": "logs-%F",
-      "bulk_action": "index"
+      "bulk": {
+        "action": "index",
+        "index": "logs-%F"
+      },
+      "mode": "bulk"
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/pair-datastream.json
+++ b/modules/460-log-shipper/hooks/testdata/pair-datastream.json
@@ -141,9 +141,12 @@
         "verify_hostname": false
       },
       "compression": "gzip",
-      "index": "logs-%F",
+      "bulk": {
+        "action": "create",
+        "index": "logs-%F"
+      },
       "pipeline": "testpipe",
-      "bulk_action": "create"
+      "mode": "data_stream"
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/simple-pair.json
+++ b/modules/460-log-shipper/hooks/testdata/simple-pair.json
@@ -133,9 +133,12 @@
         "verify_hostname": false
       },
       "compression": "gzip",
-      "index": "logs-%F",
+      "bulk": {
+        "action": "index",
+        "index": "logs-%F"
+      },
       "pipeline": "testpipe",
-      "bulk_action": "index"
+      "mode": "bulk"
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Migrate fields according to the guide

## Why do we need it, and what problem does it solve?
https://vector.dev/highlights/2021-12-28-0-19-0-upgrade-guide/#elasticsearch-sink-deprecated-fields

## Changelog entries
```changes
section: log-shipper
type: fix
summary: Migrate deprecated elasticsearch fields
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
