### PR TITLE
[global-hooks] Remove CSI taints only after `spec.drivers` are filled

### DIFF
--- a/modules/040-node-manager/hooks/remove_csi_taints_test.go
+++ b/modules/040-node-manager/hooks/remove_csi_taints_test.go
@@ -64,7 +64,11 @@ apiVersion: v1
 kind: Node
 metadata:
   name: node-4
-spec: {}
+spec:
+  taints:
+  - effect: NoSchedule
+    key: node.deckhouse.io/csi-not-bootstrapped
+    value: ""
 ---
 apiVersion: v1
 kind: Node
@@ -78,6 +82,9 @@ apiVersion: storage.k8s.io/v1
 kind: CSINode
 metadata:
   name: node-1
+spec:
+  drivers:
+  - name: test
 `
 		stateCSINode2 = `
 ---
@@ -85,6 +92,9 @@ apiVersion: storage.k8s.io/v1
 kind: CSINode
 metadata:
   name: node-2
+spec:
+  drivers:
+  - name: test
 `
 		stateCSINode4 = `
 ---
@@ -146,7 +156,7 @@ metadata:
 				Expect(f.KubernetesGlobalResource("Node", "node-1").Field("spec.taints").String()).To(MatchJSON(`[{"effect": "PreferNoSchedule","key":"somekey-1"}]`))
 				Expect(f.KubernetesGlobalResource("Node", "node-2").Field("spec.taints").String()).To(MatchJSON(`[{"effect": "PreferNoSchedule","key": "somekey-2"},{"effect": "NoSchedule","key": "node.deckhouse.io/csi-not-bootstrapped","value": ""}]`))
 				Expect(f.KubernetesGlobalResource("Node", "node-3").Field("spec.taints").String()).To(MatchJSON(`[{"effect": "PreferNoSchedule","key":"somekey-3"}]`))
-				Expect(f.KubernetesGlobalResource("Node", "node-4").Field("spec.taints").Exists()).To(BeFalse())
+				Expect(f.KubernetesGlobalResource("Node", "node-4").Field("spec.taints").String()).To(MatchJSON(`[{"effect":"NoSchedule","key":"node.deckhouse.io/csi-not-bootstrapped","value":""}]`))
 			})
 		})
 

--- a/modules/042-kube-dns/templates/deployment.yaml
+++ b/modules/042-kube-dns/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
       # hardcoded, because kube-dns is a critical component and system-cluster-critical priority class exists by default
       priorityClassName: system-cluster-critical
       serviceAccountName: d8-kube-dns
-      {{- include "helm_lib_tolerations" (tuple $context "any-node-with-no-csi") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "any-node-with-no-csi") | nindent 6 }}
       containers:
       - name: coredns
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}

--- a/modules/042-kube-dns/templates/deployment.yaml
+++ b/modules/042-kube-dns/templates/deployment.yaml
@@ -62,21 +62,7 @@ spec:
       # hardcoded, because kube-dns is a critical component and system-cluster-critical priority class exists by default
       priorityClassName: system-cluster-critical
       serviceAccountName: d8-kube-dns
-      # Policy #0: kube-dns must be able to work on every master and every specific node
-      tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - key: node-role.kubernetes.io/master
-      - key: node-role/system
-      - key: dedicated.deckhouse.io
-        operator: Equal
-        value: kube-dns
-      - key: dedicated.deckhouse.io
-        operator: Equal
-        value: system
-      - key: dedicated.deckhouse.io
-        operator: Equal
-        value: master
+      {{- include "helm_lib_tolerations" (tuple $context "any-node-with-no-csi") | nindent 6 }}
       containers:
       - name: coredns
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Remove `csi-not-bootstrapped` taint only after at least one CSI driver is properly registered in the CSINode object.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Closes https://github.com/deckhouse/deckhouse/issues/1613

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: global-hooks
type: fix
summary: Remove `csi-not-bootstrapped` taint only after at least one CSI driver is properly registered in the CSINode object.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
