### PR TITLE
[upmeter] Remote write exporter: don't retry sending metrics on 4xx errors from storage

### DIFF
--- a/modules/500-upmeter/images/upmeter/pkg/check/episode.go
+++ b/modules/500-upmeter/images/upmeter/pkg/check/episode.go
@@ -125,8 +125,8 @@ func (e Episode) EqualTimers(a Episode) bool {
 }
 
 func (e Episode) String() string {
-	return fmt.Sprintf("start=%s probe='%s' s=%s f=%s u=%s n=%s",
-		e.TimeSlot.Format(time.StampMilli),
+	return fmt.Sprintf("slot=%s probe=%s up=%s down=%s uncertain=%s notmeasured=%s",
+		e.TimeSlot.Format(time.Stamp),
 		e.ProbeRef.Id(),
 		e.Up,
 		e.Down,

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/episode.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/episode.go
@@ -41,8 +41,6 @@ type AddEpisodesHandler struct {
 }
 
 func (h *AddEpisodesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	log.Infoln("Downtime", r.RemoteAddr, r.RequestURI)
-
 	if r.Method != http.MethodPost {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		fmt.Fprintf(w, "%d POST is required\n", http.StatusBadRequest)
@@ -90,7 +88,7 @@ func save(dbctx *dbcontext.DbContext, remoteWrite remotewrite.Exporter, data Epi
 
 	// Send episodes to metrics storage
 
-	log.Debugf("exporting 30s episodes by agent=%s", origin)
+	log.Debugf("Storing for export 30s episodes by agent=%s", origin)
 
 	err := remoteWrite.Export(origin, saved30s, 30*time.Second)
 	if err != nil {
@@ -102,7 +100,7 @@ func save(dbctx *dbcontext.DbContext, remoteWrite remotewrite.Exporter, data Epi
 		return nil
 	}
 
-	log.Debugf("exporting 5m episodes by agent=%s", origin)
+	log.Debugf("Storing for export 5m episodes by agent=%s", origin)
 
 	err = remoteWrite.Export(origin, fulfilled5m, 5*time.Minute)
 	if err != nil {

--- a/modules/500-upmeter/images/upmeter/pkg/server/entity/episode.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/entity/episode.go
@@ -119,8 +119,8 @@ func txSave30sEpisode(tx *dbcontext.DbContext, episode check.Episode) (*check.Ep
 	}
 
 	if storedEntity.Rowid == -1 {
-		// none saved, just insert new one
-		log.Infof("Inserting 30s episode %s", episode.String())
+		// none saved yet, insert new one
+		log.Debugf("Inserting 30s episode %s", episode.String())
 
 		err = dao30s.Insert(episode)
 		if err != nil {
@@ -133,7 +133,7 @@ func txSave30sEpisode(tx *dbcontext.DbContext, episode check.Episode) (*check.Ep
 	combined := episode.Combine(storedEntity.Episode, slotSize)
 
 	// note extra whitespace to align with "Inserting..."
-	log.Infof("Updating  30s episode %s", episode.String())
+	log.Debugf("Updating  30s episode %s", episode.String())
 
 	err = dao30s.Update(storedEntity.Rowid, combined)
 	if err != nil {

--- a/modules/500-upmeter/images/upmeter/pkg/server/remotewrite/controller.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/remotewrite/controller.go
@@ -145,6 +145,7 @@ func (s *updateHandler) OnAdd(rw *v1.RemoteWrite) {
 	if err != nil {
 		s.logger.Errorf("cannot add remote_write exporter %q: %v", rw.Name, err)
 	}
+	s.logger.Infof("added remote_write exporter %q", rw.Name)
 }
 
 func (s *updateHandler) OnModify(rw *v1.RemoteWrite) {
@@ -152,9 +153,11 @@ func (s *updateHandler) OnModify(rw *v1.RemoteWrite) {
 	if err != nil {
 		s.logger.Errorf("cannot update remote_write exporter %q: %v", rw.Name, err)
 	}
+	s.logger.Infof("updated remote_write exporter %q", rw.Name)
 }
 
 func (s *updateHandler) OnDelete(rw *v1.RemoteWrite) {
 	config := newExportConfig(rw, s.headers)
 	s.syncers.Delete(config) // TODO: ctx? final exporter requests can take some time
+	s.logger.Infof("deleted remote_write exporter %q", rw.Name)
 }

--- a/modules/500-upmeter/images/upmeter/pkg/server/remotewrite/controller.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/remotewrite/controller.go
@@ -45,6 +45,7 @@ type ControllerConfig struct {
 	// read metrics and track exporter state in the DB
 	DbCtx        *dbcontext.DbContext
 	OriginsCount int
+	UserAgent    string
 
 	Logger *log.Logger
 }
@@ -64,6 +65,7 @@ func (cc *ControllerConfig) Controller() *Controller {
 		kubeMonitor: kubeMonitor,
 		syncers:     syncers,
 		logger:      controllerLogger,
+		userAgent:   cc.UserAgent,
 	}
 
 	return controller

--- a/modules/500-upmeter/images/upmeter/pkg/server/remotewrite/syncer.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/remotewrite/syncer.go
@@ -18,6 +18,7 @@ package remotewrite
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -30,8 +31,6 @@ import (
 	v1 "d8.io/upmeter/pkg/crd/v1"
 	"d8.io/upmeter/pkg/db/dao"
 )
-
-var ErrSkip = fmt.Errorf("skip export")
 
 // syncer links puller and exporter via channel in exporter
 type syncer struct {
@@ -100,8 +99,7 @@ func (s *syncer) exportLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			err := s.export(ctx)
-			if err != nil && err != ErrSkip {
+			if err := s.export(ctx); err != nil {
 				s.logger.Errorln(err)
 			}
 		case <-ctx.Done():
@@ -134,10 +132,10 @@ func (s *syncer) cleanupLoop(ctx context.Context) {
 func (s *syncer) export(ctx context.Context) error {
 	// Get
 	timeseries, slot, err := s.getTimeseries()
-	if err == ErrSkip {
-		return nil
-	}
 	if err != nil {
+		if errors.Is(err, ErrNoCompleteEpisodes) {
+			return nil
+		}
 		return fmt.Errorf("cannot get timeseries: %v", err)
 	}
 
@@ -147,49 +145,56 @@ func (s *syncer) export(ctx context.Context) error {
 	}
 
 	// Send to the remote storage
-	err = s.exporter.Export(ctx, timeseries)
-	if err != nil {
-		return fmt.Errorf("cannot export: %v", err)
+	if err = s.exporter.Export(ctx, timeseries); err != nil {
+		if errors.Is(err, ErrNotAcceptedByStorage) {
+			// will not retry
+			return s.clean(slot)
+		}
+		if errors.Is(err, ErrNoCompleteEpisodes) || errors.Is(err, ErrInternalStorageError) {
+			// will send later
+			return nil
+		}
+		return fmt.Errorf("exporting timeseries %s: %w", slot.Format("15:04:05"), err)
 	}
 
-	s.logger.Debugf("exported timeseries %s", slot.Format("15:04:05"))
+	s.logger.Infof("exported timeseries %s", slot.Format("15:04:05"))
+	return s.clean(slot)
+}
 
-	// Delete from the database
-	err = s.storage.Delete(s.syncID, slot)
+func (s *syncer) clean(slot time.Time) error {
+	err := s.storage.Delete(s.syncID, slot)
 	if err != nil {
-		return fmt.Errorf("cannot delete exported episodes %v: %v", slot.Format("15:04:05"), err)
+		return fmt.Errorf("cleaning exported episodes %s: %w", slot.Format("15:04:05"), err)
 	}
-
 	s.logger.Debugf("cleaned exported episodes %s", slot.Format("15:04:05"))
-
 	return nil
 }
 
 func (s *syncer) getTimeseries() ([]*prompb.TimeSeries, time.Time, error) {
-	var timestamp time.Time
+	var slot time.Time
 
 	episodes, err := s.storage.Get(s.syncID)
-	if err == dao.ErrNotFound {
-		return nil, timestamp, ErrSkip
-	}
 	if err != nil {
-		return nil, timestamp, err
+		if errors.Is(err, dao.ErrNotFound) {
+			return nil, slot, ErrNoCompleteEpisodes
+		}
+		return nil, slot, err
 	}
 
 	// Skip incomplete slots. Send only data from two slots ago and earlier.
 	//  - Current timestamp is incomplete.
 	//  - One timestamp ago is also incomplete, because the last 30s are sent after it finishes.
-	//  - Two slots ago should be complete.
-	timestamp = episodes[0].TimeSlot
+	//  - Two slots ago should be complete. When exporting 5m episodes, it causes 10m delay in timeseries.
+	slot = episodes[0].TimeSlot
 	twoSlotsAgo := time.Now().Truncate(s.slotSize).Add(-2 * s.slotSize)
-	if timestamp.After(twoSlotsAgo) {
-		return nil, timestamp, ErrSkip
+	if slot.After(twoSlotsAgo) {
+		return nil, slot, ErrNoCompleteEpisodes
 	}
 	s.logger.Debugf("got %d episodes", len(episodes))
 
-	timeseries := convEpisodes2Timeseries(timestamp, episodes, s.labels)
+	ts := convEpisodes2Timeseries(slot, episodes, s.labels)
 
-	return timeseries, timestamp, nil
+	return ts, slot, nil
 }
 
 func (s *syncer) Add(origin string, episodes []*check.Episode) error {

--- a/modules/500-upmeter/images/upmeter/pkg/server/server.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/server.go
@@ -96,7 +96,7 @@ func (s *server) Start(ctx context.Context) error {
 	}
 
 	// Metrics controller
-	s.remoteWriteController, err = initRemoteWriteController(ctx, dbctx, kubeClient, s.config.OriginsCount, s.logger)
+	s.remoteWriteController, err = initRemoteWriteController(ctx, dbctx, kubeClient, s.config.OriginsCount, s.logger, s.config.UserAgent)
 	if err != nil {
 		s.logger.Debugf("starting controller... did't happen: %v", err)
 		return fmt.Errorf("cannot start remote_write controller: %v", err)
@@ -182,7 +182,7 @@ func writeOk(w http.ResponseWriter, _ *http.Request) {
 	_, _ = w.Write([]byte("OK"))
 }
 
-func initRemoteWriteController(ctx context.Context, dbCtx *dbcontext.DbContext, kubeClient kube.KubernetesClient, originsCount int, logger *log.Logger) (*remotewrite.Controller, error) {
+func initRemoteWriteController(ctx context.Context, dbCtx *dbcontext.DbContext, kubeClient kube.KubernetesClient, originsCount int, logger *log.Logger, userAgent string) (*remotewrite.Controller, error) {
 	config := &remotewrite.ControllerConfig{
 		// collecting/exporting episodes as metrics
 		Period: 2 * time.Second,
@@ -191,6 +191,7 @@ func initRemoteWriteController(ctx context.Context, dbCtx *dbcontext.DbContext, 
 		// read metrics and track exporter state in the DB
 		DbCtx:        dbCtx,
 		OriginsCount: originsCount,
+		UserAgent:    userAgent,
 		Logger:       logger,
 	}
 	controller := config.Controller()

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -81,6 +81,7 @@ spec:
             {{- range $probeRef := .Values.upmeter.internal.disabledProbes }}
             - --disable-probe={{ $probeRef }}
             {{- end }}
+            - --user-agent=UpmeterAgent/1.0 (Deckhouse {{ $.Values.global.deckhouseEdition }} {{ $.Values.global.deckhouseVersion }})
           volumeMounts:
           - mountPath: /db
             name: data

--- a/modules/500-upmeter/templates/upmeter/statefulset.yaml
+++ b/modules/500-upmeter/templates/upmeter/statefulset.yaml
@@ -101,6 +101,7 @@ spec:
           {{- range $probeRef := .Values.upmeter.internal.disabledProbes }}
           - --disable-probe={{ $probeRef }}
           {{- end }}
+          - --user-agent=Upmeter/1.0 (Deckhouse {{ $.Values.global.deckhouseEdition }} {{ $.Values.global.deckhouseVersion }})
         env:
           - name: UPMETER_DB_PATH
             value: "/db/downtime.db.sqlite"


### PR DESCRIPTION
## Description

Fix potential error looop in remote write exporter. Add minor enhancements.

## Why do we need it, and what problem does it solve?

Fixes potential bug in telemetry collection.

## Changelog entries

```changes
section: upmeter
type: chore
summary: Switched the logging of upmeter metrics on info level while exporting.
---
section: upmeter
type: fix
summary: Fixed potential error loops in remote write exporter
impact: If a storage responds with 4xx error, the unaccepted metrics will not be re-sent.
---
section: upmeter
type: fix
summary: 'Added missing User-Agent header to remote write exporter, defined as `Upmeter/1.0 (Deckhouse <edition> <version>)`'
```
