### PR TITLE
[docs] Suggest gp3 as disk type in bastion instance

### DIFF
--- a/candi/cloud-providers/aws/docs/LAYOUTS.md
+++ b/candi/cloud-providers/aws/docs/LAYOUTS.md
@@ -77,6 +77,7 @@ withNAT:
     instanceClass:
       instanceType: m5.large
       ami: ami-09a4a23815cdb5e06
+      diskType: gp3
 masterNodeGroup:
   # Number of master nodes.
   # If there is more than one master node, the etcd cluster will be set up automatically.

--- a/candi/cloud-providers/aws/docs/LAYOUTS_RU.md
+++ b/candi/cloud-providers/aws/docs/LAYOUTS_RU.md
@@ -79,6 +79,7 @@ withNAT:
     instanceClass:
       instanceType: m5.large
       ami: ami-09a4a23815cdb5e06
+      diskType: gp3
 masterNodeGroup:
   # Количество master-узлов.
   # Если указано больше одного master-узла, то etcd-кластер соберётся автоматически.

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.with_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.with_nat.ce.inc
@@ -95,6 +95,9 @@ withNAT:
       # [<en>] you might consider changing this
       # [<ru>] возможно, захотите изменить
       ami: ami-09a4a23815cdb5e06
+      # [<en>] Disk type
+      # [<ru>] Тип диска
+      diskType: gp3
 # [<en>] parameters of the master node group
 # [<ru>] параметры группы master-узлов
 masterNodeGroup:

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.with_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.with_nat.ee.inc
@@ -101,6 +101,9 @@ withNAT:
       # [<en>] you might consider changing this
       # [<ru>] возможно, захотите изменить
       ami: ami-09a4a23815cdb5e06
+      # [<en>] Disk type
+      # [<ru>] Тип диска
+      diskType: gp3
 # [<en>] parameters of the master node group
 # [<ru>] параметры группы master-узлов
 masterNodeGroup:


### PR DESCRIPTION
## Description

Suggest gp3

## Why do we need it, and what problem does it solve?

Easy mindless copying

## Changelog entries

```changes
section: docs
type: chore
summary: "Suggest gp3 for bastion instance in AWS-based 'Getting started'"
```
