### PR TITLE
[docs] Change the diskType from the gp2 to gp3 in the Getting started for AWS

### DIFF
--- a/candi/cloud-providers/aws/docs/LAYOUTS.md
+++ b/candi/cloud-providers/aws/docs/LAYOUTS.md
@@ -26,8 +26,14 @@ provider:
 masterNodeGroup:
   replicas: 1
   instanceClass:
+    # type of the instance
     instanceType: m5.xlarge
+    # Amazon Machine Image id
     ami: ami-03818140b4ac9ae2b
+    # master node VM disk size
+    diskSizeGb: 30
+    # master node VM disk type to use
+    diskType: gp3
 nodeGroups:
   - name: mydb
     nodeTemplate:
@@ -76,8 +82,14 @@ masterNodeGroup:
   # If there is more than one master node, the etcd cluster will be set up automatically.
   replicas: 1
   instanceClass:
+    # type of the instance
     instanceType: m5.xlarge
+    # Amazon Machine Image id
     ami: ami-03818140b4ac9ae2b
+    # master node VM disk size
+    diskSizeGb: 30
+    # master node VM disk type to use
+    diskType: gp3
 nodeGroups:
   - name: mydb
     nodeTemplate:

--- a/candi/cloud-providers/aws/docs/LAYOUTS_RU.md
+++ b/candi/cloud-providers/aws/docs/LAYOUTS_RU.md
@@ -28,8 +28,14 @@ masterNodeGroup:
   # Если указано больше одного master-узла, то etcd-кластер соберётся автоматически.
   replicas: 1
   instanceClass:
+    # тип используемого инстанса
     instanceType: m5.xlarge
+    # id образа виртуальной машины в Amazon
     ami: ami-03818140b4ac9ae2b
+    # размер диска для виртуальной машины master-узла
+    diskSizeGb: 30
+    # используемый тип диска для виртуальной машины master-узла
+    diskType: gp3
 nodeGroups:
   - name: mydb
     nodeTemplate:
@@ -78,8 +84,14 @@ masterNodeGroup:
   # Если указано больше одного master-узла, то etcd-кластер соберётся автоматически.
   replicas: 1
   instanceClass:
+    # тип используемого инстанса
     instanceType: m5.xlarge
+    # id образа виртуальной машины в Amazon
     ami: ami-03818140b4ac9ae2b
+    # размер диска для виртуальной машины master-узла
+    diskSizeGb: 30
+    # используемый тип диска для виртуальной машины master-узла
+    diskType: gp3
 nodeGroups:
   - name: mydb
     nodeTemplate:

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.standard.ce.inc
@@ -92,6 +92,16 @@ masterNodeGroup:
   # [<en>] Parameters of the VM image
   # [<ru>] параметры инстанса
   instanceClass:
+    # [<en>] master node VM disk size
+    # [<ru>] размер диска для виртуальной машины master-узла
+    # [<en>] you might consider changing this
+    # [<ru>] возможно, захотите изменить
+    diskSizeGb: 30
+    # [<en>] master node VM disk type to use
+    # [<ru>] используемый тип диска для виртуальной машины master-узла
+    # [<en>] you might consider changing this
+    # [<ru>] возможно, захотите изменить
+    diskType: gp3
     # [<en>] type of the instance
     # [<ru>] тип используемого инстанса
     # [<en>] you might consider changing this

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.standard.ee.inc
@@ -98,6 +98,16 @@ masterNodeGroup:
   # [<en>] Parameters of the VM image
   # [<ru>] параметры инстанса
   instanceClass:
+    # [<en>] master node VM disk size
+    # [<ru>] размер диска для виртуальной машины master-узла
+    # [<en>] you might consider changing this
+    # [<ru>] возможно, захотите изменить
+    diskSizeGb: 30
+    # [<en>] master node VM disk type to use
+    # [<ru>] используемый тип диска для виртуальной машины master-узла
+    # [<en>] you might consider changing this
+    # [<ru>] возможно, захотите изменить
+    diskType: gp3
     # [<en>] type of the instance
     # [<ru>] тип используемого инстанса
     # [<en>] you might consider changing this

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.with_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.with_nat.ce.inc
@@ -106,6 +106,16 @@ masterNodeGroup:
   # [<en>] parameters of the VM image
   # [<ru>] параметры инстанса
   instanceClass:
