### PR TITLE
[helm_lib] ephemeral-storage to helm_lib_resources_management_pod_resources

### DIFF
--- a/ee/modules/110-istio/template_tests/module_test.go
+++ b/ee/modules/110-istio/template_tests/module_test.go
@@ -505,6 +505,7 @@ a-b-c-1-2-3:
 requests:
   cpu: 50m
   memory: 256Mi
+  ephemeral-storage: 50Mi
 limits: {}
 `))
 			vpa := f.KubernetesResource("VerticalPodAutoscaler", "d8-istio", "istiod-v1x8x1")
@@ -555,6 +556,7 @@ static:
 requests:
   cpu: 11m
   memory: 22Mi
+  ephemeral-storage: 50Mi
 limits:
   cpu: 33
   memory: 44Gi
@@ -601,6 +603,7 @@ limits:
   cpu: 253m
   memory: "1342177280"
 requests:
+  ephemeral-storage: 50Mi
   cpu: 101m
   memory: 512Mi
 `))
@@ -656,6 +659,7 @@ limits:
   cpu: 7500m
   memory: "833"
 requests:
+  ephemeral-storage: 50Mi
   cpu: "3"
   memory: "333"
 `))

--- a/ee/modules/110-istio/templates/control-plane/iop.yaml
+++ b/ee/modules/110-istio/templates/control-plane/iop.yaml
@@ -137,7 +137,7 @@ spec:
       image: "{{ $.Values.global.modulesImages.registry }}:{{ index $.Values.global.modulesImages.tags.istio (printf "pilot%s" ($revision | title)) }}"
       configNamespace: d8-{{ $.Chart.Name }}
       resources:
-{{ include "helm_lib_resources_management_pod_resources" $.Values.istio.controlPlane.resourcesManagement | nindent 8 }}
+{{ include "helm_lib_resources_management_pod_resources" (list $.Values.istio.controlPlane.resourcesManagement) | nindent 8 }}
   {{- if $.Values.istio.controlPlane.nodeSelector }}
       nodeSelector:
 {{ $.Values.istio.controlPlane.nodeSelector | toYaml | nindent 8 }}

--- a/helm_lib/templates/_resources_management.tpl
+++ b/helm_lib/templates/_resources_management.tpl
@@ -1,6 +1,26 @@
-{{- /* Usage: {{ include "helm_lib_resources_management_pod_resources" <resources configuration> }} */ -}}
+{{- /* Usage: {{ include "helm_lib_resources_management_pod_resources" (list <resources configuration> [ephemeral storage requests]) }} */ -}}
 {{- /* returns rendered resources section based on configuration if it is */ -}}
 {{- define "helm_lib_resources_management_pod_resources" -}}
+  {{- $configuration     := index . 0 -}}
+
+  {{- $ephemeral_storage := "50Mi" -}}
+  {{- if eq (len .) 2 -}}
+    {{- $ephemeral_storage = index . 1 -}}
+  {{- end -}}
+
+  {{- $pod_resources := (include "helm_lib_resources_management_original_pod_resources" $configuration | fromYaml) -}}
+  {{- if not (hasKey $pod_resources "requests") -}}
+    {{- $_ := set $pod_resources "requests" (dict) -}}
+  {{- end -}}
+  {{- $_ := set $pod_resources.requests "ephemeral-storage" $ephemeral_storage -}}
+
+  {{- $pod_resources | toYaml -}}
+{{- end -}}
+
+
+{{- /* Usage: {{ include "helm_lib_resources_management_original_pod_resources" <resources configuration> }} */ -}}
+{{- /* returns rendered resources section based on configuration if it is */ -}}
+{{- define "helm_lib_resources_management_original_pod_resources" -}}
   {{- $configuration := . -}}
 
   {{- if $configuration -}}


### PR DESCRIPTION
## Description
Add ephemeral-storage configurator to `helm_lib_resources_management_pod_resources` function.

## Why do we need it, and what problem does it solve?
There are `helm_lib_module_ephemeral_storage_only_logs` and `helm_lib_module_ephemeral_storage_logs_with_extra` functions which configure the ephemeral-storage requests. It was impossible to set ephemeral-storage with `helm_lib_resources_management_pod_resources` one.

## Changelog entries

```changes
section: helm_lib
type: feature
summary: Add ephemeral-storage configurator to `helm_lib_resources_management_pod_resources` function.
impact: istiod will restart.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
