### PR TITLE
[kubernetes-api-proxy] prepull image

### DIFF
--- a/candi/bashible/common-steps/node-group/050_configure_and_start_docker.sh.tpl
+++ b/candi/bashible/common-steps/node-group/050_configure_and_start_docker.sh.tpl
@@ -46,11 +46,12 @@ bb-sync-file /etc/docker/certs.d/{{ .registry.address }}/ca.crt  - << "EOF"
 {{ .registry.ca }}
 EOF
 {{- end }}
-
-{{- if .registry.auth }}
-username="$(base64 -d <<< "{{ .registry.auth }}" | awk -F ":" '{print $1}')"
-password="$(base64 -d <<< "{{ .registry.auth }}" | awk -F ":" '{print $2}')"
-HOME=/ docker login --username "${username}" --password "${password}" {{ .registry.address }}
 {{- end }}
 
+{{- if .registry.auth }}
+if docker version >/dev/null 2>/dev/null; then
+  username="$(base64 -d <<< "{{ .registry.auth }}" | awk -F ":" '{print $1}')"
+  password="$(base64 -d <<< "{{ .registry.auth }}" | awk -F ":" '{print $2}')"
+  HOME=/ docker login --username "${username}" --password "${password}" {{ .registry.address }}
+fi
 {{- end }}

--- a/candi/bashible/common-steps/node-group/051_pull_kubernetes_api_proxy.sh.tpl
+++ b/candi/bashible/common-steps/node-group/051_pull_kubernetes_api_proxy.sh.tpl
@@ -1,0 +1,19 @@
+# Copyright 2021 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if docker version >/dev/null 2>/dev/null; then
+  HOME=/ docker pull {{ printf "%s%s:%s" $.registry.address $.registry.path (index $.images.controlPlaneManager "kubernetesApiProxy") }}
+elif crictl version >/dev/null 2>/dev/null; then
+  crictl pull {{ printf "%s%s:%s" $.registry.address $.registry.path (index $.images.controlPlaneManager "kubernetesApiProxy") }}
+fi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Prepull kubernetes-api-proxy image.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
To avoid problems when we change from system kubernetes-api-proxy to static pod kubernetes-api-proxy.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: Prepull kubernetes-api-proxy image to avoid problems when we change from system kubernetes-api-proxy to static pod kubernetes-api-proxy.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
