### PR TITLE
CI: fix regex in module discovery

### DIFF
--- a/.github/scripts/js/changelog-find-sections.js
+++ b/.github/scripts/js/changelog-find-sections.js
@@ -25,6 +25,7 @@ module.exports = function findSections() {
 
 // For testing in Node REPL
 // const { find } = require('./.github/scripts/js/changelog-find-sections.js')
+// find([".", "modules", "ee/modules", "ee/fe/modules"], ["^\\.", "CHANGELOG", "^ee$", "^modules$"])
 module.exports.find = find;
 
 /**

--- a/.github/scripts/js/changelog-find-sections.js
+++ b/.github/scripts/js/changelog-find-sections.js
@@ -32,7 +32,7 @@ module.exports.find = find;
  * @param {string[]} roots      the array of directories, e.g. [".", "modules", "ee/modules", "ee/fe/modules"]
  * @param {string[]} exclusions the array of sections to exclude, e.g. ["^\\.", "CHANGELOG", "ee", "modules"]
  * @returns the array of sections
- * call([".", "modules", "ee/modules", "ee/fe/modules"], ["^\\.", "CHANGELOG", "ee", "modules"])
+ * call([".", "modules", "ee/modules", "ee/fe/modules"], ["^\\.", "CHANGELOG", "^ee$", "^modules$"])
  */
 function find(roots = [], exclusions = []) {
   const foundSections = roots.flatMap((root) => getSections(root, exclusions));


### PR DESCRIPTION
Signed-off-by: Eugene Shevchenko <evgeny.shevchenko@flant.com>

## Description

Fixes module discovery with regex applied to dir names.

## Why do we need it, and what problem does it solve?

Fixes missing "keepalived" as known module

## Changelog entries

```changes
section: ci
type: fix
summary: 'Fixed missing modules in changelog (e.g. keepalived due to /ee/ regex)'
impact_level: low
```
