### PR TITLE
[log-shipper] Drop metrics with the file label

### DIFF
--- a/modules/460-log-shipper/templates/podmonitor.yaml
+++ b/modules/460-log-shipper/templates/podmonitor.yaml
@@ -32,4 +32,11 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    metricRelabelings:
+    # Vector has a problem with internal metrics registry grows unbounded.
+    # Drop metrics with high cardinality labels here to avoid overloading Prometheus instances.
+    # https://github.com/vectordotdev/vector/issues/11995
+    - sourceLabels: [file]
+      regex: '.+'
+      action: drop
 {{- end }}


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Drop some metrics. Vector cannot expire metrics in its current state.

## Why do we need it, and what problem does it solve?
Closes #1574 

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: log-shipper
type: fix
summary: Reduce the amount of exported metrics by log-shipper agents. Fixes metrics leak for dynamic environments.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
