### PR TITLE
[ci] Add Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ layouts-tests-tmp/
 # macOS Finder files
 *.DS_Store
 ._*
+
+# Dev environment
+bin/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,21 +1,22 @@
 run:
   timeout: 10m
   skip-dirs:
-    - go_lib/dependency/k8s/drain # this code has been copied from kubectl cli. No need to lint external code
-    - modules/302-vertical-pod-autoscaler/hooks/internal/vertical-pod-autoscaler/v1 # # this code has been copied from kubernetes vertical-pod-autoscaler. No need to lint external code
+    # this code has been copied from kubectl cli. No need to lint external code.
+    - go_lib/dependency/k8s/drain
+    # this code has been copied from kubernetes vertical-pod-autoscaler. No need to lint external code.
+    - modules/302-vertical-pod-autoscaler/hooks/internal/vertical-pod-autoscaler/v1
 issues:
   exclude:
   - ST1005.*
   - "should not use dot imports"
   - "don't use an underscore in package name"
+  - "exported: .*"
 
 linters-settings:
   gci:
     local-prefixes: github.com/deckhouse/
   goimports:
     local-prefixes: github.com/deckhouse/
-  golint:
-    min-confidence: 0
   errcheck:
     ignore: fmt:.*,[rR]ead|[wW]rite|[cC]lose,io:Copy
 
@@ -27,7 +28,7 @@ linters:
   - gocritic
   - gofmt
   - goimports
-  - golint
   - gosimple
   - govet
   - misspell
