### PR TITLE
[ci] dhctl golangci-lint update to 1.46.2

### DIFF
--- a/dhctl/Makefile
+++ b/dhctl/Makefile
@@ -14,7 +14,7 @@
 
 
 # Dependency versions
-GOLANGCI_VERSION = 1.42.0
+GOLANGCI_VERSION = 1.46.2
 GOFUMPT_VERSION=0.1.1
 
 # Build versions

--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -143,7 +143,7 @@ func DefineCreateResourcesCommand(parent *kingpin.CmdClause) *kingpin.CmdClause 
 			resourcesToCreate = parsedResources
 		}
 
-		if resourcesToCreate == nil || len(resourcesToCreate) == 0 {
+		if len(resourcesToCreate) == 0 {
 			log.WarnLn("Resources to create were not found.")
 			return nil
 		}

--- a/dhctl/pkg/kubernetes/client/client.go
+++ b/dhctl/pkg/kubernetes/client/client.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	klient "github.com/flant/kube-client/client"
-
 	// oidc allows using oidc provider in kubeconfig
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 


### PR DESCRIPTION
## Description
golangci-lint update to 1.46.2 for dhctl.

## Why do we need it, and what problem does it solve?
There are floating problems with 1.42.0 version.

## Changelog entries

```changes
section: ci
type: fix
summary: golangci-lint update to 1.46.2 for dhctl.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
