### PR TITLE
[candi] fix containerd registry package build for centos-8

### DIFF
--- a/modules/007-registrypackages/images/containerd-centos/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd-centos/werf.inc.yaml
@@ -1,5 +1,5 @@
 {{- $containerd_versions := list }}
-{{- $selinux_version := dict "7" "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.119.2-1.911c772.el7_8.noarch.rpm" "8" "http://ftp.funet.fi/pub/mirrors/centos.org/8.5.2111/AppStream/x86_64/os/Packages/container-selinux-2.167.0-1.module_el8.5.0+911+f19012f9.noarch.rpm" }}
+{{- $selinux_version := dict "7" "http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.119.2-1.911c772.el7_8.noarch.rpm" "8" "http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/Packages/container-selinux-2.167.0-1.module_el8.6.0+926+8bef8ae7.noarch.rpm" }}
 {{- range $key, $value := .CandiVersionMap.k8s }}
   {{- range $key, $versions := $value.bashible.centos }}
     {{- if $versions.containerd.desiredVersion }}
@@ -40,10 +40,10 @@ shell:
   - apk add --no-cache curl
   setup:
   {{- if contains "el7" $image_version }}
-  - curl -sL https://download.docker.com/linux/centos/7/x86_64/stable/Packages/{{ $version }}.rpm --output /containerd.io.x86_64.rpm
-  - curl -sL {{ index $selinux_version "7" }} --output /container-selinux.x86_64.rpm
+  - wget https://download.docker.com/linux/centos/7/x86_64/stable/Packages/{{ $version }}.rpm --output-file /containerd.io.x86_64.rpm
+  - wget {{ index $selinux_version "7" }} --output-file /container-selinux.x86_64.rpm
   {{- else if contains "el8" $image_version }}
-  - curl -sL https://download.docker.com/linux/centos/8/x86_64/stable/Packages/{{ $version }}.rpm --output /containerd.io.x86_64.rpm
-  - curl -sL {{ index $selinux_version "8" }} --output /container-selinux.x86_64.rpm
+  - wget https://download.docker.com/linux/centos/8/x86_64/stable/Packages/{{ $version }}.rpm --output-file /containerd.io.x86_64.rpm
+  - wget {{ index $selinux_version "8" }} --output-file /container-selinux.x86_64.rpm
   {{- end }}
 {{- end }}

--- a/modules/007-registrypackages/images/containerd-centos/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd-centos/werf.inc.yaml
@@ -40,10 +40,10 @@ shell:
   - apk add --no-cache curl
   setup:
   {{- if contains "el7" $image_version }}
-  - wget https://download.docker.com/linux/centos/7/x86_64/stable/Packages/{{ $version }}.rpm --output-file /containerd.io.x86_64.rpm
-  - wget {{ index $selinux_version "7" }} --output-file /container-selinux.x86_64.rpm
+  - wget https://download.docker.com/linux/centos/7/x86_64/stable/Packages/{{ $version }}.rpm --output-document /containerd.io.x86_64.rpm
+  - wget {{ index $selinux_version "7" }} --output-document /container-selinux.x86_64.rpm
   {{- else if contains "el8" $image_version }}
-  - wget https://download.docker.com/linux/centos/8/x86_64/stable/Packages/{{ $version }}.rpm --output-file /containerd.io.x86_64.rpm
-  - wget {{ index $selinux_version "8" }} --output-file /container-selinux.x86_64.rpm
+  - wget https://download.docker.com/linux/centos/8/x86_64/stable/Packages/{{ $version }}.rpm --output-document /containerd.io.x86_64.rpm
+  - wget {{ index $selinux_version "8" }} --output-document /container-selinux.x86_64.rpm
   {{- end }}
 {{- end }}

--- a/modules/007-registrypackages/images/containerd-centos/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd-centos/werf.inc.yaml
@@ -40,10 +40,10 @@ shell:
   - apk add --no-cache curl
   setup:
   {{- if contains "el7" $image_version }}
-  - wget https://download.docker.com/linux/centos/7/x86_64/stable/Packages/{{ $version }}.rpm --output-document /containerd.io.x86_64.rpm
-  - wget {{ index $selinux_version "7" }} --output-document /container-selinux.x86_64.rpm
+  - curl -sfL https://download.docker.com/linux/centos/7/x86_64/stable/Packages/{{ $version }}.rpm --output /containerd.io.x86_64.rpm
+  - curl -sfL {{ index $selinux_version "7" }} --output /container-selinux.x86_64.rpm
   {{- else if contains "el8" $image_version }}
-  - wget https://download.docker.com/linux/centos/8/x86_64/stable/Packages/{{ $version }}.rpm --output-document /containerd.io.x86_64.rpm
-  - wget {{ index $selinux_version "8" }} --output-document /container-selinux.x86_64.rpm
+  - curl -sfL https://download.docker.com/linux/centos/8/x86_64/stable/Packages/{{ $version }}.rpm --output /containerd.io.x86_64.rpm
+  - curl -sfL {{ index $selinux_version "8" }} --output /container-selinux.x86_64.rpm
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
fix containerd registry package build for centos-8.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
https://github.com/deckhouse/deckhouse/issues/1693
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: fix containerd registry package build for centos-8
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
