### PR TITLE
[prometheus] Grafana 8.5.2, statusmap 0.5.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -38,6 +38,6 @@ trim_trailing_whitespace = false
 ; golang
 ###########################################################
 
-[*.go]
+[{*.go, *.patch}]
 indent_style = tab
 indent_size = 4

--- a/modules/300-prometheus/images/grafana/Dockerfile
+++ b/modules/300-prometheus/images/grafana/Dockerfile
@@ -2,11 +2,11 @@ ARG BASE_ALPINE
 ARG BASE_NODE_16_ALPINE
 ARG BASE_GOLANG_17_BUSTER
 ARG BASE_DEBIAN
-# Note no 'v' prefix!
-ARG STATUSMAP_VERSION="0.4.2"
+ARG GRAFANA_VERSION="8.5.2"
+ARG STATUSMAP_VERSION="0.5.1"
 ARG BUNDLED_PLUGINS="grafana-image-renderer,petrslavotinek-carpetplot-panel,vonage-status-panel,btplc-status-dot-panel,natel-plotly-panel,savantly-heatmap-panel,grafana-piechart-panel,grafana-worldmap-panel"
 
-# This Dockerfile is based on Dockerfile from https://github.com/grafana/grafana/blob/v8.2.3/Dockerfile
+# This Dockerfile is based on Dockerfile from https://github.com/grafana/grafana/blob/v8.5.2/Dockerfile
 # Changes:
 # - Source files are not available in the current directory.
 #   Archive is downloaded and patched using an intermediate image.
@@ -18,7 +18,8 @@ ARG BUNDLED_PLUGINS="grafana-image-renderer,petrslavotinek-carpetplot-panel,vona
 FROM $BASE_ALPINE as src-files
 WORKDIR /usr/src/app
 RUN apk add --no-cache patch
-RUN wget https://github.com/grafana/grafana/archive/v8.2.7.tar.gz -O - | tar -xz  --strip-components=1
+ARG GRAFANA_VERSION
+RUN wget https://github.com/grafana/grafana/archive/v${GRAFANA_VERSION}.tar.gz -O - | tar -xz  --strip-components=1
 # Extra '__interval_*' vars for prometheus datasource.
 COPY ./patches/feat_prometheus_extra_vars.patch .
 RUN patch -p1 < ./feat_prometheus_extra_vars.patch
@@ -42,9 +43,9 @@ FROM $BASE_NODE_16_ALPINE as js-builder
 COPY --from=src-files /usr/src/app /usr/src/app
 WORKDIR /usr/src/app
 RUN apk --no-cache add git
-RUN yarn install --pure-lockfile --no-progress
+RUN yarn install
 ENV NODE_ENV production
-ENV NODE_OPTIONS "--max_old_space_size=4096"
+ENV NODE_OPTIONS "--max_old_space_size=8000"
 RUN yarn build
 
 
@@ -53,15 +54,11 @@ RUN yarn build
 # Difference from original:
 # - No COPY actions: copy whole source code at start.
 # - WORKDIR $GOPATH/src/github.com/grafana/grafana is not needed to build with go modules.
-# - Get packages to fix 'missing go.sum entry for module providing package'
 # - Add 'make gen-go' to fix 'cli.go:163:12: undefined: server.Initialize'
 # - Use debian: see step 4 for details.
 FROM $BASE_GOLANG_17_BUSTER as go-builder
 COPY --from=src-files /usr/src/app /usr/src/app
 WORKDIR /usr/src/app/
-# Temporary fix for v8.2.4. Try to remove for future Grafana versions.
-RUN go get github.com/hashicorp/memberlist@v0.2.4 && \
-    go get github.com/hashicorp/go-plugin@v1.4.2
 RUN make gen-go
 RUN go run build.go build
 

--- a/modules/300-prometheus/images/grafana/patches/build_go.patch
+++ b/modules/300-prometheus/images/grafana/patches/build_go.patch
@@ -1,13 +1,15 @@
 diff --git a/pkg/build/cmd.go b/pkg/build/cmd.go
-index 5817cee065..a7a19cc30e 100644
+index bd0128d..b4d7550 100644
 --- a/pkg/build/cmd.go
 +++ b/pkg/build/cmd.go
