### PR TITLE
[log-shipper] elasticsearch upgrade fix

### DIFF
--- a/modules/460-log-shipper/hooks/internal/vector/destination.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination.go
@@ -176,7 +176,9 @@ func NewLokiDestination(name string, cspec v1alpha1.ClusterLogDestinationSpec) i
 func NewElasticsearchDestination(name string, cspec v1alpha1.ClusterLogDestinationSpec) impl.LogDestination {
 	spec := cspec.Elasticsearch
 	var ESBatch batch
-	var BulkAction string = "index"
+
+	bulkAction := "index"
+	mode := "bulk"
 
 	common := commonDestinationSettings{
 		Name: "d8_cluster_sink_" + name,
@@ -260,7 +262,8 @@ func NewElasticsearchDestination(name string, cspec v1alpha1.ClusterLogDestinati
 	}
 
 	if spec.DataStreamEnabled {
-		BulkAction = "create"
+		bulkAction = "create"
+		mode = "data_stream"
 	}
 
 	return &elasticsearchDestination{
@@ -272,12 +275,13 @@ func NewElasticsearchDestination(name string, cspec v1alpha1.ClusterLogDestinati
 		Batch:                     ESBatch,
 		Endpoint:                  spec.Endpoint,
 		Compression:               "gzip",
-		Index:                     spec.Index,
-		Pipeline:                  spec.Pipeline,
-		BulkAction:                BulkAction,
-		DocType:                   spec.DocType,
-		// We do not neet this field for vector 0.14
-		//Mode:                      "normal",
+		Bulk: ElasticsearchBulk{
+			Action: bulkAction,
+			Index:  spec.Index,
+		},
+		Pipeline: spec.Pipeline,
+		DocType:  spec.DocType,
+		Mode:     mode,
 	}
 }
 

--- a/modules/460-log-shipper/hooks/internal/vector/model.go
+++ b/modules/460-log-shipper/hooks/internal/vector/model.go
@@ -190,15 +190,18 @@ type elasticsearchDestination struct {
 
 	Compression string `json:"compression,omitempty"`
 
-	Index string `json:"index,omitempty"`
+	Bulk ElasticsearchBulk `json:"bulk,omitempty"`
 
 	Pipeline string `json:"pipeline,omitempty"`
-
-	BulkAction string `json:"bulk_action,omitempty"`
 
 	Mode string `json:"mode,omitempty"`
 
 	DocType string `json:"doc_type,omitempty"`
+}
+
+type ElasticsearchBulk struct {
+	Action string `json:"action,omitempty"`
+	Index  string `json:"index,omitempty"`
 }
 
 type logstashDestination struct {

--- a/modules/460-log-shipper/hooks/internal/vector/testdata/config/config_3.json
+++ b/modules/460-log-shipper/hooks/internal/vector/testdata/config/config_3.json
@@ -30,8 +30,11 @@
         "enabled": false
       },
       "compression": "gzip",
-      "bulk_action": "index",
-      "index": "{{ kubernetes.namespace }}-%F",
+      "bulk": {
+        "action": "index",
+        "index": "{{ kubernetes.namespace }}-%F"
+      },
+      "mode": "bulk",
       "pipeline": "test-pipe"
     }
   }

--- a/modules/460-log-shipper/hooks/testdata/es-5x.json
+++ b/modules/460-log-shipper/hooks/testdata/es-5x.json
@@ -133,9 +133,12 @@
         "verify_hostname": false
       },
       "compression": "gzip",
-      "index": "logs-%F",
+      "bulk": {
+        "action": "index",
+        "index": "logs-%F"
+      },
       "pipeline": "testpipe",
-      "bulk_action": "index",
+      "mode": "bulk",
       "doc_type": "_doc"
     }
   }

--- a/modules/460-log-shipper/hooks/testdata/multiline.json
+++ b/modules/460-log-shipper/hooks/testdata/multiline.json
@@ -105,9 +105,12 @@
         "verify_hostname": false
       },
       "compression": "gzip",
-      "index": "logs-%F",
+      "bulk": {
+        "action": "index",
+        "index": "logs-%F"
+      },
       "pipeline": "testpipe",
-      "bulk_action": "index"
+      "mode": "bulk"
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/multiple-dests.json
+++ b/modules/460-log-shipper/hooks/testdata/multiple-dests.json
@@ -308,8 +308,11 @@
         "verify_hostname": false
       },
       "compression": "gzip",
-      "index": "logs-%F",
-      "bulk_action": "index"
+      "bulk": {
+        "action": "index",
+        "index": "logs-%F"
+      },
+      "mode": "bulk"
     },
     "d8_cluster_sink_test-logstash-dest": {
       "type": "socket",

--- a/modules/460-log-shipper/hooks/testdata/namespaced-source.json
+++ b/modules/460-log-shipper/hooks/testdata/namespaced-source.json
@@ -227,8 +227,11 @@
         "timeout_secs": 1
       },
       "compression": "gzip",
-      "index": "logs-%F",
-      "bulk_action": "index"
+      "bulk": {
+        "action": "index",
+        "index": "logs-%F"
+      },
+      "mode": "bulk"
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/one-dest.json
+++ b/modules/460-log-shipper/hooks/testdata/one-dest.json
@@ -108,8 +108,11 @@
         "verify_hostname": false
       },
       "compression": "gzip",
-      "index": "logs-%F",
-      "bulk_action": "index"
+      "bulk": {
+        "action": "index",
+        "index": "logs-%F"
+      },
+      "mode": "bulk"
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/pair-datastream.json
+++ b/modules/460-log-shipper/hooks/testdata/pair-datastream.json
@@ -141,9 +141,12 @@
         "verify_hostname": false
       },
       "compression": "gzip",
-      "index": "logs-%F",
+      "bulk": {
+        "action": "create",
+        "index": "logs-%F"
+      },
       "pipeline": "testpipe",
-      "bulk_action": "create"
+      "mode": "data_stream"
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/simple-pair.json
+++ b/modules/460-log-shipper/hooks/testdata/simple-pair.json
@@ -133,9 +133,12 @@
         "verify_hostname": false
       },
       "compression": "gzip",
-      "index": "logs-%F",
+      "bulk": {
+        "action": "index",
+        "index": "logs-%F"
+      },
       "pipeline": "testpipe",
-      "bulk_action": "index"
+      "mode": "bulk"
     }
   }
 }


### PR DESCRIPTION
Backport https://github.com/deckhouse/deckhouse/pull/1453

## Changelog entries
```changes
section: log-shipper
type: fix
summary: Migrate deprecated elasticsearch fields
impact_level: default
```