### PR TITLE
[node-manager] Truncate event message to allowed maximums in update_node_group_status hook

### DIFF
--- a/modules/040-node-manager/hooks/update_node_group_status.go
+++ b/modules/040-node-manager/hooks/update_node_group_status.go
@@ -351,6 +351,9 @@ func handleUpdateNGStatus(input *go_hook.HookInput) error {
 		}
 		statusMsg := fmt.Sprintf("%s %s", nodeGroup.Error, failureReason)
 		statusMsg = strings.TrimSpace(statusMsg)
+		// truncate to maximum allowed message limit
+		// https://github.com/kubernetes/kubernetes/blob/3e442b74f717ab2f43897d7af50de6114486e459/pkg/apis/core/validation/events.go#L38
+		statusMsg = statusMsg[:1024]
 		if len(statusMsg) > 0 {
 			prev := ngStatusCache[nodeGroup.Name]
 			// skip events with the same in-row message

--- a/modules/040-node-manager/hooks/update_node_group_status.go
+++ b/modules/040-node-manager/hooks/update_node_group_status.go
@@ -351,10 +351,12 @@ func handleUpdateNGStatus(input *go_hook.HookInput) error {
 		}
 		statusMsg := fmt.Sprintf("%s %s", nodeGroup.Error, failureReason)
 		statusMsg = strings.TrimSpace(statusMsg)
-		// truncate to maximum allowed message limit
-		// https://github.com/kubernetes/kubernetes/blob/3e442b74f717ab2f43897d7af50de6114486e459/pkg/apis/core/validation/events.go#L38
-		statusMsg = statusMsg[:1024]
 		if len(statusMsg) > 0 {
+			// truncate to maximum allowed message limit
+			// https://github.com/kubernetes/kubernetes/blob/3e442b74f717ab2f43897d7af50de6114486e459/pkg/apis/core/validation/events.go#L38
+			if len(statusMsg) > 1024 {
+				statusMsg = statusMsg[:1024]
+			}
 			prev := ngStatusCache[nodeGroup.Name]
 			// skip events with the same in-row message
 			if prev != statusMsg {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Events with messages longer than 1024 bytes fail apiserver validation.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Avoid hook failures:
```
Module hook failed, requeue task to retry after delay. Failed count is 1. Error: 1 error occurred:
        * Create object: events.k8s.io/v1/Event/default/: Event "ng-node-qgvpq" is invalid: message: Invalid value: "": can have at most 1024 characters
```

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Truncate event message to allowed maximums in update_node_group_status hook
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
