### PR TITLE
[monitoring-kubernetes] Fix K8SKubeletDown alerts

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/coreos/kubelet.tpl
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/coreos/kubelet.tpl
@@ -22,7 +22,7 @@
       description: '{{ `{{ $value }}` }}% of Kubernetes nodes are not ready'
       summary: Too many nodes are not ready
   - alert: K8SKubeletDown
-    expr: (count(up{job="kubelet"} == 0) or absent(up{job="kubelet"} == 1)) / count(up{job="kubelet"})) * 100 > 3
+    expr: (count(up{job="kubelet"} == 0) or absent(up{job="kubelet"} == 1)) / count(up{job="kubelet"}) * 100 > 3
     for: 10m
     labels:
       severity_level: "4"
@@ -33,7 +33,7 @@
       description: Prometheus failed to scrape {{ `{{ $value }}` }}% of kubelets.
       summary: A few kubelets cannot be scraped
   - alert: K8SKubeletDown
-    expr: (count(up{job="kubelet"} == 0) or absent(up{job="kubelet"} == 1)) / count(up{job="kubelet"})) * 100 > 10
+    expr: (count(up{job="kubelet"} == 0) or absent(up{job="kubelet"} == 1)) / count(up{job="kubelet"}) * 100 > 10
     for: 30m
     labels:
       severity_level: "3"


### PR DESCRIPTION
## Description
Fix K8SKubeletDown alerts.
Remove unexpected right parenthesis.

## Why do we need it, and what problem does it solve?
Prometheus rules are not deployed with error.
```
level=info ts=2022-05-10T13:19:38.156994272Z caller=rules.go:330 component=prometheusoperator msg="Invalid rule" err="58:11: group \"coreos.kubelet\", rule 3, \"K8SKubeletDown\": could not parse expression: 1:94: parse error: unexpected right parenthesis ')'"
level=info ts=2022-05-10T13:19:38.157087907Z caller=rules.go:330 component=prometheusoperator msg="Invalid rule" err="58:11: group \"coreos.kubelet\", rule 4, \"K8SKubeletDown\": could not parse expression: 1:94: parse error: unexpected right parenthesis ')'"
level=error ts=2022-05-10T13:19:38.210221845Z caller=klog.go:116 component=k8s_client_runtime func=ErrorDepth msg="Sync \"d8-monitoring/main\" failed: Invalid rule"
```

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring-kubernetes
type: fix
summary: Fix K8SKubeletDown alerts
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
