### PR TITLE
[docs] Fix rendering CRD file with a dot in the name

### DIFF
--- a/docs/documentation/modules_generate_cr.sh
+++ b/docs/documentation/modules_generate_cr.sh
@@ -8,7 +8,7 @@ for schema_path in $(find $MODULES_DIR -regex '^.*/crds/.*.yaml$' -print | grep 
   module_path=$(echo $schema_path | cut -d\/ -f-2 )
   module_file_name=$(echo $schema_path | awk -F\/ '{print $NF}')
   module_name=$(echo $schema_path | cut -d\/ -f2 | cut -d- -f2-)
-  schema_path_relative=$(echo $schema_path | cut -d\/ -f3- | sed "s#\.yaml##; s#\/#\.#")
+  schema_path_relative=$(echo $schema_path | cut -d\/ -f3- | sed "s#\.yaml##; s#\.##g; s#\/#\.#g")
   mkdir -p _data/schemas/${module_name}/crds
   cp -f $schema_path _data/schemas/${module_name}/crds/
   if [ -f "${module_path}/crds/doc-ru-${module_file_name}" ]; then


### PR DESCRIPTION
## Description
Jekyll sanitizes the data filename, so we must delete dots from the file name to access data.

## Why do we need it, and what problem does it solve?
If the CRD file contains a dot in the name, it doesn't render

## Changelog entries
```changes
section: docs
type: fix
summary: Fixed rendering CRD file with a dot in the name.
impact_level: low
```
