### PR TITLE
[cni-cilium] Fixed value modifying hook

### DIFF
--- a/modules/021-cni-cilium/hooks/enable_node_routes.go
+++ b/modules/021-cni-cilium/hooks/enable_node_routes.go
@@ -31,23 +31,27 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, enableNodeRoutes)
 
 func enableNodeRoutes(input *go_hook.HookInput) error {
+	input.Values.Set("cniCilium.createNodeRoutes", shouldEnableNodeRoutes(input))
+
+	return nil
+}
+
+func shouldEnableNodeRoutes(input *go_hook.HookInput) bool {
 	// if value is set directly - skip this hook
 	_, ok := input.ConfigValues.GetOk("cniCilium.createNodeRoutes")
 	if ok {
-		return nil
+		return false
 	}
 
 	providerRaw, ok := input.Values.GetOk("global.clusterConfiguration.cloud.provider")
 	if !ok {
-		return nil
+		return false
 	}
 
 	switch strings.ToLower(providerRaw.String()) {
 	case "openstack", "vsphere":
-		input.Values.Set("cniCilium.createNodeRoutes", true)
-	default:
-		return nil
+		return true
 	}
 
-	return nil
+	return false
 }

--- a/modules/021-cni-cilium/hooks/enable_node_routes_test.go
+++ b/modules/021-cni-cilium/hooks/enable_node_routes_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: enable-node-routes", func() 
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
 		})
-		It("should set default value", func() {
+		It("should be true value", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("cniCilium.createNodeRoutes").Bool()).To(BeTrue())
 		})
@@ -63,7 +63,7 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: enable-node-routes", func() 
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
 		})
-		It("should set default value", func() {
+		It("should be false value", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("cniCilium.createNodeRoutes").Bool()).To(BeFalse())
 		})
@@ -76,7 +76,7 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: enable-node-routes", func() 
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
 		})
-		It("should set default value", func() {
+		It("should be false value", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("cniCilium.createNodeRoutes").Bool()).To(BeFalse())
 		})


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixed a hook so it won't ever return nil.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We rely on this value in Helm templates: `Error: helm upgrade failed: error validating \"\": error validating data: unknown object type \"nil\" in ConfigMap.data.auto-direct-node-routes\n"`.

The error was introduced via a last-minute change in the original Cilium PR that [removed](https://github.com/deckhouse/deckhouse/pull/592#discussion_r869625527) defaulting in OpenAPI.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cni-cilium
type: fix
summary: Fixed value modifying hook so that it won't ever leave a value as nil
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
