### PR TITLE
[ingress-nginx] Fix wildcard vhost metrics

### DIFF
--- a/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -207,7 +207,7 @@ local function fill_buffer()
   ngx.var.total_upstream_response_time = 0
   ngx.var.upstream_retries = 0
 
-  local var_server_name = ngx.var.server_name:gsub("^*", "")
+  local var_server_name = ngx.var.server_name:gsub("~^%(%?<subdomain>%[\\w%-]%+%)", ""):gsub("^*", ""):gsub("$$", ""):gsub("\\", "")
 
   if var_server_name == "_" then
     _increment("c22", 22)

--- a/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -207,7 +207,9 @@ local function fill_buffer()
   ngx.var.total_upstream_response_time = 0
   ngx.var.upstream_retries = 0
 
-  local var_server_name = ngx.var.server_name:gsub("~^%(%?<subdomain>%[\\w%-]%+%)", ""):gsub("^*", ""):gsub("$$", ""):gsub("\\", "")
+  -- Since the 0.41 version ingress controller renders weird vhost for wildcard hosts like ~^(?<subdomain>[\w-]+)\.example\.com$
+  -- For older versions we just cut of the asterisk from vhost
+  local var_server_name = ngx.var.server_name:gsub("^*", ""):gsub("~^%(%?<subdomain>%[\\w%-]%+%)", ""):gsub("$$", ""):gsub("\\", "")
 
   if var_server_name == "_" then
     _increment("c22", 22)

--- a/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -207,7 +207,7 @@ local function fill_buffer()
   ngx.var.total_upstream_response_time = 0
   ngx.var.upstream_retries = 0
 
-  local var_server_name = ngx.var.server_name:gsub("^*", "")
+  local var_server_name = ngx.var.server_name:gsub("~^%(%?<subdomain>%[\\w%-]%+%)", ""):gsub("^*", ""):gsub("$$", ""):gsub("\\", "")
 
   if var_server_name == "_" then
     _increment("c22", 22)

--- a/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -207,7 +207,9 @@ local function fill_buffer()
   ngx.var.total_upstream_response_time = 0
   ngx.var.upstream_retries = 0
 
-  local var_server_name = ngx.var.server_name:gsub("~^%(%?<subdomain>%[\\w%-]%+%)", ""):gsub("^*", ""):gsub("$$", ""):gsub("\\", "")
+  -- Since the 0.41 version ingress controller renders weird vhost for wildcard hosts like ~^(?<subdomain>[\w-]+)\.example\.com$
+  -- For older versions we just cut of the asterisk from vhost
+  local var_server_name = ngx.var.server_name:gsub("^*", ""):gsub("~^%(%?<subdomain>%[\\w%-]%+%)", ""):gsub("$$", ""):gsub("\\", "")
 
   if var_server_name == "_" then
     _increment("c22", 22)

--- a/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -207,7 +207,7 @@ local function fill_buffer()
   ngx.var.total_upstream_response_time = 0
   ngx.var.upstream_retries = 0
 
-  local var_server_name = ngx.var.server_name:gsub("^*", "")
+  local var_server_name = ngx.var.server_name:gsub("~^%(%?<subdomain>%[\\w%-]%+%)", ""):gsub("^*", ""):gsub("$$", ""):gsub("\\", "")
 
   if var_server_name == "_" then
     _increment("c22", 22)

--- a/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -207,7 +207,9 @@ local function fill_buffer()
   ngx.var.total_upstream_response_time = 0
   ngx.var.upstream_retries = 0
 
-  local var_server_name = ngx.var.server_name:gsub("~^%(%?<subdomain>%[\\w%-]%+%)", ""):gsub("^*", ""):gsub("$$", ""):gsub("\\", "")
+  -- Since the 0.41 version ingress controller renders weird vhost for wildcard hosts like ~^(?<subdomain>[\w-]+)\.example\.com$
+  -- For older versions we just cut of the asterisk from vhost
+  local var_server_name = ngx.var.server_name:gsub("^*", ""):gsub("~^%(%?<subdomain>%[\\w%-]%+%)", ""):gsub("$$", ""):gsub("\\", "")
 
   if var_server_name == "_" then
     _increment("c22", 22)

--- a/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -207,7 +207,7 @@ local function fill_buffer()
   ngx.var.total_upstream_response_time = 0
   ngx.var.upstream_retries = 0
 
-  local var_server_name = ngx.var.server_name:gsub("^*", "")
+  local var_server_name = ngx.var.server_name:gsub("~^%(%?<subdomain>%[\\w%-]%+%)", ""):gsub("^*", ""):gsub("$$", ""):gsub("\\", "")
 
   if var_server_name == "_" then
     _increment("c22", 22)

--- a/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -207,7 +207,9 @@ local function fill_buffer()
   ngx.var.total_upstream_response_time = 0
   ngx.var.upstream_retries = 0
 
-  local var_server_name = ngx.var.server_name:gsub("~^%(%?<subdomain>%[\\w%-]%+%)", ""):gsub("^*", ""):gsub("$$", ""):gsub("\\", "")
+  -- Since the 0.41 version ingress controller renders weird vhost for wildcard hosts like ~^(?<subdomain>[\w-]+)\.example\.com$
+  -- For older versions we just cut of the asterisk from vhost
+  local var_server_name = ngx.var.server_name:gsub("^*", ""):gsub("~^%(%?<subdomain>%[\\w%-]%+%)", ""):gsub("$$", ""):gsub("\\", "")
 
   if var_server_name == "_" then
     _increment("c22", 22)


### PR DESCRIPTION
## Description
Fix wildcard vhost label in ingress-controller metrics

## Why do we need it, and what problem does it solve?
Fixes https://github.com/deckhouse/deckhouse/issues/1425.

## Changelog entries

```changes
section: ingress-nginx
type: fix
summary: Fix wildcard vhost label in ingress-controller metrics
impact: Ingress controller pods will be restarted
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