-@@ -243,7 +243,7 @@ func ldflags(opts BuildOpts) (string, error) {
- 	b.WriteString(fmt.Sprintf(" -X main.version=%s", opts.version))
- 	b.WriteString(fmt.Sprintf(" -X main.commit=%s", getGitSha()))
+@@ -206,8 +206,8 @@ func ldflags(opts BuildOpts) (string, error) {
+
+ 	var b bytes.Buffer
+ 	b.WriteString("-w")
+-	b.WriteString(fmt.Sprintf(" -X main.version=%s", opts.version))
+-	b.WriteString(fmt.Sprintf(" -X main.commit=%s", getGitSha()))
++	b.WriteString(fmt.Sprintf(" -X main.version=%s", "8.5.2"))
++	b.WriteString(fmt.Sprintf(" -X main.commit=%s", "fix_heatmap,feat_extra_vars"))
  	b.WriteString(fmt.Sprintf(" -X main.buildstamp=%d", buildStamp))
--	b.WriteString(fmt.Sprintf(" -X main.buildBranch=%s", getGitBranch()))
-+	b.WriteString(fmt.Sprintf(" -X main.buildBranch=%s", "fix_heatmap,feat_extra_vars"))
+ 	b.WriteString(fmt.Sprintf(" -X main.buildBranch=%s", getGitBranch()))
  	if v := os.Getenv("LDFLAGS"); v != "" {
- 		b.WriteString(fmt.Sprintf(" -extldflags \"%s\"", v))
- 	}

--- a/modules/300-prometheus/images/grafana/patches/feat_prometheus_extra_vars.patch
+++ b/modules/300-prometheus/images/grafana/patches/feat_prometheus_extra_vars.patch
@@ -1,11 +1,12 @@
-diff --git a/public/app/plugins/datasource/prometheus/datasource.ts b/public/app/plugins/datasource/prometheus/datasource.ts
-index f090e947aa..66bdd6503c 100644
---- a/public/app/plugins/datasource/prometheus/datasource.ts
-+++ b/public/app/plugins/datasource/prometheus/datasource.ts
-@@ -446,6 +446,23 @@ export class PrometheusDatasource extends DataSourceApi<PromQuery, PromOptions>
+diff --git a/public/app/plugins/datasource/prometheus/datasource.tsx b/public/app/plugins/datasource/prometheus/datasource.tsx
+index b0a9b91..0ef0450 100644
+--- a/public/app/plugins/datasource/prometheus/datasource.tsx
++++ b/public/app/plugins/datasource/prometheus/datasource.tsx
+@@ -518,6 +518,24 @@ export class PrometheusDatasource
          ...this.getRangeScopedVars(options.range),
        });
      }
++    // Flant custom variables: adjusted intervals.
 +    const intervalScrapeX3ForOverTimeVectors = Math.max(rangeUtil.intervalToSeconds(this.interval) * 3, interval);
 +    const intervalScrapeX4ForRangeVectors = Math.max(rangeUtil.intervalToSeconds(this.interval) * 4, interval);
 +    const intervalForRangeVectors = Math.max(rangeUtil.intervalToSeconds(this.interval) * 2, interval);
@@ -27,10 +28,10 @@ index f090e947aa..66bdd6503c 100644
 
      let expr = target.expr;
 diff --git a/public/app/plugins/datasource/prometheus/promql.ts b/public/app/plugins/datasource/prometheus/promql.ts
-index 2550c90b99..9925adbd3c 100644
+index 7d0f213..865ece5 100644
 --- a/public/app/plugins/datasource/prometheus/promql.ts
 +++ b/public/app/plugins/datasource/prometheus/promql.ts
