### PR TITLE
[user-authz] Fix gitlab-runner access rights doc

### DIFF
--- a/docs/site/_includes/getting_started/existing/STEP_FINISH.md
+++ b/docs/site/_includes/getting_started/existing/STEP_FINISH.md
@@ -85,7 +85,7 @@ Deploying your first application
 Setting up a CI/CD system
 </h3>
 <div class="cards-item__text" markdown="1">
-Enable the [user-authz](/{{ page.lang }}/documentation/v1/modules/140-user-authz/) module and [create](/{{ page.lang }}/documentation/v1/modules/140-user-authz/usage.html#creating-a-serviceaccount-and-granting-it-access) a ServiceAccount to use for deploying to the cluster and grant it all the necessary privileges.
+Enable the [user-authz](/{{ page.lang }}/documentation/v1/modules/140-user-authz/) module and [create](/{{ page.lang }}/documentation/v1/modules/140-user-authz/usage.html#creating-a-serviceaccount-for-a-machine-and-granting-it-access) a ServiceAccount to use for deploying to the cluster and grant it all the necessary privileges.
 
 You can use the generated `kubeconfig` file in Kubernetes with any deployment system.
 </div>

--- a/docs/site/_includes/getting_started/existing/STEP_FINISH_RU.md
+++ b/docs/site/_includes/getting_started/existing/STEP_FINISH_RU.md
@@ -80,7 +80,7 @@ Status page
 Настройка CI/CD-системы
 </h3>
 <div class="cards-item__text" markdown="1">
-Включите модуль [user-authz](/{{ page.lang }}/documentation/v1/modules/140-user-authz/) и [создайте](/{{ page.lang }}/documentation/v1/modules/140-user-authz/usage.html#создание-serviceaccount-и-предоставление-ему-доступа) ServiceAccount, который будет осуществлять деплой в кластер.
+Включите модуль [user-authz](/{{ page.lang }}/documentation/v1/modules/140-user-authz/) и [создайте](/{{ page.lang }}/documentation/v1/modules/140-user-authz/usage.html#создание-serviceaccount-для-сервера-и-предоставление-ему-доступа) ServiceAccount, который будет осуществлять деплой в кластер.
 
 Результатом станет `kubeconfig`, который можно использовать во всех системах деплоя в Kubernetes.
 </div>

--- a/docs/site/_includes/getting_started/global/STEP_FINISH.md
+++ b/docs/site/_includes/getting_started/global/STEP_FINISH.md
@@ -83,7 +83,7 @@ Deploying your first application
 Setting up a CI/CD system
 </h3>
 <div class="cards-item__text" markdown="1">
-[Create](/{{ page.lang }}/documentation/v1/modules/140-user-authz/usage.html#creating-a-serviceaccount-and-granting-it-access)
+[Create](/{{ page.lang }}/documentation/v1/modules/140-user-authz/usage.html#creating-a-serviceaccount-for-a-machine-and-granting-it-access)
 a ServiceAccount to use for deploying to the cluster and grant it all the necessary privileges.
 
 You can use the generated `kubeconfig` file in Kubernetes with any deployment system.

--- a/docs/site/_includes/getting_started/global/STEP_FINISH_RU.md
+++ b/docs/site/_includes/getting_started/global/STEP_FINISH_RU.md
@@ -83,7 +83,7 @@ Status page
 Настройка CI/CD-системы
 </h3>
 <div class="cards-item__text" markdown="1">
-[Создайте](/{{ page.lang }}/documentation/v1/modules/140-user-authz/usage.html#создание-serviceaccount-и-предоставление-ему-доступа) ServiceAccount, который будет осуществлять деплой в кластер, и выделите ему права.
+[Создайте](/{{ page.lang }}/documentation/v1/modules/140-user-authz/usage.html#создание-serviceaccount-для-сервера-и-предоставление-ему-доступа) ServiceAccount, который будет осуществлять деплой в кластер, и выделите ему права.
 
 Результатом станет `kubeconfig`, который можно использовать во всех системах деплоя в Kubernetes.
 </div>

--- a/docs/site/_includes/getting_started/kind/STEP_FINISH.md
+++ b/docs/site/_includes/getting_started/kind/STEP_FINISH.md
@@ -84,7 +84,7 @@ Deckhouse makes it easier to set up CI/CD system access to a cluster to deploy y
 Setting up a CI/CD system
 </h3>
 <div class="cards-item__text" markdown="1">
-[Create](/{{ page.lang }}/documentation/v1/modules/140-user-authz/usage.html#creating-a-serviceaccount-and-granting-it-access) a ServiceAccount to use for deploying to the cluster and grant it all the necessary privileges.
+[Create](/{{ page.lang }}/documentation/v1/modules/140-user-authz/usage.html#creating-a-serviceaccount-for-a-machine-and-granting-it-access) a ServiceAccount to use for deploying to the cluster and grant it all the necessary privileges.
 
 You can use the generated `kubeconfig` file in Kubernetes with any deployment system.
 </div>

--- a/docs/site/_includes/getting_started/kind/STEP_FINISH_RU.md
+++ b/docs/site/_includes/getting_started/kind/STEP_FINISH_RU.md
@@ -81,7 +81,7 @@ Deckhouse делает проще настройку доступа CI/CD-сис
 Настройка CI/CD-системы
 </h3>
 <div class="cards-item__text" markdown="1">
-Включите модуль [user-authz](/{{ page.lang }}/documentation/v1/modules/140-user-authz/) и [создайте](/{{ page.lang }}/documentation/v1/modules/140-user-authz/usage.html#создание-serviceaccount-и-предоставление-ему-доступа) ServiceAccount, который будет осуществлять деплой в кластер.
+Включите модуль [user-authz](/{{ page.lang }}/documentation/v1/modules/140-user-authz/) и [создайте](/{{ page.lang }}/documentation/v1/modules/140-user-authz/usage.html#создание-serviceaccount-для-сервера-и-предоставление-ему-доступа) ServiceAccount, который будет осуществлять деплой в кластер.
 
 Результатом станет `kubeconfig`, который можно использовать во всех системах деплоя в Kubernetes.
 </div>

--- a/modules/140-user-authz/docs/USAGE.md
+++ b/modules/140-user-authz/docs/USAGE.md
@@ -43,13 +43,13 @@ It may be required to give your machine static access to the Kubernetes API, e.g
 
 1. Create a `ServiceAccount` in the `d8-service-accounts` namespace (you can change the name):
 
-   ```bash
+   ```shell
    kubectl -n d8-service-accounts create serviceaccount gitlab-runner-deploy
    ```
 
 2. Grant the necessary rights to the `ServiceAccount` (using the [ClusterAuthorizationRule](cr.html#clusterauthorizationrule) CR)
 
-   ```bash
+   ```shell
    kubectl create -f - <<EOF
    apiVersion: deckhouse.io/v1
    kind: ClusterAuthorizationRule
@@ -69,7 +69,7 @@ It may be required to give your machine static access to the Kubernetes API, e.g
 
 3. Generate a `kube-config` (don't forget to substitute your values).
 
-   ```bash
+   ```shell
    cluster_name=my-cluster
    user_name=gitlab-runner-deploy.my-cluster
    context_name=${cluster_name}-${user_name}
@@ -80,7 +80,7 @@ It may be required to give your machine static access to the Kubernetes API, e.g
      * If there is direct access to the API server, then use its IP address:
        1. Get the CA of our Kubernetes cluster:
 
-          ```bash
+          ```shell
           cat /etc/kubernetes/kubelet.conf \
             | grep certificate-authority-data | awk '{ print $2 }' \
             | base64 -d > /tmp/ca.crt
@@ -88,7 +88,7 @@ It may be required to give your machine static access to the Kubernetes API, e.g
 
        2. Generate a section using the API server's IP:
 
-          ```bash
+          ```shell
           kubectl config set-cluster $cluster_name --embed-certs=true \
             --server=https://<API_SERVER_IP>:6443 \
             --certificate-authority=/tmp/ca.crt \
@@ -98,7 +98,7 @@ It may be required to give your machine static access to the Kubernetes API, e.g
      * If there is no direct access to the API server, [enable](../../modules/150-user-authn/configuration.html#parameters) the `publishAPI` parameter containing the `whitelistSourceRanges` array. Or you can do that via a separate Ingress-controller using the `ingressClass` option with the finite `SourceRange`. That is, specify the requests' source addresses in the `acceptRequestsFrom` controller parameter.
        1. Get the CA from the secret containing the `api.%s` domain's certificate:
 
-          ```bash
+          ```shell
           kubectl -n d8-user-authn get secrets -o json \
             $(kubectl -n d8-user-authn get ing kubernetes-api -o jsonpath="{.spec.tls[0].secretName}") \
             | jq -rc '.data."ca.crt" // .data."tls.crt"' \
@@ -107,7 +107,7 @@ It may be required to give your machine static access to the Kubernetes API, e.g
 
        2. Generate a section with the external domain:
 
-          ```bash
+          ```shell
           kubectl config set-cluster $cluster_name --embed-certs=true \
             --server=https://$(kubectl -n d8-user-authn get ing kubernetes-api -ojson | jq '.spec.rules[].host' -r) \
             --certificate-authority=/tmp/ca.crt \
@@ -116,7 +116,7 @@ It may be required to give your machine static access to the Kubernetes API, e.g
 
    * Generate the `user` section using the token from the `ServiceAccount` secret:
 
-     ```bash
+     ```shell
      kubectl config set-credentials $user_name \
        --token=$(kubectl get secret $(kubectl get sa gitlab-runner-deploy -n d8-service-accounts  -o json | jq -r .secrets[].name) -n d8-service-accounts -o json |jq -r '.data["token"]' | base64 -d) \
        --kubeconfig=$file_name
@@ -124,7 +124,7 @@ It may be required to give your machine static access to the Kubernetes API, e.g
 
    * Generate the `context` to bind it all together:
 
-     ```bash
+     ```shell
      kubectl config set-context $context_name \
        --cluster=$cluster_name --user=$user_name \
        --kubeconfig=$file_name
@@ -231,9 +231,9 @@ Execute the command below with the following parameters:
 * `user` - the name of the user;
 * `groups` - user groups;
 
-P.S. You can use Dex logs to find out groups and a username if this module is used together with the `user-authn` module (`kubectl -n d8-user-authn logs -l app=dex`); logs available only if the user is authorized).
+> You can use Dex logs to find out groups and a username if this module is used together with the `user-authn` module (`kubectl -n d8-user-authn logs -l app=dex`); logs available only if the user is authorized).
 
-```bash
+```shell
 cat  <<EOF | 2>&1 kubectl  create --raw  /apis/authorization.k8s.io/v1/subjectaccessreviews -f - | jq .status
 {
   "apiVersion": "authorization.k8s.io/v1",
@@ -265,7 +265,7 @@ You will see if access is allowed and what role is used:
 
 If the **multitenancy** mode is enabled in your cluster, you need to perform another check to be sure that the user has access to the namespace:
 
-```bash
+```shell
 cat  <<EOF | 2>&1 kubectl --kubeconfig /etc/kubernetes/deckhouse/extra-files/webhook-config.yaml create --raw / -f - | jq .status
 {
   "apiVersion": "authorization.k8s.io/v1",

--- a/modules/140-user-authz/docs/USAGE.md
+++ b/modules/140-user-authz/docs/USAGE.md
@@ -29,102 +29,112 @@ spec:
 ## Creating a user
 
 There are two types of users in Kubernetes:
+
 * Service accounts managed by Kubernetes via the API;
 * Regular users managed by some external tool that the cluster administrator configures. There are many authentication mechanisms and, accordingly, many ways to create users. Currently, two authentication methods are supported:
-    * Via the [user-authn](../../modules/150-user-authn/) module.
-    * Via the certificates.
+  * Via the [user-authn](../../modules/150-user-authn/) module.
+  * Via the certificates.
 
 When issuing the authentication certificate, you need to specify the name (`CN=<name>`), the required number of groups (`O=<group>`), and sign it using the root CA of the cluster. It is this mechanism that authenticates you in the cluster when, for example, you use kubectl on a bastion node.
 
-### Creating a ServiceAccount and granting it access
-* Create a `ServiceAccount` in the `d8-service-accounts` namespace
+### Creating a ServiceAccount for a machine and granting it access
 
-  An example of creating `gitlab-runner-deploy` `ServiceAccount`:
-  ```bash
-  kubectl -n d8-service-accounts create serviceaccount gitlab-runner-deploy
-  ```
+It may be required to give your machine static access to the Kubernetes API, e.g., for deploying applications from a CI system runner.
 
-* Grant the necessary rights to the `ServiceAccount` (using the [ClusterAuthorizationRule](cr.html#clusterauthorizationrule) CR)
+1. Create a `ServiceAccount` in the `d8-service-accounts` namespace (you can change the name):
 
-  An example:
-  ```bash
-  kubectl create -f - <<EOF
-  apiVersion: deckhouse.io/v1
-  kind: ClusterAuthorizationRule
-  metadata:
-    name: gitlab-runner-deploy
-  spec:
-    subjects:
-    - kind: ServiceAccount
+    ```bash
+    kubectl -n d8-service-accounts create serviceaccount gitlab-runner-deploy
+    ```
+
+3. Grant the necessary rights to the `ServiceAccount` (using the [ClusterAuthorizationRule](cr.html#clusterauthorizationrule) CR)
+
+    ```bash
+    kubectl create -f - <<EOF
+    apiVersion: deckhouse.io/v1
+    kind: ClusterAuthorizationRule
+    metadata:
       name: gitlab-runner-deploy
-      namespace: d8-service-accounts
-    accessLevel: SuperAdmin
-    allowAccessToSystemNamespaces: true      # This option is only available if the enableMultiTenancy parameter is set (Enterprise Edition version)
-  EOF
-  ```
+    spec:
+      subjects:
+      - kind: ServiceAccount
+        name: gitlab-runner-deploy
+        namespace: d8-service-accounts
+      accessLevel: SuperAdmin
+      allowAccessToSystemNamespaces: true      # This option is only available if the enableMultiTenancy parameter is set (Enterprise Edition version)
+    EOF
+    ```
 
-	If the multitenancy mode is enabled in the Deckhouse configuration, you need to specify the `allowAccessToSystemNamespaces: true` parameter to give the ServiceAccount access to the system namespaces. 
+    If the multitenancy mode is enabled in the Deckhouse configuration, you need to specify the `allowAccessToSystemNamespaces: true` parameter to give the ServiceAccount access to the system namespaces.
 
-* Generate a `kube-config` (don't forget to substitute your values).
+4. Generate a `kube-config` (don't forget to substitute your values).
 
-  ```bash
-  cluster_name=my-cluster
-  user_name=gitlab-runner-deploy.my-cluster
-  context_name=${cluster_name}-${user_name}
-  file_name=kube.config
-  ```
+    ```bash
+    cluster_name=my-cluster
+    user_name=gitlab-runner-deploy.my-cluster
+    context_name=${cluster_name}-${user_name}
+    file_name=kube.config
+    ```
 
-  * The `cluster` section:
-      
-      * If there is direct access to the API server, then use its IP address:
-          
-        Get the CA of our Kubernetes cluster:
+    * The `cluster` section:
+
+        * If there is direct access to the API server, then use its IP address:
+
+          1. Get the CA of our Kubernetes cluster:
+
+            ```bash
+            cat /etc/kubernetes/kubelet.conf \
+              | grep certificate-authority-data | awk '{ print $2 }' \
+              | base64 -d > /tmp/ca.crt
+            ```
+
+          2. Generate a section using the API server's IP:
+
+            ```bash
+            kubectl config set-cluster $cluster_name --embed-certs=true \
+              --server=https://<API_SERVER_IP>:6443 \
+              --certificate-authority=/tmp/ca.crt \
+              --kubeconfig=$file_name
+            ```
+
+        *  If there is no direct access to the API server, [enable](../../modules/150-user-authn/configuration.html#parameters) the `publishAPI` parameter containing the `whitelistSourceRanges` array. Or you can do that via a separate Ingress-controller using the `ingressClass` option with the finite `SourceRange`. That is, specify the requests' source addresses in the `acceptRequestsFrom` controller parameter.
+
+           1. Get the CA from the secret containing the `api.%s` domain's certificate:
+
+             ```bash
+             kubectl -n d8-user-authn get secrets -o json \
+               $(kubectl -n d8-user-authn get ing kubernetes-api -o jsonpath="{.spec.tls[0].secretName}") \
+               | jq -rc '.data."ca.crt" // .data."tls.crt"' \
+               | base64 -d > /tmp/ca.crt
+             ```
+
+           2. Generate a section with the external domain:
+
+             ```bash
+             kubectl config set-cluster $cluster_name --embed-certs=true \
+               --server=https://$(kubectl -n d8-user-authn get ing kubernetes-api -ojson | jq '.spec.rules[].host' -r) \
+               --certificate-authority=/tmp/ca.crt \
+               --kubeconfig=$file_name
+             ```
+
+    * Generate the `user` section using the token from the `ServiceAccount` secret:
+
         ```bash
-        cat /etc/kubernetes/kubelet.conf \
-          | grep certificate-authority-data | awk '{ print $2 }' \
-          | base64 -d > /tmp/ca.crt
-        ```
-          
-        Generate a section using the API server's IP:
-        ```bash
-        kubectl config set-cluster $cluster_name --embed-certs=true \
-          --server=https://<API_SERVER_IP>:6443 \
-          --certificate-authority=/tmp/ca.crt \
+        kubectl config set-credentials $user_name \
+          --token=$(kubectl get secret $(kubectl get sa gitlab-runner-deploy -n d8-service-accounts  -o json | jq -r .secrets[].name) -n d8-service-accounts -o json |jq -r '.data["token"]' | base64 -d) \
           --kubeconfig=$file_name
         ```
 
-      *  If there is no direct access to the API server, [enable](../../modules/150-user-authn/configuration.html#parameters) the `publishAPI` parameter containing the `whitelistSourceRanges` array. Or you can do that via a separate Ingress-controller using the `ingressClass` option with the finite `SourceRange`. That is, specify the requests' source addresses in the `acceptRequestsFrom` controller parameter.
+    * Generate the `context` to bind it all together:
 
-         Get the CA from the secret containing the `api.%s` domain's certificate:
-         ```bash
-         kubectl -n d8-user-authn get secrets kubernetes-tls -o json \
-           | jq -rc '.data."ca.crt" // .data."tls.crt"' \
-           | base64 -d > /tmp/ca.crt
-         ```
-
-         Generate a section with the external domain:
-         ```
-         kubectl config set-cluster $cluster_name --embed-certs=true \
-           --server=https://$(kubectl -n d8-user-authn get ing kubernetes-api -ojson | jq '.spec.rules[].host' -r) \
-           --certificate-authority=/tmp/ca.crt \
-           --kubeconfig=$file_name
-         ```
-
-  * Generate the `user` section using the token from the `ServiceAccount` secret:
-    ```bash
-    kubectl config set-credentials $user_name \
-      --token=$(kubectl get secret $(kubectl get sa gitlab-runner-deploy -n d8-service-accounts  -o json | jq -r .secrets[].name) -n d8-service-accounts -o json |jq -r '.data["token"]' | base64 -d) \
-      --kubeconfig=$file_name
-    ```
-
-  * Generate the `context` to bind it all together:
-    ```bash
-    kubectl config set-context $context_name \
-      --cluster=$cluster_name --user=$user_name \
-      --kubeconfig=$file_name
-    ```
+        ```bash
+        kubectl config set-context $context_name \
+          --cluster=$cluster_name --user=$user_name \
+          --kubeconfig=$file_name
+        ```
 
 ### How to create a user using a client certificate
+
 #### Creating a user
 
 * Get the cluster's root certificate (ca.crt and ca.key).
@@ -175,6 +185,7 @@ When issuing the authentication certificate, you need to specify the name (`CN=<
 #### Granting access to the created user
 
 Create `ClusterAuthorizationRule`:
+
 ```yaml
 apiVersion: deckhouse.io/v1
 kind: ClusterAuthorizationRule
@@ -195,6 +206,7 @@ The multi-tenancy mode, which allows you to restrict access to namespaces, is en
 Working in multi-tenancy mode requires enabling the [Webhook authorization plugin](https://kubernetes.io/docs/reference/access-authn-authz/webhook/) and configuring a `kube-apiserver.` All actions necessary for the multi-tenancy mode are performed **automatically** by the [control-plane-manager](../../modules/040-control-plane-manager/) module; no additional steps are required.
 
 Changes to the `kube-apiserver` manifest that will occur after enabling multi-tenancy mode:
+
 * The `--authorization-mode` argument will be modified: the Webhook method will be added in front of the RBAC method (e.g., `--authorization-mode=Node,Webhook,RBAC`);
 * The `--authorization-webhook-config-file=/etc/kubernetes/authorization-webhook-config.yaml` will be added;
 * The `volumeMounts` parameter will be added:
@@ -204,6 +216,7 @@ Changes to the `kube-apiserver` manifest that will occur after enabling multi-te
     mountPath: /etc/kubernetes/authorization-webhook-config.yaml
     readOnly: true
   ```
+
 * The `volumes` parameter will be added:
 
   ```yaml
@@ -216,6 +229,7 @@ Changes to the `kube-apiserver` manifest that will occur after enabling multi-te
 ## How do I check that a user has access?
 
 Execute the command below with the following parameters:
+
 * `resourceAttributes` (the same as in RBAC) - target resources;
 * `user` - the name of the user;
 * `groups` - user groups;
@@ -280,7 +294,9 @@ EOF
   "allowed": false
 }
 ```
+
 The `allowed: false` message means that the webhook doesn't block access. In case of webhook denying the request, you will see, e.g., the following message:
+
 ```json
 {
   "allowed": false,

--- a/modules/140-user-authz/docs/USAGE.md
+++ b/modules/140-user-authz/docs/USAGE.md
@@ -47,7 +47,7 @@ It may be required to give your machine static access to the Kubernetes API, e.g
    kubectl -n d8-service-accounts create serviceaccount gitlab-runner-deploy
    ```
 
-2. Grant the necessary rights to the `ServiceAccount` (using the [ClusterAuthorizationRule](cr.html#clusterauthorizationrule) CR)
+2. Grant the necessary rights to the `ServiceAccount` (using the [ClusterAuthorizationRule](cr.html#clusterauthorizationrule) custom resource):
 
    ```shell
    kubectl create -f - <<EOF
@@ -67,7 +67,7 @@ It may be required to give your machine static access to the Kubernetes API, e.g
 
    If the multitenancy mode is enabled in the Deckhouse configuration, you need to specify the `allowAccessToSystemNamespaces: true` parameter to give the ServiceAccount access to the system namespaces.
 
-3. Generate a `kube-config` (don't forget to substitute your values).
+3. Generate a `kube-config` (don't forget to substitute your values):
 
    ```shell
    cluster_name=my-cluster

--- a/modules/140-user-authz/docs/USAGE_RU.md
+++ b/modules/140-user-authz/docs/USAGE_RU.md
@@ -47,7 +47,7 @@ spec:
    kubectl -n d8-service-accounts create serviceaccount gitlab-runner-deploy
    ```
 
-2. Дайте необходимые `ServiceAccount` права (используя CR [ClusterAuthorizationRule](cr.html#clusterauthorizationrule))
+2. Дайте необходимые `ServiceAccount` права (используя custom resource [ClusterAuthorizationRule](cr.html#clusterauthorizationrule)):
 
    ```shell
    kubectl create -f - <<EOF
@@ -67,7 +67,7 @@ spec:
 
    Если в конфигурации Deckhouse включен режим multitenancy (доступно только в версии Enterprise Edition), то, чтобы дать SA доступ в системные namespace'ы укажите `allowAccessToSystemNamespaces: true`.
 
-3. Сгенерируйте `kube-config`, подставив свои значения переменных в начале.
+3. Сгенерируйте `kube-config`, подставив свои значения переменных в начале:
 
    ```shell
    cluster_name=my-cluster

--- a/modules/140-user-authz/docs/USAGE_RU.md
+++ b/modules/140-user-authz/docs/USAGE_RU.md
@@ -29,103 +29,112 @@ spec:
 ## Создание пользователя
 
 В Kubernetes есть две категории пользователей:
+
 * ServiceAccount-ы, учёт которых ведёт сам Kubernetes через API.
 * Остальные пользователи, чей учёт ведёт не сам Kubernetes, а некоторый внешний софт, который настраивает администратор кластера – существует множество механизмов аутентификации и, соответственно, множество способов заводить пользователей. В настоящий момент поддерживается два способа аутентификации:
-    * Через модуль [user-authn](../../modules/150-user-authn/).
-    * С помощью сертификатов.
+  * Через модуль [user-authn](../../modules/150-user-authn/).
+  * С помощью сертификатов.
 
-При выпуске сертификата для аутентификации, нужно  указать в нем имя (`CN=<имя>`), необходимое количество групп (`O=<группа>`) и подписать его с помощью корневого CA кластера. Именно этим механизмом вы аутентифицируетесь в кластере, когда например используете kubectl на bastion-узле.
+При выпуске сертификата для аутентификации, нужно указать в нем имя (`CN=<имя>`), необходимое количество групп (`O=<группа>`) и подписать его с помощью корневого CA кластера. Именно этим механизмом вы аутентифицируетесь в кластере, когда например используете kubectl на bastion-узле.
 
-### Создание ServiceAccount и предоставление ему доступа
-* Создать `ServiceAccount` в namespace `d8-service-accounts`
+### Создание ServiceAccount для сервера и предоставление ему доступа
 
-  Пример создания `ServiceAccount` `gitlab-runner-deploy`:
-  ```bash
-  kubectl -n d8-service-accounts create serviceaccount gitlab-runner-deploy
-  ```
+Может быть необходимо выдать постоянный доступ к Kubernetes API для сервера, например, чтобы CI-система могла выкладывать приложения в кластер.
 
-* Дать необходимые `ServiceAccount` права (используя CR [ClusterAuthorizationRule](cr.html#clusterauthorizationrule))
+1. Создать `ServiceAccount` в namespace `d8-service-accounts` (имя можно изменить):
 
-  Пример:
-  ```bash
-  kubectl create -f - <<EOF
-  apiVersion: deckhouse.io/v1
-  kind: ClusterAuthorizationRule
-  metadata:
-    name: gitlab-runner-deploy
-  spec:
-    subjects:
-    - kind: ServiceAccount
+    ```bash
+    kubectl -n d8-service-accounts create serviceaccount gitlab-runner-deploy
+    ```
+
+2. Дать необходимые `ServiceAccount` права (используя CR [ClusterAuthorizationRule](cr.html#clusterauthorizationrule))
+
+    ```bash
+    kubectl create -f - <<EOF
+    apiVersion: deckhouse.io/v1
+    kind: ClusterAuthorizationRule
+    metadata:
       name: gitlab-runner-deploy
-      namespace: d8-service-accounts
-    accessLevel: SuperAdmin
-    allowAccessToSystemNamespaces: true     # Опция доступна только при включенном режиме enableMultiTenancy (версия Enterprise Edition)
-  EOF
-  ```
+    spec:
+      subjects:
+      - kind: ServiceAccount
+        name: gitlab-runner-deploy
+        namespace: d8-service-accounts
+      accessLevel: SuperAdmin
+      allowAccessToSystemNamespaces: true      # Опция доступна только при включенном режиме enableMultiTenancy (версия Enterprise Edition)
+    EOF
+    ```
 
-  Если в конфигурации Deckhouse включен режим multitenancy (доступно только в версии Enterprise Edition), то чтобы дать SA доступ в системные namespace'ы нужно указать `allowAccessToSystemNamespaces: true`.
+    Если в конфигурации Deckhouse включен режим multitenancy (доступно только в версии Enterprise Edition), то, чтобы дать SA доступ в системные namespace'ы, нужно указать `allowAccessToSystemNamespaces: true`.
 
-* Сгенерировать `kube-config`, подставив свои значения переменных в начале.
+3. Сгенерировать `kube-config`, подставив свои значения переменных в начале.
 
-  ```bash
-  cluster_name=my-cluster
-  user_name=gitlab-runner-deploy.my-cluster
-  context_name=${cluster_name}-${user_name}
-  file_name=kube.config
-  ```
+   ```bash
+   cluster_name=my-cluster
+   user_name=gitlab-runner-deploy.my-cluster
+   context_name=${cluster_name}-${user_name}
+   file_name=kube.config
+   ```
 
-  * Секция `cluster`:
-      
-    * Если есть доступ напрямую до API-сервера, то используем его IP:
+    * Секция `cluster`:
+        * Если есть доступ напрямую до API-сервера, то используем его IP:
 
-      Достаем CA нашего кластера Kubernetes:
-      ```bash
-      cat /etc/kubernetes/kubelet.conf \
-        | grep certificate-authority-data | awk '{ print $2 }' \
-        | base64 -d > /tmp/ca.crt
-      ```
+          1. Достаем CA нашего кластера Kubernetes:
 
-      Генерируем секцию с IP API-сервера:
-      ```bash
-      kubectl config set-cluster $cluster_name --embed-certs=true \
-        --server=https://<API_SERVER_IP>:6443 \
-        --certificate-authority=/tmp/ca.crt \
-        --kubeconfig=$file_name
-      ```
+          ```bash
+          cat /etc/kubernetes/kubelet.conf \
+            | grep certificate-authority-data | awk '{ print $2 }' \
+            | base64 -d > /tmp/ca.crt
+          ```
 
-    *  Если прямого доступа до API-сервера нет, то [включаем](../../modules/150-user-authn/configuration.html#параметры) `publishAPI` с `whitelistSourceRanges`. Либо через отдельный
-       Ingress-controller при помощи опции `ingressClass` с конечным списком `SourceRange` прописываем в настройках контроллера `acceptRequestsFrom` только адреса с которых будут идти запросы.
+          2. Генерируем секцию с IP API-сервера:
 
-        Достаем CA из secret'а с сертификатом для домена `api.%s`:
+          ```bash
+          kubectl config set-cluster $cluster_name --embed-certs=true \
+            --server=https://<API_SERVER_IP>:6443 \
+            --certificate-authority=/tmp/ca.crt \
+            --kubeconfig=$file_name
+          ```
+
+        * Если прямого доступа до API-сервера нет, то [включаем](../../modules/150-user-authn/configuration.html#параметры) `publishAPI` с `whitelistSourceRanges`. Либо через отдельный
+          Ingress-controller при помощи опции `ingressClass` с конечным списком `SourceRange` прописываем в настройках контроллера `acceptRequestsFrom` только адреса с которых будут идти запросы.
+  
+          1. Достаем CA из secret'а с сертификатом для домена `api.%s`:
+
+          ```bash
+          kubectl -n d8-user-authn get secrets -o json \
+            $(kubectl -n d8-user-authn get ing kubernetes-api -o jsonpath="{.spec.tls[0].secretName}") \
+            | jq -rc '.data."ca.crt" // .data."tls.crt"' \
+            | base64 -d > /tmp/ca.crt
+          ```
+
+          2. Генерируем секцию с внешним доменом:
+
+          ```bash
+          kubectl config set-cluster $cluster_name --embed-certs=true \
+            --server=https://$(kubectl -n d8-user-authn get ing kubernetes-api -ojson | jq '.spec.rules[].host' -r) \
+            --certificate-authority=/tmp/ca.crt \
+            --kubeconfig=$file_name
+          ```
+
+    * Секция `user` с токеном из секрета `ServiceAccount`:
+
         ```bash
-        kubectl -n d8-user-authn get secrets kubernetes-tls -o json \
-          | jq -rc '.data."ca.crt" // .data."tls.crt"' \
-          | base64 -d > /tmp/ca.crt
-        ```
-
-        Генерируем секцию с внешним доменом:
-        ```shell
-        kubectl config set-cluster $cluster_name --embed-certs=true \
-          --server=https://$(kubectl -n d8-user-authn get ing kubernetes-api -ojson | jq '.spec.rules[].host' -r) \
-          --certificate-authority=/tmp/ca.crt \
+        kubectl config set-credentials $user_name \
+          --token=$(kubectl get secret $(kubectl get sa gitlab-runner-deploy -n d8-service-accounts  -o json | jq -r .secrets[].name) -n d8-service-accounts -o json |jq -r '.data["token"]' | base64 -d) \
           --kubeconfig=$file_name
         ```
 
-  * Секция `user` с токеном из секрета `ServiceAccount`:
-    ```bash
-    kubectl config set-credentials $user_name \
-      --token=$(kubectl get secret $(kubectl get sa gitlab-runner-deploy -n d8-service-accounts  -o json | jq -r .secrets[].name) -n d8-service-accounts -o json |jq -r '.data["token"]' | base64 -d) \
-      --kubeconfig=$file_name
-    ```
+    * Секция `context` для связи:
 
-  * Секция `context` для связи всего этого:
-    ```bash
-    kubectl config set-context $context_name \
-      --cluster=$cluster_name --user=$user_name \
-      --kubeconfig=$file_name
-    ```
+        ```bash
+        kubectl config set-context $context_name \
+          --cluster=$cluster_name --user=$user_name \
+          --kubeconfig=$file_name
+        ```
 
 ### Создание пользователя с помощью клиентского сертификата
+
 #### Создание пользователя
 
 * Достаём корневой сертификат кластера (ca.crt и ca.key).
@@ -176,6 +185,7 @@ spec:
 #### Предоставление доступа созданному пользователю
 
 Создадим `ClusterAuthorizationRule`:
+
 ```yaml
 apiVersion: deckhouse.io/v1
 kind: ClusterAuthorizationRule
@@ -191,11 +201,12 @@ spec:
 
 ### Настройка `kube-apiserver` для работы в режиме multi-tenancy
 
-Режим multi-tenancy, позволяющий ограничивать доступ к namespace, включается [параметром](configuration.html) `enableMultiTenancy` модуля. 
+Режим multi-tenancy, позволяющий ограничивать доступ к namespace, включается [параметром](configuration.html) `enableMultiTenancy` модуля.
 
 Работа в режиме multi-tenancy требует включения [плагина авторизации Webhook](https://kubernetes.io/docs/reference/access-authn-authz/webhook/) и выполнения настройки `kube-apiserver`. Все необходимые для работы режима multi-tenancy действия **выполняются автоматически** модулем [control-plane-manager](../../modules/040-control-plane-manager/), никаких ручных действий не требуется.
 
 Изменения манифеста `kube-apiserver`, которые произойдут после включения режима multi-tenancy:
+
 * Исправление аргумента `--authorization-mode`. Перед методом RBAC добавится метод Webhook (например — `--authorization-mode=Node,Webhook,RBAC`).
 * Добавление аргумента `--authorization-webhook-config-file=/etc/kubernetes/authorization-webhook-config.yaml`.
 * Добавление `volumeMounts`:
@@ -205,6 +216,7 @@ spec:
     mountPath: /etc/kubernetes/authorization-webhook-config.yaml
     readOnly: true
   ```
+
 * Добавление `volumes`:
 
   ```yaml
@@ -217,6 +229,7 @@ spec:
 ## Как проверить, что у пользователя есть доступ?
 
 Необходимо выполнить следующую команду, в которой будут указаны:
+
 * `resourceAttributes` (как в RBAC) — к чему мы проверяем доступ
 * `user` — имя пользователя
 * `groups` — группы пользователя
@@ -281,7 +294,9 @@ EOF
   "allowed": false
 }
 ```
+
 Сообщение `allowed: false` значит что webhook не блокирует запрос. В случае блокировки запроса webhook'ом вы увидите, например, следующее сообщение:
+
 ```json
 {
   "allowed": false,


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
Now Deckhouse deploys a certificate for the published API with a different name for each mode, so I added a kubectl command to dynamically pick the name of the certificate from the corresponding ingress resource.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: user-authz
type: fix
summary: Fix gitlab-runner access rights doc
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
