### PR TITLE
[docs] Highlight default Kubernetes version

### DIFF
--- a/docs/documentation/_data/i18n.yml
+++ b/docs/documentation/_data/i18n.yml
@@ -47,6 +47,9 @@ common:
   default_value:
     en: default
     ru: по умолчанию
+  default_version:
+    en: default version
+    ru: версия по умолчанию
   deprecated:
     en: deprecated
     ru: устарел

--- a/docs/documentation/_includes/SUPPORTED_VERSIONS.md
+++ b/docs/documentation/_includes/SUPPORTED_VERSIONS.md
@@ -41,8 +41,9 @@ The following Kubernetes versions are currently supported:
   <td style="text-align: center">
     <img src="{{ iconStatus }}" alt="" />
   </td>
-  <td style="text-align: center">
-    <p>{{ site.data.supported_versions.k8s_statuses[k8sStatus][page.lang] }}</p>
+  <td style="text-align: left">
+    <p>{%- if k8sItem[0] == site.data.version_kubernetes.default %}<strong>{{ site.data.i18n.common['default_version'][page.lang] | capitalize }}.</strong> {% endif %}
+    {{ site.data.supported_versions.k8s_statuses[k8sStatus][page.lang] }}</p>
   </td>
 </tr>
 {%- endfor %}

--- a/docs/documentation/werf-git-section.inc.yaml
+++ b/docs/documentation/werf-git-section.inc.yaml
@@ -207,3 +207,9 @@
   group: jekyll
   stageDependencies:
     setup: ['**/*']
+- add: /dhctl/pkg/config/base.go
+  to: /srv/jekyll-data/documentation/_data/dhctl-base.go
+  owner: jekyll
+  group: jekyll
+  stageDependencies:
+    setup: ['**/*']

--- a/docs/documentation/werf.yaml
+++ b/docs/documentation/werf.yaml
@@ -115,6 +115,12 @@ ansible:
       args:
         executable: /bin/bash
         chdir: /srv/jekyll-data/documentation/
+    - name: "Extract the default Kubernetes version"
+      shell: |
+        echo "default: \"$(grep "DefaultKubernetesVersion" -m 1 _data/dhctl-base.go | grep -Eo '[0-9.]+')\"" > _data/version_kubernetes.yml
+      args:
+        executable: /bin/bash
+        chdir: /srv/jekyll-data/documentation/
     - shell: |
         mkdir -m 777 -p /app/_site/
         {{- if eq $.Env "development" }}

--- a/modules/810-deckhouse-web/images/web/werf.inc.yaml
+++ b/modules/810-deckhouse-web/images/web/werf.inc.yaml
@@ -113,6 +113,12 @@ ansible:
       args:
         executable: /bin/bash
         chdir: /srv/jekyll-data/documentation/
+    - name: "Extract the default Kubernetes version"
+      shell: |
+        echo "default: \"$(grep "DefaultKubernetesVersion" -m 1 _data/dhctl-base.go | grep -Eo '[0-9.]+')\"" > _data/version_kubernetes.yml
+      args:
+        executable: /bin/bash
+        chdir: /srv/jekyll-data/documentation/
     - name: "Convert public documentation links to internal relative"
       shell: |
         grep -rl '](https://deckhouse.io' /srv/jekyll-data/documentation/_data/schemas/ | \


### PR DESCRIPTION
## Description
Mark Kubernetes version used by default in the supported versions table.

## Changelog entries
```changes
section: docs
type: fix
summary: Highlight default Kubernetes version in the supported versions table on the site.
impact_level: low
```
