### PR TITLE
[extended-monitoring] Image availability exporter v0.3.2

### DIFF
--- a/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -5,8 +5,7 @@ ARG BASE_GOLANG_17_ALPINE
 FROM $BASE_GOLANG_17_ALPINE as artifact
 WORKDIR /src
 ENV GOARCH=amd64
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends git && \
+RUN apt add --no-cache git && \
     git clone --branch b1f42fdbcf983c4c45c033d2ac960b1da5ae6a5c --depth 1 https://github.com/deckhouse/k8s-image-availability-exporter.git /src && \
     go get -d -v ./... && \
     CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o /k8s-image-availability-exporter main.go

--- a/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_GOLANG_17_ALPINE
 FROM $BASE_GOLANG_17_ALPINE as artifact
 WORKDIR /src
 ENV GOARCH=amd64
-RUN wget --no-check-certificate https://github.com/deckhouse/k8s-image-availability-exporter/tarball/v0.3.0 -O - | tar -xz --strip-components=1 && \
+RUN wget --no-check-certificate https://github.com/deckhouse/k8s-image-availability-exporter/tarball/v0.3.2 -O - | tar -xz --strip-components=1 && \
     go get -d -v ./... && \
     CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o /k8s-image-availability-exporter main.go
 

--- a/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_GOLANG_17_ALPINE
 FROM $BASE_GOLANG_17_ALPINE as artifact
 WORKDIR /src
 ENV GOARCH=amd64
-RUN apt add --no-cache git && \
+RUN apk add --no-cache git && \
     git clone --branch b1f42fdbcf983c4c45c033d2ac960b1da5ae6a5c --depth 1 https://github.com/deckhouse/k8s-image-availability-exporter.git /src && \
     go get -d -v ./... && \
     CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o /k8s-image-availability-exporter main.go

--- a/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_GOLANG_17_ALPINE
 FROM $BASE_GOLANG_17_ALPINE as artifact
 WORKDIR /src
 ENV GOARCH=amd64
-RUN wget --no-check-certificate https://github.com/deckhouse/k8s-image-availability-exporter/tarball/51e508a7fc0727556780b34f6e54ee4ef9706816 -O - | tar -xz --strip-components=1 && \
+RUN wget --no-check-certificate https://github.com/deckhouse/k8s-image-availability-exporter/tarball/47abb888830960af0d2c859be4777174b80eb653 -O - | tar -xz --strip-components=1 && \
     go get -d -v ./... && \
     CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o /k8s-image-availability-exporter main.go
 

--- a/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -1,13 +1,13 @@
 ARG BASE_ALPINE
-ARG BASE_GOLANG_16_BUSTER
+ARG BASE_GOLANG_17_ALPINE
 
 # Based on https://github.com/deckhouse/k8s-image-availability-exporter/blob/master/Dockerfile
-FROM $BASE_GOLANG_16_BUSTER as artifact
+FROM $BASE_GOLANG_17_ALPINE as artifact
 WORKDIR /src
 ENV GOARCH=amd64
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git && \
-    git clone --branch v0.2.0 --depth 1 https://github.com/deckhouse/k8s-image-availability-exporter.git /src && \
+    git clone --branch b1f42fdbcf983c4c45c033d2ac960b1da5ae6a5c --depth 1 https://github.com/deckhouse/k8s-image-availability-exporter.git /src && \
     go get -d -v ./... && \
     CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o /k8s-image-availability-exporter main.go
 

--- a/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_GOLANG_17_ALPINE
 FROM $BASE_GOLANG_17_ALPINE as artifact
 WORKDIR /src
 ENV GOARCH=amd64
-RUN wget --no-check-certificate https://github.com/deckhouse/k8s-image-availability-exporter/tarball/40e30d26ac81a681dd6d5129217e14e2523fcdd3 -O - | tar -xz --strip-components=1 && \
+RUN wget --no-check-certificate https://github.com/deckhouse/k8s-image-availability-exporter/tarball/51e508a7fc0727556780b34f6e54ee4ef9706816 -O - | tar -xz --strip-components=1 && \
     go get -d -v ./... && \
     CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o /k8s-image-availability-exporter main.go
 

--- a/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_GOLANG_17_ALPINE
 FROM $BASE_GOLANG_17_ALPINE as artifact
 WORKDIR /src
 ENV GOARCH=amd64
