### PR TITLE
[CI] Sign-off commits by bot

### DIFF
--- a/.github/actions/milestone-changelog/action.yml
+++ b/.github/actions/milestone-changelog/action.yml
@@ -78,7 +78,10 @@ runs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3.10.1
       with:
-        commit-message: Re-generate changelog
+        commit-message: |
+          Re-generate changelog
+
+          Signed-off-by: deckhouse-BOaTswain <89150800+deckhouse-boatswain@users.noreply.github.com>
         base: main
         branch: changelog/${{ steps.args.outputs.milestone_title }}
         milestone: ${{ steps.args.outputs.milestone_number }}


### PR DESCRIPTION
Signed-off-by: Eugene Shevchenko <evgeny.shevchenko@flant.com>

## Description

Add sign-off for commit messages from bot

## Why do we need it, and what problem does it solve?

Lets changelog PRs pass DCO check.

## Changelog entries

```changes
section: ci
type: chore
summary: "Added sign-off line to bot's commit messages"
```
