### PR TITLE
[cloud-provider-yandex] Move NAT-instance to ru-central1-a and opportunity choice zone with externalSubnetID and internalSubnetID for new instances

### DIFF
--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/main.tf
@@ -19,23 +19,23 @@ locals {
   kube_b_v4_cidr_block = local.should_create_subnets ? cidrsubnet(var.node_network_cidr, ceil(log(3, 2)), 1) : null
   kube_c_v4_cidr_block = local.should_create_subnets ? cidrsubnet(var.node_network_cidr, ceil(log(3, 2)), 2) : null
 
-  is_existing_subnet_a = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-a", null) == null)
-  is_existing_subnet_b = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-b", null) == null)
-  is_existing_subnet_c = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-c", null) == null)
+  not_have_existing_subnet_a = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-a", null) == null)
+  not_have_existing_subnet_b = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-b", null) == null)
+  not_have_existing_subnet_c = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-c", null) == null)
 }
 
 data "yandex_vpc_subnet" "kube_a" {
-  count      = local.is_existing_subnet_a ? 0 : 1
+  count      = local.not_have_existing_subnet_a ? 0 : 1
   subnet_id  = var.existing_zone_to_subnet_id_map.ru-central1-a
 }
 
 data "yandex_vpc_subnet" "kube_b" {
-  count     = local.is_existing_subnet_b ? 0 : 1
+  count     = not_have_existing_subnet_b ? 0 : 1
   subnet_id = var.existing_zone_to_subnet_id_map.ru-central1-b
 }
 
 data "yandex_vpc_subnet" "kube_c" {
-  count     = local.is_existing_subnet_c ? 0 : 1
+  count     = local.not_have_existing_subnet_c ? 0 : 1
   subnet_id = var.existing_zone_to_subnet_id_map.ru-central1-c
 }
 

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/main.tf
@@ -30,7 +30,7 @@ data "yandex_vpc_subnet" "kube_a" {
 }
 
 data "yandex_vpc_subnet" "kube_b" {
-  count     = not_have_existing_subnet_b ? 0 : 1
+  count     = local.not_have_existing_subnet_b ? 0 : 1
   subnet_id = var.existing_zone_to_subnet_id_map.ru-central1-b
 }
 

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/main.tf
@@ -19,22 +19,24 @@ locals {
   kube_b_v4_cidr_block = local.should_create_subnets ? cidrsubnet(var.node_network_cidr, ceil(log(3, 2)), 1) : null
   kube_c_v4_cidr_block = local.should_create_subnets ? cidrsubnet(var.node_network_cidr, ceil(log(3, 2)), 2) : null
 
-  nat_instance_internal_address_calculated = var.should_create_nat_instance ? (var.nat_instance_internal_address == null ? (local.should_create_subnets ? cidrhost(local.kube_c_v4_cidr_block, 10) : cidrhost(data.yandex_vpc_subnet.kube_c[0].v4_cidr_blocks[0], 10)) : var.nat_instance_internal_address) : null
+  is_existing_subnet_a = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-a", null) == null)
+  is_existing_subnet_b = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-b", null) == null)
+  is_existing_subnet_c = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-c", null) == null)
 }
 
 data "yandex_vpc_subnet" "kube_a" {
-  count          = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-a", null) == null) ? 0 : 1
-  subnet_id             = var.existing_zone_to_subnet_id_map.ru-central1-a
+  count      = local.is_existing_subnet_a ? 0 : 1
+  subnet_id  = var.existing_zone_to_subnet_id_map.ru-central1-a
 }
 
 data "yandex_vpc_subnet" "kube_b" {
-  count          = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-b", null) == null) ? 0 : 1
-  subnet_id             = var.existing_zone_to_subnet_id_map.ru-central1-b
+  count     = local.is_existing_subnet_b ? 0 : 1
+  subnet_id = var.existing_zone_to_subnet_id_map.ru-central1-b
 }
 
 data "yandex_vpc_subnet" "kube_c" {
-  count          = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-c", null) == null) ? 0 : 1
-  subnet_id             = var.existing_zone_to_subnet_id_map.ru-central1-c
+  count     = local.is_existing_subnet_c ? 0 : 1
+  subnet_id = var.existing_zone_to_subnet_id_map.ru-central1-c
 }
 
 resource "yandex_vpc_route_table" "kube" {

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
@@ -53,7 +53,7 @@ locals {
   # if internal and external subnet are not set, but user pass subnets, get cidr for subnet in ru-central1-a zone
   # else use cidr from our created subnet in ru-central1-a zone
   # zone_to_cidr contains or our created subnet cidr's or user passed
-  from_manual_or_our_created_internal_cidr = local.zone_to_cidr["ru-central1-c"]
+  from_manual_or_our_created_internal_cidr = local.zone_to_cidr["ru-central1-a"]
 
   nat_instance_cidr = coalesce(local.with_internal_nat_instance_internal_cidr, local.with_external_nat_instance_internal_cidr, local.from_manual_or_our_created_internal_cidr)
 
@@ -129,7 +129,17 @@ resource "yandex_compute_instance" "nat_instance" {
       hostname,
       metadata,
       boot_disk[0].initialize_params[0].image_id,
-      boot_disk[0].initialize_params[0].size
+      boot_disk[0].initialize_params[0].size,
+      # By default, we used ru-central1-c, but it zone was deprecated
+      # https://cloud.yandex.ru/docs/overview/concepts/ru-central1-c-deprecation
+      # We choice ru-central1-a by default. This change can break cluster,
+      # if natInstance.internalSubnetID and natInstance.natInstanceInternalAddress was not set
+      # by TerraformAutoConverger.
+      # First, we should silent changes in network interfaces and zones and notify client about this changes
+      # and add instruction for fix it.
+      # After 4 releases, for example, in 1.38 release remove network_interface and zone from here.
+      network_interface,
+      zone
     ]
   }
 

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
@@ -139,8 +139,8 @@ resource "yandex_compute_instance" "nat_instance" {
       # First, we should silent changes in network interfaces and zones and notify client about this changes
       # and add instruction for fix it.
       # After 4 releases, for example, in 1.38 release remove network_interface and zone from here.
-      #network_interface,
-      #zone
+      network_interface,
+      zone
     ]
   }
 

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
@@ -61,7 +61,6 @@ locals {
 
   # but if user pass nat instance internal address directly (it for backward compatibility) use passed address,
   # else get 10 host address from cidr which got in previous step
-  # kubectl -n d8-system exec -it deploy/deckhouse -- deckhouse-controller module values -o json cloud-provider-yandex | jq -r '.cloudProviderYandex.internal.providerDiscoveryData.zoneToSubnetIdMap["ru-central1-c"]'
   nat_instance_internal_address_calculated = var.should_create_nat_instance ? (var.nat_instance_internal_address == null ? cidrhost(local.nat_instance_cidr, 10) : var.nat_instance_internal_address) : null
 
   assign_external_ip_address = var.nat_instance_external_subnet_id == null ? true : false
@@ -140,8 +139,8 @@ resource "yandex_compute_instance" "nat_instance" {
       # First, we should silent changes in network interfaces and zones and notify client about this changes
       # and add instruction for fix it.
       # After 4 releases, for example, in 1.38 release remove network_interface and zone from here.
-      network_interface,
-      zone
+      #network_interface,
+      #zone
     ]
   }
 

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
@@ -18,7 +18,15 @@ data "yandex_compute_image" "nat_image" {
 }
 
 data "yandex_vpc_subnet" "internal_subnet" {
-  subnet_id = var.nat_instance_internal_subnet_id == null ? (local.should_create_subnets ? yandex_vpc_subnet.kube_c[0].id : data.yandex_vpc_subnet.kube_c[0].id) : var.nat_instance_internal_subnet_id
+  subnet_id = var.nat_instance_internal_subnet_id == null ? (local.should_create_subnets ? yandex_vpc_subnet.kube_a[0].id : data.yandex_vpc_subnet.kube_a[0].id) : var.nat_instance_internal_subnet_id
+}
+
+# it need
+# we can not use data.yandex_vpc_subnet.internal_subnet because we will get cycle
+# because local.nat_instance_internal_address_calculated uses in route table and yandex_vpc_subnet.kube_* depend on route table
+data "yandex_vpc_subnet" "user_internal_subnet" {
+  count = var.nat_instance_internal_subnet_id == null ? 0 : 1
+  subnet_id = var.nat_instance_internal_subnet_id
 }
 
 data "yandex_vpc_subnet" "external_subnet" {
@@ -31,16 +39,27 @@ locals {
   external_subnet_zone = var.nat_instance_external_subnet_id == null ? null : join("", data.yandex_vpc_subnet.external_subnet.*.zone) # https://github.com/hashicorp/terraform/issues/23222#issuecomment-547462883
 
   zone_to_cidr = tomap({
-    "ru-central1-a" = local.should_create_subnets ? local.kube_a_v4_cidr_block : (local.is_existing_subnet_a ? data.yandex_vpc_subnet.kube_a[0] : null)
-    "ru-central1-b" = local.should_create_subnets ? local.kube_b_v4_cidr_block : (local.is_existing_subnet_b ? data.yandex_vpc_subnet.kube_b[0] : null)
-    "ru-central1-c" = local.should_create_subnets ? local.kube_c_v4_cidr_block : (local.is_existing_subnet_c ? data.yandex_vpc_subnet.kube_c[0] : null)
+    "ru-central1-a" = local.should_create_subnets ? local.kube_a_v4_cidr_block : (local.is_existing_subnet_a ? data.yandex_vpc_subnet.kube_a[0].v4_cidr_blocks[0] : null)
+    "ru-central1-b" = local.should_create_subnets ? local.kube_b_v4_cidr_block : (local.is_existing_subnet_b ? data.yandex_vpc_subnet.kube_b[0].v4_cidr_blocks[0] : null)
+    "ru-central1-c" = local.should_create_subnets ? local.kube_c_v4_cidr_block : (local.is_existing_subnet_c ? data.yandex_vpc_subnet.kube_c[0].v4_cidr_blocks[0] : null)
   })
 
-  with_internal_nat_instance_internal_cidr = var.nat_instance_internal_subnet_id == null ? null : data.yandex_vpc_subnet.kube_c[0].v4_cidr_blocks[0]
-  with_external_nat_instance_internal_cidr = var.nat_instance_external_subnet_id == null ? null : local.zone_to_cidr[local.external_subnet_zone]
-  manual_subnets_nat_instance_internal_cidr = local.should_create_subnets ? null : data.yandex_vpc_subnet.kube_c[0].v4_cidr_blocks[0]
-  nat_instance_cidr = coalesce(local.with_internal_nat_instance_internal_cidr, local.with_external_nat_instance_internal_cidr, local.manual_subnets_nat_instance_internal_cidr, local.kube_c_v4_cidr_block)
+  # if user set internal subnet id for nat instance get cidr from its subnet
+  with_internal_nat_instance_internal_cidr = var.nat_instance_internal_subnet_id == null ? null : data.yandex_vpc_subnet.user_internal_subnet[0].v4_cidr_blocks[0]
 
+  # if user does not set internal subnet id but set external subnet id, we get cidr from user passed subnet or our created subnet in zone where located external subnet
+  with_external_nat_instance_internal_cidr = var.nat_instance_external_subnet_id == null ? null : local.zone_to_cidr[local.external_subnet_zone]
+
+  # if internal and external subnet are not set, but user pass subnets, get cidr for subnet in ru-central1-a zone
+  # else use cidr from our created subnet in ru-central1-a zone
+  # zone_to_cidr contains or our created subnet cidr's or user passed
+  from_manual_or_our_created_internal_cidr = local.zone_to_cidr["ru-central1-c"]
+
+  nat_instance_cidr = coalesce(local.with_internal_nat_instance_internal_cidr, local.with_external_nat_instance_internal_cidr, local.from_manual_or_our_created_internal_cidr)
+
+  # but if user pass nat instance internal address directly (it for backward compatibility) use passed address,
+  # else get 10 host address from cidr which got in previous step
+  # kubectl -n d8-system exec -it deploy/deckhouse -- deckhouse-controller module values -o json cloud-provider-yandex | jq -r '.cloudProviderYandex.internal.providerDiscoveryData.zoneToSubnetIdMap["ru-central1-c"]'
   nat_instance_internal_address_calculated = var.should_create_nat_instance ? (var.nat_instance_internal_address == null ? cidrhost(local.nat_instance_cidr, 10) : var.nat_instance_internal_address) : null
 
   assign_external_ip_address = var.nat_instance_external_subnet_id == null ? true : false


### PR DESCRIPTION
## Description
Change NAT-instance zone and CIDR for internal address algorithm:
- if has intenalSubnetID get zone from it
- if has externalSubnetID get zone from it and choose CIDR from our created subnet or passed subnet
- if client passed subnet choice from it.
- else choice `ru-central1-a` zone and use our created CIDR.

## Why do we need it, and what problem does it solve?
`ru-central1-c` zone was deprecated.
https://cloud.yandex.ru/docs/overview/concepts/ru-central1-c-deprecation

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-yandex
type: feature
summary: Move NAT-instance to ru-central1-a for new instances.
impact: |
  `ru-central1-c` zone was [deprecated](https://cloud.yandex.ru/docs/overview/concepts/ru-central1-c-deprecation).
   For new clusters NAT-instance will be created in `ru-central1-a` zone. For old instances you should add to `withNATInstance.natInstanceInternalAddress` (you can get address from Yandex.Cloud console) and `withNATInstance.internalSubnetID` (you can get address with command `kubectl -n d8-system exec -it deploy/deckhouse -- deckhouse-controller module values cloud-provider-yandex -o json | jq -r '.cloudProviderYandex.internal.providerDiscoveryData.zoneToSubnetIdMap["ru-central1-c"]'`) to prevent recreate NAT-instance during converge.
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
