### PR TITLE
[user-authn] dex-authenticator's port name to https

### DIFF
--- a/modules/150-user-authn/templates/dex-authenticator/service.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/service.yaml
@@ -9,7 +9,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
 spec:
   ports:
-  - name: http
+  - name: https
     port: 443
     targetPort: 8443
   selector:


### PR DESCRIPTION
## Description
Change dex-authenticator's port name from `http` to `https`.

## Why do we need it, and what problem does it solve?
In istio-enabled namespaces there is problem with protocol mismatch. dex-authenticator's istio sidecar tries to handle dex service as pure http.

## Changelog entries
```changes
section: user-authn
type: fix
summary: Change dex-authenticator's port name from `http` to `https`
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
