### PR TITLE
[dhctl][node-manager] Old dockerCfg format support (construct auth from username and password)

### DIFF
--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -516,7 +516,7 @@ func (m *MetaConfig) ParseRegistryData() (map[string]interface{}, error) {
 			return nil, fmt.Errorf("cannot base64 decode docker cfg: %v", err)
 		}
 
-		log.DebugF("parse registry data: dockerCfg after base64 decode = %s\n", string(bytes))
+		log.DebugF("parse registry data: dockerCfg after base64 decode = %s\n", bytes)
 		err = json.Unmarshal(bytes, &dc)
 		if err != nil {
 			return nil, fmt.Errorf("cannot unmarshal docker cfg: %v", err)

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -523,12 +523,13 @@ func (m *MetaConfig) ParseRegistryData() (map[string]interface{}, error) {
 		}
 
 		if registry, ok := dc.Auths[m.Registry.Address]; ok {
-			if registry.Auth != nil {
+			switch true {
+			case registry.Auth != nil:
 				registryAuth = *registry.Auth
-			} else if registry.Username != nil && registry.Password != nil {
+			case registry.Username != nil && registry.Password != nil:
 				auth := fmt.Sprintf("%s:%s", *registry.Username, *registry.Password)
 				registryAuth = base64.StdEncoding.EncodeToString([]byte(auth))
-			} else {
+			default:
 				log.DebugF("auth or username with password not found in dockerCfg %s for %s. Use empty string", string(bytes), m.Registry.Address)
 			}
 		}

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -497,9 +497,9 @@ func (m *MetaConfig) LoadVersionMap(filename string) error {
 func (m *MetaConfig) ParseRegistryData() (map[string]interface{}, error) {
 	type dockerCfg struct {
 		Auths map[string]struct {
-			Auth     *string `json:"auth"`
-			Username *string `json:"username"`
-			Password *string `json:"password"`
+			Auth     string `json:"auth"`
+			Username string `json:"username"`
+			Password string `json:"password"`
 		} `json:"auths"`
 	}
 
@@ -524,13 +524,13 @@ func (m *MetaConfig) ParseRegistryData() (map[string]interface{}, error) {
 
 		if registry, ok := dc.Auths[m.Registry.Address]; ok {
 			switch {
-			case registry.Auth != nil:
-				registryAuth = *registry.Auth
-			case registry.Username != nil && registry.Password != nil:
-				auth := fmt.Sprintf("%s:%s", *registry.Username, *registry.Password)
+			case registry.Auth != "":
+				registryAuth = registry.Auth
+			case registry.Username != "" && registry.Password != "":
+				auth := fmt.Sprintf("%s:%s", registry.Username, registry.Password)
 				registryAuth = base64.StdEncoding.EncodeToString([]byte(auth))
 			default:
-				log.DebugF("auth or username with password not found in dockerCfg %s for %s. Use empty string", string(bytes), m.Registry.Address)
+				log.DebugF("auth or username with password not found in dockerCfg %s for %s. Use empty string", bytes, m.Registry.Address)
 			}
 		}
 	}

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -523,7 +523,7 @@ func (m *MetaConfig) ParseRegistryData() (map[string]interface{}, error) {
 		}
 
 		if registry, ok := dc.Auths[m.Registry.Address]; ok {
-			switch true {
+			switch {
 			case registry.Auth != nil:
 				registryAuth = *registry.Auth
 			case registry.Username != nil && registry.Password != nil:

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -202,7 +202,7 @@ func TestPrepareRegistry(t *testing.T) {
 				Path:      "/deckhouse/ce",
 				Scheme:    "https",
 				CA:        "",
-				DockerCfg: "eyAiYXV0aHMiOiB7ICJyLmV4YW1wbGUuY29tIjogeyAiYXV0aCI6ICJZVHBpIiB9IH0gfQ==",
+				DockerCfg: "eyJhdXRocyI6eyJyLmV4YW1wbGUuY29tIjp7ImF1dGgiOiJZVHBpIn19fQ==",
 			}
 
 			require.Equal(t, cfg.Registry, expectedData)

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -144,7 +144,7 @@ func dockerCfgAuth(username, password string) string {
 }
 
 func generateDockerCfg(host, username, password string) string {
-	return fmt.Sprintf(`{ "auths": { "%s": { "auth": "%s" } } }`, host, dockerCfgAuth(username, password))
+	return fmt.Sprintf(`{"auths":{"%s":{"auth":"%s"}}}`, host, dockerCfgAuth(username, password))
 }
 
 func generateOldDockerCfg(host string, username, password *string) string {

--- a/dhctl/pkg/config/meta_test.go
+++ b/dhctl/pkg/config/meta_test.go
@@ -260,7 +260,11 @@ func TestParseRegistryData(t *testing.T) {
 
 		t.Run("does not have username", func(t *testing.T) {
 			t.Run("sets empty auth key", func(t *testing.T) {
-				cfg := generateMetaConfig(t, make(map[string]interface{}))
+				password := "old_password"
+				cfg := generateMetaConfig(t, map[string]interface{}{
+					"dockerCfg":  generateOldDockerCfg("r.example.com", nil, &password),
+					"imagesRepo": "r.example.com/deckhouse/ce/",
+				})
 
 				m, err := cfg.ParseRegistryData()
 				require.NoError(t, err)
@@ -271,7 +275,11 @@ func TestParseRegistryData(t *testing.T) {
 
 		t.Run("does not have password", func(t *testing.T) {
 			t.Run("sets empty auth key", func(t *testing.T) {
-				cfg := generateMetaConfig(t, make(map[string]interface{}))
+				user := "old_user"
+				cfg := generateMetaConfig(t, map[string]interface{}{
+					"dockerCfg":  generateOldDockerCfg("r.example.com", &user, nil),
+					"imagesRepo": "r.example.com/deckhouse/ce/",
+				})
 
 				m, err := cfg.ParseRegistryData()
 				require.NoError(t, err)

--- a/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
@@ -359,10 +359,10 @@ func (rid registryInputData) toRegistry() registry {
 
 		if registryObj, ok := dcfg.Auths[rid.Address]; ok {
 			switch {
-			case registryObj.Auth != nil:
-				auth = *registryObj.Auth
-			case registryObj.Username != nil && registryObj.Password != nil:
-				authRaw := fmt.Sprintf("%s:%s", *registryObj.Username, *registryObj.Password)
+			case registryObj.Auth != "":
+				auth = registryObj.Auth
+			case registryObj.Username != "" && registryObj.Password != "":
+				authRaw := fmt.Sprintf("%s:%s", registryObj.Username, registryObj.Password)
 				auth = base64.StdEncoding.EncodeToString([]byte(authRaw))
 			}
 		}
@@ -502,9 +502,9 @@ type registryInputData struct {
 
 type dockerCfg struct {
 	Auths map[string]struct {
-		Auth     *string `json:"auth"`
-		Username *string `json:"username"`
-		Password *string `json:"password"`
+		Auth     string `json:"auth"`
+		Username string `json:"username"`
+		Password string `json:"password"`
 	} `json:"auths"`
 }
 

--- a/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
@@ -358,7 +358,7 @@ func (rid registryInputData) toRegistry() registry {
 		}
 
 		if registryObj, ok := dcfg.Auths[rid.Address]; ok {
-			switch true {
+			switch {
 			case registryObj.Auth != nil:
 				auth = *registryObj.Auth
 			case registryObj.Username != nil && registryObj.Password != nil:

--- a/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
@@ -358,9 +358,10 @@ func (rid registryInputData) toRegistry() registry {
 		}
 
 		if registryObj, ok := dcfg.Auths[rid.Address]; ok {
-			if registryObj.Auth != nil {
+			switch true {
+			case registryObj.Auth != nil:
 				auth = *registryObj.Auth
-			} else if registryObj.Username != nil && registryObj.Password != nil {
+			case registryObj.Username != nil && registryObj.Password != nil:
 				authRaw := fmt.Sprintf("%s:%s", *registryObj.Username, *registryObj.Password)
 				auth = base64.StdEncoding.EncodeToString([]byte(authRaw))
 			}


### PR DESCRIPTION
## Description
Close #194

Add support in dhctl and bashible-apiserver.

if registryDockerCfg does not contain "auth" field, use username and password fields to construct registry.auth parameter for bashible.


## Why do we need it, and what problem does it solve?
We should support old docker config format.
We can not bootstrap cluster and bashible does not work, if we change deckhouse-registry secret in old format. 

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: fix
summary: Old dockerCfg format support (construct auth from username and password)
impact_level: low
---
section: node-manager
type: fix
summary: Old dockerCfg format support in bashible-apiserver (construct auth from username and password)
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
