### PR TITLE
[openvpn] improved migration to secrets

### DIFF
--- a/ee/fe/modules/500-openvpn/images/easyrsa-migrator/easyrsa-migrator.go
+++ b/ee/fe/modules/500-openvpn/images/easyrsa-migrator/easyrsa-migrator.go
@@ -158,41 +158,33 @@ func main() {
 
 		var s clientSecret
 
-		switch cert.Flag {
-		case "V":
-			file, err := ioutil.ReadFile(fmt.Sprintf("%s/pki/issued/%s.crt", easyrsaDir, cert.CommonName))
-			if err != nil {
-				log.Error(err)
-			}
-			s.cert = string(file)
+		path := fmt.Sprintf("%s/pki/issued/%s.crt", easyrsaDir, cert.CommonName)
+		if !checkFileExists(path) {
+			log.Printf("file not found: %s", path)
+			path = fmt.Sprintf("%s/pki/revoked/certs_by_serial/%s.crt", easyrsaDir, cert.SerialNumber)
+		}
+		file, err := ioutil.ReadFile(path)
+		if err != nil {
+			log.Error(err)
+		}
+		s.cert = string(file)
 
-			file, err = ioutil.ReadFile(fmt.Sprintf("%s/pki/private/%s.key", easyrsaDir, cert.CommonName))
-			if err != nil {
-				log.Error(err)
-			}
-			s.key = string(file)
-		case "R":
-			path := fmt.Sprintf("%s/pki/issued/%s.crt", easyrsaDir, cert.CommonName)
-			if !checkFileExists(path) {
-				path = fmt.Sprintf("%s/pki/revoked/certs_by_serial/%s.crt", easyrsaDir, cert.SerialNumber)
-			}
-			file, err := ioutil.ReadFile(path)
-			if err != nil {
-				log.Error(err)
-			}
-			s.cert = string(file)
+		path = fmt.Sprintf("%s/pki/private/%s.key", easyrsaDir, cert.CommonName)
+		if !checkFileExists(path) {
+			log.Printf("file not found: %s", path)
+			path = fmt.Sprintf("%s/pki/revoked/private_by_serial/%s.key", easyrsaDir, cert.SerialNumber)
+		}
+		file, err = ioutil.ReadFile(path)
+		if err != nil {
+			log.Error(err)
+		}
+		s.key = string(file)
 
-			path = fmt.Sprintf("%s/pki/private/%s.key", easyrsaDir, cert.CommonName)
-			if !checkFileExists(path) {
-				path = fmt.Sprintf("%s/pki/revoked/private_by_serial/%s.key", easyrsaDir, cert.SerialNumber)
-			}
-			file, err = ioutil.ReadFile(path)
-			if err != nil {
-				log.Error(err)
-			}
-			s.key = string(file)
+		if cert.Flag == "R" {
 			s.revokedAt = cert.RevocationDate
-		default:
+		}
+
+		if cert.Flag != "V" && cert.Flag != "R" {
 			log.Errorf("unknown flag: %s", cert.Flag)
 		}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Regardless of the status of the certificate, if the file was not found, we try to read it from the pki/revoked directory.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In some older installations, certificates were left in the pki/revoked directory after unrevoke. This bug has already been fixed a long time ago.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: openvpn
type: fix
summary: improved migration to secrets
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
