### PR TITLE
[Upmeter] Add alerts for probe garbage

### DIFF
--- a/modules/500-upmeter/hooks/probe_deckhouse_configuration.go
+++ b/modules/500-upmeter/hooks/probe_deckhouse_configuration.go
@@ -69,7 +69,10 @@ func mirrorProbeValue(input *go_hook.HookInput) error {
 		namespace  = ""
 	)
 
-	for _, raw := range input.Snapshots["probe_objects"] {
+	snaps := input.Snapshots["probe_objects"]
+	input.MetricsCollector.Set("d8_upmeter_upmeterhookprobe_count", float64(len(snaps)), nil)
+
+	for _, raw := range snaps {
 		obj := raw.(probeObject)
 
 		patchRaw := map[string]interface{}{

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/d8_clusterconfiguration.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/d8_clusterconfiguration.go
@@ -163,8 +163,8 @@ kind: UpmeterHookProbe
 metadata:
   name: %q
   labels:
-    heritage: upmeter
     app: upmeter
+    heritage: upmeter
     upmeter-agent: %q
     upmeter-group: deckhouse
     upmeter-probe: cluster-configuration

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_configmap.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_configmap.go
@@ -64,7 +64,7 @@ func (c *configMapLifecycleChecker) BusyWith() string {
 }
 
 func (c *configMapLifecycleChecker) Check() check.Error {
-	configMap := createConfigMap()
+	configMap := createConfigMapObject()
 	c.checker = c.new(configMap)
 	return c.checker.Check()
 }
@@ -155,7 +155,7 @@ func (c *configMapDeletionChecker) Check() check.Error {
 	return nil
 }
 
-func createConfigMap() *v1.ConfigMap {
+func createConfigMapObject() *v1.ConfigMap {
 	name := util.RandomIdentifier("upmeter-basic")
 
 	return &v1.ConfigMap{
@@ -166,6 +166,7 @@ func createConfigMap() *v1.ConfigMap {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
+				"app":           "upmeter",
 				"heritage":      "upmeter",
 				"upmeter-agent": util.AgentUniqueId(),
 				"upmeter-group": "control-plane",

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_deployment.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_deployment.go
@@ -97,7 +97,7 @@ func (c *deploymentLifecycleChecker) new(deployment *appsv1.Deployment) check.Ch
 	pingControlPlane := newControlPlaneChecker(c.access, c.controlPlaneAccessTimeout)
 
 	// Clean all prior garbage that could be left by agent restarts. We rely on agent ID in
-	// assumption that master nodes are not a subject for renamimg.
+	// assumption that master nodes are not a subject for renaming.
 	labels := map[string]string{agentLabelKey: c.agentId}
 	collectGarbage := newGarbageCollectorCheckerByLabels(c.access, deployment.Kind, c.namespace, labels, c.garbageCollectionTimeout)
 
@@ -204,6 +204,7 @@ func createDeploymentObject(agentId string) *appsv1.Deployment {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
+				"app":           "upmeter",
 				"heritage":      "upmeter",
 				agentLabelKey:   agentId,
 				"upmeter-group": "control-plane",
@@ -222,6 +223,7 @@ func createDeploymentObject(agentId string) *appsv1.Deployment {
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
+						"app":           "upmeter",
 						"heritage":      "upmeter",
 						agentLabelKey:   agentId,
 						"upmeter-group": "control-plane",

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_namespace.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_namespace.go
@@ -157,6 +157,7 @@ func createNamespaceObject() *v1.Namespace {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
+				"app":           "upmeter",
 				"heritage":      "upmeter",
 				"upmeter-agent": util.AgentUniqueId(),
 				"upmeter-group": "control-plane",

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_pod.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_pod.go
@@ -236,6 +236,7 @@ func createPodObject(nodeName string, image *kubernetes.ProbeImage) *v1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: podName,
 			Labels: map[string]string{
+				"app":           "upmeter",
 				"heritage":      "upmeter",
 				"upmeter-agent": util.AgentUniqueId(),
 				"upmeter-group": "control-plane",

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/smoke_mini.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/smoke_mini.go
@@ -49,7 +49,7 @@ func (s SmokeMiniAvailable) Checker() check.Checker {
 		timeout: s.DnsTimeout,
 	}
 
-	// timouts are maintained in request context
+	// timeouts are maintained in request context
 	client := &http.Client{
 		Transport: &http.Transport{
 			MaxIdleConns:    5,

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -166,3 +166,269 @@
 
           If you have no disk provisioning system in the cluster,
           you can disable ordering volumes for the some-mini through the module settings.
+
+- name: d8.upmeter.resources
+  rules:
+    - alert: D8UpmeterProbeGarbageConfigmap
+      expr: |
+        (
+          count (kube_configmap_info{namespace="d8-upmeter", configmap=~"upmeter-basic-.*"})
+          /
+          count (kube_pod_labels{namespace="d8-upmeter", label_app="upmeter-agent"})
+        ) >= 2
+      for: 10m
+      labels:
+        severity_level: "9"
+        tier: cluster
+        d8_module: upmeter
+        d8_component: upmeter-agent
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_create_group_if_not_exists__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse"
+        plk_labels_as_annotations: "configmap"
+        summary: Garbage produced by basic probe is not being cleaned.
+        description: |
+          Probe configmaps found.
+
+          Upmeter agents should clean ConfigMaps produced by control-plane/basic probe. There should not be more
+          configmaps than master nodes (upmeter-agent is a DaemonSet with master nodeSelector). Also, they should be
+          deleted within seconds.
+
+          This might be an indication of a problem with kube-apiserver. Or, possibly, the configmaps were left by old
+          upmeter-agent pods due to Upmeter update.
+
+          1. Check upmeter-agent logs
+
+          `kubectl -n d8-upmeter logs ds/upmeter-agent | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "basic-functionality") | [.time, .level, .msg] | @tsv'`
+
+          2. Check that control plane is functional.
+
+          3. Delete configmaps manually:
+
+          `kubectl -n d8-upmeter delete cm -l heritage=upmeter`
+
+    - alert: D8UpmeterProbeGarbageDeployment
+      expr: |
+        (
+          count (kube_deployment_labels{namespace="d8-upmeter", label_heritage="upmeter",
+                                                                label_upmeter_probe="controller-manager"})
+          /
+          count (kube_pod_labels{namespace="d8-upmeter", label_app="upmeter-agent"} )
+        ) >= 2
+      for: 10m
+      labels:
+        severity_level: "9"
+        tier: cluster
+        d8_module: upmeter
+        d8_component: upmeter-agent
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_create_group_if_not_exists__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse"
+        plk_labels_as_annotations: "deployment"
+        summary: Garbage produced by controller-manager probe is not being cleaned.
+        description: |
+          Average probe deployments count per upmeter-agent pod: {{ $value }}.
+
+          Upmeter agents should clean Deployments produced by control-plane/controller-manager probe. There should not
+          be more deployments than master nodes (upmeter-agent is a DaemonSet with master nodeSelector).
+          Also, they should be deleted within seconds.
+
+          This might be an indication of a problem with kube-apiserver. Or, possibly, the deployments were left by old
+          upmeter-agent pods due to Upmeter update.
+
+          1. Check upmeter-agent logs
+
+          `kubectl -n d8-upmeter logs ds/upmeter-agent | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "controller-manager") | [.time, .level, .msg] | @tsv'`
+
+          2. Check that control plane is functional, kube-controller-manager in particular.
+
+          3. Delete deployments manually:
+
+          `kubectl -n d8-upmeter delete deploy -l heritage=upmeter`
+
+    - alert: D8UpmeterProbeGarbagePodsFromDeployments
+      expr: |
+        (
+          count (kube_pod_labels{namespace="d8-upmeter", label_heritage="upmeter",
+                                                         label_upmeter_probe="controller-manager"})
+          /
+          count (kube_pod_labels{namespace="d8-upmeter", label_app="upmeter-agent"})
+        ) >= 1
+      for: 10m
+      labels:
+        severity_level: "9"
+        tier: cluster
+        d8_module: upmeter
+        d8_component: upmeter-agent
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_create_group_if_not_exists__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse"
+        plk_labels_as_annotations: "pod"
+        summary: Garbage produced by controller-manager probe is not being cleaned.
+        description: |
+          Average probe pods count per upmeter-agent pod: {{ $value }}.
+
+          Upmeter agents should clean Deployments produced by control-plane/controller-manager probe,
+          and hence kube-controller-manager should clean their pods. There should not be more of these pods than
+          master nodes (upmeter-agent is a DaemonSet with master nodeSelector). Also, they should be
+          deleted within seconds.
+
+          This might be an indication of a problem with kube-apiserver or kube-controller-manager. Or, probably,
+          the pods were left by old upmeter-agent pods due to Upmeter update.
+
+          1. Check upmeter-agent logs
+
+          `kubectl -n d8-upmeter logs ds/upmeter-agent | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "controller-manager") | [.time, .level, .msg] | @tsv'`
+
+          2. Check that control plane is functional, kube-controller-manager in particular.
+
+          3. Delete pods manually:
+
+          `kubectl -n d8-upmeter delete po -l upmeter-probe=controller-manager`
+
+    - alert: D8UpmeterProbeGarbagePods
+      expr: |
+        (
+          count (kube_pod_labels{namespace="d8-upmeter", label_heritage="upmeter",
+                                                         label_upmeter_probe="scheduler"})
+          /
+          count (kube_pod_labels{namespace="d8-upmeter", label_app="upmeter-agent"})
+        ) >= 2
+      for: 10m
+      labels:
+        severity_level: "9"
+        tier: cluster
+        d8_module: upmeter
+        d8_component: upmeter-agent
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_create_group_if_not_exists__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse"
+        plk_labels_as_annotations: "pod"
+        summary: Garbage produced by scheduler probe is not being cleaned.
+        description: |
+          Average probe pods count per upmeter-agent pod: {{ $value }}.
+
+          Upmeter agents should clean Pods produced by control-plane/scheduler probe. There should not be more
+          of these pods than master nodes (upmeter-agent is a DaemonSet with master nodeSelector). Also, they should be
+          deleted within seconds.
+
+          This might be an indication of a problem with kube-apiserver. Or, possibly, the pods were left
+          by old upmeter-agent pods due to Upmeter update.
+
+          1. Check upmeter-agent logs
+
+          `kubectl -n d8-upmeter logs ds/upmeter-agent | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "scheduler") | [.time, .level, .msg] | @tsv'`
+
+          2. Check that control plane is functional.
+
+          3. Delete pods manually:
+
+          `kubectl -n d8-upmeter delete po -l upmeter-probe=scheduler`
+
+    - alert: D8UpmeterProbeGarbageNamespaces
+      expr: |
+        (
+          count (kube_namespace_status_phase{namespace=~"upmeter-.*"})
+          /
+          count (kube_pod_labels{namespace="d8-upmeter", label_app="upmeter-agent"})
+        ) >= 2
+      for: 10m
+      labels:
+        severity_level: "9"
+        tier: cluster
+        d8_module: upmeter
+        d8_component: upmeter-agent
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_create_group_if_not_exists__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse"
+        plk_labels_as_annotations: "namespace"
+        summary: Garbage produced by namespace probe is not being cleaned.
+        description: |
+          Average probe namespace per upmeter-agent pod: {{ $value }}.
+
+          Upmeter agents should clean namespaces produced by control-plane/namespace probe. There should not be more
+          of these namespaces than master nodes (upmeter-agent is a DaemonSet with master nodeSelector).
+          Also, they should be deleted within seconds.
+
+          This might be an indication of a problem with kube-apiserver. Or, possibly, the namespaces were left
+          by old upmeter-agent pods due to Upmeter update.
+
+          1. Check upmeter-agent logs
+
+          `kubectl -n d8-upmeter logs ds/upmeter-agent | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "namespace") | [.time, .level, .msg] | @tsv'`
+
+          2. Check that control plane is functional.
+
+          3. Delete namespaces manually: `kubectl -n d8-upmeter delete ns -l heritage=upmeter`
+
+    - alert: D8UpmeterTooManyHookProbeObjects
+      expr: |
+        (
+          sum (d8_upmeter_upmeterhookprobe_count)
+          /
+          count (kube_pod_labels{namespace="d8-upmeter", label_app="upmeter-agent"})
+        ) > 1
+      for: 10m
+      labels:
+        severity_level: "9"
+        tier: cluster
+        d8_module: upmeter
+        d8_component: upmeter-agent
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_create_group_if_not_exists__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse"
+        plk_labels_as_annotations: "upmeterhookprobe"
+        summary: Too many UpmeterHookProbe objects in cluster
+        description: |
+          Average UpmeterHookProbe count per upmeter-agent pod is {{ $value }}, but should be strictly 1.
+
+          Some of the objects were left by old upmeter-agent pods due to Upmeter update or downscale.
+
+          Leave only newest objects corresponding to upemter-agent pods, when the reason it investigated.
+
+          See `kubectl get upmeterhookprobes.deckhouse.io`.
+
+    - alert: D8UpmeterSmokeMiniMoreThanOnePVxPVC
+      expr: |
+        max (
+          count by (volumename, persistentvolumeclaim) (
+            0 * (label_replace(kube_persistentvolume_status_phase{ phase!="Bound" }, "volumename", "$1", "persistentvolume", "^(.*)$" ))
+            +
+            on (volumename) group_left (persistentvolumeclaim)
+            (kube_persistentvolumeclaim_info{namespace="d8-upmeter", persistentvolumeclaim=~"disk-smoke-mini-.*"})
+          )
+        ) > 1
+      for: 1h
+      labels:
+        severity_level: "9"
+        tier: cluster
+        d8_module: upmeter
+        d8_component: upmeter-agent
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_create_group_if_not_exists__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse"
+        plk_labels_as_annotations: "volume"
+        summary: Unnecessary smoke-mini volumes in cluster
+        description: |
+          PV count per smoke-mini PVC: {{ $value }}.
+
+          Smoke-mini PVs should be deleted when released. Probably smoke-mini storage class has Retain policy by default,
+          or there is CSI/cloud issue.
+
+          These PVs have no valuable data on them an should be deleted.
+
+          The list of PVs: `kubectl get pv | grep disk-smoke-mini`.


### PR DESCRIPTION
## Description

Add alerts for garbage left by upmeter probes.

## Why do we need it, and what problem does it solve?

We should clean the garbage when it cannot be deleted. Moreover, upmeter agent does not delete
garbage by labels, it only tracks objects by name within single run.

## Changelog entries

```changes
section: upmeter
type: chore
summary: Added alerts for garbage objects left by probes
```
