### PR TITLE
[prometheus] fix: rename errors related metrics

### DIFF
--- a/modules/020-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/020-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -190,7 +190,7 @@
         Please, refer to the corresponding logs: `kubectl -n d8-system logs -f -l app=deckhouse`.
 
   - alert: D8DeckhouseGlobalHookFailsTooOften
-    expr: max(increase({job="deckhouse", __name__=~"deckhouse_global_hook.*_errors"}[__SCRAPE_INTERVAL_X_4__])) by (pod, instance, hook) > 1
+    expr: max(increase({job="deckhouse", __name__=~"deckhouse_global_hook.*_errors_total"}[__SCRAPE_INTERVAL_X_4__])) by (pod, instance, hook) > 1
     labels:
       severity_level: "9"
       tier: cluster
@@ -209,7 +209,7 @@
         Please, refer to the corresponding logs: `kubectl -n d8-system logs -f -l app=deckhouse`.
 
   - alert: D8DeckhouseModuleHookFailsTooOften
-    expr: max(increase({job="deckhouse", __name__=~"deckhouse_module_hook.*_errors"}[__SCRAPE_INTERVAL_X_4__])) by (pod, instance, module, hook) > 1
+    expr: max(increase({job="deckhouse", __name__=~"deckhouse_module_hook.*_errors_total"}[__SCRAPE_INTERVAL_X_4__])) by (pod, instance, module, hook) > 1
     labels:
       severity_level: "9"
       tier: cluster
@@ -228,7 +228,7 @@
         Please, refer to the corresponding logs: `kubectl -n d8-system logs -f -l app=deckhouse`.
 
   - alert: D8DeckhouseCouldNotDiscoverModules
-    expr: max by (pod, instance) (increase(deckhouse_modules_discover_errors[__SCRAPE_INTERVAL_X_4__])) > 1
+    expr: max by (pod, instance) (increase(deckhouse_modules_discover_errors_total[__SCRAPE_INTERVAL_X_4__])) > 1
     labels:
       severity_level: "4"
       tier: cluster
@@ -245,7 +245,7 @@
         Please, refer to the corresponding logs: `kubectl -n d8-system logs -f -l app=deckhouse`.
 
   - alert: D8DeckhouseCouldNotRunModule
-    expr: max(increase(deckhouse_module_run_errors[__SCRAPE_INTERVAL_X_4__])) by (pod, instance, module) > 1
+    expr: max(increase(deckhouse_module_run_errors_total[__SCRAPE_INTERVAL_X_4__])) by (pod, instance, module) > 1
     labels:
       severity_level: "4"
       tier: cluster
@@ -262,7 +262,7 @@
         Please, refer to the corresponding logs: `kubectl -n d8-system logs -f -l app=deckhouse`.
 
   - alert: D8DeckhouseCouldNotDeleteModule
-    expr: max(increase(deckhouse_module_delete_errors[__SCRAPE_INTERVAL_X_4__])) by (pod, instance, module) > 1
+    expr: max(increase(deckhouse_module_delete_errors_total[__SCRAPE_INTERVAL_X_4__])) by (pod, instance, module) > 1
     labels:
       severity_level: "4"
       tier: cluster
@@ -279,7 +279,7 @@
         Please, refer to the corresponding logs: `kubectl -n d8-system logs -f -l app=deckhouse`.
 
   - alert: D8DeckhouseCouldNotRunGlobalHook
-    expr: max(increase(deckhouse_global_hook_errors[__SCRAPE_INTERVAL_X_4__])) by (pod, instance, hook) > 1
+    expr: max(increase(deckhouse_global_hook_errors_total[__SCRAPE_INTERVAL_X_4__])) by (pod, instance, hook) > 1
     labels:
       severity_level: "5"
       tier: cluster
@@ -296,7 +296,7 @@
         Please, refer to the corresponding logs: `kubectl -n d8-system logs -f -l app=deckhouse`.
 
   - alert: D8DeckhouseCouldNotRunModuleHook
-    expr: max(increase(deckhouse_module_hook_errors[__SCRAPE_INTERVAL_X_4__])) by (pod, instance, module, hook) > 1
+    expr: max(increase(deckhouse_module_hook_errors_total[__SCRAPE_INTERVAL_X_4__])) by (pod, instance, module, hook) > 1
     labels:
       severity_level: "7"
       tier: cluster


### PR DESCRIPTION
## Description

Use new metrics names in alert rules.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Errors related metrics was renamed in https://github.com/flant/addon-operator/pull/133

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: fix
summary: Use new metrics names in alert rules.
impact: Re-enable alerts on hook errors.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
