### PR TITLE
[candi][terraform-manager] Upgrade Yandex Cloud terraform provider to 0.74.0

### DIFF
--- a/.github/ci_includes/terraform_versions.yml
+++ b/.github/ci_includes/terraform_versions.yml
@@ -19,6 +19,6 @@ TF_VSPHERE_TYPE: vsphere
 TF_VSPHERE_VERSION: 2.0.2
 TF_YANDEX_NAMESPACE: yandex-cloud
 TF_YANDEX_TYPE: yandex
-TF_YANDEX_VERSION: 0.45.1
+TF_YANDEX_VERSION: 0.74.0
 # </template: terraform_versions_envs>
 {!{- end -}!}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -73,7 +73,7 @@ env:
   TF_VSPHERE_VERSION: 2.0.2
   TF_YANDEX_NAMESPACE: yandex-cloud
   TF_YANDEX_TYPE: yandex
-  TF_YANDEX_VERSION: 0.45.1
+  TF_YANDEX_VERSION: 0.74.0
   # </template: terraform_versions_envs>
 
 # Analog of Gitlab's "interruptible: true" behaviour.

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -81,7 +81,7 @@ env:
   TF_VSPHERE_VERSION: 2.0.2
   TF_YANDEX_NAMESPACE: yandex-cloud
   TF_YANDEX_TYPE: yandex
-  TF_YANDEX_VERSION: 0.45.1
+  TF_YANDEX_VERSION: 0.74.0
   # </template: terraform_versions_envs>
 
 # Analog of Gitlab's "interruptible: true" behaviour.

--- a/.github/workflows/deploy-web-stage.yml
+++ b/.github/workflows/deploy-web-stage.yml
@@ -91,7 +91,7 @@ env:
   TF_VSPHERE_VERSION: 2.0.2
   TF_YANDEX_NAMESPACE: yandex-cloud
   TF_YANDEX_TYPE: yandex
-  TF_YANDEX_VERSION: 0.45.1
+  TF_YANDEX_VERSION: 0.74.0
   # </template: terraform_versions_envs>
 
   # Analog of Gitlab's "interruptible: true" behaviour.

--- a/.github/workflows/deploy-web-test.yml
+++ b/.github/workflows/deploy-web-test.yml
@@ -91,7 +91,7 @@ env:
   TF_VSPHERE_VERSION: 2.0.2
   TF_YANDEX_NAMESPACE: yandex-cloud
   TF_YANDEX_TYPE: yandex
-  TF_YANDEX_VERSION: 0.45.1
+  TF_YANDEX_VERSION: 0.74.0
   # </template: terraform_versions_envs>
 
   # Analog of Gitlab's "interruptible: true" behaviour.

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -96,7 +96,7 @@ env:
   TF_VSPHERE_VERSION: 2.0.2
   TF_YANDEX_NAMESPACE: yandex-cloud
   TF_YANDEX_TYPE: yandex
-  TF_YANDEX_VERSION: 0.45.1
+  TF_YANDEX_VERSION: 0.74.0
   # </template: terraform_versions_envs>
 
 # Note: no concurrency section for e2e workflows.

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -96,7 +96,7 @@ env:
   TF_VSPHERE_VERSION: 2.0.2
   TF_YANDEX_NAMESPACE: yandex-cloud
   TF_YANDEX_TYPE: yandex
-  TF_YANDEX_VERSION: 0.45.1
+  TF_YANDEX_VERSION: 0.74.0
   # </template: terraform_versions_envs>
 
 # Note: no concurrency section for e2e workflows.

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -96,7 +96,7 @@ env:
   TF_VSPHERE_VERSION: 2.0.2
   TF_YANDEX_NAMESPACE: yandex-cloud
   TF_YANDEX_TYPE: yandex
-  TF_YANDEX_VERSION: 0.45.1
+  TF_YANDEX_VERSION: 0.74.0
   # </template: terraform_versions_envs>
 
 # Note: no concurrency section for e2e workflows.

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -96,7 +96,7 @@ env:
   TF_VSPHERE_VERSION: 2.0.2
   TF_YANDEX_NAMESPACE: yandex-cloud
   TF_YANDEX_TYPE: yandex
-  TF_YANDEX_VERSION: 0.45.1
+  TF_YANDEX_VERSION: 0.74.0
   # </template: terraform_versions_envs>
 
 # Note: no concurrency section for e2e workflows.

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -96,7 +96,7 @@ env:
   TF_VSPHERE_VERSION: 2.0.2
   TF_YANDEX_NAMESPACE: yandex-cloud
   TF_YANDEX_TYPE: yandex
-  TF_YANDEX_VERSION: 0.45.1
+  TF_YANDEX_VERSION: 0.74.0
   # </template: terraform_versions_envs>
 
 # Note: no concurrency section for e2e workflows.

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -96,7 +96,7 @@ env:
   TF_VSPHERE_VERSION: 2.0.2
   TF_YANDEX_NAMESPACE: yandex-cloud
   TF_YANDEX_TYPE: yandex
-  TF_YANDEX_VERSION: 0.45.1
+  TF_YANDEX_VERSION: 0.74.0
   # </template: terraform_versions_envs>
 
 # Note: no concurrency section for e2e workflows.

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -96,7 +96,7 @@ env:
   TF_VSPHERE_VERSION: 2.0.2
   TF_YANDEX_NAMESPACE: yandex-cloud
   TF_YANDEX_TYPE: yandex
-  TF_YANDEX_VERSION: 0.45.1
+  TF_YANDEX_VERSION: 0.74.0
   # </template: terraform_versions_envs>
 
 # Note: no concurrency section for e2e workflows.

--- a/.github/workflows/schedule-cleanup.yml
+++ b/.github/workflows/schedule-cleanup.yml
@@ -71,7 +71,7 @@ env:
   TF_VSPHERE_VERSION: 2.0.2
   TF_YANDEX_NAMESPACE: yandex-cloud
   TF_YANDEX_TYPE: yandex
-  TF_YANDEX_VERSION: 0.45.1
+  TF_YANDEX_VERSION: 0.74.0
   # </template: terraform_versions_envs>
 
 # Always run a single job at a time.


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Upgrade yandex cloud terraform provider

## Why do we need it, and what problem does it solve?
Close #1576

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: feature
summary: Upgrade Yandex Cloud terraform provider to 0.74.0
---
section: terraform-manager
type: feature
summary: Upgrade Yandex Cloud terraform provider to 0.74.0
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
