### PR TITLE
[docs] Disable accordion mode in the sidebar

### DIFF
--- a/docs/site/_includes/head-site.html
+++ b/docs/site/_includes/head-site.html
@@ -65,7 +65,7 @@
         // Initialize navgoco with default options
         $("#mysidebar").navgoco({
             caretHtml: '',
-            accordion: true,
+            accordion: false,
             openClass: 'active', // open
             save: false, // leave false or nav highlighting doesn't work right
             cookie: {


### PR DESCRIPTION
## Description
Sets sidebar accordion mode to false to not collapse the expanded item of the sidebar when expanding the item.

## Changelog entries
```changes
section: docs
type: feature
summary: Don't collapse the expanded item in the sidebar when expanding the item.
impact_level: low
```
