### PR TITLE
[docs] Hide a patch version number in the dropdown menu on the site

### DIFF
--- a/docs/site/_includes/channel-menu.html
+++ b/docs/site/_includes/channel-menu.html
@@ -12,20 +12,21 @@
 <div class="submenu-container">
     <ul class="submenu">
     {{- range (slice .VersionItems 1) }}
-       {{- if not (and (eq .Version "latest") (eq .Version $prevVersion)) }}
+      {{- $majMinVersion := regexReplaceAll "(v[0-9]+\\.[0-9]+).+" .Version "$1" }}
+      {{- if not (and (eq .Version "latest") (eq $majMinVersion $prevVersion)) }}
             <li class="submenu-item">
                 <a data-proofer-ignore class="submenu-item-link" href="/{{ $CurrentLang }}/documentation/{{ .VersionURL }}/{{ $CurrentPageURLRelative }}">
             {{- if eq .Version "latest" }}
-                    <span class="submenu-item-channel"> {{ .Version }}</span>
+                    <span class="submenu-item-channel">latest</span>
             {{- else }}
-                    <span class="submenu-item-channel">{{ .Channel }}</span>
-                    <span class="submenu-item-dot{{ if eq $prevVersion .Version }} submenu-item-dot_special{{ end }}"></span>
-                    <span class="submenu-item-release">{{ .Version }}</span>
+                    <span class="submenu-item-channel">{{ .Channel | replace "ea" "Early Access" | replace "-" " " | title }}</span>
+                    <span class="submenu-item-dot{{ if eq $prevVersion $majMinVersion }} submenu-item-dot_special{{ end }}"></span>
+                    <span class="submenu-item-release">{{ $majMinVersion }}</span>
             {{- end }}
                 </a>
             </li>
-        {{ $prevVersion = .Version }}
-       {{ end }}
+       {{- $prevVersion = $majMinVersion }}
+       {{- end }}
     {{- end }}
     </ul>
 </div>

--- a/docs/site/werf.yaml
+++ b/docs/site/werf.yaml
@@ -76,7 +76,7 @@ ansible:
         chdir: /go/src/app
 git:
   - url: https://github.com/flant/web-router.git
-    tag: v1.0.11
+    tag: v1.0.12
     add: /
     to: /go/src/app
     stageDependencies:


### PR DESCRIPTION
## Description
Bump web-router to use Sprig functions. Update the channel menu template to hide a patch version number in the dropdown menu on the site

## Changelog entries
```changes
section: docs
type: feature
summary: Hide a patch version number in the dropdown menu on the site.
impact_level: low
```
