### PR TITLE
[log-shipper] No dedot for file

### DIFF
--- a/modules/460-log-shipper/hooks/generate_config_test.go
+++ b/modules/460-log-shipper/hooks/generate_config_test.go
@@ -713,7 +713,6 @@ metadata:
   name: test-source
 spec:
   type: KubernetesPods
-  #kubernetesPods: {}
   destinationRefs:
     - test-es-dest
 ---
@@ -753,6 +752,58 @@ spec:
 			Expect(secret).To(Not(BeEmpty()))
 
 			assertConfig(secret, "throttle.json")
+		})
+		Context("With deleting object", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(""))
+				f.RunHook()
+			})
+			It("Should delete secret and deactivate module", func() {
+				Expect(f).To(ExecuteSuccessfully())
+				Expect(f.ValuesGet("logShipper.internal.activated").Bool()).To(BeFalse())
+				Expect(f.KubernetesResource("Secret", "d8-log-shipper", "d8-log-shipper-config").Exists()).To(BeFalse())
+			})
+		})
+	})
+
+	Context("File to Elasticsearch", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLoggingConfig
+metadata:
+  name: test-source
+spec:
+  type: File
+  file:
+    include: ["/var/log/kube-audit/audit.log"]
+  destinationRefs:
+    - test-es-dest
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLogDestination
+metadata:
+  name: test-es-dest
+spec:
+  type: Elasticsearch
+  elasticsearch:
+    index: "logs-%F"
+    pipeline: "testpipe"
+    endpoint: "http://192.168.1.1:9200"
+---
+`))
+			f.RunHook()
+		})
+
+		It("Should create secret", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			Expect(f.ValuesGet("logShipper.internal.activated").Bool()).To(BeTrue())
+
+			secret := f.KubernetesResource("Secret", "d8-log-shipper", "d8-log-shipper-config")
+			Expect(secret).To(Not(BeEmpty()))
+
+			assertConfig(secret, "file-to-elastic.json")
 		})
 		Context("With deleting object", func() {
 			BeforeEach(func() {

--- a/modules/460-log-shipper/hooks/internal/handler/apply.go
+++ b/modules/460-log-shipper/hooks/internal/handler/apply.go
@@ -23,7 +23,10 @@ import (
 )
 
 type transformApplier struct {
-	destination   v1alpha1.ClusterLogDestination
+	destination v1alpha1.ClusterLogDestination
+
+	sourceType string
+
 	multilineType v1alpha1.MultiLineParserType
 
 	labelFilter []v1alpha1.Filter
@@ -32,7 +35,7 @@ type transformApplier struct {
 
 func (t *transformApplier) Do(transforms []impl.LogTransform) ([]impl.LogTransform, error) {
 	transforms = append(transforms, transform.CreateMultiLineTransforms(t.multilineType)...)
-	transforms = append(transforms, transform.CreateDefaultTransforms(t.destination)...)
+	transforms = append(transforms, transform.CreateDefaultTransforms(t.sourceType, t.destination)...)
 
 	labelFilterTransforms, err := transform.CreateLabelFilterTransforms(t.labelFilter)
 	if err != nil {

--- a/modules/460-log-shipper/hooks/internal/handler/generator.go
+++ b/modules/460-log-shipper/hooks/internal/handler/generator.go
@@ -95,6 +95,7 @@ func (g *Generator) convertPodLoggingConfig(podLoggingConfig v1alpha1.PodLogging
 
 		applier := transformApplier{
 			destination:   g.logDestinations[dest],
+			sourceType:    model.SourceKubernetesPods,
 			labelFilter:   podLoggingConfig.Spec.LabelFilters,
 			logFilter:     podLoggingConfig.Spec.LogFilters,
 			multilineType: podLoggingConfig.Spec.MultiLineParser.Type,
@@ -133,6 +134,7 @@ func (g *Generator) convertClusterLoggingConfig(clusterLoggingConfig v1alpha1.Cl
 
 		applier := transformApplier{
 			destination:   g.logDestinations[dest],
+			sourceType:    clusterLoggingConfig.Spec.Type,
 			labelFilter:   clusterLoggingConfig.Spec.LabelFilters,
 			logFilter:     clusterLoggingConfig.Spec.LogFilters,
 			multilineType: clusterLoggingConfig.Spec.MultiLineParser.Type,

--- a/modules/460-log-shipper/hooks/internal/vector/transform/default.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/default.go
@@ -49,7 +49,7 @@ func JSONParseTransform() *DynamicTransform {
 	}
 }
 
-func CreateDefaultTransforms(dest v1alpha1.ClusterLogDestination) []impl.LogTransform {
+func CreateDefaultTransforms(sourceType string, dest v1alpha1.ClusterLogDestination) []impl.LogTransform {
 	transforms := []impl.LogTransform{
 		CleanUpAfterSourceTransform(),
 		JSONParseTransform(),
@@ -57,7 +57,9 @@ func CreateDefaultTransforms(dest v1alpha1.ClusterLogDestination) []impl.LogTran
 
 	switch dest.Spec.Type {
 	case model.DestElasticsearch, model.DestLogstash:
-		transforms = append(transforms, DeDotTransform())
+		if sourceType == model.SourceKubernetesPods {
+			transforms = append(transforms, DeDotTransform())
+		}
 
 		if len(dest.Spec.ExtraLabels) > 0 {
 			transforms = append(transforms, ExtraFieldTransform(dest.Spec.ExtraLabels))

--- a/modules/460-log-shipper/hooks/internal/vector/transform/transforms_test.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/transforms_test.go
@@ -56,7 +56,7 @@ func TestTransformSnippet(t *testing.T) {
 			},
 		}
 
-		defaultTransforms := CreateDefaultTransforms(dest)
+		defaultTransforms := CreateDefaultTransforms(model.SourceKubernetesPods, dest)
 
 		transforms = append(transforms, defaultTransforms...)
 		transforms = append(transforms, CreateDefaultCleanUpTransforms(dest)...)

--- a/modules/460-log-shipper/hooks/testdata/file-to-elastic.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-elastic.json
@@ -1,0 +1,62 @@
+{
+  "sources": {
+    "test-source_test-es-dest": {
+      "type": "file",
+      "include": [
+        "/var/log/kube-audit/audit.log"
+      ]
+    }
+  },
+  "transforms": {
+    "d8_tf_test-source_test-es-dest_00_clean_up": {
+      "drop_on_abort": false,
+      "inputs": [
+        "test-source_test-es-dest"
+      ],
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "type": "remap"
+    },
+    "d8_tf_test-source_test-es-dest_01_json_parse": {
+      "drop_on_abort": false,
+      "inputs": [
+        "d8_tf_test-source_test-es-dest_00_clean_up"
+      ],
+      "source": "structured, err = parse_json(.message)\nif err == null {\n    .parsed_data = structured\n} else {\n    .parsed_data = .message\n}",
+      "type": "remap"
+    },
+    "d8_tf_test-source_test-es-dest_02_del_parsed_data": {
+      "drop_on_abort": false,
+      "inputs": [
+        "d8_tf_test-source_test-es-dest_01_json_parse"
+      ],
+      "source": "if exists(.parsed_data) {\n    del(.parsed_data)\n}",
+      "type": "remap"
+    }
+  },
+  "sinks": {
+    "d8_cluster_sink_test-es-dest": {
+      "type": "elasticsearch",
+      "inputs": [
+        "d8_tf_test-source_test-es-dest_02_del_parsed_data"
+      ],
+      "healthcheck": {
+        "enabled": false
+      },
+      "endpoint": "http://192.168.1.1:9200",
+      "encoding": {
+        "timestamp_format": "rfc3339"
+      },
+      "batch": {
+        "max_bytes": 10485760,
+        "timeout_secs": 1
+      },
+      "compression": "gzip",
+      "bulk": {
+        "action": "index",
+        "index": "logs-%F"
+      },
+      "pipeline": "testpipe",
+      "mode": "bulk"
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
Dedot transform drops all entries without pod labels

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: log-shipper
type: fix
summary: Fix integration of the File source with the Elasticsearch destination.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
