### PR TITLE
[monitoring-kubernetes] change timings and severity for kubelet scraping

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/coreos/kubelet.tpl
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/coreos/kubelet.tpl
@@ -31,7 +31,7 @@
       plk_protocol_version: "1"
       plk_group_for__target_down: "TargetDown,prometheus=deckhouse,job=kubelet"
       description: Prometheus failed to scrape {{ `{{ $value }}` }}% of kubelets.
-      summary: A few Kubelets cannot be scraped
+      summary: A few kubelets cannot be scraped
   - alert: K8SKubeletDown
     expr: (count(up{job="kubelet"} == 0) or absent(up{job="kubelet"} == 1)) / count(up{job="kubelet"})) * 100 > 10
     for: 30m
@@ -42,7 +42,7 @@
       plk_protocol_version: "1"
       plk_group_for__target_down: "TargetDown,prometheus=deckhouse,job=kubelet"
       description: Prometheus failed to scrape {{ `{{ $value }}` }}% of kubelets.
-      summary: Many Kubelets cannot be scraped
+      summary: Many kubelets cannot be scraped
   - alert: K8SKubeletTooManyPods
 {{- if semverCompare "<1.19" .Values.global.discovery.kubernetesVersion }}
     expr: kubelet_running_pod_count > on(node) kube_node_status_capacity_pods * 0.9


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Make kubelet alers more obvious

## Why do we need it, and what problem does it solve?
Kubelet alerts were messed and have unstable behavior

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring-kubernetes
type: fix
summary: Fix kubelet alerts
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
