### PR TITLE
[candi] Change default storage type to gp3

### DIFF
--- a/candi/cloud-providers/aws/layouts/standard/master-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/standard/master-node/variables.tf
@@ -37,8 +37,8 @@ data "aws_availability_zones" "available" {}
 
 locals {
   prefix = var.clusterConfiguration.cloud.prefix
-  root_volume_size = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskSizeGb", 20)
-  root_volume_type = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskType", "gp2")
+  root_volume_size = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskSizeGb", 30)
+  root_volume_type = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskType", "gp3")
   additional_security_groups = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalSecurityGroups", [])
   actual_zones = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
   zones = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", null) != null ? tolist(setintersection(local.actual_zones, var.providerClusterConfiguration.masterNodeGroup["zones"])) : local.actual_zones

--- a/candi/cloud-providers/aws/layouts/standard/static-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/standard/static-node/variables.tf
@@ -43,8 +43,8 @@ locals {
   prefix = var.clusterConfiguration.cloud.prefix
   node_groups = lookup(var.providerClusterConfiguration, "nodeGroups", [])
   node_group = [for i in local.node_groups: i if i.name == var.nodeGroupName][0]
-  root_volume_size = lookup(local.node_group.instanceClass, "diskSizeGb", 20)
-  root_volume_type = lookup(local.node_group.instanceClass, "diskType", "gp2")
+  root_volume_size = lookup(local.node_group.instanceClass, "diskSizeGb", 30)
+  root_volume_type = lookup(local.node_group.instanceClass, "diskType", "gp3")
   additional_security_groups = lookup(local.node_group.instanceClass, "additionalSecurityGroups", [])
   actual_zones = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
   zones = lookup(local.node_group, "zones", null) != null ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones

--- a/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/main.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/main.tf
@@ -209,8 +209,8 @@ locals {
 
   vpc_security_group_ids = concat([module.security-groups.security_group_id_node, module.security-groups.security_group_id_ssh_accessible], local.additional_security_groups)
 
-  root_volume_size = lookup(local.instance_class, "diskSizeGb", 20)
-  root_volume_type = lookup(local.instance_class, "diskType", "gp2")
+  root_volume_size = lookup(local.instance_class, "diskSizeGb", 30)
+  root_volume_type = lookup(local.instance_class, "diskType", "gp3")
 }
 
 resource "aws_instance" "bastion" {

--- a/candi/cloud-providers/aws/layouts/with-nat/master-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/master-node/variables.tf
@@ -37,8 +37,8 @@ data "aws_availability_zones" "available" {}
 
 locals {
   prefix = var.clusterConfiguration.cloud.prefix
-  root_volume_size = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskSizeGb", 20)
-  root_volume_type = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskType", "gp2")
+  root_volume_size = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskSizeGb", 30)
+  root_volume_type = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskType", "gp3")
   additional_security_groups = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalSecurityGroups", [])
   actual_zones = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
   zones = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", null) != null ? tolist(setintersection(local.actual_zones, var.providerClusterConfiguration.masterNodeGroup["zones"])) : local.actual_zones

--- a/candi/cloud-providers/aws/layouts/with-nat/static-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/static-node/variables.tf
@@ -43,8 +43,8 @@ locals {
   prefix = var.clusterConfiguration.cloud.prefix
   node_groups = lookup(var.providerClusterConfiguration, "nodeGroups", [])
   node_group = [for i in local.node_groups: i if i.name == var.nodeGroupName][0]
-  root_volume_size = lookup(local.node_group.instanceClass, "diskSizeGb", 20)
-  root_volume_type = lookup(local.node_group.instanceClass, "diskType", "gp2")
+  root_volume_size = lookup(local.node_group.instanceClass, "diskSizeGb", 30)
+  root_volume_type = lookup(local.node_group.instanceClass, "diskType", "gp3")
   additional_security_groups = lookup(local.node_group.instanceClass, "additionalSecurityGroups", [])
   actual_zones = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
   zones = lookup(local.node_group, "zones", null) != null ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones

--- a/candi/cloud-providers/aws/layouts/without-nat/master-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/master-node/variables.tf
@@ -37,8 +37,8 @@ data "aws_availability_zones" "available" {}
 
 locals {
   prefix = var.clusterConfiguration.cloud.prefix
-  root_volume_size = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskSizeGb", 20)
-  root_volume_type = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskType", "gp2")
+  root_volume_size = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskSizeGb", 30)
+  root_volume_type = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskType", "gp3")
   additional_security_groups = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalSecurityGroups", [])
   zones = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", data.aws_availability_zones.available.names)
   tags = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(var.providerClusterConfiguration.masterNodeGroup, "additionalTags", {}))

--- a/candi/cloud-providers/aws/layouts/without-nat/static-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/static-node/variables.tf
@@ -43,8 +43,8 @@ locals {
   prefix = var.clusterConfiguration.cloud.prefix
   node_groups = lookup(var.providerClusterConfiguration, "nodeGroups", [])
   node_group = [for i in local.node_groups: i if i.name == var.nodeGroupName][0]
-  root_volume_size = lookup(local.node_group.instanceClass, "diskSizeGb", 20)
-  root_volume_type = lookup(local.node_group.instanceClass, "diskType", "gp2")
+  root_volume_size = lookup(local.node_group.instanceClass, "diskSizeGb", 30)
+  root_volume_type = lookup(local.node_group.instanceClass, "diskType", "gp3")
   additional_security_groups = lookup(local.node_group.instanceClass, "additionalSecurityGroups", [])
   actual_zones = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
   zones = lookup(local.node_group, "zones", null) != null ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones

--- a/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
@@ -64,7 +64,7 @@ apiVersions:
                   type: string
               diskType:
                 description: Instance EBS disk type.
-                example: "gp2"
+                example: "gp3"
                 type: string
                 enum: [gp3, gp2, io2, io1, st1, sc1]
               diskSizeGb:
@@ -260,9 +260,9 @@ apiVersions:
                       type: string
                   diskType:
                     description: Instance EBS disk type.
-                    example: "gp2"
+                    example: "gp3"
                     type: string
-                    enum: [gp3, gp2, io2, io1, st1, sc1]
+                    enum: [gp3, gp3, io2, io1, st1, sc1]
                   diskSizeGb:
                     description: Instance disk size in gigabytes.
                     example: 20

--- a/candi/cloud-providers/aws/openapi/instance_class.yaml
+++ b/candi/cloud-providers/aws/openapi/instance_class.yaml
@@ -51,9 +51,9 @@ spec:
                   type: boolean
                 diskType:
                   description: Instance EBS disk type.
-                  example: "gp2"
+                  example: "gp3"
                   type: string
-                  x-doc-default: "gp2"
+                  x-doc-default: "gp3"
                 iops:
                   description: IOPS rate for io1 diskType
                   example: "500"

--- a/candi/cloud-providers/aws/terraform-modules/master-node/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/master-node/main.tf
@@ -34,7 +34,7 @@ locals {
 
 resource "aws_ebs_volume" "kubernetes_data" {
   size            = 150 # To achieve io rate burst limit 450iops, average io rate for etcd is 300iops
-  type            = "gp2"
+  type            = "gp3"
   tags = merge(var.tags, {
     Name = "${var.prefix}-kubernetes-data-${var.node_index}"
   })


### PR DESCRIPTION
## Description

Change storage class defaults to gp3 in AWS configs

## Why do we need it, and what problem does it solve?

gp3 is of high demand compared to gp2, so the default can be more reasonable

## Changelog entries

```changes
section: candi
type: chore
summary: Update default storage type to gp3 for AWS
```
