### PR TITLE
[terraform-manager][ci]  Migrate from werf ansible to werf shell image builds for terraform based images

### DIFF
--- a/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
@@ -1,21 +1,27 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: {{ .ModuleName }}/base-terraform-manager
 git:
-- add: /ee/candi/cloud-providers/openstack
-  to: /deckhouse/candi/cloud-providers/openstack
-ansible:
+  - add: /ee/candi/cloud-providers/openstack
+    to: /deckhouse/candi/cloud-providers/openstack
+import:
+- artifact: terraform-provider-openstack
+  add: /terraform-provider-openstack
+  to: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_OPENSTACK_NAMESPACE" }}/{{ env "TF_OPENSTACK_TYPE" }}/{{ env "TF_OPENSTACK_VERSION" }}/linux_amd64
+  before: setup
+shell:
   install:
-  - name: "Create a directory for terraform provider openstack"
-    file:
-      path: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_OPENSTACK_NAMESPACE" }}/{{ env "TF_OPENSTACK_TYPE" }}/{{ env "TF_OPENSTACK_VERSION" }}/linux_amd64
-      state: directory
-  - name: "Install terraform provider openstack"
-    unarchive:
-      src: https://releases.hashicorp.com/terraform-provider-openstack/{{ env "TF_OPENSTACK_VERSION" }}/terraform-provider-openstack_{{ env "TF_OPENSTACK_VERSION" }}_linux_amd64.zip
-      remote_src: yes
-      dest: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_OPENSTACK_NAMESPACE" }}/{{ env "TF_OPENSTACK_TYPE" }}/{{ env "TF_OPENSTACK_VERSION" }}/linux_amd64
-      mode: +x
-  - apk:
-      name: ca-certificates
-      update_cache: yes
-  - command: rm -rf /var/cache/apk/*
+    - "apk update && apk add ca-certificates"
+    - "rm -rf /var/cache/apk/*"
+---
+artifact: terraform-provider-openstack
+# we use artifact with ubuntu because alpine can not unzip with `unzip` and `tar` command
+# current openstack zip-archive with error: "unzip: zip flag 8 (streaming) is not supported"
+from: {{ env "BASE_UBUNTU" }}
+shell:
+  beforeInstall:
+    - apt-get update && apt install -y wget unzip
+    - |
+      mkdir /out
+      wget -q https://releases.hashicorp.com/terraform-provider-openstack/{{ env "TF_OPENSTACK_VERSION" }}/terraform-provider-openstack_{{ env "TF_OPENSTACK_VERSION" }}_linux_amd64.zip -O /terraform-provider-openstack.zip
+      unzip -d /terraform-provider-openstack /terraform-provider-openstack.zip
+      chmod -R 755 /terraform-provider-openstack

--- a/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
+++ b/ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
@@ -1,8 +1,8 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: {{ .ModuleName }}/base-terraform-manager
 git:
-  - add: /ee/candi/cloud-providers/openstack
-    to: /deckhouse/candi/cloud-providers/openstack
+- add: /ee/candi/cloud-providers/openstack
+  to: /deckhouse/candi/cloud-providers/openstack
 import:
 - artifact: terraform-provider-openstack
   add: /terraform-provider-openstack

--- a/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
@@ -5,35 +5,49 @@ from: {{ env "BASE_ALPINE" }}
 docker:
   ENTRYPOINT: ["dhctl"]
 import:
-- artifact: dhctl # from main werf.yaml
-  add: /dhctl/bin/dhctl
-  to: /usr/bin/dhctl
-  before: setup
+  - artifact: dhctl # from main werf.yaml
+    add: /dhctl/bin/dhctl
+    to: /usr/bin/dhctl
+    before: setup
+  - artifact: terraform
+    add: /terraform/terraform
+    to: /bin/terraform
+    before: setup
+  - artifact: terraform
+    add: /root/.terraformrc
+    to: /root/.terraformrc
+    before: setup
 git:
-- add: /
-  to: /deckhouse
-  includePaths:
-  - candi
-  excludePaths:
-  - "candi/docs"
-  - "candi/cloud-providers"
-ansible:
+  - add: /
+    to: /deckhouse
+    includePaths:
+      - candi
+    excludePaths:
+      - "candi/docs"
+      - "candi/cloud-providers"
+shell:
   install:
-  - name: "Install terraform"
-    unarchive:
-      src: https://releases.hashicorp.com/terraform/{{ env "TF_VERSION" }}/terraform_{{ env "TF_VERSION" }}_linux_amd64.zip
-      remote_src: yes
-      dest: /bin
-      mode: +x
-  - command: rm -rf /var/cache/apk/*
-  setup:
-  - name: "Configure terraform cli"
-    copy:
-      dest: "/root/.terraformrc"
-      content: |
-        provider_installation {
-          filesystem_mirror {
-            path    = "/usr/local/share/terraform/plugins"
-            include = ["*/*/*"]
-          }
+    - "apk update && apk add ca-certificates"
+    - "rm -rf /var/cache/apk/*"
+
+---
+# use artifact for one place import for base and install images
+artifact: terraform
+# we use artifact with ubuntu because alpine can not unzip with `unzip` and `tar` command
+# current openstack zip-archive with error: "unzip: zip flag 8 (streaming) is not supported"
+from: {{ env "BASE_UBUNTU" }}
+shell:
+  beforeInstall:
+    - apt-get update && apt install -y wget unzip
+    - |
+      mkdir /terraform
+      wget https://releases.hashicorp.com/terraform/{{ env "TF_VERSION" }}/terraform_{{ env "TF_VERSION" }}_linux_amd64.zip -O - | unzip -d /terraform -
+      chmod 755 /terraform/terraform
+      cat << EOD > /root/.terraformrc
+      provider_installation {
+        filesystem_mirror {
+          path    = "/usr/local/share/terraform/plugins"
+          include = ["*/*/*"]
         }
+      }
+      EOD

--- a/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
@@ -5,26 +5,26 @@ from: {{ env "BASE_ALPINE" }}
 docker:
   ENTRYPOINT: ["dhctl"]
 import:
-  - artifact: dhctl # from main werf.yaml
-    add: /dhctl/bin/dhctl
-    to: /usr/bin/dhctl
-    before: setup
-  - artifact: terraform
-    add: /terraform/terraform
-    to: /bin/terraform
-    before: setup
-  - artifact: terraform
-    add: /root/.terraformrc
-    to: /root/.terraformrc
-    before: setup
+- artifact: dhctl # from main werf.yaml
+  add: /dhctl/bin/dhctl
+  to: /usr/bin/dhctl
+  before: setup
+- artifact: terraform
+  add: /terraform/terraform
+  to: /bin/terraform
+  before: setup
+- artifact: terraform
+  add: /root/.terraformrc
+  to: /root/.terraformrc
+  before: setup
 git:
-  - add: /
-    to: /deckhouse
-    includePaths:
-      - candi
-    excludePaths:
-      - "candi/docs"
-      - "candi/cloud-providers"
+- add: /
+  to: /deckhouse
+  includePaths:
+    - candi
+  excludePaths:
+    - "candi/docs"
+    - "candi/cloud-providers"
 shell:
   install:
     - "apk update && apk add ca-certificates"

--- a/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/base-terraform-manager/werf.inc.yaml
@@ -41,7 +41,8 @@ shell:
     - apt-get update && apt install -y wget unzip
     - |
       mkdir /terraform
-      wget https://releases.hashicorp.com/terraform/{{ env "TF_VERSION" }}/terraform_{{ env "TF_VERSION" }}_linux_amd64.zip -O - | unzip -d /terraform -
+      wget https://releases.hashicorp.com/terraform/{{ env "TF_VERSION" }}/terraform_{{ env "TF_VERSION" }}_linux_amd64.zip -O /terraform.zip
+      unzip -d /terraform /terraform.zip
       chmod 755 /terraform/terraform
       cat << EOD > /root/.terraformrc
       provider_installation {

--- a/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
@@ -23,5 +23,5 @@ shell:
     - |
       mkdir /terraform-provider-aws
       wget -q https://releases.hashicorp.com/terraform-provider-aws/{{ env "TF_AWS_VERSION" }}/terraform-provider-aws_{{ env "TF_AWS_VERSION" }}_linux_amd64.zip -O /terraform-provider-aws.zip
-      unzip -d /terraform-provider-yandex /terraform-provider-aws.zip
+      unzip -d /terraform-provider-aws /terraform-provider-aws.zip
       chmod -R 755 /terraform-provider-aws

--- a/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
@@ -1,8 +1,8 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: {{ .ModuleName }}/base-terraform-manager
 git:
-  - add: /candi/cloud-providers/aws
-    to: /deckhouse/candi/cloud-providers/aws
+- add: /candi/cloud-providers/aws
+  to: /deckhouse/candi/cloud-providers/aws
 import:
 - artifact: terraform-provider-aws
   add: /terraform-provider-aws

--- a/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
@@ -1,21 +1,27 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: {{ .ModuleName }}/base-terraform-manager
 git:
-- add: /candi/cloud-providers/aws
-  to: /deckhouse/candi/cloud-providers/aws
-ansible:
+  - add: /candi/cloud-providers/aws
+    to: /deckhouse/candi/cloud-providers/aws
+import:
+- artifact: terraform-provider-aws
+  add: /terraform-provider-aws
+  to: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_AWS_NAMESPACE" }}/{{ env "TF_AWS_TYPE" }}/{{ env "TF_AWS_VERSION" }}/linux_amd64
+  before: setup
+shell:
   install:
-  - name: "Create a directory for terraform provider aws"
-    file:
-      path: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_AWS_NAMESPACE" }}/{{ env "TF_AWS_TYPE" }}/{{ env "TF_AWS_VERSION" }}/linux_amd64
-      state: directory
-  - name: "Install terraform provider aws"
-    unarchive:
-      src: https://releases.hashicorp.com/terraform-provider-aws/{{ env "TF_AWS_VERSION" }}/terraform-provider-aws_{{ env "TF_AWS_VERSION" }}_linux_amd64.zip
-      remote_src: yes
-      dest: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_AWS_NAMESPACE" }}/{{ env "TF_AWS_TYPE" }}/{{ env "TF_AWS_VERSION" }}/linux_amd64
-      mode: +x
-  - apk:
-      name: ca-certificates
-      update_cache: yes
-  - command: rm -rf /var/cache/apk/*
+    - "apk update && apk add ca-certificates"
+    - "rm -rf /var/cache/apk/*"
+---
+artifact: terraform-provider-aws
+# we use artifact with ubuntu because alpine can not unzip with `unzip` and `tar` command
+# current openstack zip-archive with error: "unzip: zip flag 8 (streaming) is not supported"
+from: {{ env "BASE_UBUNTU" }}
+shell:
+  beforeInstall:
+    - apt-get update && apt install -y wget unzip
+    - |
+      mkdir /terraform-provider-aws
+      wget -q https://releases.hashicorp.com/terraform-provider-aws/{{ env "TF_AWS_VERSION" }}/terraform-provider-aws_{{ env "TF_AWS_VERSION" }}_linux_amd64.zip -O /terraform-provider-aws.zip
+      unzip -d /terraform-provider-yandex /terraform-provider-aws.zip
+      chmod -R 755 /terraform-provider-aws

--- a/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
@@ -23,5 +23,5 @@ shell:
     - |
       mkdir /terraform-provider-azure
       wget -q https://releases.hashicorp.com/terraform-provider-azurerm/{{ env "TF_AZURE_VERSION" }}/terraform-provider-azurerm_{{ env "TF_AZURE_VERSION" }}_linux_amd64.zip -O /terraform-provider-azure.zip
-      unzip -d /terraform-provider-yandex /terraform-provider-azure.zip
+      unzip -d /terraform-provider-azure /terraform-provider-azure.zip
       chmod -R 755 /terraform-provider-azure

--- a/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
@@ -1,21 +1,27 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: {{ .ModuleName }}/base-terraform-manager
 git:
-- add: /candi/cloud-providers/azure
-  to: /deckhouse/candi/cloud-providers/azure
-ansible:
+  - add: /candi/cloud-providers/azure
+    to: /deckhouse/candi/cloud-providers/azure
+import:
+- artifact: terraform-provider-azure
+  add: /terraform-provider-azure
+  to: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_AZURE_NAMESPACE" }}/{{ env "TF_AZURE_TYPE" }}/{{ env "TF_AZURE_VERSION" }}/linux_amd64
+  before: setup
+shell:
   install:
-  - name: "Create a directory for terraform provider azurerm"
-    file:
-      path: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_AZURE_NAMESPACE" }}/{{ env "TF_AZURE_TYPE" }}/{{ env "TF_AZURE_VERSION" }}/linux_amd64
-      state: directory
-  - name: "Install terraform provider azurerm"
-    unarchive:
-      src: https://releases.hashicorp.com/terraform-provider-azurerm/{{ env "TF_AZURE_VERSION" }}/terraform-provider-azurerm_{{ env "TF_AZURE_VERSION" }}_linux_amd64.zip
-      remote_src: yes
-      dest: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_AZURE_NAMESPACE" }}/{{ env "TF_AZURE_TYPE" }}/{{ env "TF_AZURE_VERSION" }}/linux_amd64
-      mode: +x
-  - apk:
-      name: ca-certificates
-      update_cache: yes
-  - command: rm -rf /var/cache/apk/*
+    - "apk update && apk add ca-certificates"
+    - "rm -rf /var/cache/apk/*"
+---
+artifact: terraform-provider-azure
+# we use artifact with ubuntu because alpine can not unzip with `unzip` and `tar` command
+# current openstack zip-archive with error: "unzip: zip flag 8 (streaming) is not supported"
+from: {{ env "BASE_UBUNTU" }}
+shell:
+  beforeInstall:
+    - apt-get update && apt install -y wget unzip
+    - |
+      mkdir /terraform-provider-azure
+      wget -q https://releases.hashicorp.com/terraform-provider-azurerm/{{ env "TF_AZURE_VERSION" }}/terraform-provider-azurerm_{{ env "TF_AZURE_VERSION" }}_linux_amd64.zip -O /terraform-provider-azure.zip
+      unzip -d /terraform-provider-yandex /terraform-provider-azure.zip
+      chmod -R 755 /terraform-provider-azure

--- a/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
@@ -1,8 +1,8 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: {{ .ModuleName }}/base-terraform-manager
 git:
-  - add: /candi/cloud-providers/azure
-    to: /deckhouse/candi/cloud-providers/azure
+- add: /candi/cloud-providers/azure
+  to: /deckhouse/candi/cloud-providers/azure
 import:
 - artifact: terraform-provider-azure
   add: /terraform-provider-azure

--- a/modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
@@ -1,21 +1,27 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: {{ .ModuleName }}/base-terraform-manager
 git:
-- add: /candi/cloud-providers/yandex
-  to: /deckhouse/candi/cloud-providers/yandex
-ansible:
+  - add: /candi/cloud-providers/yandex
+    to: /deckhouse/candi/cloud-providers/yandex
+import:
+- artifact: terraform-provider-yandex
+  add: /terraform-provider-yandex
+  to: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_YANDEX_NAMESPACE" }}/{{ env "TF_YANDEX_TYPE" }}/{{ env "TF_YANDEX_VERSION" }}/linux_amd64
+  before: setup
+shell:
   install:
-  - name: "Create a directory for terraform provider yandex"
-    file:
-      path: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_YANDEX_NAMESPACE" }}/{{ env "TF_YANDEX_TYPE" }}/{{ env "TF_YANDEX_VERSION" }}/linux_amd64
-      state: directory
-  - name: "Install terraform provider yandex"
-    unarchive:
-      src: https://releases.hashicorp.com/terraform-provider-yandex/{{ env "TF_YANDEX_VERSION" }}/terraform-provider-yandex_{{ env "TF_YANDEX_VERSION" }}_linux_amd64.zip
-      remote_src: yes
-      dest: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_YANDEX_NAMESPACE" }}/{{ env "TF_YANDEX_TYPE" }}/{{ env "TF_YANDEX_VERSION" }}/linux_amd64
-      mode: +x
-  - apk:
-      name: ca-certificates
-      update_cache: yes
-  - command: rm -rf /var/cache/apk/*
+    - "apk update && apk add ca-certificates"
+    - "rm -rf /var/cache/apk/*"
+---
+artifact: terraform-provider-yandex
+# we use artifact with ubuntu because alpine can not unzip with `unzip` and `tar` command
+# current openstack zip-archive with error: "unzip: zip flag 8 (streaming) is not supported"
+from: {{ env "BASE_UBUNTU" }}
+shell:
+  beforeInstall:
+    - apt-get update && apt install -y wget unzip
+    - |
+      mkdir /out
+      wget -q https://releases.hashicorp.com/terraform-provider-yandex/{{ env "TF_YANDEX_VERSION" }}/terraform-provider-yandex_{{ env "TF_YANDEX_VERSION" }}_linux_amd64.zip -O /terraform-provider-yandex.zip
+      unzip -d /terraform-provider-yandex /terraform-provider-yandex.zip
+      chmod -R 755 /terraform-provider-yandex

--- a/modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
+++ b/modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
@@ -1,8 +1,8 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: {{ .ModuleName }}/base-terraform-manager
 git:
-  - add: /candi/cloud-providers/yandex
-    to: /deckhouse/candi/cloud-providers/yandex
+- add: /candi/cloud-providers/yandex
+  to: /deckhouse/candi/cloud-providers/yandex
 import:
 - artifact: terraform-provider-yandex
   add: /terraform-provider-yandex

--- a/werf.yaml
+++ b/werf.yaml
@@ -597,6 +597,7 @@ shell:
 
     cat <<"EOD" > /etc/bashrc
     PS1='\[\033[01;30m\][deckhouse]\[\033[00m\] \[\033[01;33m\]\u@\h\[\033[01;34m\] \w \$\[\033[00m\] '
+
     source /etc/profile.d/bash_completion.sh
     EOD
 

--- a/werf.yaml
+++ b/werf.yaml
@@ -548,8 +548,8 @@ import:
   to: /bin/terraform
   before: setup
 - artifact: terraform # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
-  to: /root/.terraformrc
-  add: /etc/terraformrc
+  add: /root/.terraformrc
+  to: /etc/terraformrc
   before: setup
 - artifact: terraform-provider-aws # from modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
   add: /terraform-provider-aws

--- a/werf.yaml
+++ b/werf.yaml
@@ -588,25 +588,25 @@ shell:
   beforeInstall:
   - "apk update && apk install openssh-client gettext bash bash-completion coreutils util-linux sed gawk grep ca-certificates vim"
   - "rm -rf /var/cache/apk/*"
-setup:
-- |
-  cat <<"EOD" > /etc/inputrc
-{{- .Files.Get "deckhouse-controller/files/inputrc" | nindent 2 }}
-  EOD
+  setup:
+  - |
+    cat <<"EOD" > /etc/inputrc
+    {{- .Files.Get "deckhouse-controller/files/inputrc" | nindent 4 }}
+    EOD
 
-  cat <<"EOD" > /etc/bashrc
-  PS1='\[\033[01;30m\][deckhouse]\[\033[00m\] \[\033[01;33m\]\u@\h\[\033[01;34m\] \w \$\[\033[00m\] '
-  source /etc/profile.d/bash_completion.sh
-  EOD
+    cat <<"EOD" > /etc/bashrc
+    PS1='\[\033[01;30m\][deckhouse]\[\033[00m\] \[\033[01;33m\]\u@\h\[\033[01;34m\] \w \$\[\033[00m\] '
+    source /etc/profile.d/bash_completion.sh
+    EOD
 
-  ln -s /etc/bashrc /root/.bashrc
-  ln -s /etc/bashrc /.bashrc
+    ln -s /etc/bashrc /root/.bashrc
+    ln -s /etc/bashrc /.bashrc
 
-  cat <<"EOD" > /etc/vim/vimrc.local
-{{- .Files.Get "deckhouse-controller/files/vimrc.local" | nindent 2 }}
-  EOD
+    cat <<"EOD" > /etc/vim/vimrc.local
+  {{- .Files.Get "deckhouse-controller/files/vimrc.local" | nindent 4 }}
+    EOD
 
-  echo 'eval "$(dhctl --completion-script-bash)"' >> /etc/bashrc
+    echo 'eval "$(dhctl --completion-script-bash)"' >> /etc/bashrc
 
 ---
 image: release-channel-version

--- a/werf.yaml
+++ b/werf.yaml
@@ -594,11 +594,9 @@ shell:
     {{- .Files.Get "deckhouse-controller/files/inputrc" | nindent 4 }}
     EOD
 
-    ln -s /etc/bashrc /root/.bashrc
-    ln -s /etc/bashrc /.bashrc
-
-    cat <<"EOD" > /etc/vim/vimrc.local
-  {{- .Files.Get "deckhouse-controller/files/vimrc.local" | nindent 4 }}
+    cat <<"EOD" > /etc/bashrc
+    PS1='\[\033[01;30m\][deckhouse]\[\033[00m\] \[\033[01;33m\]\u@\h\[\033[01;34m\] \w \$\[\033[00m\] '
+    source /etc/profile.d/bash_completion.sh
     EOD
 
     echo 'eval "$(dhctl --completion-script-bash)"' >> /etc/bashrc

--- a/werf.yaml
+++ b/werf.yaml
@@ -591,7 +591,7 @@ shell:
 setup:
 - |
   cat <<"EOD" > /etc/inputrc
-  {{- .Files.Get "deckhouse-controller/files/inputrc" | nindent 8 }}
+{{- .Files.Get "deckhouse-controller/files/inputrc" | nindent 2 }}
   EOD
 
   cat <<"EOD" > /etc/bashrc
@@ -603,7 +603,7 @@ setup:
   ln -s /etc/bashrc /.bashrc
 
   cat <<"EOD" > /etc/vim/vimrc.local
-  {{- .Files.Get "deckhouse-controller/files/vimrc.local" | nindent 8 }}
+{{- .Files.Get "deckhouse-controller/files/vimrc.local" | nindent 2 }}
   EOD
 
   echo 'eval "$(dhctl --completion-script-bash)"' >> /etc/bashrc

--- a/werf.yaml
+++ b/werf.yaml
@@ -543,16 +543,39 @@ import:
   add: /dhctl/bin/dhctl
   to: /usr/bin/dhctl
   after: setup
+- artifact: terraform # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
+  add: /terraform/terraform
+  to: /bin/terraform
+  before: setup
+- artifact: terraform # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
+  to: /root/.terraformrc
+  add: /root/.terraformrc
+- artifact: terraform-provider-aws # from modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
+  add: /terraform-provider-aws
+  to: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_AWS_NAMESPACE" }}/{{ env "TF_AWS_TYPE" }}/{{ env "TF_AWS_VERSION" }}/linux_amd64
+  before: setup
+- artifact: terraform-provider-azure # from modules/040-terraform-manager/images/terraform-manager-azure/werf.inc.yaml
+  add: /terraform-provider-azure
+  to: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_AZURE_NAMESPACE" }}/{{ env "TF_AZURE_TYPE" }}/{{ env "TF_AZURE_VERSION" }}/linux_amd64
+  before: setup
+- artifact: terraform-provider-gcp # from modules/040-terraform-manager/images/terraform-manager-gcp/werf.inc.yaml
+  add: /terraform-provider-gcp/terraform-provider-gcp
+  to: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_GCP_NAMESPACE" }}/{{ env "TF_GCP_TYPE" }}/{{ env "TF_GCP_VERSION" }}/linux_amd64/terraform-provider-google
+  after: setup
+- artifact: terraform-provider-yandex # from modules/040-terraform-manager/images/terraform-manager-yandex/werf.inc.yaml
+  add: /terraform-provider-yandex
+  to: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_YANDEX_NAMESPACE" }}/{{ env "TF_YANDEX_TYPE" }}/{{ env "TF_YANDEX_VERSION" }}/linux_amd64
+  before: setup
 {{- if ne .Env "CE" }}
+- artifact: terraform-provider-openstack # from ee/modules/040-terraform-manager/images/terraform-manager-openstack/werf.inc.yaml
+  add: /terraform-provider-openstack
+  to: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_OPENSTACK_NAMESPACE" }}/{{ env "TF_OPENSTACK_TYPE" }}/{{ env "TF_OPENSTACK_VERSION" }}/linux_amd64
+  before: setup
 - artifact: terraform-provider-vsphere # from modules/040-terraform-manager/images/terraform-manager-vsphere/werf.inc.yaml
   add: /terraform-provider-vsphere/terraform-provider-vsphere
   to: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_VSPHERE_NAMESPACE" }}/{{ env "TF_VSPHERE_TYPE" }}/{{ env "TF_VSPHERE_VERSION" }}/linux_amd64/terraform-provider-vsphere
   after: setup
 {{- end }}
-- artifact: terraform-provider-gcp # from modules/040-terraform-manager/images/terraform-manager-gcp/werf.inc.yaml
-  add: /terraform-provider-gcp/terraform-provider-gcp
-  to: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_GCP_NAMESPACE" }}/{{ env "TF_GCP_TYPE" }}/{{ env "TF_GCP_VERSION" }}/linux_amd64/terraform-provider-google
-  after: setup
 - image: images-tags
   add: /images_tags.json
   to: /deckhouse/candi/images_tags.json
@@ -561,119 +584,29 @@ docker:
   ENV:
     EDITOR: vim
     TF_CLI_CONFIG_FILE: /etc/terraformrc
-ansible:
+shell:
   beforeInstall:
-  - name: "Install dependencies"
-    apk:
-      name:
-      - openssh-client
-      - gettext
-      - bash
-      - bash-completion
-      - coreutils
-      - util-linux
-      - sed
-      - gawk
-      - grep
-      - ca-certificates
-      - vim
+  - "apk update && apk install openssh-client gettext bash bash-completion coreutils util-linux sed gawk grep ca-certificates vim"
+  - "rm -rf /var/cache/apk/*"
+setup:
+- |
+  cat <<"EOD" > /etc/inputrc
+  {{- .Files.Get "deckhouse-controller/files/inputrc" | nindent 8 }}
+  EOD
 
-  - name: "Install terraform"
-    unarchive:
-      src: https://releases.hashicorp.com/terraform/{{ env "TF_VERSION" }}/terraform_{{ env "TF_VERSION" }}_linux_amd64.zip
-      remote_src: yes
-      dest: /bin
-      mode: +x
+  cat <<"EOD" > /etc/bashrc
+  PS1='\[\033[01;30m\][deckhouse]\[\033[00m\] \[\033[01;33m\]\u@\h\[\033[01;34m\] \w \$\[\033[00m\] '
+  source /etc/profile.d/bash_completion.sh
+  EOD
 
-  - raw: rm -rf /var/cache/apk/*
+  ln -s /etc/bashrc /root/.bashrc
+  ln -s /etc/bashrc /.bashrc
 
-  install:
-  - name: "Create a directory for terraform provider aws"
-    file:
-      path: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_AWS_NAMESPACE" }}/{{ env "TF_AWS_TYPE" }}/{{ env "TF_AWS_VERSION" }}/linux_amd64
-      state: directory
-  - name: "Install terraform provider aws"
-    unarchive:
-      src: https://releases.hashicorp.com/terraform-provider-aws/{{ env "TF_AWS_VERSION" }}/terraform-provider-aws_{{ env "TF_AWS_VERSION" }}_linux_amd64.zip
-      remote_src: yes
-      dest: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_AWS_NAMESPACE" }}/{{ env "TF_AWS_TYPE" }}/{{ env "TF_AWS_VERSION" }}/linux_amd64
-      mode: +x
+  cat <<"EOD" > /etc/vim/vimrc.local
+  {{- .Files.Get "deckhouse-controller/files/vimrc.local" | nindent 8 }}
+  EOD
 
-  - name: "Create a directory for terraform provider openstack"
-    file:
-      path: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_OPENSTACK_NAMESPACE" }}/{{ env "TF_OPENSTACK_TYPE" }}/{{ env "TF_OPENSTACK_VERSION" }}/linux_amd64
-      state: directory
-  - name: "Install terraform provider openstack"
-    unarchive:
-      src: https://releases.hashicorp.com/terraform-provider-openstack/{{ env "TF_OPENSTACK_VERSION" }}/terraform-provider-openstack_{{ env "TF_OPENSTACK_VERSION" }}_linux_amd64.zip
-      remote_src: yes
-      dest: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_OPENSTACK_NAMESPACE" }}/{{ env "TF_OPENSTACK_TYPE" }}/{{ env "TF_OPENSTACK_VERSION" }}/linux_amd64
-      mode: +x
-
-  - name: "Create a directory for terraform provider yandex"
-    file:
-      path: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_YANDEX_NAMESPACE" }}/{{ env "TF_YANDEX_TYPE" }}/{{ env "TF_YANDEX_VERSION" }}/linux_amd64
-      state: directory
-  - name: "Install terraform provider yandex"
-    unarchive:
-      src: https://releases.hashicorp.com/terraform-provider-yandex/{{ env "TF_YANDEX_VERSION" }}/terraform-provider-yandex_{{ env "TF_YANDEX_VERSION" }}_linux_amd64.zip
-      remote_src: yes
-      dest: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_YANDEX_NAMESPACE" }}/{{ env "TF_YANDEX_TYPE" }}/{{ env "TF_YANDEX_VERSION" }}/linux_amd64
-      mode: +x
-
-  - name: "Create a directory for terraform provider azurerm"
-    file:
-      path: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_AZURE_NAMESPACE" }}/{{ env "TF_AZURE_TYPE" }}/{{ env "TF_AZURE_VERSION" }}/linux_amd64
-      state: directory
-  - name: "Install terraform provider azurerm"
-    unarchive:
-      src: https://releases.hashicorp.com/terraform-provider-azurerm/{{ env "TF_AZURE_VERSION" }}/terraform-provider-azurerm_{{ env "TF_AZURE_VERSION" }}_linux_amd64.zip
-      remote_src: yes
-      dest: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_AZURE_NAMESPACE" }}/{{ env "TF_AZURE_TYPE" }}/{{ env "TF_AZURE_VERSION" }}/linux_amd64
-      mode: +x
-
-  setup:
-  - name: "Shell comfort: inputrc"
-    copy:
-      content: |
-        {{- .Files.Get "deckhouse-controller/files/inputrc" | nindent 8 }}
-      dest: /etc/inputrc
-
-  - name: "Shell comfort: bashrc"
-    copy:
-      content: |
-        PS1='\[\033[01;30m\][deckhouse]\[\033[00m\] \[\033[01;33m\]\u@\h\[\033[01;34m\] \w \$\[\033[00m\] '
-
-        source /etc/profile.d/bash_completion.sh
-
-      dest: /etc/bashrc
-
-  - name: "Shell comfort: add bashrc for root"
-    shell: ln -s /etc/bashrc /root/.bashrc
-
-  - name: "Shell comfort: add bashrc for nobody"
-    shell: ln -s /etc/bashrc /.bashrc
-
-  - name: "Shell comfort: vimrc.local"
-    copy:
-      content: |
-        {{- .Files.Get "deckhouse-controller/files/vimrc.local" | nindent 8 }}
-      dest: /etc/vim/vimrc.local
-
-  - name: "Add dhctl completion"
-    shell: |
-      echo 'eval "$(dhctl --completion-script-bash)"' >> /etc/bashrc
-
-  - name: "Configure terraform cli"
-    copy:
-      dest: "/etc/terraformrc"
-      content: |
-        provider_installation {
-          filesystem_mirror {
-            path    = "/usr/local/share/terraform/plugins"
-            include = ["*/*/*"]
-          }
-        }
+  echo 'eval "$(dhctl --completion-script-bash)"' >> /etc/bashrc
 
 ---
 image: release-channel-version

--- a/werf.yaml
+++ b/werf.yaml
@@ -590,10 +590,6 @@ shell:
   - "rm -rf /var/cache/apk/*"
   setup:
   - |
-    cat <<"EOD" > /etc/inputrc
-    {{- .Files.Get "deckhouse-controller/files/inputrc" | nindent 4 }}
-    EOD
-
     cat <<"EOD" > /etc/bashrc
     PS1='\[\033[01;30m\][deckhouse]\[\033[00m\] \[\033[01;33m\]\u@\h\[\033[01;34m\] \w \$\[\033[00m\] '
     source /etc/profile.d/bash_completion.sh

--- a/werf.yaml
+++ b/werf.yaml
@@ -550,6 +550,7 @@ import:
 - artifact: terraform # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
   to: /root/.terraformrc
   add: /root/.terraformrc
+  before: setup
 - artifact: terraform-provider-aws # from modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
   add: /terraform-provider-aws
   to: /usr/local/share/terraform/plugins/registry.terraform.io/{{ env "TF_AWS_NAMESPACE" }}/{{ env "TF_AWS_TYPE" }}/{{ env "TF_AWS_VERSION" }}/linux_amd64
@@ -597,6 +598,13 @@ shell:
     cat <<"EOD" > /etc/bashrc
     PS1='\[\033[01;30m\][deckhouse]\[\033[00m\] \[\033[01;33m\]\u@\h\[\033[01;34m\] \w \$\[\033[00m\] '
     source /etc/profile.d/bash_completion.sh
+    EOD
+
+    ln -s /etc/bashrc /root/.bashrc
+    ln -s /etc/bashrc /.bashrc
+
+    cat <<"EOD" > /etc/vim/vimrc.local
+    {{- .Files.Get "deckhouse-controller/files/vimrc.local" | nindent 4 }}
     EOD
 
     echo 'eval "$(dhctl --completion-script-bash)"' >> /etc/bashrc

--- a/werf.yaml
+++ b/werf.yaml
@@ -590,9 +590,8 @@ shell:
   - "rm -rf /var/cache/apk/*"
   setup:
   - |
-    cat <<"EOD" > /etc/bashrc
-    PS1='\[\033[01;30m\][deckhouse]\[\033[00m\] \[\033[01;33m\]\u@\h\[\033[01;34m\] \w \$\[\033[00m\] '
-    source /etc/profile.d/bash_completion.sh
+    cat <<"EOD" > /etc/inputrc
+    {{- .Files.Get "deckhouse-controller/files/inputrc" | nindent 4 }}
     EOD
 
     ln -s /etc/bashrc /root/.bashrc

--- a/werf.yaml
+++ b/werf.yaml
@@ -587,7 +587,7 @@ docker:
     TF_CLI_CONFIG_FILE: /etc/terraformrc
 shell:
   beforeInstall:
-  - "apk update && apk install openssh-client gettext bash bash-completion coreutils util-linux sed gawk grep ca-certificates vim"
+  - "apk update && apk add openssh-client gettext bash bash-completion coreutils util-linux sed gawk grep ca-certificates vim"
   - "rm -rf /var/cache/apk/*"
   setup:
   - |

--- a/werf.yaml
+++ b/werf.yaml
@@ -549,7 +549,7 @@ import:
   before: setup
 - artifact: terraform # from modules/040-terraform-manager/images/terraform-manager-base/werf.inc.yaml
   to: /root/.terraformrc
-  add: /root/.terraformrc
+  add: /etc/terraformrc
   before: setup
 - artifact: terraform-provider-aws # from modules/040-terraform-manager/images/terraform-manager-aws/werf.inc.yaml
   add: /terraform-provider-aws


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Migrate from werf ansible to werf shell for terraform based images.

Move terraform and cloud providers into artifacts images.

## Why do we need it, and what problem does it solve?
Terraform based images can not build.
Ansible step is trying use its own CA certificates and we can not download terraform and terrafrom plugins.


## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: fix
summary: Migrate from werf ansible to werf shell image builds for terraform based images
impact_level: low
```

```changes
section: terraform-manager
type: fix
summary: Migrate from werf ansible to werf shell image builds for terraform based images
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
