### PR TITLE
[docs] Don't add layout description to the link title attribute in the Getting Started

### DIFF
--- a/docs/site/_includes/getting_started/global/step_cluster_setup.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup.html
@@ -256,7 +256,7 @@ Preset is the structure of nodes in the cluster. There are several pre-defined p
 <div class="tabs">
 {% for preset in site.data.getting_started.data.presets %}
   <a href="javascript:void(0)" class="tabs__btn tabs__btn_preset{% if preset[1].recommended %} active{% endif %}"
-  onclick="openTabAndSaveStatus(event, 'tabs__btn_preset', 'tabs__content_preset', 'preset_{{ preset[0] }}', 'dhctl-preset', '{{ preset[0] }}');" title="{{ preset[1].description[page.lang] }}">
+  onclick="openTabAndSaveStatus(event, 'tabs__btn_preset', 'tabs__content_preset', 'preset_{{ preset[0] }}', 'dhctl-preset', '{{ preset[0] }}');">
     {{ preset[1].name[page.lang] }}
   </a>
 {% endfor %}

--- a/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
@@ -253,7 +253,7 @@
 <div class="tabs">
 {% for preset in site.data.getting_started.data.presets %}
   <a href="javascript:void(0)" class="tabs__btn tabs__btn_preset{% if preset[1].recommended %} active{% endif %}"
-  onclick="openTabAndSaveStatus(event, 'tabs__btn_preset', 'tabs__content_preset', 'preset_{{ preset[0] }}', 'dhctl-preset', '{{ preset[0] }}');" title="{{ preset[1].description[page.lang] }}">
+  onclick="openTabAndSaveStatus(event, 'tabs__btn_preset', 'tabs__content_preset', 'preset_{{ preset[0] }}', 'dhctl-preset', '{{ preset[0] }}');">
     {{ preset[1].name[page.lang] }}
   </a>
 {% endfor %}


### PR DESCRIPTION
## Description
Don't add layout description to the link title attribute in the Getting Started as the description content format is not suitable for the title.

## Changelog entries
```changes
section: docs
type: fix
summary: Don't add layout description to the link title attribute in the Getting Started as the description content format is not suitable for the title.
impact_level: low
```
