### PR TITLE
[cilium] Alerts and policy map limit

### DIFF
--- a/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
+++ b/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
@@ -1,0 +1,95 @@
+- name: cni-cilium
+  rules:
+  - alert: CiliumAgentControllersRunsFailing
+    expr: max by (pod,namespace) (cilium_controllers_failing) > 0
+    for: 15m
+    labels:
+      d8_module: cni-cilium
+      d8_component: agent
+      tier: cluster
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      summary: Some controllers (internal logical loops) are failing in agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}`
+      description: |
+        Check what's going on: `kubectl -n `{{`{{ $labels.namespace }}`}}` logs `{{`{{ $labels.pod }}`}}``
+
+  - alert: CiliumAgentUnreachableNodes
+    expr: max by (namespace, pod) (cilium_unreachable_nodes) > 0
+    for: 5m
+    labels:
+      d8_module: cni-cilium
+      d8_component: agent
+      tier: cluster
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      summary: Some nodes are not reachable by agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}`.
+      description: |
+        Check what's going on: `kubectl -n `{{`{{ $labels.namespace }}`}}` logs `{{`{{ $labels.pod }}`}}``
+
+  - alert: CiliumAgentUnreachableHealthEndpoints
+    expr: max by (namespace, pod) (cilium_unreachable_health_endpoints) > 0
+    for: 5m
+    labels:
+      d8_module: cni-cilium
+      d8_component: agent
+      tier: cluster
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      summary: Some nodes' health endpoints are not reachable by agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}`.
+      description: |
+        Check what's going on: `kubectl -n `{{`{{ $labels.namespace }}`}}` logs `{{`{{ $labels.pod }}`}}``
+
+  - alert: CiliumAgentEndpointsNotReady
+    expr: sum by (namespace, pod) (cilium_endpoint_state{endpoint_state="ready"} / cilium_endpoint_state) < 0.5
+    for: 5m
+    labels:
+      d8_module: cni-cilium
+      d8_component: agent
+      tier: cluster
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      summary: More than half of all known Endpoints are not ready in agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}`.
+      description: |
+        Check what's going on: `kubectl -n `{{`{{ $labels.namespace }}`}}` logs `{{`{{ $labels.pod }}`}}``
+
+  - alert: CiliumAgentMapPressureCritical
+    expr: sum by (namespace, pod, map_name) (cilium_bpf_map_pressure > 0.8)
+    for: 5m
+    labels:
+      d8_module: cni-cilium
+      d8_component: agent
+      tier: cluster
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      summary: eBPF map `{{`{{ $labels.map_name }}`}}` is more than 80% full in agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}`.
+      description: We've reached resource limit of eBPF maps. Consult with vendor for possible remediation steps.
+  - alert: CiliumAgentPolicyImportErrors
+    expr: sum by (namespace, pod) (rate(cilium_policy_import_errors_total[2m]) > 0)
+    for: 5m
+    labels:
+      d8_module: cni-cilium
+      d8_component: agent
+      tier: cluster
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      summary: Agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}` fails to import policies.
+      description: |
+        Check what's going on: `kubectl -n `{{`{{ $labels.namespace }}`}}` logs `{{`{{ $labels.pod }}`}}``

--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -11,6 +11,8 @@ data:
 
   debug: {{ .Values.cniCilium.debugLogging | quote }}
 
+  metrics: "+cilium_bpf_map_pressure"
+
   agent-health-port: "9876"
   prometheus-serve-addr: "127.0.0.1:9090"
   operator-prometheus-serve-addr: "127.0.0.1:9092"
@@ -78,6 +80,7 @@ data:
   enable-remote-node-identity: "true"
 
   bpf-map-dynamic-size-ratio: "0.005"
+  bpf-policy-map-max: "65536"
 
   # Local hubble sever section
   enable-hubble: "true"

--- a/modules/021-cni-cilium/templates/monitoring.yaml
+++ b/modules/021-cni-cilium/templates/monitoring.yaml
@@ -1,0 +1,1 @@
+{{- include "helm_lib_prometheus_rules" (list . "d8-cni-cilium") }}

--- a/testing/matrix/linter/rules/modules/monitoring.go
+++ b/testing/matrix/linter/rules/modules/monitoring.go
@@ -113,7 +113,7 @@ func monitoringModuleRule(moduleName, modulePath, moduleNamespace string) errors
 			moduleLabel(moduleName),
 			searchingFilePath,
 			"The content of the 'templates/monitoring.yaml' should be equal to:\n%s\nGot:\n%s",
-			fmt.Sprintf(desiredContentBuilder.String(), "YOUR NAMESAPCE TO DEPLOY RULES: d8-monitoring, d8-system or module namespaces"),
+			fmt.Sprintf(desiredContentBuilder.String(), "YOUR NAMESPACE TO DEPLOY RULES: d8-monitoring, d8-system or module namespaces"),
 			string(content),
 		)
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Alerts and raising policy map limit.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Basic alerts that notify user when cilium agent is not working properly.

Policy map is the largest contributor to eBPF map load. It seems reasonable to increase it preemptively.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cni-cilium
type: feature
summary: Raised policy map limit to four times the default. Also added alert for Cilium agent. 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