-@@ -5,6 +5,8 @@ import { CompletionItem } from '@grafana/ui';
+@@ -6,6 +6,8 @@ import { CompletionItem } from '@grafana/ui';
  // @see public/app/plugins/datasource/loki/language_provider.ts
  export const RATE_RANGES: CompletionItem[] = [
    { label: '$__interval', sortValue: '$__interval' },
@@ -39,3 +40,45 @@ index 2550c90b99..9925adbd3c 100644
    { label: '$__rate_interval', sortValue: '$__rate_interval' },
    { label: '$__range', sortValue: '$__range' },
    { label: '1m', sortValue: '00:01:00' },
+diff --git a/pkg/tsdb/prometheus/time_series_query.go b/pkg/tsdb/prometheus/time_series_query.go
+index d768738..f00b4d5 100644
+--- a/pkg/tsdb/prometheus/time_series_query.go
++++ b/pkg/tsdb/prometheus/time_series_query.go
+@@ -289,6 +289,19 @@ func calculateRateInterval(interval time.Duration, scrapeInterval string, interv
+ 	return rateInterval
+ }
+
++func scrapeInterval(scrapeInterval string) time.Duration {
++	scrape := scrapeInterval
++	if scrape == "" {
++		scrape = "15s"
++	}
++
++	scrapeIntervalDuration, err := intervalv2.ParseIntervalStringToTimeDuration(scrape)
++	if err != nil {
++		return time.Duration(0)
++	}
++	return scrapeIntervalDuration
++}
++
+ func interpolateVariables(model *QueryModel, interval time.Duration, timeRange time.Duration, intervalCalculator intervalv2.Calculator, timeInterval string) string {
+ 	expr := model.Expr
+ 	rangeMs := timeRange.Milliseconds()
+@@ -301,6 +314,17 @@ func interpolateVariables(model *QueryModel, interval time.Duration, timeRange t
+ 		rateInterval = calculateRateInterval(interval, timeInterval, intervalCalculator)
+ 	}
+
++	// Flant custom variables.
++	scrapeX3ForOverTimeVectors := time.Duration(math.Max(float64(scrapeInterval(timeInterval))*3, float64(interval)))
++	scrapeX4ForRangeVectors := time.Duration(math.Max(float64(scrapeInterval(timeInterval))*4, float64(interval)))
++	intervalForRangeVectors := time.Duration(math.Max(float64(scrapeInterval(timeInterval))*2, float64(interval)))
++	expr = strings.ReplaceAll(expr, "$__interval_rv", intervalv2.FormatDuration(intervalForRangeVectors))
++	expr = strings.ReplaceAll(expr, "${__interval_rv}", intervalv2.FormatDuration(intervalForRangeVectors))
++	expr = strings.ReplaceAll(expr, "$__interval_sx3", intervalv2.FormatDuration(scrapeX3ForOverTimeVectors))
++	expr = strings.ReplaceAll(expr, "${__interval_sx3}", intervalv2.FormatDuration(scrapeX3ForOverTimeVectors))
++	expr = strings.ReplaceAll(expr, "$__interval_sx4", intervalv2.FormatDuration(scrapeX4ForRangeVectors))
++	expr = strings.ReplaceAll(expr, "${__interval_sx4}", intervalv2.FormatDuration(scrapeX4ForRangeVectors))
++
+ 	expr = strings.ReplaceAll(expr, varIntervalMs, strconv.FormatInt(int64(interval/time.Millisecond), 10))
+ 	expr = strings.ReplaceAll(expr, varInterval, intervalv2.FormatDuration(interval))
+ 	expr = strings.ReplaceAll(expr, varRangeMs, strconv.FormatInt(rangeMs, 10))

--- a/modules/300-prometheus/images/grafana/patches/fix_heatmap_thin_bars_on_ff.patch
+++ b/modules/300-prometheus/images/grafana/patches/fix_heatmap_thin_bars_on_ff.patch
@@ -1,8 +1,8 @@
 diff --git a/public/app/core/time_series2.ts b/public/app/core/time_series2.ts
-index 8a9a515d48..c3cd098317 100644
+index e2c301d..8335348 100644
 --- a/public/app/core/time_series2.ts
 +++ b/public/app/core/time_series2.ts
-@@ -222,6 +222,7 @@ export default class TimeSeries {
+@@ -223,6 +223,7 @@ export default class TimeSeries {
      let previousTime;
      let previousValue = 0;
      let previousDeltaUp = true;
@@ -10,7 +10,7 @@ index 8a9a515d48..c3cd098317 100644
 
      for (let i = 0; i < this.datapoints.length; i++) {
        currentValue = this.datapoints[i][0];
-@@ -231,8 +232,15 @@ export default class TimeSeries {
+@@ -232,8 +233,15 @@ export default class TimeSeries {
        // so we have to find the minimum one (could occur with aggregators such as ZimSum)
        if (previousTime !== undefined) {
          const timeStep = currentTime - previousTime;
@@ -28,16 +28,16 @@ index 8a9a515d48..c3cd098317 100644
        }
        previousTime = currentTime;
 diff --git a/public/app/plugins/panel/heatmap/heatmap_data_converter.ts b/public/app/plugins/panel/heatmap/heatmap_data_converter.ts
-index 570590adec..36e5abf3ca 100644
+index 95183a6..186d0aa 100644
 --- a/public/app/plugins/panel/heatmap/heatmap_data_converter.ts
 +++ b/public/app/plugins/panel/heatmap/heatmap_data_converter.ts
 @@ -1,4 +1,4 @@
 -import { concat, forEach, isEmpty, isEqual, isNumber, sortBy } from 'lodash';
 +import { concat, forEach, isEmpty, isEqual, isNumber, sortBy, toNumber } from 'lodash';
- import { TimeSeries } from 'app/core/core';
- import { Bucket, HeatmapCard, HeatmapCardStats, YBucket, XBucket } from './types';
 
-@@ -399,10 +399,28 @@ function calculateBucketSize(bounds: number[], logBase = 1): number {
+ import { TimeSeries } from 'app/core/core';
+
+@@ -401,10 +401,28 @@ function calculateBucketSize(bounds: number[], logBase = 1): number {
      return bounds[0];
    } else {
      bounds = sortBy(bounds);


### PR DESCRIPTION
## Description

- Update Grafana to 8.5.2
- Update statusmap to 0.5.1
- Build: remove workaround from go-builder
- Build: remove deprecated yarn options
- Build: increase max_old_space_size to 8000 (since 8.3.0)
- Custom variables: support interpolation on backend

## Why do we need it, and what problem does it solve?

Use latest Grafana.

<img width="982" src="https://user-images.githubusercontent.com/1055474/167854372-f6a51a3a-74bc-4291-abd3-32833e09a19a.png">

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: feature
summary: Use Grafana 8.5.2
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
