### PR TITLE
[candi][yandex] Remove master node coreFraction setting from openapi

### DIFF
--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -72,13 +72,6 @@ apiVersions:
                 description: |
                   Amount of CPU cores to provision on a Yandex Compute Instance.
                 type: integer
-              coreFraction:
-                description: |
-                  Percent of reserved CPU capacity on a Yandex Compute Instance. [Details...](https://cloud.yandex.com/en/docs/compute/concepts/performance-levels)
-                type: integer
-                example: 20
-                x-doc-default: 100
-                enum: [ 0,5,20,50,100 ]
               memory:
                 type: integer
                 description: |
@@ -227,6 +220,13 @@ apiVersions:
                 Partial contents of the fields of the [YandexInstanceClass](https://deckhouse.io/en/documentation/v1/modules/030-cloud-provider-yandex/cr.html#yandexinstanceclass).
               properties:
                 <<: *instanceClassProperties
+                coreFraction:
+                  description: |
+                    Percent of reserved CPU capacity on a Yandex Compute Instance. [Details...](https://cloud.yandex.com/en/docs/compute/concepts/performance-levels)
+                  type: integer
+                  example: 20
+                  x-doc-default: 100
+                  enum: [ 0,5,20,50,100 ]
       existingNetworkID:
         type: string
         description: |

--- a/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
@@ -25,9 +25,6 @@ apiVersions:
               cores:
                 description: |
                   Количество ядер у создаваемых инстансов.
-              coreFraction:
-                description: |
-                  Базовый уровень производительности каждого ядра CPU у создаваемых инстансов. [Подробнее...](https://cloud.yandex.ru/docs/compute/concepts/performance-levels)
               memory:
                 description: |
                   Количество оперативной памяти (в мегабайтах) у создаваемых инстансов.
@@ -98,6 +95,9 @@ apiVersions:
                 Частичное содержимое полей [YandexInstanceClass](https://deckhouse.io/ru/documentation/v1/modules/030-cloud-provider-yandex/cr.html#yandexinstanceclass).
               properties:
                 <<: *instanceClassProperties_ru
+                coreFraction:
+                  description: |
+                    Базовый уровень производительности каждого ядра CPU у создаваемых инстансов. [Подробнее...](https://cloud.yandex.ru/docs/compute/concepts/performance-levels)
       existingNetworkID:
         description: |
           ID существующей VPC Network.


### PR DESCRIPTION
## Description
Remove master node `coreFraction` setting from YandexClusterConfiguration openapi spec

## Why do we need it, and what problem does it solve?
We don't allow using non-100% `coreFraction` on master nodes and we don't have realisation.

## Changelog entries

```changes
section: candi
type: fix
summary: Remove master node `coreFraction` setting from YandexClusterConfiguration openapi spec
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
