### PR TITLE
[docs] Revert dont-use-public-control-plane-images parameter for closed envs getting started and add /install for dhctl image for closed envs getting started

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER.liquid
+++ b/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER.liquid
@@ -19,7 +19,7 @@ docker run --pull=always {% if page.platform_code == "kind" %} --network host {%
 docker run --pull=always {% if page.platform_code == "kind" %} --network host {% endif %}-it -v "$PWD/config.yml:/config.yml"{%- if page.platform_type != 'existing' %} -v "$HOME/.ssh/:/tmp/.ssh/" \
 {% endif %}{% if page.platform_type == "existing" or page.platform_code == "kind" %} -v "$HOME/.kube/config:/kubeconfig" \
 {% endif %}{% if page.platform_type == "cloud" %} -v "$PWD/resources.yml:/resources.yml" -v "$PWD/dhctl-tmp:/tmp/dhctl" {% endif %}
-{%- if page.platform_code == "bm-private" %} <IMAGES_REPO_URI>:stable
+{%- if page.platform_code == "bm-private" %} <IMAGES_REPO_URI>/install:stable
 {%- else %} registry.deckhouse.io/deckhouse/ce/install:stable{% endif %} bash
 ```
 {% endsnippetcut %}
@@ -44,6 +44,9 @@ dhctl bootstrap \
   --ssh-host=<master_ip> \
   --ssh-agent-private-keys=/tmp/.ssh/id_rsa \
   --config=/config.yml \
+{%- if page.platform_code == "bm-private" %}
+  --dont-use-public-control-plane-images \
+{%- endif %}
   --ask-become-pass
 {%- elsif page.platform_type == "cloud" %}
 dhctl bootstrap \

--- a/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/INSTALL_OTHER_RU.liquid
@@ -19,7 +19,7 @@ docker run --pull=always {% if page.platform_code == "kind" %} --network host {%
 docker run --pull=always {% if page.platform_code == "kind" %} --network host {% endif %}-it -v "$PWD/config.yml:/config.yml"{%- if page.platform_type != 'existing' %} -v "$HOME/.ssh/:/tmp/.ssh/" \
 {% endif %}{% if page.platform_type == "existing" or page.platform_code == "kind" %} -v "$HOME/.kube/config:/kubeconfig" \
 {% endif %}{% if page.platform_type == "cloud" %} -v "$PWD/resources.yml:/resources.yml" -v "$PWD/dhctl-tmp:/tmp/dhctl" {% endif %}
-{%- if page.platform_code == "bm-private" %} <IMAGES_REPO_URI>:stable
+{%- if page.platform_code == "bm-private" %} <IMAGES_REPO_URI>/install:stable
 {%- else %} registry.deckhouse.io/deckhouse/ce/install:stable{% endif %} bash
 ```
 {% endsnippetcut %}
@@ -44,6 +44,9 @@ dhctl bootstrap \
   --ssh-host=<master_ip> \
   --ssh-agent-private-keys=/tmp/.ssh/id_rsa \
   --config=/config.yml \
+{%- if page.platform_code == "bm-private" %}
+  --dont-use-public-control-plane-images \
+{%- endif %}
   --ask-become-pass
 {%- elsif page.platform_type == "cloud" %}
 dhctl bootstrap \

--- a/docs/site/js/getting-started-private.js
+++ b/docs/site/js/getting-started-private.js
@@ -104,6 +104,9 @@ $(document).ready(function () {
   }
 
   if (registryImagesRepo && registryImagesRepo.length > 0) {
+    // trim right / symbol
+    // for example: registry.deckhouse.io/deckhouse/ce/ -> registry.deckhouse.io/deckhouse/ce
+    const cleanedRegistryImagesRepo = registryImagesRepo.replace(/\/+$/, '');
     update_parameter('dhctl-registry-docker-cfg', 'registryDockerCfg', '<YOUR_PRIVATE_ACCESS_STRING_IS_HERE>', null, '[config-yml]');
     update_parameter('dhctl-registry-images-repo', 'imagesRepo', '<IMAGES_REPO_URI>', null, '[config-yml]');
     update_parameter('dhctl-registry-ca', 'registryCA', '<REGISTRY_CA>', null, '[config-yml]', 4);
@@ -125,10 +128,10 @@ $(document).ready(function () {
     $('.highlight code').filter(function () {
       return this.innerText.match('<IMAGES_REPO_URI>');
     }).each(function () {
-      $(this).text($(this).text().replace('<IMAGES_REPO_URI>', registryImagesRepo));
+      $(this).text($(this).text().replace('<IMAGES_REPO_URI>', cleanedRegistryImagesRepo));
     });
 
-    updateTextInSnippet('[docker-login-ce]', '<IMAGES_REPO_URI>', registryImagesRepo);
+    updateTextInSnippet('[docker-login-ce]', '<IMAGES_REPO_URI>', cleanedRegistryImagesRepo);
   }
 
   // delete empty lines in snippet


### PR DESCRIPTION
## Description
Revert dont-use-public-control-plane-images parameter for closed envs getting started and add /install for dhctl image for closed envs getting started

## Why do we need it, and what problem does it solve?
Getting started is not versioned and we removed deprecate `dont-use-public-control-plane-images` in next version.
For closed envs we have incorrect dhctl image.

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
