### PR TITLE
[Upmeter] Fix (again) sections discovery

### DIFF
--- a/.github/actions/milestone-changelog/action.yml
+++ b/.github/actions/milestone-changelog/action.yml
@@ -23,8 +23,21 @@ runs:
       with:
         result-encoding: string
         script: |
-          const findSections = require('./.github/scripts/js/changelog-find-sections.js')
-          return findSections().join("\n")
+          const { find } = require('./.github/scripts/js/changelog-find-sections.js')
+          const rootDirs = [
+            ".",
+            "modules",
+            "ee/modules",
+            "ee/fe/modules"
+          ]
+          const excludePatterns = [
+            "^\\.",
+            "CHANGELOG",
+            "^ee$",
+            "^modules$"
+          ]
+          const sections = find(rootDirs, excludePatterns)
+          return sections.join("\n")
 
     - name: Collect Changelog
       id: changelog

--- a/.github/scripts/js/changelog-find-sections.js
+++ b/.github/scripts/js/changelog-find-sections.js
@@ -1,31 +1,10 @@
 //@ts-check
 const fs = require('fs');
 
-// Defined behavior to use
-//
-// const findSections = require('./.github/scripts/js/changelog-find-sections.js')
-module.exports = function findSections() {
-  const roots = [
-    //
-    '.',
-    'modules',
-    'ee/modules',
-    'ee/fe/modules'
-  ];
-
-  const exclusions = [
-    '^\\.', //    dotfiles
-    'CHANGELOG',
-    'ee', //      found in "."
-    'modules' //  found in "."
-  ];
-
-  return find(roots, exclusions);
-};
-
-// For testing in Node REPL
-// const { find } = require('./.github/scripts/js/changelog-find-sections.js')
-// find([".", "modules", "ee/modules", "ee/fe/modules"], ["^\\.", "CHANGELOG", "^ee$", "^modules$"])
+// How to test:
+//  $ node
+//  > const { find } = require('./.github/scripts/js/changelog-find-sections.js')
+//  > find([".", "modules", "ee/modules", "ee/fe/modules"], ["^\\.", "CHANGELOG", "^ee$", "^modules$"])
 module.exports.find = find;
 
 /**
@@ -41,7 +20,7 @@ function find(roots = [], exclusions = []) {
   return Array.from(uniqSections).sort();
 }
 
-// returns sections excluding items with given regexes
+// getSections returns sections excluding items with given regexes
 function getSections(root, exclusions = []) {
   // trim numbers
   const sections = getSubdirs(root).map((name) => name.replace(/^\d+-/g, ''));
@@ -54,10 +33,10 @@ function getSections(root, exclusions = []) {
   return sections.filter((s) => !shouldExclude(s));
 }
 
-// returns dir names in a given root dir
+// getSubdirs returns dir names in a given root dir
 function getSubdirs(root) {
   return fs
-    .readdirSync(root, { withFileTypes: true })
+    .readdirSync(root, {withFileTypes: true})
     .filter((d) => d.isDirectory())
     .map((d) => d.name);
 }


### PR DESCRIPTION
Signed-off-by: Eugene Shevchenko <evgeny.shevchenko@flant.com>

## Description

Fixes module discovery with regex applied to dir names.

## Why do we need it, and what problem does it solve?

Fixes missing "keepalived" as known module

## Changelog entries

```changes
section: ci
type: fix
summary: 'Fixed missing modules in changelog (e.g. keepalived due to /ee/ regex)'
impact_level: low
```