-RUN wget --no-check-certificate https://github.com/deckhouse/k8s-image-availability-exporter/tarball/47abb888830960af0d2c859be4777174b80eb653 -O - | tar -xz --strip-components=1 && \
+RUN wget --no-check-certificate https://github.com/deckhouse/k8s-image-availability-exporter/tarball/5cbbc7d507a029fe87f3543166dbde8a90d0de4d -O - | tar -xz --strip-components=1 && \
     go get -d -v ./... && \
     CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o /k8s-image-availability-exporter main.go
 

--- a/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_GOLANG_17_ALPINE
 FROM $BASE_GOLANG_17_ALPINE as artifact
 WORKDIR /src
 ENV GOARCH=amd64
-RUN wget --no-check-certificate https://github.com/deckhouse/k8s-image-availability-exporter/tarball/5cbbc7d507a029fe87f3543166dbde8a90d0de4d -O - | tar -xz --strip-components=1 && \
+RUN wget --no-check-certificate https://github.com/deckhouse/k8s-image-availability-exporter/tarball/v0.3.0 -O - | tar -xz --strip-components=1 && \
     go get -d -v ./... && \
     CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o /k8s-image-availability-exporter main.go
 

--- a/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/ee/fe/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -5,8 +5,7 @@ ARG BASE_GOLANG_17_ALPINE
 FROM $BASE_GOLANG_17_ALPINE as artifact
 WORKDIR /src
 ENV GOARCH=amd64
-RUN apk add --no-cache git && \
-    git clone --branch b1f42fdbcf983c4c45c033d2ac960b1da5ae6a5c --depth 1 https://github.com/deckhouse/k8s-image-availability-exporter.git /src && \
+RUN wget --no-check-certificate https://github.com/deckhouse/k8s-image-availability-exporter/tarball/40e30d26ac81a681dd6d5129217e14e2523fcdd3 -O - | tar -xz --strip-components=1 && \
     go get -d -v ./... && \
     CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o /k8s-image-availability-exporter main.go
 

--- a/ee/fe/modules/340-extended-monitoring/monitoring/prometheus-rules/image-availability/exporter-health.yaml
+++ b/ee/fe/modules/340-extended-monitoring/monitoring/prometheus-rules/image-availability/exporter-health.yaml
@@ -12,6 +12,7 @@
       plk_markup_format: "markdown"
       plk_pending_until_firing_for: "1m"
       plk_grouped_by__main: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
+      plk_create_group_if_not_exists__main: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_ignore_labels: "job"
       description: |
         Check the Pod status: `kubectl -n d8-monitoring get pod -l app=image-availability-exporter`
@@ -31,6 +32,7 @@
       plk_pending_until_firing_for: "15m"
       plk_ignore_labels: "job"
       plk_grouped_by__main: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
+      plk_create_group_if_not_exists__main: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
       description: |
         Check the Pod status: `kubectl -n d8-monitoring get pod -l app=image-availability-exporter`
 
@@ -49,6 +51,7 @@
       plk_pending_until_firing_for: "30m"
       plk_labels_as_annotations: "pod"
       plk_grouped_by__main: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
+      plk_create_group_if_not_exists__main: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
       summary: The image-availability-exporter Pod is NOT Ready.
       description: |
         The images listed in the `image` field are not checked for availability in the container registry.
@@ -68,6 +71,7 @@
       plk_markup_format: "markdown"
       plk_pending_until_firing_for: "30m"
       plk_grouped_by__main: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
+      plk_create_group_if_not_exists__main: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
       summary: The image-availability-exporter Pod is NOT Running.
       description: |
         The images listed in the `image` field are not checked for availability in the container registry.
