### PR TITLE
[ci] GolangCI Linter upgrade to 1.46.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ help:
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make ${FORMATTING_BEGIN_YELLOW}<target>${FORMATTING_END}\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  ${FORMATTING_BEGIN_BLUE}%-46s${FORMATTING_END} %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 
-GOLANGCI_VERSION = 1.42.0
+GOLANGCI_VERSION = 1.46.2
 TESTS_TIMEOUT="15m"
 
 ##@ Tests

--- a/ee/modules/600-flant-integration/hooks/license_test.go
+++ b/ee/modules/600-flant-integration/hooks/license_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Flant JSC
+Copyright 2021 Flant JSC
 Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 

--- a/ee/modules/600-flant-integration/hooks/license_test.go
+++ b/ee/modules/600-flant-integration/hooks/license_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Flant JSC
+Copyright 2022 Flant JSC
 Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
@@ -89,7 +89,7 @@ var _ = Describe("Flant integration :: hooks :: license ::", func() {
 			registry := rand.String(8)
 			auth := getConfig()
 			passwordWithNoSpaces := auth.Password
-			auth.Password = auth.Password + "\n"
+			auth.Password += "\n"
 			auth.Auth = base64.StdEncoding.EncodeToString([]byte(auth.Username + ":" + auth.Password))
 			dockerCfg := prepareDockerConfig(auth, registry)
 

--- a/modules/040-node-manager/hooks/discover_standby_ng_test.go
+++ b/modules/040-node-manager/hooks/discover_standby_ng_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Flant JSC
+Copyright 2022 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -473,7 +473,7 @@ status:
 		BeforeEach(func() {
 			state := nodeGroupWithoutZones
 			for i := 1; i <= 12; i++ {
-				state = state + fmt.Sprintf(nodeWorkerTemplate, i)
+				state += fmt.Sprintf(nodeWorkerTemplate, i)
 			}
 			f.BindingContexts.Set(f.KubeStateSet(state))
 			f.ValuesSet("nodeManager.internal.cloudProvider.zones", []string{"zoneA", "zoneB", "zoneC"})

--- a/modules/040-node-manager/hooks/discover_standby_ng_test.go
+++ b/modules/040-node-manager/hooks/discover_standby_ng_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Flant JSC
+Copyright 2021 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/testing/library/sandbox_runner/runner.go
+++ b/testing/library/sandbox_runner/runner.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Flant JSC
+Copyright 2021 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/testing/library/sandbox_runner/runner.go
+++ b/testing/library/sandbox_runner/runner.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Flant JSC
+Copyright 2022 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"syscall"
 	"time"
 
@@ -57,15 +56,13 @@ func Run(cmd *exec.Cmd, opts ...SandboxOption) *gexec.Session {
 
 func WithFile(path string, contents []byte, envOpts ...EnvOption) SandboxOption {
 	return func(conf sandboxConfig) error {
-		filePath := filepath.Join(path)
-
-		err := ioutil.WriteFile(filePath, contents, os.FileMode(0644))
+		err := ioutil.WriteFile(path, contents, os.FileMode(0644))
 		if err != nil {
 			return err
 		}
 
 		for _, opt := range envOpts {
-			opt(conf.cmd, filePath)
+			opt(conf.cmd, path)
 		}
 
 		return nil

--- a/werf.yaml
+++ b/werf.yaml
@@ -333,7 +333,7 @@ ansible:
   - name: "Install GolangCI linter"
     shell: |
       curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-        | sh -s -- -b $(go env GOPATH)/bin v1.42.0
+        | sh -s -- -b $(go env GOPATH)/bin v1.46.2
 
   - raw: rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
## Description
GolangCI Linter upgrade to 1.46.2

## Why do we need it, and what problem does it solve?
The 1.42.0 version is no longer available, so we need to upgrade.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: chore
summary: GolangCI Linter upgrade to 1.46.2
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
