### PR TITLE
[docs] Add all available inbox ClusterIssuers to the documentation

### DIFF
--- a/global-hooks/openapi/config-values.yaml
+++ b/global-hooks/openapi/config-values.yaml
@@ -107,7 +107,7 @@ properties:
                 description: |
                   Name of a `ClusterIssuer` to use for Deckhouse modules.
 
-                  The [cert-manager](https://deckhouse.io/en/documentation/v1/modules/101-cert-manager/) module offers the following `ClusterIssuer`: `letsencrypt`, `letsencrypt-staging`, `selfsigned`. Also, you can use your own `ClusterIssuer`.
+                  The [cert-manager](https://deckhouse.io/en/documentation/v1/modules/101-cert-manager/) module offers the following `ClusterIssuer`: `letsencrypt`, `letsencrypt-staging`, `selfsigned`, `clouddns`, `cloudflare`, `digitalocean`, `route53`. Also, you can use your own `ClusterIssuer`.
           customCertificate:
             type: object
             additionalProperties: false

--- a/global-hooks/openapi/doc-ru-config-values.yaml
+++ b/global-hooks/openapi/doc-ru-config-values.yaml
@@ -55,7 +55,7 @@ properties:
                 description: |
                   Имя `ClusterIssuer`, используемого для модулями Deckhouse.
 
-                  В модуле [cert-manager](https://deckhouse.io/ru/documentation/v1/modules/101-cert-manager/) доступны следующие `ClusterIssuer`: `letsencrypt`, `letsencrypt-staging`, `selfsigned`. Также, вы можете использовать свой `ClusterIssuer`.
+                  В модуле [cert-manager](https://deckhouse.io/ru/documentation/v1/modules/101-cert-manager/) доступны следующие `ClusterIssuer`: `letsencrypt`, `letsencrypt-staging`, `selfsigned`, `clouddns`, `cloudflare`, `digitalocean`, `route53`. Также, вы можете использовать свой `ClusterIssuer`.
           customCertificate:
             properties:
               secretName:


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Add all in-box Deckhouse's ClusterIssuers to the documentation

## Why do we need it, and what problem does it solve?
Documentation can lead to some misunderstanding cause of limited list of ClsuterIssuers

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: docs
type: chore
summary: Add all available ClusterIssuers to the documentation
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
