### PR TITLE
[upmeter] Rename scaling to extensions, cp/access to cp/apiserver

### DIFF
--- a/modules/500-upmeter/images/status/src/en.ts
+++ b/modules/500-upmeter/images/status/src/en.ts
@@ -21,9 +21,9 @@ const known: { [name: string]: IGroupData } = {
 		name: "Monitoring and Autoscaling",
 		description: "Availability of monitoring and autoscaling applications in the cluster.",
 	},
-	"scaling": {
-		name: "Cluster scaling",
-		description: "Availability of cluster scaling controllers and controller managers.",
+	"extensions": {
+		name: "Extensions",
+		description: "Availability of extensions apps.",
 	},
 	"load-balancing": {
 		name: "Load Balancing",

--- a/modules/500-upmeter/images/upmeter/pkg/db/dao/episode5m_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/db/dao/episode5m_test.go
@@ -42,7 +42,7 @@ func Test_Fill_RandomDB_For_Today(t *testing.T) {
 
 	groupProbes := map[string][]string{
 		"control-plane": {
-			"access",
+			"apiserver",
 			"basic",
 			"controller-manager",
 			"namespace",
@@ -113,7 +113,7 @@ func Test_Fill_30s_OneDay(t *testing.T) {
 
 	groupProbes := map[string][]string{
 		"control-plane": {
-			"access",
+			"apiserver",
 			"basic",
 			"controller-manager",
 			"namespace",
@@ -167,7 +167,7 @@ func Test_FillOneDay(t *testing.T) {
 
 	groupProbes := map[string][]string{
 		"control-plane": {
-			"access",
+			"apiserver",
 			"basic",
 			"controller-manager",
 			"namespace",
@@ -220,7 +220,7 @@ func Test_Fill_Year(t *testing.T) {
 
 	groupProbes := map[string][]string{
 		"control-plane": {
-			"access",
+			"apiserver",
 			"basic",
 			"controller-manager",
 			"namespace",

--- a/modules/500-upmeter/images/upmeter/pkg/db/migrations/agent/0002_rename_extensions.down.sql
+++ b/modules/500-upmeter/images/upmeter/pkg/db/migrations/agent/0002_rename_extensions.down.sql
@@ -1,0 +1,15 @@
+/*
+
+- Revert renaming "scaling" group to "extensions" for current two probes
+- Revert rename of control-plane/access probe to control-plane/apiserver
+
+https://github.com/deckhouse/deckhouse/issues/1532
+
+*/
+
+BEGIN IMMEDIATE;
+
+UPDATE episodes_30s    SET   group_name="scaling"  WHERE group_name="extensions" AND (probe_name="cluster-scaling" OR probe_name="cluster-autoscaler");
+UPDATE episodes_30s    SET   probe_name="access"   WHERE group_name="control-plane" AND probe_name="apiserver";
+
+COMMIT;

--- a/modules/500-upmeter/images/upmeter/pkg/db/migrations/agent/0002_rename_extensions.up.sql
+++ b/modules/500-upmeter/images/upmeter/pkg/db/migrations/agent/0002_rename_extensions.up.sql
@@ -1,0 +1,15 @@
+/*
+
+- Rename "scaling" group to "extensions"
+- Rename control-plane/access probe to control-plane/apiserver
+
+https://github.com/deckhouse/deckhouse/issues/1532
+
+*/
+
+BEGIN IMMEDIATE;
+
+UPDATE episodes_30s    SET   group_name="extensions"  WHERE group_name="scaling";
+UPDATE episodes_30s    SET   probe_name="apiserver"   WHERE group_name="control-plane" AND probe_name="access";
+
+COMMIT;

--- a/modules/500-upmeter/images/upmeter/pkg/db/migrations/server/0009_rename_extensions.down.sql
+++ b/modules/500-upmeter/images/upmeter/pkg/db/migrations/server/0009_rename_extensions.down.sql
@@ -1,0 +1,20 @@
+/*
+
+- Revert renaming "scaling" group to "extensions" for current two probes
+- Revert rename of control-plane/access probe to control-plane/apiserver
+
+https://github.com/deckhouse/deckhouse/issues/1532
+
+*/
+
+BEGIN IMMEDIATE;
+
+UPDATE downtime30s     SET   group_name="scaling"  WHERE group_name="extensions" AND (probe_name="cluster-scaling" OR probe_name="cluster-autoscaler");
+UPDATE downtime5m      SET   group_name="scaling"  WHERE group_name="extensions" AND (probe_name="cluster-scaling" OR probe_name="cluster-autoscaler");
+UPDATE export_episodes SET   group_name="scaling"  WHERE group_name="extensions" AND (probe_name="cluster-scaling" OR probe_name="cluster-autoscaler");
+
+UPDATE downtime30s     SET   probe_name="access"  WHERE group_name="control-plane" AND probe_name="apiserver";
+UPDATE downtime5m      SET   probe_name="access"  WHERE group_name="control-plane" AND probe_name="apiserver";
+UPDATE export_episodes SET   probe_name="access"  WHERE group_name="control-plane" AND probe_name="apiserver";
+
+COMMIT;

--- a/modules/500-upmeter/images/upmeter/pkg/db/migrations/server/0009_rename_extensions.down.sql
+++ b/modules/500-upmeter/images/upmeter/pkg/db/migrations/server/0009_rename_extensions.down.sql
@@ -9,12 +9,12 @@ https://github.com/deckhouse/deckhouse/issues/1532
 
 BEGIN IMMEDIATE;
 
-UPDATE downtime30s     SET   group_name="scaling"  WHERE group_name="extensions" AND (probe_name="cluster-scaling" OR probe_name="cluster-autoscaler");
-UPDATE downtime5m      SET   group_name="scaling"  WHERE group_name="extensions" AND (probe_name="cluster-scaling" OR probe_name="cluster-autoscaler");
+UPDATE episodes_30s    SET   group_name="scaling"  WHERE group_name="extensions" AND (probe_name="cluster-scaling" OR probe_name="cluster-autoscaler");
+UPDATE episodes_5m     SET   group_name="scaling"  WHERE group_name="extensions" AND (probe_name="cluster-scaling" OR probe_name="cluster-autoscaler");
 UPDATE export_episodes SET   group_name="scaling"  WHERE group_name="extensions" AND (probe_name="cluster-scaling" OR probe_name="cluster-autoscaler");
 
-UPDATE downtime30s     SET   probe_name="access"  WHERE group_name="control-plane" AND probe_name="apiserver";
-UPDATE downtime5m      SET   probe_name="access"  WHERE group_name="control-plane" AND probe_name="apiserver";
+UPDATE episodes_30s    SET   probe_name="access"  WHERE group_name="control-plane" AND probe_name="apiserver";
+UPDATE episodes_5m     SET   probe_name="access"  WHERE group_name="control-plane" AND probe_name="apiserver";
 UPDATE export_episodes SET   probe_name="access"  WHERE group_name="control-plane" AND probe_name="apiserver";
 
 COMMIT;

--- a/modules/500-upmeter/images/upmeter/pkg/db/migrations/server/0009_rename_extensions.up.sql
+++ b/modules/500-upmeter/images/upmeter/pkg/db/migrations/server/0009_rename_extensions.up.sql
@@ -9,12 +9,12 @@ https://github.com/deckhouse/deckhouse/issues/1532
 
 BEGIN IMMEDIATE;
 
-UPDATE downtime30s     SET   group_name="extensions"  WHERE group_name="scaling";
-UPDATE downtime5m      SET   group_name="extensions"  WHERE group_name="scaling";
+UPDATE episodes_30s    SET   group_name="extensions"  WHERE group_name="scaling";
+UPDATE episodes_5m     SET   group_name="extensions"  WHERE group_name="scaling";
 UPDATE export_episodes SET   group_name="extensions"  WHERE group_name="scaling";
 
-UPDATE downtime30s     SET   probe_name="apiserver"  WHERE group_name="control-plane" AND probe_name="access";
-UPDATE downtime5m      SET   probe_name="apiserver"  WHERE group_name="control-plane" AND probe_name="access";
+UPDATE episodes_30s    SET   probe_name="apiserver"  WHERE group_name="control-plane" AND probe_name="access";
+UPDATE episodes_5m     SET   probe_name="apiserver"  WHERE group_name="control-plane" AND probe_name="access";
 UPDATE export_episodes SET   probe_name="apiserver"  WHERE group_name="control-plane" AND probe_name="access";
 
 COMMIT;

--- a/modules/500-upmeter/images/upmeter/pkg/db/migrations/server/0009_rename_extensions.up.sql
+++ b/modules/500-upmeter/images/upmeter/pkg/db/migrations/server/0009_rename_extensions.up.sql
@@ -1,0 +1,20 @@
+/*
+
+- Rename "scaling" group to "extensions"
+- Rename control-plane/access probe to control-plane/apiserver
+
+https://github.com/deckhouse/deckhouse/issues/1532
+
+*/
+
+BEGIN IMMEDIATE;
+
+UPDATE downtime30s     SET   group_name="extensions"  WHERE group_name="scaling";
+UPDATE downtime5m      SET   group_name="extensions"  WHERE group_name="scaling";
+UPDATE export_episodes SET   group_name="extensions"  WHERE group_name="scaling";
+
+UPDATE downtime30s     SET   probe_name="apiserver"  WHERE group_name="control-plane" AND probe_name="access";
+UPDATE downtime5m      SET   probe_name="apiserver"  WHERE group_name="control-plane" AND probe_name="access";
+UPDATE export_episodes SET   probe_name="apiserver"  WHERE group_name="control-plane" AND probe_name="access";
+
+COMMIT;

--- a/modules/500-upmeter/images/upmeter/pkg/probe/group_controlplane.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/group_controlplane.go
@@ -34,7 +34,7 @@ func initControlPlane(access kubernetes.Access) []runnerConfig {
 	return []runnerConfig{
 		{
 			group:  groupName,
-			probe:  "access",
+			probe:  "apiserver",
 			check:  "_",
 			period: 5 * time.Second,
 			config: checker.ControlPlaneAvailable{

--- a/modules/500-upmeter/images/upmeter/pkg/probe/group_scaling.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/group_scaling.go
@@ -23,9 +23,9 @@ import (
 	"d8.io/upmeter/pkg/probe/checker"
 )
 
-func initScaling(access kubernetes.Access) []runnerConfig {
+func initExtensions(access kubernetes.Access) []runnerConfig {
 	const (
-		groupName = "scaling"
+		groupName = "extensions"
 		cpTimeout = 5 * time.Second
 	)
 

--- a/modules/500-upmeter/images/upmeter/pkg/probe/load.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/load.go
@@ -57,7 +57,7 @@ func (l *Loader) collectConfigs() []runnerConfig {
 	l.configs = append(l.configs, initSynthetic(l.access, l.logger)...)
 	l.configs = append(l.configs, initControlPlane(l.access)...)
 	l.configs = append(l.configs, initMonitoringAndAutoscaling(l.access)...)
-	l.configs = append(l.configs, initScaling(l.access)...)
+	l.configs = append(l.configs, initExtensions(l.access)...)
 	l.configs = append(l.configs, initLoadBalancing(l.access)...)
 	l.configs = append(l.configs, initDeckhouse(l.access, l.logger)...)
 

--- a/modules/500-upmeter/images/upmeter/pkg/probe/load_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/load_test.go
@@ -54,15 +54,15 @@ func TestLoader_Groups(t *testing.T) {
 	allGroups := []string{
 		"control-plane",
 		"deckhouse",
+		"extensions",
 		"load-balancing",
 		"monitoring-and-autoscaling",
-		"scaling",
 		"synthetic",
 	}
 	assert.Equal(t, allGroups, unfiltered.Groups())
 
 	filtered := &Loader{
-		filter: NewProbeFilter([]string{"deckhouse", "scaling/"}),
+		filter: NewProbeFilter([]string{"deckhouse", "extensions/"}),
 		access: &kubernetes.Accessor{},
 		logger: newDummyLogger().Logger,
 	}
@@ -84,12 +84,14 @@ func TestLoader_Probes(t *testing.T) {
 	}
 
 	allProbesSorted := []check.ProbeRef{
-		{Group: "control-plane", Probe: "access"},
+		{Group: "control-plane", Probe: "apiserver"},
 		{Group: "control-plane", Probe: "basic-functionality"},
 		{Group: "control-plane", Probe: "controller-manager"},
 		{Group: "control-plane", Probe: "namespace"},
 		{Group: "control-plane", Probe: "scheduler"},
 		{Group: "deckhouse", Probe: "cluster-configuration"},
+		{Group: "extensions", Probe: "cluster-autoscaler"},
+		{Group: "extensions", Probe: "cluster-scaling"},
 		{Group: "load-balancing", Probe: "load-balancer-configuration"},
 		{Group: "load-balancing", Probe: "metallb"},
 		{Group: "monitoring-and-autoscaling", Probe: "key-metrics-present"},
@@ -98,8 +100,6 @@ func TestLoader_Probes(t *testing.T) {
 		{Group: "monitoring-and-autoscaling", Probe: "prometheus-metrics-adapter"},
 		{Group: "monitoring-and-autoscaling", Probe: "trickster"},
 		{Group: "monitoring-and-autoscaling", Probe: "vertical-pod-autoscaler"},
-		{Group: "scaling", Probe: "cluster-autoscaler"},
-		{Group: "scaling", Probe: "cluster-scaling"},
 		{Group: "synthetic", Probe: "access"},
 		{Group: "synthetic", Probe: "dns"},
 		{Group: "synthetic", Probe: "neighbor"},
@@ -109,18 +109,19 @@ func TestLoader_Probes(t *testing.T) {
 	assert.Equal(t, allProbesSorted, unfiltered.Probes())
 
 	filtered := &Loader{
-		filter: NewProbeFilter([]string{"deckhouse", "scaling/", "load-balancing/metallb"}),
+		filter: NewProbeFilter([]string{"deckhouse", "extensions/", "load-balancing/metallb"}),
 		access: &kubernetes.Accessor{},
 		logger: newDummyLogger().Logger,
 	}
 
 	filteredProbesSorted := []check.ProbeRef{
-		{Group: "control-plane", Probe: "access"},
+		{Group: "control-plane", Probe: "apiserver"},
 		{Group: "control-plane", Probe: "basic-functionality"},
 		{Group: "control-plane", Probe: "controller-manager"},
 		{Group: "control-plane", Probe: "namespace"},
 		{Group: "control-plane", Probe: "scheduler"},
 		// --    deckhouse/...
+		// --    extensions/...
 		{Group: "load-balancing", Probe: "load-balancer-configuration"},
 		// --    load-balancing/metallb
 		{Group: "monitoring-and-autoscaling", Probe: "key-metrics-present"},
@@ -129,7 +130,6 @@ func TestLoader_Probes(t *testing.T) {
 		{Group: "monitoring-and-autoscaling", Probe: "prometheus-metrics-adapter"},
 		{Group: "monitoring-and-autoscaling", Probe: "trickster"},
 		{Group: "monitoring-and-autoscaling", Probe: "vertical-pod-autoscaler"},
-		// --    scale/...
 		{Group: "synthetic", Probe: "access"},
 		{Group: "synthetic", Probe: "dns"},
 		{Group: "synthetic", Probe: "neighbor"},

--- a/modules/500-upmeter/images/upmeter/pkg/server/server_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/server_test.go
@@ -29,12 +29,14 @@ func Test_newProbeLister(t *testing.T) {
 	pl := newProbeLister([]string{})
 
 	allProbesSorted := []check.ProbeRef{
-		{Group: "control-plane", Probe: "access"},
+		{Group: "control-plane", Probe: "apiserver"},
 		{Group: "control-plane", Probe: "basic-functionality"},
 		{Group: "control-plane", Probe: "controller-manager"},
 		{Group: "control-plane", Probe: "namespace"},
 		{Group: "control-plane", Probe: "scheduler"},
 		{Group: "deckhouse", Probe: "cluster-configuration"},
+		{Group: "extensions", Probe: "cluster-autoscaler"},
+		{Group: "extensions", Probe: "cluster-scaling"},
 		{Group: "load-balancing", Probe: "load-balancer-configuration"},
 		{Group: "load-balancing", Probe: "metallb"},
 		{Group: "monitoring-and-autoscaling", Probe: "horizontal-pod-autoscaler"},
@@ -44,8 +46,6 @@ func Test_newProbeLister(t *testing.T) {
 		{Group: "monitoring-and-autoscaling", Probe: "prometheus-metrics-adapter"},
 		{Group: "monitoring-and-autoscaling", Probe: "trickster"},
 		{Group: "monitoring-and-autoscaling", Probe: "vertical-pod-autoscaler"},
-		{Group: "scaling", Probe: "cluster-autoscaler"},
-		{Group: "scaling", Probe: "cluster-scaling"},
 		{Group: "synthetic", Probe: "access"},
 		{Group: "synthetic", Probe: "dns"},
 		{Group: "synthetic", Probe: "neighbor"},
@@ -55,9 +55,9 @@ func Test_newProbeLister(t *testing.T) {
 	allGroupsSorted := []string{
 		"control-plane",
 		"deckhouse",
+		"extensions",
 		"load-balancing",
 		"monitoring-and-autoscaling",
-		"scaling",
 		"synthetic",
 	}
 

--- a/modules/500-upmeter/images/webui/src/app/i18n/en.ts
+++ b/modules/500-upmeter/images/webui/src/app/i18n/en.ts
@@ -95,11 +95,11 @@ const langPack: LangPack = {
             <p>Group result is a combination of probe results with the priority of the worst results.</p>
             `,
     },
-    scaling: {
+    extensions: {
       ...GROUP_DEFAULT_TOOLTIP,
-      title: "Scaling",
+      title: "Extensions",
       description: `
-            <p>Checks the availability of cluster scaling and autoscaling controllers and controller managers.</p>
+            <p>Checks the availability of various extensions apps.</p>
             <p>Group result is a combination of probe results with the priority of the worst results.</p>
             `,
     },
@@ -120,8 +120,8 @@ const langPack: LangPack = {
   },
   probe: {
     "control-plane": {
-      access: {
-        title: "Access",
+      apiserver: {
+        title: "API server",
         description: "The probe requests <code>/version</code> endpoint from kube-apiserver",
         reasonUp: "<code>/version</code> returns 200 OK.",
         reasonDown: "<code>/version</code> returns other codes or there is no connection to kube-apiserver.",
@@ -253,7 +253,7 @@ const langPack: LangPack = {
           "Every 5 seconds resolve sample application IPs and request <code>/neighbor-via-service</code> endpoint until first success",
       },
     },
-    scaling: {
+    extensions: {
       "cluster-scaling": {
         title: "Cluster Scaling",
         description:


### PR DESCRIPTION

## Description

Renaming things according to mk8s terms of service

- added migrations
- fixed tests
- fixed naming in web ui
- fixed naming on status page


## Why do we need it, and what problem does it solve?

Comply with SLA availability groups from the Terms of Service

## Changelog entries


```changes
section: upmeter
type: chore
summary: Renamed current state of groups and probes according to SLA in the Terms of Service
```
