### PR TITLE
[docs] Disable certificateOwnerRef

### DIFF
--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -79,7 +79,7 @@ kind: Certificate
 metadata:
   name: {{ .Chart.Name }}-cert
 spec:
-  certificateOwnerRef: false
+  # certificateOwnerRef: false
   secretName: tls-{{ $host }}
   issuerRef:
     kind: ClusterIssuer


### PR DESCRIPTION
## Description
Temporarily disable using `certificateOwnerRef:` in a Certificate resource of the site (was set in https://github.com/deckhouse/deckhouse/pull/1601). 

Will be enabled when Deckhouse v1.33 is on the production web cluster.

## Changelog entries
```changes
section: docs
type: fix
summary: disable using `certificateOwnerRef:` in a Certificate resource of the site
impact_level: low
```
