### PR TITLE
[candi] fix aws terraform lookup bastion_instance

### DIFF
--- a/candi/cloud-providers/aws/layouts/standard/base-infrastructure/outputs.tf
+++ b/candi/cloud-providers/aws/layouts/standard/base-infrastructure/outputs.tf
@@ -24,7 +24,7 @@ output "cloud_discovery_data" {
       "iamProfileName": "${local.prefix}-node"
     }
     "loadBalancerSecurityGroup" = module.security-groups.load_balancer_security_group
-    "zones" = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
+    "zones" = lookup(var.providerClusterConfiguration, "zones", {}) != {} ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
     "zoneToSubnetIdMap" = {
       for subnet in aws_subnet.kube_internal:
       subnet.availability_zone => subnet.id

--- a/candi/cloud-providers/aws/layouts/standard/master-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/standard/master-node/variables.tf
@@ -40,7 +40,7 @@ locals {
   root_volume_size = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskSizeGb", 20)
   root_volume_type = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskType", "gp2")
   additional_security_groups = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalSecurityGroups", [])
-  actual_zones = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
-  zones = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", null) != null ? tolist(setintersection(local.actual_zones, var.providerClusterConfiguration.masterNodeGroup["zones"])) : local.actual_zones
+  actual_zones = lookup(var.providerClusterConfiguration, "zones", {}) != {} ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
+  zones = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", {}) != {} ? tolist(setintersection(local.actual_zones, var.providerClusterConfiguration.masterNodeGroup["zones"])) : local.actual_zones
   tags = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(var.providerClusterConfiguration.masterNodeGroup, "additionalTags", {}))
 }

--- a/candi/cloud-providers/aws/layouts/standard/static-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/standard/static-node/variables.tf
@@ -46,7 +46,7 @@ locals {
   root_volume_size = lookup(local.node_group.instanceClass, "diskSizeGb", 20)
   root_volume_type = lookup(local.node_group.instanceClass, "diskType", "gp2")
   additional_security_groups = lookup(local.node_group.instanceClass, "additionalSecurityGroups", [])
-  actual_zones = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
-  zones = lookup(local.node_group, "zones", null) != null ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones
+  actual_zones = lookup(var.providerClusterConfiguration, "zones", {}) != {} ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
+  zones = lookup(local.node_group, "zones", {}) != {} ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones
   tags = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(local.node_group, "additionalTags", {}))
 }

