### PR TITLE
[upmeter] Fix missing init container with migrations for emptyDir

### DIFF
--- a/go_lib/hooks/storage_class_change/hook.go
+++ b/go_lib/hooks/storage_class_change/hook.go
@@ -278,8 +278,9 @@ func storageClassChangeWithArgs(input *go_hook.HookInput, dc dependency.Containe
 
 	effectiveStorageClass := calculateEffectiveStorageClass(input, args, currentStorageClass)
 
-	if currentStorageClass != effectiveStorageClass {
-		if len(currentStorageClass) != 0 {
+	if !storageClassesAreEqual(currentStorageClass, effectiveStorageClass) {
+		wasPvc := !isEmptyOrFalseStr(currentStorageClass)
+		if wasPvc {
 			for _, obj := range pvcs {
 				pvc := obj.(PVC)
 				input.LogEntry.Infof("storage class changed, deleting %s/PersistentVolumeClaim/%s", pvc.Namespace, pvc.Name)
@@ -305,6 +306,17 @@ func storageClassChangeWithArgs(input *go_hook.HookInput, dc dependency.Containe
 		}
 	}
 	return nil
+}
+
+func storageClassesAreEqual(sc1, sc2 string) bool {
+	if sc1 == sc2 {
+		return true
+	}
+	return isEmptyOrFalseStr(sc1) && isEmptyOrFalseStr(sc2)
+}
+
+func isEmptyOrFalseStr(sc string) bool {
+	return sc == "" || sc == "false"
 }
 
 func storageClassChange(args Args) func(input *go_hook.HookInput, dc dependency.Container) error {

--- a/go_lib/hooks/storage_class_change/hook.go
+++ b/go_lib/hooks/storage_class_change/hook.go
@@ -315,6 +315,10 @@ func storageClassesAreEqual(sc1, sc2 string) bool {
 	return isEmptyOrFalseStr(sc1) && isEmptyOrFalseStr(sc2)
 }
 
+// isEmptyOrFalseStr returns true if sc is empty string or "false". For storage class values or
+// configuration, empty strings and "false" mean the same: no storage class specified. "false" is
+// set by humans, while absent values resolve to empty strings and it means to use starage class
+// specification from elsewhere.
 func isEmptyOrFalseStr(sc string) bool {
 	return sc == "" || sc == "false"
 }

--- a/go_lib/hooks/storage_class_change/hook.go
+++ b/go_lib/hooks/storage_class_change/hook.go
@@ -317,8 +317,7 @@ func storageClassesAreEqual(sc1, sc2 string) bool {
 
 // isEmptyOrFalseStr returns true if sc is empty string or "false". For storage class values or
 // configuration, empty strings and "false" mean the same: no storage class specified. "false" is
-// set by humans, while absent values resolve to empty strings and it means to use starage class
-// specification from elsewhere.
+// set by humans, while absent values resolve to empty strings.
 func isEmptyOrFalseStr(sc string) bool {
 	return sc == "" || sc == "false"
 }

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -67,10 +67,6 @@ spec:
           - "-path=/data/migrations/agent"
           - "-database=sqlite3:///db/db.sqlite?x-no-tx-wrap=true"
           - up
-        securityContext:
-          runAsNonRoot: false
-          runAsUser: 0
-          runAsGroup: 0
         volumeMounts:
           - mountPath: /db
             name: data

--- a/modules/500-upmeter/templates/upmeter/statefulset.yaml
+++ b/modules/500-upmeter/templates/upmeter/statefulset.yaml
@@ -84,10 +84,6 @@ spec:
           - "-path=/data/migrations/server"
           - "-database=sqlite3:///db/downtime.db.sqlite?x-no-tx-wrap=true"
           - up
-        securityContext:
-          runAsNonRoot: false
-          runAsUser: 0
-          runAsGroup: 0
         volumeMounts:
           - mountPath: /db
             name: data

--- a/modules/500-upmeter/templates/upmeter/statefulset.yaml
+++ b/modules/500-upmeter/templates/upmeter/statefulset.yaml
@@ -73,7 +73,7 @@ spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
       initContainers:
 {{- $storageClass := .Values.upmeter.internal.effectiveStorageClass }}
-{{- if $storageClass }}
+{{- if ne $storageClass "false" }}
       {{- include "helm_lib_module_init_container_chown_nobody_volume" (tuple . "data") | nindent 6 }}
 {{- end }}
       - name: migrator

--- a/modules/500-upmeter/templates/upmeter/statefulset.yaml
+++ b/modules/500-upmeter/templates/upmeter/statefulset.yaml
@@ -71,10 +71,11 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      initContainers:
 {{- $storageClass := .Values.upmeter.internal.effectiveStorageClass }}
 {{- if $storageClass }}
-      initContainers:
       {{- include "helm_lib_module_init_container_chown_nobody_volume" (tuple . "data") | nindent 6 }}
+{{- end }}
       - name: migrator
         image: "{{ $.Values.global.modulesImages.registry }}:{{ $.Values.global.modulesImages.tags.upmeter.upmeter }}"
         command:
@@ -93,7 +94,6 @@ spec:
             readOnly: false
           - mountPath: /tmp
             name: tmp
-{{- end }}
       containers:
       - name: upmeter
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}

--- a/modules/500-upmeter/templates/upmeter/statefulset.yaml
+++ b/modules/500-upmeter/templates/upmeter/statefulset.yaml
@@ -73,7 +73,7 @@ spec:
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
       initContainers:
 {{- $storageClass := .Values.upmeter.internal.effectiveStorageClass }}
-{{- if ne $storageClass "false" }}
+{{- if $storageClass }}
       {{- include "helm_lib_module_init_container_chown_nobody_volume" (tuple . "data") | nindent 6 }}
 {{- end }}
       - name: migrator


### PR DESCRIPTION
## Description

Upmeter server does not work with emptydirs because migrations init container is skipped on emptyDir

## Why do we need it, and what problem does it solve?

Upmeter does not work on emptydirs

## Changelog entries


```changes
section: upmeter
type: fix
summary: Fix non-working upmeter server on emptyDirs
```