+  - revive

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+export PATH := $(abspath bin/):${PATH}
+
+FORMATTING_BEGIN_YELLOW = \033[0;33m
+FORMATTING_BEGIN_BLUE = \033[36m
+FORMATTING_END = \033[0m
+
+TESTS_TIMEOUT="15m"
+FOCUS=""
+
+help:
+	@printf -- "\n"
+	@printf -- "${FORMATTING_BEGIN_BLUE}     ██████╗░███████╗░█████╗░██╗░░██╗██╗░░██╗░█████╗░██╗░░░██╗░██████╗███████╗${FORMATTING_END}\n"
+	@printf -- "${FORMATTING_BEGIN_BLUE}     ██╔══██╗██╔════╝██╔══██╗██║░██╔╝██║░░██║██╔══██╗██║░░░██║██╔════╝██╔════╝${FORMATTING_END}\n"
+	@printf -- "${FORMATTING_BEGIN_BLUE}     ██║░░██║█████╗░░██║░░╚═╝█████═╝░███████║██║░░██║██║░░░██║╚█████╗░█████╗░░${FORMATTING_END}\n"
+	@printf -- "${FORMATTING_BEGIN_BLUE}     ██║░░██║██╔══╝░░██║░░██╗██╔═██╗░██╔══██║██║░░██║██║░░░██║░╚═══██╗██╔══╝░░${FORMATTING_END}\n"
+	@printf -- "${FORMATTING_BEGIN_BLUE}     ██████╔╝███████╗╚█████╔╝██║░╚██╗██║░░██║╚█████╔╝╚██████╔╝██████╔╝███████╗${FORMATTING_END}\n"
+	@printf -- "${FORMATTING_BEGIN_BLUE}     ╚═════╝░╚══════╝░╚════╝░╚═╝░░╚═╝╚═╝░░╚═╝░╚════╝░░╚═════╝░╚═════╝░╚══════╝${FORMATTING_END}\n"
+	@printf -- "\n"
+	@printf -- "-----------------------------------------------------------------------------------\n"
+	@printf -- "\n"
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make ${FORMATTING_BEGIN_YELLOW}<target>${FORMATTING_END}\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  ${FORMATTING_BEGIN_BLUE}%-46s${FORMATTING_END} %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+
+GOLANGCI_VERSION = 1.42.0
+TESTS_TIMEOUT="15m"
+
+##@ Tests
+
+.PHONY: tests-modules tests-matrix tests-openapi
+tests-modules: ## Run unit tests for modules hooks and templates.
+	@go test -timeout=${TESTS_TIMEOUT} -vet=off ./modules/... ./global-hooks/... ./ee/modules/... ./ee/fe/modules/...
+
+tests-matrix: ## Test how helm templates are rendered with different input values generated from values examples. Use 'FOCUS' environment variable to run tests for a particular module.
+	@go test ./testing/matrix/ -v
+
+tests-openapi: ## Run tests against modules openapi values schemas.
+	@go test -vet=off ./testing/openapi_cases/
+
+.PHONY: validate
+validate: ## Check common patterns through all modules.
+	@go test -tags=validation -run Validation -timeout=${TESTS_TIMEOUT} ./testing/...
+
+bin/golangci-lint:
+	@mkdir -p bin
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | BINARY=golangci-lint bash -s -- v${GOLANGCI_VERSION}
+
+.PHONY: lint lint-fix
+lint: bin/golangci-lint ## Run linter.
+	golangci-lint run
+
+lint-fix: bin/golangci-lint ## Fix lint violations.
+	golangci-lint run --fix
+
+##@ Generate
+
+.PHONY: generate
+generate: ## Run all generate-* jobs in bulk.
+	cd tools; go generate

--- a/deckhouse-controller/pkg/deckhouse/start.go
+++ b/deckhouse-controller/pkg/deckhouse/start.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Ignore error: type name will be used as deckhouse.DeckhouseController by other packages, and that stutters
-//nolint:golint
+//nolint:revive
 type DeckhouseController struct {
 	*addon_operator.AddonOperator
 

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,3 @@ replace github.com/go-openapi/validate => github.com/flant/go-openapi-validate v
 replace k8s.io/client-go => k8s.io/client-go v0.19.11
 
 replace k8s.io/api => k8s.io/api v0.19.11
-
-//
-replace github.com/deckhouse/deckhouse/ee/modules/030-cloud-provider-openstack/internal => ./ee/modules/030-cloud-provider-openstack/internal

--- a/go_lib/hooks/update/window.go
+++ b/go_lib/hooks/update/window.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	hh_mm = "15:04" // nolint: golint
+	hh_mm = "15:04" // nolint: revive
 )
 
 // Windows update windows

--- a/modules/040-node-manager/hooks/update_approval.go
+++ b/modules/040-node-manager/hooks/update_approval.go
@@ -558,7 +558,7 @@ var metricStatuses = []string{
 
 func setNodeStatusesMetrics(input *go_hook.HookInput, nodeName, nodeGroup, nodeStatus string) {
 	for _, status := range metricStatuses {
-		var value float64 = 0
+		var value float64
 		if status == nodeStatus {
 			value = 1
 		}

--- a/testing/matrix/matrix_test.go
+++ b/testing/matrix/matrix_test.go
@@ -32,7 +32,7 @@ func TestMatrix(t *testing.T) {
 	require.NoError(t, err)
 
 	// Use environment variable to focus on specific module, e.g. D8_TEST_MATRIX_FOCUS=user-authn,user-authz
-	focus := os.Getenv("D8_TEST_MATRIX_FOCUS")
+	focus := os.Getenv("FOCUS")
 
 	focusNames := make(map[string]struct{})
 	if focus != "" {

--- a/testing/openapi_validation/library.go
+++ b/testing/openapi_validation/library.go
@@ -85,7 +85,7 @@ func GetOpenAPIYAMLFiles(rootPath string) ([]string, error) {
 }
 
 // RunOpenAPIValidator runs validator, get channel with file paths and returns channel with results
-// nolint: golint // its a private lib, we dont need an exported struct
+// nolint: revive // its a private lib, we dont need an exported struct
 func RunOpenAPIValidator(fileC chan fileValidation) chan fileValidation {
 	resultC := make(chan fileValidation, 1)
 


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
Closes https://github.com/deckhouse/deckhouse/issues/414

Only testing and lining are supported right now, but they do not work correctly 😅
The main idea is to abstain from running tests inside a docker container and keep all logic for both ci and local development in one file.

This is a small PR to start with.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: chore
summary: Add Makefile
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