+    # [<en>] master node VM disk size
+    # [<ru>] размер диска для виртуальной машины master-узла
+    # [<en>] you might consider changing this
+    # [<ru>] возможно, захотите изменить
+    diskSizeGb: 30
+    # [<en>] master node VM disk type to use
+    # [<ru>] используемый тип диска для виртуальной машины master-узла
+    # [<en>] you might consider changing this
+    # [<ru>] возможно, захотите изменить
+    diskType: gp3
     # [<en>] type of the instance
     # [<ru>] тип используемого инстанса
     # [<en>] you might consider changing this

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.with_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.with_nat.ee.inc
@@ -112,6 +112,16 @@ masterNodeGroup:
   # [<en>] Parameters of the VM image
   # [<ru>] параметры инстанса
   instanceClass:
+    # [<en>] master node VM disk size
+    # [<ru>] размер диска для виртуальной машины master-узла
+    # [<en>] you might consider changing this
+    # [<ru>] возможно, захотите изменить
+    diskSizeGb: 30
+    # [<en>] master node VM disk type to use
+    # [<ru>] используемый тип диска для виртуальной машины master-узла
+    # [<en>] you might consider changing this
+    # [<ru>] возможно, захотите изменить
+    diskType: gp3
     # [<en>] type of the instance
     # [<ru>] тип используемого инстанса
     # [<en>] you might consider changing this

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
@@ -86,6 +86,16 @@ masterNodeGroup:
   # [<en>] Parameters of the VM image
   # [<ru>] параметры инстанса
   instanceClass:
+    # [<en>] master node VM disk size
+    # [<ru>] размер диска для виртуальной машины master-узла
+    # [<en>] you might consider changing this
+    # [<ru>] возможно, захотите изменить
+    diskSizeGb: 30
+    # [<en>] master node VM disk type to use
+    # [<ru>] используемый тип диска для виртуальной машины master-узла
+    # [<en>] you might consider changing this
+    # [<ru>] возможно, захотите изменить
+    diskType: gp3
     # [<en>] type of the instance
     # [<ru>] тип используемого инстанса
     # [<en>] you might consider changing this

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ee.inc
@@ -92,6 +92,16 @@ masterNodeGroup:
   # [<en>] Parameters of the VM image
   # [<ru>] параметры инстанса
   instanceClass:
+    # [<en>] master node VM disk size
+    # [<ru>] размер диска для виртуальной машины master-узла
+    # [<en>] you might consider changing this
+    # [<ru>] возможно, захотите изменить
+    diskSizeGb: 30
+    # [<en>] master node VM disk type to use
+    # [<ru>] используемый тип диска для виртуальной машины master-узла
+    # [<en>] you might consider changing this
+    # [<ru>] возможно, захотите изменить
+    diskType: gp3
     # [<en>] type of the instance
     # [<ru>] тип используемого инстанса
     # [<en>] you might consider changing this

--- a/docs/site/_includes/getting_started/aws/partials/resources.yml.ha.inc
+++ b/docs/site/_includes/getting_started/aws/partials/resources.yml.ha.inc
@@ -18,7 +18,7 @@ spec:
   # [<ru>] используемый тип диска для виртуальной машины
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить
-  diskType: gp2
+  diskType: gp3
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить
   instanceType: c5.xlarge

--- a/docs/site/_includes/getting_started/aws/partials/resources.yml.minimal.inc
+++ b/docs/site/_includes/getting_started/aws/partials/resources.yml.minimal.inc
@@ -18,7 +18,7 @@ spec:
   # [<ru>] используемый тип диска для виртуальной машины
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить
-  diskType: gp2
+  diskType: gp3
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить
   instanceType: c5.xlarge

--- a/docs/site/_includes/getting_started/aws/partials/resources.yml.production.inc
+++ b/docs/site/_includes/getting_started/aws/partials/resources.yml.production.inc
@@ -18,7 +18,7 @@ spec:
   # [<ru>] используемый тип диска для виртуальной машины
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить
-  diskType: gp2
+  diskType: gp3
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить
   instanceType: c5.xlarge
@@ -88,7 +88,7 @@ spec:
   # [<ru>] используемый тип диска для виртуальной машины
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить
-  diskType: gp2
+  diskType: gp3
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить
   instanceType: c5.large
@@ -129,7 +129,7 @@ metadata:
   name: worker
 spec:
   diskSizeGb: 30
-  diskType: gp2
+  diskType: gp3
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить
   instanceType: c5.xlarge


### PR DESCRIPTION
## Description

Change the diskType from the gp2 to gp3 in the Getting started for AWS.

## Changelog entries
```changes
section: docs
type: fix
summary: Change the diskType from the gp2 to gp3 in the Getting started for AWS.
impact_level: low
```
