### PR TITLE
[node-manager] Static node can not reboot after bootstrap.

### DIFF
--- a/modules/040-node-manager/templates/node-group/_bootstrap_script.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap_script.tpl
@@ -38,6 +38,7 @@ while [ "$patch_pending" = true ] ; do
 done
 
 # Start output bootstrap logs
+bootstrap_job_log_pid=""
 if type socat >/dev/null 2>&1; then
   socat -u FILE:/var/log/cloud-init-output.log,ignoreeof TCP4-LISTEN:8000,fork,reuseaddr &
   bootstrap_job_log_pid=$!


### PR DESCRIPTION
## Description
Fix unset variable error for static nodes bootstrap

## Why do we need it, and what problem does it solve?
After bootstrap node can not reboot because script is terminated. We used unset variable.  

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Static node can not reboot after bootstrap.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
