### PR TITLE
[docs] Bump web-router

### DIFF
--- a/docs/site/werf.yaml
+++ b/docs/site/werf.yaml
@@ -76,7 +76,7 @@ ansible:
         chdir: /go/src/app
 git:
   - url: https://github.com/flant/web-router.git
-    tag: v1.0.12
+    tag: v1.0.13
     add: /
     to: /go/src/app
     stageDependencies:


### PR DESCRIPTION
## Description
Show default doc version on `/<lang>/documentation` requests (without trailing `/`).

## Changelog entries
```changes
section: docs
type: fix
summary: Show default doc version on `/<lang>/documentation` requests (without trailing `/`).
impact_level: low
```
