### PR TITLE
[upmeter] Fix neighbor-via-service probe

### DIFF
--- a/modules/500-upmeter/images/smoke-mini/smoke-mini.go
+++ b/modules/500-upmeter/images/smoke-mini/smoke-mini.go
@@ -172,9 +172,9 @@ func neighborHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "ok")
 }
 
-// neighborViaServiceHandler checks the availabilty of any smoke-mini pod including themselves. It
-// gets responses from common headless service URL which targets all smoke-mini pods including
-// current one. In worst case, the pod gets all responses from it.
+// neighborViaServiceHandler checks the availabilty of any smoke-mini pod including themselves via
+// service "cluster IP", i.e. via iptables rules. In worst case, the pod gets all responses from
+// itself.
 func neighborViaServiceHandler(w http.ResponseWriter, r *http.Request) {
 	maxErrors := 2
 

--- a/modules/500-upmeter/images/smoke-mini/smoke-mini.go
+++ b/modules/500-upmeter/images/smoke-mini/smoke-mini.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -33,18 +32,24 @@ import (
 )
 
 var (
-	listenHost              = "0.0.0.0"
-	listenPort              = "8080"
+	listenHost = "0.0.0.0"
+	listenPort = "8080"
+
+	// targetServices is the list of neighbor indexes, e.g. for "c" it is []string{"a", "b", "d", "e"}
+	targetServices   = strings.Split(os.Getenv("SMOKE_MINI_STS_LIST"), " ")
+	commonServiceURL = "http://smoke-mini:8080"
+
 	serviceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-	ready                   = true
-	serviceURL              = "http://smoke-mini:8080"
+
+	// state for shutdown
+	ready = true
 )
 
 func podHost(x string) string {
 	return fmt.Sprintf("smoke-mini-%s-0", x)
 }
 
-func podURL(x string) string {
+func singleTargetServiceURL(x string) string {
 	return fmt.Sprintf("http://smoke-mini-%s:%s/", x, listenPort)
 }
 
@@ -89,15 +94,14 @@ func main() {
 func setupHandlers() *http.ServeMux {
 	mux := http.NewServeMux()
 
+	// k8s
 	mux.HandleFunc("/ready", readyHandler)
+
+	// upmeter probes
 	mux.HandleFunc("/", rootHandler)
-	mux.HandleFunc("/error", errorHandler)
-	mux.HandleFunc("/api", apiHandler)
-	mux.HandleFunc("/disk", diskHandler)
 	mux.HandleFunc("/dns", dnsHandler)
 	mux.HandleFunc("/neighbor", neighborHandler)
 	mux.HandleFunc("/neighbor-via-service", neighborViaServiceHandler)
-	mux.HandleFunc("/prometheus", prometheusHandler)
 
 	return mux
 }
@@ -112,93 +116,13 @@ func readyHandler(w http.ResponseWriter, r *http.Request) {
 
 func rootHandler(w http.ResponseWriter, r *http.Request) {
 	log.Info(os.Getenv("HOSTNAME"), r.RemoteAddr, r.RequestURI)
+
 	if r.RequestURI != "/" {
 		w.WriteHeader(404)
 		fmt.Fprintf(w, "404 Not Found %s\n", r.RequestURI)
 		return
 	}
 	fmt.Fprintf(w, "ok")
-}
-
-func errorHandler(w http.ResponseWriter, r *http.Request) {
-	log.Info(r.RemoteAddr, r.RequestURI)
-	w.WriteHeader(500)
-	fmt.Fprintf(w, "ok")
-}
-
-func apiHandler(w http.ResponseWriter, r *http.Request) {
-	log.Info(r.RemoteAddr, r.RequestURI)
-
-	apiserverEndpoint := "https://127.0.0.1:6445/readyz/ping"
-
-	kubernetesServiceHost := os.Getenv("KUBERNETES_SERVICE_HOST")
-	kubernetesServicePort := os.Getenv("KUBERNETES_SERVICE_PORT_HTTPS")
-	namespace := os.Getenv("POD_NAMESPACE")
-	podName := os.Getenv("HOSTNAME")
-	if kubernetesServiceHost != "" && kubernetesServicePort != "" {
-		apiserverEndpoint = fmt.Sprintf("https://%s:%s/api/v1/namespaces/%s/pods/%s", kubernetesServiceHost, kubernetesServicePort, namespace, podName)
-	}
-
-	serviceaccountToken, err := ioutil.ReadFile(serviceAccountTokenPath)
-	if err != nil {
-		w.WriteHeader(500)
-		log.Error(err)
-		return
-	}
-
-	bearer := fmt.Sprintf("Bearer %s", string(serviceaccountToken))
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	req, nil := http.NewRequest("GET", apiserverEndpoint, nil)
-	req.Header.Add("Authorization", bearer)
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		log.Error(err)
-		w.WriteHeader(500)
-		return
-	}
-	defer resp.Body.Close()
-	log.Info(resp.StatusCode, resp.Request.URL)
-	if resp.StatusCode != 200 {
-		w.WriteHeader(500)
-		return
-	}
-	_, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		log.Error(err)
-		w.WriteHeader(500)
-		return
-	}
-	fmt.Fprintf(w, "ok")
-}
-
-func diskHandler(w http.ResponseWriter, r *http.Request) {
-	log.Info(r.RemoteAddr, r.RequestURI)
-	originalContent := fmt.Sprint(time.Now().UnixNano())
-	tmpFilePath := fmt.Sprintf("/disk/sm-%s", originalContent)
-	err := ioutil.WriteFile(tmpFilePath, []byte(originalContent), 0o644)
-	if err != nil {
-		log.Error(err)
-		w.WriteHeader(500)
-		return
-	}
-	content, err := ioutil.ReadFile(tmpFilePath)
-	if err != nil {
-		w.WriteHeader(500)
-		log.Error(err)
-		return
-	}
-	err = os.Remove(tmpFilePath)
-	if err != nil {
-		w.WriteHeader(500)
-		log.Error(err)
-		return
-	}
-	if originalContent == string(content) {
-		fmt.Fprintf(w, "ok")
-	} else {
-		w.WriteHeader(500)
-	}
 }
 
 func dnsHandler(w http.ResponseWriter, r *http.Request) {
@@ -212,41 +136,11 @@ func dnsHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "ok")
 }
 
-func prometheusHandler(w http.ResponseWriter, r *http.Request) {
-	log.Info(r.RemoteAddr, r.RequestURI)
-	prometheusEndpoint := "https://prometheus.d8-monitoring:9090/api/v1/metadata?metric=prometheus_build_info"
-
-	serviceaccountToken, err := ioutil.ReadFile(serviceAccountTokenPath)
-	if err != nil {
-		w.WriteHeader(500)
-		log.Error(err)
-		return
-	}
-
-	bearer := fmt.Sprintf("Bearer %s", string(serviceaccountToken))
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	req, nil := http.NewRequest("GET", prometheusEndpoint, nil)
-	req.Header.Add("Authorization", bearer)
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		log.Error(err)
-		w.WriteHeader(500)
-		return
-	}
-	defer resp.Body.Close()
-	_, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		log.Error(err)
-		w.WriteHeader(500)
-		return
-	}
-	fmt.Fprintf(w, "ok")
-}
-
+// neighborHandler checks other smoke-mini pods availabilty. It gets responses from pods via
+// headless single-instance service URL, e.g. for "c" it would be "http://smoke-mini-c:<port>", which
+// targets single pod "smoke-mini-c-0".
 func neighborHandler(w http.ResponseWriter, r *http.Request) {
 	log.Info(r.RemoteAddr, r.RequestURI)
-	targetServices := strings.Split(os.Getenv("SMOKE_MINI_STS_LIST"), " ")
 	for i := len(targetServices) - 1; i >= 0; i-- {
 		if podHost(targetServices[i]) == os.Getenv("HOSTNAME") {
 			targetServices = append(targetServices[:i], targetServices[i+1:]...)
@@ -258,7 +152,7 @@ func neighborHandler(w http.ResponseWriter, r *http.Request) {
 	errorCount := 0
 	for i := 0; i < len(targetServices); i++ {
 		if errorCount <= 2 {
-			resp, err := client.Get(podURL(targetServices[i]))
+			resp, err := client.Get(singleTargetServiceURL(targetServices[i]))
 			if err != nil {
 				log.Error(err)
 				errorCount++
@@ -278,23 +172,26 @@ func neighborHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "ok")
 }
 
+// neighborViaServiceHandler checks the availabilty of any smoke-mini pod including themselves. It
+// gets responses from common headless service URL which targets all smoke-mini pods including
+// current one. In worst case, the pod gets all responses from it.
 func neighborViaServiceHandler(w http.ResponseWriter, r *http.Request) {
-	log.Info(r.RemoteAddr, r.RequestURI)
-	targetsCount := len(strings.Split(os.Getenv("SMOKE_MINI_STS_LIST"), " ")) - 1
-	client := http.Client{
-		Timeout: 2 * time.Second,
-	}
-	errorCount := 0
 	maxErrors := 2
-	for i := 0; i < targetsCount; i++ {
+
+	log.Info(r.RemoteAddr, r.RequestURI)
+	client := http.Client{Timeout: 2 * time.Second}
+
+	errorCount := 0
+	for i := 0; i < len(targetServices)-1; i++ {
 		if errorCount <= maxErrors {
-			resp, err := client.Get(serviceURL)
+			resp, err := client.Get(commonServiceURL)
 			if err != nil {
 				log.Error(err)
 				errorCount++
 				continue
 			}
 			defer resp.Body.Close()
+
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil || string(body) != "ok" {
 				log.Error(err)
@@ -305,5 +202,6 @@ func neighborViaServiceHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+
 	fmt.Fprintf(w, "ok")
 }

--- a/modules/500-upmeter/images/smoke-mini/smoke-mini.go
+++ b/modules/500-upmeter/images/smoke-mini/smoke-mini.go
@@ -36,8 +36,8 @@ var (
 	listenPort = "8080"
 
 	// targetServices is the list of neighbor indexes, e.g. for "c" it is []string{"a", "b", "d", "e"}
-	targetServices   = strings.Split(os.Getenv("SMOKE_MINI_STS_LIST"), " ")
-	commonServiceURL = "http://smoke-mini:8080"
+	targetServices      = strings.Split(os.Getenv("SMOKE_MINI_STS_LIST"), " ")
+	clusterIpServiceUrl = "http://smoke-mini-cluster-ip:8080"
 
 	serviceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
@@ -184,7 +184,7 @@ func neighborViaServiceHandler(w http.ResponseWriter, r *http.Request) {
 	errorCount := 0
 	for i := 0; i < len(targetServices)-1; i++ {
 		if errorCount <= maxErrors {
-			resp, err := client.Get(commonServiceURL)
+			resp, err := client.Get(clusterIpServiceUrl)
 			if err != nil {
 				log.Error(err)
 				errorCount++

--- a/modules/500-upmeter/templates/smoke-mini/services.yaml
+++ b/modules/500-upmeter/templates/smoke-mini/services.yaml
@@ -35,4 +35,19 @@ spec:
     protocol: TCP
   selector:
     app: smoke-mini
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: smoke-mini-cluster-ip
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "smoke-mini")) | nindent 2 }}
+spec:
+  # has cluster IP for kube-proxy/iptables packets path
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+  selector:
+    app: smoke-mini
 {{- end }}


### PR DESCRIPTION
## Description

Access smoke-mini neighbors via cluster ip service in neighbor-via-service probe.

## Why do we need it, and what problem does it solve?

Fixes the initial design of neighbor-via-service probe.

## Changelog entries


```changes
section: upmeter
type: fix
summary: Fix the correctness of neighbor-via-service probe by using ClusterIP service type.
```
