### PR TITLE
[dhctl] Some improvements and fixes

### DIFF
--- a/dhctl/pkg/kubernetes/actions/converge/converge.go
+++ b/dhctl/pkg/kubernetes/actions/converge/converge.go
@@ -366,6 +366,7 @@ func (c *NodeGroupController) Run() error {
 	replicas := getReplicasByNodeGroupName(c.config, nodeGroupName)
 	step := getStepByNodeGroupName(nodeGroupName)
 
+	// we hide deckhouse logs because we always have config
 	nodeCloudConfig, err := GetCloudConfig(c.client, nodeGroupName, HideDeckhouseLogs)
 	if err != nil {
 		return err

--- a/dhctl/pkg/operations/bootstrap.go
+++ b/dhctl/pkg/operations/bootstrap.go
@@ -311,7 +311,8 @@ func BootstrapTerraNodes(kubeCl *client.KubernetesClient, metaConfig *config.Met
 				return err
 			}
 
-			cloudConfig, err := converge.GetCloudConfig(kubeCl, ng.Name)
+			const showDeckhouseLogs = true
+			cloudConfig, err := converge.GetCloudConfig(kubeCl, ng.Name, showDeckhouseLogs)
 			if err != nil {
 				return err
 			}
@@ -379,7 +380,8 @@ func GetBastionHostFromCache() (string, error) {
 
 func BootstrapAdditionalMasterNodes(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, addressTracker map[string]string) error {
 	return log.Process("bootstrap", "Create master NodeGroup", func() error {
-		masterCloudConfig, err := converge.GetCloudConfig(kubeCl, converge.MasterNodeGroupName)
+		const showDeckhouseLogs = true
+		masterCloudConfig, err := converge.GetCloudConfig(kubeCl, converge.MasterNodeGroupName, ShowDeckhouseLogs)
 		if err != nil {
 			return err
 		}

--- a/dhctl/pkg/operations/bootstrap.go
+++ b/dhctl/pkg/operations/bootstrap.go
@@ -311,8 +311,7 @@ func BootstrapTerraNodes(kubeCl *client.KubernetesClient, metaConfig *config.Met
 				return err
 			}
 
-			const showDeckhouseLogs = true
-			cloudConfig, err := converge.GetCloudConfig(kubeCl, ng.Name, showDeckhouseLogs)
+			cloudConfig, err := converge.GetCloudConfig(kubeCl, ng.Name, converge.ShowDeckhouseLogs)
 			if err != nil {
 				return err
 			}
@@ -380,8 +379,7 @@ func GetBastionHostFromCache() (string, error) {
 
 func BootstrapAdditionalMasterNodes(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, addressTracker map[string]string) error {
 	return log.Process("bootstrap", "Create master NodeGroup", func() error {
-		const showDeckhouseLogs = true
-		masterCloudConfig, err := converge.GetCloudConfig(kubeCl, converge.MasterNodeGroupName, ShowDeckhouseLogs)
+		masterCloudConfig, err := converge.GetCloudConfig(kubeCl, converge.MasterNodeGroupName, converge.ShowDeckhouseLogs)
 		if err != nil {
 			return err
 		}

--- a/dhctl/pkg/operations/converge/infra/hook/node.go
+++ b/dhctl/pkg/operations/converge/infra/hook/node.go
@@ -36,33 +36,8 @@ type NodeChecker interface {
 	Name() string
 }
 
-func IsAllNodesReady(checkers []NodeChecker, nodes []string, sourceCommandName, processName string) error {
-	if checkers == nil {
-		return nil
-	}
-
-	if len(nodes) == 0 {
-		return fmt.Errorf("Do not have nodes for %s.", processName)
-	}
-
-	return log.Process(sourceCommandName, processName, func() error {
-		for _, nodeName := range nodes {
-			ready, err := IsNodeReady(checkers, nodeName, sourceCommandName)
-			if err != nil {
-				return err
-			}
-
-			if !ready {
-				return ErrNotReady
-			}
-		}
-
-		return nil
-	})
-}
-
 func IsNodeReady(checkers []NodeChecker, nodeName, sourceCommandName string) (bool, error) {
-	title := fmt.Sprintf("Node %s is ready", nodeName)
+	title := fmt.Sprintf("Node %s readiness check", nodeName)
 	var lastErr error
 
 	err := retry.NewLoop(title, 30, 10*time.Second).Run(func() error {

--- a/dhctl/pkg/system/ssh/cmd/scp.go
+++ b/dhctl/pkg/system/ssh/cmd/scp.go
@@ -87,6 +87,7 @@ func (s *SCP) SCP() *SCP {
 		"-o", "ControlPersist=600s",
 		"-o", "StrictHostKeyChecking=accept-new",
 		"-o", "UserKnownHostsFile=.ssh_known_hosts",
+		"-o", "PasswordAuthentication=no",
 	}
 
 	if s.Session.ExtraArgs != "" {

--- a/dhctl/pkg/system/ssh/cmd/ssh.go
+++ b/dhctl/pkg/system/ssh/cmd/ssh.go
@@ -76,6 +76,7 @@ func (s *SSH) Cmd() *exec.Cmd {
 		"-o", "ServerAliveInterval=7",
 		"-o", "ServerAliveCountMax=2",
 		"-o", "ConnectTimeout=5",
+		"-o", "PasswordAuthentication=no",
 	}
 
 	if s.Session.ExtraArgs != "" {


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Add `-o PasswordAuthentication=no` parameter to ssh command to prevent waiting enter password when user pass incorrect ssh key

Add confirmation for waiting Deckhouse controller readiness and control-plane node readiness.

Do not output Deckhouse logs when getting node group cloud config for created node groups.  

## Why do we need it, and what problem does it solve?
Close #1202
Close #1200

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl 
type: feature
summary: Add confirmation for waiting Deckhouse controller readiness and control-plane node readiness.
```

```changes
section: dhctl 
type: fix
summary: Exclude password authentication check while connecting to host
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