--- a/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/main.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/main.tf
@@ -195,9 +195,9 @@ locals {
   instance_class             = lookup(local.bastion_instance, "instanceClass", {})
   additional_security_groups = lookup(local.instance_class, "additionalSecurityGroups", [])
 
-  actual_zones = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
+  actual_zones = lookup(var.providerClusterConfiguration, "zones", {}) != {} ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
 
-  zone = lookup(local.bastion_instance, "zone", null) != null ? local.bastion_instance.zone : local.actual_zones[0]
+  zone = lookup(local.bastion_instance, "zone", {}) != {} ? local.bastion_instance.zone : local.actual_zones[0]
 
   zone_to_subnet_id_map = {
     for subnet in aws_subnet.kube_public :
@@ -211,7 +211,7 @@ locals {
 }
 
 resource "aws_instance" "bastion" {
-  count                  = local.bastion_instance != null ? 1 : 0
+  count                  = local.bastion_instance != {} ? 1 : 0
   ami                    = local.instance_class.ami
   instance_type          = local.instance_class.instanceType
   key_name               = local.prefix
@@ -237,7 +237,7 @@ resource "aws_instance" "bastion" {
 }
 
 resource "aws_eip" "bastion" {
-  count = local.bastion_instance != null ? 1 : 0
+  count = local.bastion_instance != {} ? 1 : 0
   vpc   = true
   tags = merge(local.tags, {
     Name = "${local.prefix}-bastion"
@@ -245,7 +245,7 @@ resource "aws_eip" "bastion" {
 }
 
 resource "aws_eip_association" "bastion" {
-  count         = local.bastion_instance != null ? 1 : 0
+  count         = local.bastion_instance != {} ? 1 : 0
   instance_id   = aws_instance.bastion[0].id
   allocation_id = aws_eip.bastion[0].id
 }

--- a/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/outputs.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/outputs.tf
@@ -24,7 +24,7 @@ output "cloud_discovery_data" {
       "iamProfileName" : "${local.prefix}-node"
     }
     "loadBalancerSecurityGroup" = module.security-groups.load_balancer_security_group
-    "zones"                     = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
+    "zones"                     = lookup(var.providerClusterConfiguration, "zones", {}) != {} ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
     "zoneToSubnetIdMap" = {
       for subnet in aws_subnet.kube_internal :
       subnet.availability_zone => subnet.id
@@ -33,5 +33,5 @@ output "cloud_discovery_data" {
 }
 
 output "bastion_ip_address_for_ssh" {
-  value = local.bastion_instance != null ? aws_eip.bastion[0].public_ip : ""
+  value = local.bastion_instance != {} ? aws_eip.bastion[0].public_ip : ""
 }

--- a/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/variables.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/variables.tf
@@ -35,7 +35,7 @@ variable "clusterUUID" {
 }
 
 locals {
-  bastion_instance = lookup(var.providerClusterConfiguration, "withNAT", null) != null ? lookup(var.providerClusterConfiguration.withNAT ,"bastionInstance", null) : null
+  bastion_instance = lookup(var.providerClusterConfiguration, "withNAT", {}) != {} ? lookup(var.providerClusterConfiguration.withNAT ,"bastionInstance", {}) : {}
   prefix           = var.clusterConfiguration.cloud.prefix
   vpc_network_cidr = lookup(var.providerClusterConfiguration, "vpcNetworkCIDR", "")
   existing_vpc_id  = lookup(var.providerClusterConfiguration, "existingVPCID", "")

--- a/candi/cloud-providers/aws/layouts/with-nat/master-node/main.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/master-node/main.tf
@@ -24,5 +24,5 @@ module "master-node" {
   cloud_config = var.cloudConfig
   zones = local.zones
   tags = local.tags
-  associate_ssh_accessible_sg = local.bastion_instance != null ? false : true
+  associate_ssh_accessible_sg = local.bastion_instance != {} ? false : true
 }

--- a/candi/cloud-providers/aws/layouts/with-nat/master-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/master-node/variables.tf
@@ -37,11 +37,11 @@ data "aws_availability_zones" "available" {}
 
 locals {
   prefix = var.clusterConfiguration.cloud.prefix
-  bastion_instance = lookup(var.providerClusterConfiguration, "withNAT", null) != null ? lookup(var.providerClusterConfiguration.withNAT ,"bastionInstance", null) : null
+  bastion_instance = lookup(var.providerClusterConfiguration, "withNAT", {}) != {} ? lookup(var.providerClusterConfiguration.withNAT ,"bastionInstance", {}) : {}
   root_volume_size = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskSizeGb", 20)
   root_volume_type = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskType", "gp2")
   additional_security_groups = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalSecurityGroups", [])
-  actual_zones = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
-  zones = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", null) != null ? tolist(setintersection(local.actual_zones, var.providerClusterConfiguration.masterNodeGroup["zones"])) : local.actual_zones
+  actual_zones = lookup(var.providerClusterConfiguration, "zones", {}) != {} ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
+  zones = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", {}) != {} ? tolist(setintersection(local.actual_zones, var.providerClusterConfiguration.masterNodeGroup["zones"])) : local.actual_zones
   tags = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(var.providerClusterConfiguration.masterNodeGroup, "additionalTags", {}))
 }

--- a/candi/cloud-providers/aws/layouts/with-nat/static-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/static-node/variables.tf
@@ -46,7 +46,7 @@ locals {
   root_volume_size = lookup(local.node_group.instanceClass, "diskSizeGb", 20)
   root_volume_type = lookup(local.node_group.instanceClass, "diskType", "gp2")
   additional_security_groups = lookup(local.node_group.instanceClass, "additionalSecurityGroups", [])
-  actual_zones = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
-  zones = lookup(local.node_group, "zones", null) != null ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones
+  actual_zones = lookup(var.providerClusterConfiguration, "zones", {}) != {} ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
+  zones = lookup(local.node_group, "zones", {}) != {} ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones
   tags = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(local.node_group, "additionalTags", {}))
 }

--- a/candi/cloud-providers/aws/layouts/without-nat/base-infrastructure/outputs.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/base-infrastructure/outputs.tf
@@ -24,7 +24,7 @@ output "cloud_discovery_data" {
       "iamProfileName": "${local.prefix}-node"
     }
     "loadBalancerSecurityGroup" = module.security-groups.load_balancer_security_group
-    "zones" = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
+    "zones" = lookup(var.providerClusterConfiguration, "zones", {}) != {} ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
     "zoneToSubnetIdMap" = {
       for subnet in aws_subnet.kube_public:
       subnet.availability_zone => subnet.id

--- a/candi/cloud-providers/aws/layouts/without-nat/static-node/variables.tf
+++ b/candi/cloud-providers/aws/layouts/without-nat/static-node/variables.tf
@@ -46,7 +46,7 @@ locals {
   root_volume_size = lookup(local.node_group.instanceClass, "diskSizeGb", 20)
   root_volume_type = lookup(local.node_group.instanceClass, "diskType", "gp2")
   additional_security_groups = lookup(local.node_group.instanceClass, "additionalSecurityGroups", [])
-  actual_zones = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
-  zones = lookup(local.node_group, "zones", null) != null ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones
+  actual_zones = lookup(var.providerClusterConfiguration, "zones", {}) != {} ? tolist(setintersection(data.aws_availability_zones.available.names, var.providerClusterConfiguration.zones)) : data.aws_availability_zones.available.names
+  zones = lookup(local.node_group, "zones", {}) != {} ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones
   tags = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(local.node_group, "additionalTags", {}))
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed use of lookup function in aws terraform for bastion_instance.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->
When bastion_instance is not set, we set it to `null` instead of `{}`, so upcoming lookup function fails with message `Invalid value for "inputMap" parameter: argument must not be null.`
```changes
section: candi
type: fix
summary:  fix aws terraform lookup bastion_instance
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
