### PR TITLE
[log-shipper] Provide structural schemas for log-shipper CRDs

### DIFF
--- a/modules/460-log-shipper/crds/cluster-logging-config.yaml
+++ b/modules/460-log-shipper/crds/cluster-logging-config.yaml
@@ -27,22 +27,23 @@ spec:
             Each CustomResource `ClusterLoggingConfig` describes rules for log fetching from cluster.
           properties:
             spec:
+              not:
+                required: [file, kubernetesPods]
+              oneOf:
+                - properties:
+                    kubernetesPods: {}
+                    type:
+                      enum: [KubernetesPods]
+                  required: [kubernetesPods]
+                - properties:
+                    file: {}
+                    type:
+                      enum: [File]
+                  required: [file]
               type: object
               required:
                 - type
                 - destinationRefs
-              anyOf:
-                - oneOf:
-                    - properties:
-                        type:
-                          enum: ["KubernetesPods"]
-                        kubernetesPods: {}
-                      required: ["kubernetesPods"]
-                    - properties:
-                        type:
-                          enum: ["File"]
-                        file: {}
-                      required: ["file"]
               properties:
                 type:
                   type: string
@@ -55,7 +56,6 @@ spec:
                     `File` source reads local file from node filesystem.
                 kubernetesPods:
                   type: object
-                  default: {}
                   properties:
                     namespaceSelector:
                       oneOf:


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
It is required to avoid misconfiguration like the following:
```yaml
...
spec:
  type: KubernetesPods
  file:
    include: ["/var/log/*"]
```
## Changelog entries

```changes
section: log-shipper
type: fix
summary: Provide structural schemas for log-shipper CRDs
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
