### PR TITLE
[docs] Add kube-dns FAQ to the sidebar menu

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -409,6 +409,8 @@ entries:
                     en: Usage
                     ru: Примеры
                   url: /modules/042-kube-dns/usage.html
+                - title: FAQ
+                  url: /modules/042-kube-dns/faq.html
             - title: node-local-dns
               d8Revision: ee
               folders:


### PR DESCRIPTION
## Description
Adds link to the FAQ of the kube-dns module in the sidebar menu of the site.

## Changelog entries
```changes
section: docs
type: fix
summary: Add link to the FAQ of the kube-dns module in the sidebar menu of the site.
impact_level: low
```
