### PR TITLE
[docs][getting started][gcp] Add taints in the resource file for the production environment

### DIFF
--- a/docs/site/_includes/getting_started/gcp/partials/resources.yml.production.inc
+++ b/docs/site/_includes/getting_started/gcp/partials/resources.yml.production.inc
@@ -72,6 +72,8 @@ metadata:
   # [<en>] name of instance class
   # [<ru>] имя инстанс класса
   name: frontend
+# [<en>] you might consider changing this
+# [<ru>] возможно, захотите изменить
 spec:
   diskSizeGb: 40
   # [<en>] Machine type in use for this instance class
@@ -106,6 +108,10 @@ spec:
     # [<ru>] аналогично стандартному полю metadata.labels
     labels:
       node-role.deckhouse.io/frontend: ""
+    taints:
+      - effect: NoExecute
+        key: dedicated.deckhouse.io
+        value: frontend
   nodeType: CloudEphemeral
 ---
 # [<en>] section containing the parameters of instance class for worker nodes

--- a/docs/site/_includes/getting_started/yandex/partials/resources.yml.production.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/resources.yml.production.inc
@@ -1,14 +1,28 @@
+# [<en>] section containing the parameters of system node group
+# [<en>] version of the Deckhouse API
+# [<ru>] секция, описывающая параметры группы узлов system
+# [<ru>] используемая версия API Deckhouse
 apiVersion: deckhouse.io/v1
 kind: NodeGroup
 metadata:
   name: system
 spec:
+  # [<en>] parameters for provisioning the cloud-based VMs
+  # [<ru>] параметры заказа облачных виртуальных машин
   cloudInstances:
+    # [<en>] the reference to the InstanceClass object
+    # [<ru>] ссылка на объект InstanceClass
     classReference:
       kind: YandexInstanceClass
       name: system
+    # [<en>] the maximum number of instances for the group in each zone
+    # [<ru>] максимальное количество инстансов в зоне
     maxPerZone: 1
+    # [<en>] the minimum number of instances for the group in each zone
+    # [<ru>] минимальное количество инстансов в зоне
     minPerZone: 1
+    # [<en>] list of availability zones to create instances in
+    # [<ru>] переопределение перечня зон, в которых создаются инстансы
     # [<en>] you might consider changing this
     # [<ru>] возможно, захотите изменить
     zones:
@@ -25,9 +39,15 @@ spec:
         value: system
   nodeType: CloudEphemeral
 ---
+# [<en>] section containing the parameters of instance class for system nodes
+# [<en>] version of the Deckhouse API
+# [<ru>] секция, описывающая параметры инстанс-класса для узлов c системными компонентами
+# [<ru>] используемая версия API Deckhouse
 apiVersion: deckhouse.io/v1
 kind: YandexInstanceClass
 metadata:
+  # [<en>] name of instance class
+  # [<ru>] имя инстанс класса
   name: system
 spec:
   # [<en>] you might consider changing this
@@ -49,7 +69,11 @@ spec:
     classReference:
       kind: YandexInstanceClass
       name: frontend
+    # [<en>] the maximum number of instances for the group in each zone
+    # [<ru>] максимальное количество инстансов в зоне
     maxPerZone: 2
+    # [<en>] the minimum number of instances for the group in each zone
+    # [<ru>] минимальное количество инстансов в зоне
     minPerZone: 1
   disruptions:
     approvalMode: Automatic
@@ -62,9 +86,15 @@ spec:
         value: frontend
   nodeType: CloudEphemeral
 ---
+# [<en>] section containing the parameters of instance class for frontend nodes
+# [<en>] version of the Deckhouse API
+# [<ru>] секция, описывающая параметры инстанс-класса для узлов c компонентами, принимающими трафик
+# [<ru>] используемая версия API Deckhouse
 apiVersion: deckhouse.io/v1
 kind: YandexInstanceClass
 metadata:
+  # [<en>] name of instance class
+  # [<ru>] имя инстанс класса
   name: frontend
 # [<en>] you might consider changing this
 # [<ru>] возможно, захотите изменить
@@ -92,6 +122,10 @@ spec:
     approvalMode: Automatic
   nodeType: CloudEphemeral
 ---
+# [<en>] section containing the parameters of instance class for worker nodes
+# [<en>] version of the Deckhouse API
+# [<ru>] секция, описывающая параметры инстанс-класса для узлов c компонентами, обеспечивающими рабочую нагрузку
+# [<ru>] используемая версия API Deckhouse
 apiVersion: deckhouse.io/v1
 kind: YandexInstanceClass
 metadata:


### PR DESCRIPTION
## Description
Adds taints in the resource file for the production environment (Getting started, Google Cloud).

Adds comments in the Yandex resource file.

Closes #1669 

## Changelog entries
```changes
section: docs
type: fix
summary: Added taints in the resource file for the production environment
impact_level: low
```
