### PR TITLE
[prometheus] Add token auth for remote write

### DIFF
--- a/modules/300-prometheus/crds/doc-ru-prometheusremotewrite.yaml
+++ b/modules/300-prometheus/crds/doc-ru-prometheusremotewrite.yaml
@@ -20,6 +20,10 @@ spec:
                       description: Пароль для аутентификации.
                     username:
                       description: Имя пользователя для аутентификации.
+                bearerToken:
+                  description: Токен на предъявителя.
+                customAuthToken:
+                  description: Пользовательский токен, передаваемый в качестве header X-Auth-Token.
                 writeRelabelConfigs:
                   description: |
                     Параметры для relabel'инга данных для отправки.

--- a/modules/300-prometheus/crds/prometheusremotewrite.yaml
+++ b/modules/300-prometheus/crds/prometheusremotewrite.yaml
@@ -49,6 +49,12 @@ spec:
                   - password
                   - username
                   type: object
+                bearerToken:
+                  type: string
+                  description: Bearer token.
+                customAuthToken:
+                  type: string
+                  description: Custom token sent as a value of the X-Auth-Token header.
                 writeRelabelConfigs:
                   description: |
                     The list of remote write relabel configurations.

--- a/modules/300-prometheus/openapi/values.yaml
+++ b/modules/300-prometheus/openapi/values.yaml
@@ -223,6 +223,10 @@ properties:
                     password:
                       type: string
                       format: password
+                bearerToken:
+                  type: string
+                customAuthToken:
+                  type: string
                 writeRelabelConfigs:
                   type: array
                   items:
@@ -261,6 +265,7 @@ properties:
                 basicAuth:
                   password: password
                   username: username
+                customAuthToken: test
                 url: https://test-victoriametrics.domain.com/api/v1/write
                 writeRelabelConfigs:
                 - action: keep

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -147,6 +147,12 @@ spec:
       password:
         name: d8-prometheus-remote-write-{{ .name }}
         key: password
+    {{- else if .spec.bearerToken }}
+    bearerToken: {{ .spec.bearerToken }}
+    {{- end }}
+    {{- if .spec.customAuthToken }}
+    headers:
+      X-Auth-Token: {{ .spec.customAuthToken }}
     {{- end }}
     {{- if .spec.writeRelabelConfigs }}
     writeRelabelConfigs:


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Add two options - bearerToken (for everyone) and customAuthToken (for okmeter)

## Why do we need it, and what problem does it solve?
Only basic auth is allowed right now, which is not flexible enough. 

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: feature
summary: Add token auth for Prometheus remote write
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
