### PR TITLE
[docs] Bump web-router

### DIFF
--- a/docs/site/werf.yaml
+++ b/docs/site/werf.yaml
@@ -76,7 +76,7 @@ ansible:
         chdir: /go/src/app
 git:
   - url: https://github.com/flant/web-router.git
-    tag: v1.0.10
+    tag: v1.0.11
     add: /
     to: /go/src/app
     stageDependencies:


### PR DESCRIPTION
## Description

Bump web-router to v1.0.11 to use links to the exact version instead of a group version in the language menu.

## Changelog entries
```changes
section: docs
type: fix
summary: Bump web-router to v1.0.11 to use links to the exact version instead of a group version in the language menu.
impact_level: low
```