@@ -75,21 +79,6 @@
         The recommended course of action:
         1. Retrieve details of the Deployment: `kubectl -n d8-monitoring describe deploy image-availability-exporter`
         2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-monitoring describe pod -l app=image-availability-exporter`
-
-  - alert: D8ImageAvailabilityExporterUnavailable
-    expr: count(ALERTS{alertname=~"D8ImageAvailabilityExporterTargetDown|D8ImageAvailabilityExporterTargetAbsent", alertstate="firing"})
-    labels:
-      d8_module: extended-monitoring
-      d8_component: image-availability-exporter
-    annotations:
-      plk_protocol_version: "1"
-      plk_markup_format: "markdown"
-      plk_alert_type: "group"
-      summary: image-availability-exporter does not work.
-      description: |
-        `image-availability-exporter` does not work.
-
-        The detailed information is available in one of the relevant alerts.
 
 - name: d8.extended-monitoring.image-availability-exporter.malfunctioning
   rules:
@@ -106,23 +95,9 @@
       plk_markup_format: "markdown"
       plk_pending_until_firing_for: "20m"
       plk_grouped_by__main: "D8ImageAvailabilityExporterMalfunctioning,tier=cluster,prometheus=deckhouse"
+      plk_create_group_if_not_exists__main: "D8ImageAvailabilityExporterMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: |
         The `image-availability-exporter` failed to perform any checks for the availability of images in the registry for over 20 minutes.
 
         You need to analyze its logs: `kubectl -n d8-monitoring logs -l app=image-availability-exporter -c image-availability-exporter`
       summary: image-availability-exporter has crashed.
-
-  - alert: D8ImageAvailabilityExporterMalfunctioning
-    expr: count(ALERTS{alertname=~"D8ImageAvailabilityExporterStuck", alertstate="firing"})
-    labels:
-      d8_module: extended-monitoring
-      d8_component: image-availability-exporter
-    annotations:
-      plk_protocol_version: "1"
-      plk_markup_format: "markdown"
-      plk_alert_type: "group"
-      description: |
-        `image-availability-exporter` does not work as expected.
-
-        The detailed information is available in one of the relevant alerts.
-      summary: image-availability-exporter does not work as expected.

--- a/ee/fe/modules/340-extended-monitoring/template_tests/image_availability_test.go
+++ b/ee/fe/modules/340-extended-monitoring/template_tests/image_availability_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Module :: extendedMonitoring :: helm template :: image availab
 				deploy := hec.KubernetesResource("Deployment", "d8-monitoring", "image-availability-exporter")
 				ignoredImagesArg := deploy.Field("spec.template.spec.containers.0.args.1").String()
 
-				Expect(ignoredImagesArg).To(Equal("--ignored-images=k8s.gcr.io/upmeter-nonexistent:3.1415"))
+				Expect(ignoredImagesArg).To(Equal("--ignored-images=.*upmeter-nonexistent.*"))
 			})
 		})
 
@@ -99,7 +99,7 @@ var _ = Describe("Module :: extendedMonitoring :: helm template :: image availab
 				deploy := hec.KubernetesResource("Deployment", "d8-monitoring", "image-availability-exporter")
 				ignoredImagesArg := deploy.Field("spec.template.spec.containers.0.args.1").String()
 
-				Expect(ignoredImagesArg).To(Equal("--ignored-images=k8s.gcr.io/upmeter-nonexistent:3.1415,a.b.com/zzz:9.7.1,cr.k8s.io/xx-yy:4.3.1"))
+				Expect(ignoredImagesArg).To(Equal("--ignored-images=.*upmeter-nonexistent.*~a.b.com/zzz:9.7.1~cr.k8s.io/xx-yy:4.3.1"))
 			})
 		})
 	})

--- a/ee/fe/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
@@ -52,7 +52,7 @@ spec:
         # The exporter checks for string equality.
         # https://github.com/deckhouse/k8s-image-availability-exporter/blob/b1589b40c18290b9d105f0ac39ddc3fc554884d9/pkg/registry_checker/checker.go#L212
         # Among known inexisting images, there is the one from Upmeter probe where we don't want a container to start.
-        {{- $ignoredImages := list "k8s.gcr.io/upmeter-nonexistent:3.1415" }}
+        {{- $ignoredImages := list ".*upmeter-nonexistent.*" }}
         {{- if .Values.extendedMonitoring.imageAvailability.ignoredImages }}
           {{- $ignoredImages = concat $ignoredImages .Values.extendedMonitoring.imageAvailability.ignoredImages }}
         {{- end }}

--- a/ee/fe/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
+++ b/ee/fe/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
@@ -56,7 +56,7 @@ spec:
         {{- if .Values.extendedMonitoring.imageAvailability.ignoredImages }}
           {{- $ignoredImages = concat $ignoredImages .Values.extendedMonitoring.imageAvailability.ignoredImages }}
         {{- end }}
-        - '--ignored-images={{ $ignoredImages | join "," }}'
+        - '--ignored-images={{ $ignoredImages | join "~" }}'
         {{- if .Values.extendedMonitoring.imageAvailability.skipRegistryCertVerification }}
         - --skip-registry-cert-verification={{ .Values.extendedMonitoring.imageAvailability.skipRegistryCertVerification }}
         {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

1. Fixed alerting so that quick exporter malfunctions won't generate a useless grouping alert.
2. Fixed stuck Prometheus scrapes.

Upstream PR: https://github.com/deckhouse/k8s-image-availability-exporter/pull/48

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The main change is a bugfix to a stuck metrics scrape.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: extended-monitoring
type: fix
summary: Exporter won't get suck on scrapes and it won't generate a useless grouping alert
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
