### PR TITLE
[testing] Matrix tests optimizations

### DIFF
--- a/ee/modules/110-istio/openapi/config-values.yaml
+++ b/ee/modules/110-istio/openapi/config-values.yaml
@@ -10,7 +10,7 @@ properties:
     description: |
       Additional versions of Istio control plane to install. You can use specific namespace labels (`istio.io/rev=`) to switch between installed revisions.
     examples:
-      - ["1.13", "1.14"]
+    - ["1.13", "1.14"]
     default: []
     items:
       type: string
@@ -36,6 +36,7 @@ properties:
   enableHTTP10:
     type: boolean
     default: false
+    x-examples: [true]
     description: |
       Whether to handle HTTP/1.0 requests in istio-sidecars or deny them with `426 Upgrade Required` response.
   federation:
@@ -135,6 +136,7 @@ properties:
         type: boolean
         description: Turn on or off tracing collection and displaying in kiali.
         default: false
+        x-examples: [true]
       collector:
         type: object
         description: Tracing collection settings.
@@ -261,6 +263,7 @@ properties:
     properties:
       holdApplicationUntilProxyStarts:
         type: boolean
+        x-examples: [true]
         default: false
         description: |
           With this feature, the sidecar-injector injects the sidecar at the first place of Pod's container list and adds a postStart hook to be sure if the Envoy proxy is initialized before the application. So the Envoy is able to handle requests without application network errors.
@@ -518,7 +521,7 @@ properties:
             default: "false"
   highAvailability:
     type: boolean
-    x-examples: [true, false]
+    x-examples: [true]
     description: |
       Manually enable the high availability mode.
 
@@ -579,6 +582,7 @@ properties:
         description: An array if CIDRs that are allowed to authenticate in module's public web interfaces.
       satisfyAny:
         type: boolean
+        x-examples: [true]
         default: false
         description: |
           Enables single authentication.

--- a/ee/modules/110-istio/openapi/config-values.yaml
+++ b/ee/modules/110-istio/openapi/config-values.yaml
@@ -533,7 +533,7 @@ properties:
     - {}
     - externalAuthentication:
         authURL: "https://dex.d8.svc.cluster.local/dex/auth"
-        authSignInURL: "https://myhost.ru/dex/sign_in"
+        authSignInURL: "https://example.com/dex/sign_in"
       allowedUserGroups:
       - admins
     description: Options related to authentication or authorization in the application.
@@ -547,14 +547,14 @@ properties:
         properties:
           authURL:
             type: string
-            x-examples: ["https://dex.d8.svc.cluster.local/dex/auth", "https://myhost.ru/dex/auth"]
+            x-examples: ["https://example.com/dex/auth"]
             description: |
               The URL of the authentication service.
 
               If the user is authenticated, the service should return an HTTP 200 response code.
           authSignInURL:
             type: string
-            x-examples: ["https://myhost.ru/dex/sign_in"]
+            x-examples: ["https://example.com/dex/sign_in"]
             description: The URL to redirect the user for authentication (if the authentication service returned a non-200 HTTP response code).
       password:
         type: string

--- a/ee/modules/110-istio/openapi/config-values.yaml
+++ b/ee/modules/110-istio/openapi/config-values.yaml
@@ -17,6 +17,7 @@ properties:
   tlsMode:
     type: string
     enum: ["Off", MutualPermissive, Mutual]
+    x-examples: ["Mutual"]
     description: |
       The mode for transparent encryption of inter-pod traffic ([Mutual TLS](https://istio.io/latest/docs/tasks/security/authentication/mtls-migration/)).
       - `Off` — outgoing requests are not encrypted; incoming unencrypted requests are accepted.
@@ -176,7 +177,6 @@ properties:
             example: "http://tracing.myjaeger.svc:16685/"
         x-examples:
         - {}
-        - jaegerURLForUsers: https://tracing-service:4443/jaeger
         - jaegerURLForUsers: https://tracing-service:4443/jaeger
           jaegerGRPCEndpoint: http://tracing.myjaeger.svc:16685/
   sidecar:
@@ -530,7 +530,6 @@ properties:
     type: object
     default: {}
     x-examples:
-    - {}
     - externalAuthentication:
         authURL: "https://dex.d8.svc.cluster.local/dex/auth"
         authSignInURL: "https://example.com/dex/sign_in"

--- a/ee/modules/110-istio/openapi/values.yaml
+++ b/ee/modules/110-istio/openapi/values.yaml
@@ -120,6 +120,7 @@ properties:
       multiclustersNeedIngressGateway:
         type: boolean
         default: false
+        x-examples: [true]
       customCertificateData:
         type: object
         properties:

--- a/modules/020-deckhouse/openapi/config-values.yaml
+++ b/modules/020-deckhouse/openapi/config-values.yaml
@@ -3,12 +3,14 @@ properties:
   logLevel:
     type: string
     enum: ["Debug", "Info", "Error"]
+    x-examples: ["Info"]
     description: |
       Deckhouse logging level.
     default: "Info"
   bundle:
     type: string
     enum: ["Default", "Minimal", "Managed"]
+    x-examples: ["Default"]
     description: |
       The Deckhouse bundle defines a set of modules enabled by default.
       - `Default` — the recommended set of modules for cluster operation: monitoring, authorization control, networking and other needs (the current list is available [here](https://github.com/deckhouse/deckhouse/blob/main/modules/values-default.yaml)).
@@ -18,6 +20,7 @@ properties:
   releaseChannel:
     type: string
     enum: ["Alpha", "Beta", "EarlyAccess", "Stable", "RockSolid"]
+    x-examples: ["Stable"]
     description: |
       Desirable Deckhouse release channel (Deckhouse will [switch](https://deckhouse.io/en/documentation/v1/deckhouse-faq.html#change-the-release-channel) to it when such an opportunity appears).
 
@@ -79,6 +82,7 @@ properties:
               description: The days of the week on which the update window is applied.
               items:
                 type: string
+                x-examples: [Mon]
                 enum:
                   - Mon
                   - Tue

--- a/modules/040-control-plane-manager/openapi/config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/config-values.yaml
@@ -182,6 +182,7 @@ properties:
             description: |
               Audit logs target stream.
             default: File
+            x-examples: ["Stdout"]
             enum:
               - File
               - Stdout

--- a/modules/040-control-plane-manager/openapi/values.yaml
+++ b/modules/040-control-plane-manager/openapi/values.yaml
@@ -16,6 +16,7 @@ properties:
       effectiveKubernetesVersion:
         type: string
         enum: ["1.19", "1.20", "1.21", "1.22", "1.23"]
+        x-examples: ["1.23"]
       etcdServers:
         type: array
         items:

--- a/modules/300-prometheus/openapi/config-values.yaml
+++ b/modules/300-prometheus/openapi/config-values.yaml
@@ -45,11 +45,11 @@ properties:
         properties:
           authURL:
             type: string
-            x-examples: ["https://dex.d8.svc.cluster.local/dex/auth", "https://myhost.ru/dex/auth"]
+            x-examples: ["https://example.com/dex/auth"]
             description: The URL of the authentication service. If the user is authenticated, the service should return an HTTP 200 response code.
           authSignInURL:
             type: string
-            x-examples: ["https://myhost.ru/dex/sign_in"]
+            x-examples: ["https://example.com/dex/sign_in"]
             description: The URL to redirect the user for authentication (if the authentication service returned a non-200 HTTP response code).
       password:
         type: string
@@ -78,6 +78,7 @@ properties:
       satisfyAny:
         type: boolean
         default: false
+        x-examples: [true]
         description: |
           Enables single authentication.
 
@@ -90,6 +91,7 @@ properties:
       useDarkTheme:
         type: boolean
         default: false
+        x-examples: [true]
         description: The dark theme is enabled by default.
       customPlugins:
         type: array
@@ -222,7 +224,7 @@ properties:
           - "Off"
   highAvailability:
     type: boolean
-    x-examples: [true, false]
+    x-examples: [true]
     description: |
       Manually enable the high availability mode.
 

--- a/modules/460-log-shipper/openapi/config-values.yaml
+++ b/modules/460-log-shipper/openapi/config-values.yaml
@@ -62,12 +62,8 @@ properties:
           max: 4096
     - mode: Static
       static:
-        requests:
-          cpu: "55m"
-          memory: "256Ki"
-        limits:
-          cpu: "2000m"
-          memory: "2Mi"
+        cpu: "55m"
+        memory: "256Ki"
     oneOf:
       - properties:
           mode:

--- a/modules/460-log-shipper/openapi/config-values.yaml
+++ b/modules/460-log-shipper/openapi/config-values.yaml
@@ -41,6 +41,33 @@ properties:
 
       If the vertical-pod-autoscaler module is disabled, then these values become the default ones.
     default: {}
+    x-examples:
+    - mode: VPA
+      vpa:
+        mode: Auto
+        cpu:
+          min: "50m"
+          max: 2
+        memory:
+          min: "256Mi"
+          max: "2Gi"
+    - mode: VPA
+      vpa:
+        mode: Initial
+        cpu:
+          min: 1
+          max: 3000m
+        memory:
+          min: 1024
+          max: 4096
+    - mode: Static
+      static:
+        requests:
+          cpu: "55m"
+          memory: "256Ki"
+        limits:
+          cpu: "2000m"
+          memory: "2Mi"
     oneOf:
       - properties:
           mode:
@@ -84,7 +111,6 @@ properties:
                   - type: string
                     pattern: "^[0-9]+m?$"
                   - type: number
-                x-examples: [3, "300m"]
                 description: |
                   Maximum allowed CPU requests.
                 default: "500m"
@@ -93,7 +119,6 @@ properties:
                   - type: string
                     pattern: "^[0-9]+m?$"
                   - type: number
-                x-examples: [5, "500m"]
                 description: |
                   Minimum allowed CPU requests.
                 default: "50m"
@@ -108,7 +133,6 @@ properties:
                   - type: string
                     pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
                   - type: number
-                x-examples: ["32Mi", 3000]
                 description: |
                   Maximum allowed memory requests.
                 default: "2048Mi"
@@ -117,7 +141,6 @@ properties:
                   - type: string
                     pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
                   - type: number
-                x-examples: ["4Mi", 400]
                 description: |
                   Minimum allowed memory requests.
                 default: "64Mi"

--- a/modules/500-cilium-hubble/openapi/config-values.yaml
+++ b/modules/500-cilium-hubble/openapi/config-values.yaml
@@ -46,11 +46,11 @@ properties:
         properties:
           authURL:
             type: string
-            x-examples: [ "https://dex.d8.svc.cluster.local/dex/auth", "https://myhost.ru/dex/auth" ]
+            x-examples: [ "https://example.com/dex/auth" ]
             description: The URL of the authentication service. If the user is authenticated, the service should return an HTTP 200 response code.
           authSignInURL:
             type: string
-            x-examples: [ "https://myhost.ru/dex/sign_in" ]
+            x-examples: [ "https://example.com/dex/sign_in" ]
             description: The URL to redirect the user for authentication (if the authentication service returned a non-200 HTTP response code).
       password:
         type: string

--- a/modules/810-deckhouse-web/openapi/config-values.yaml
+++ b/modules/810-deckhouse-web/openapi/config-values.yaml
@@ -39,7 +39,7 @@ properties:
           The password for HTTP authorization of the `admin` user (it is generated automatically, but you can change it).
 
           This parameter is used if the `externalAuthentication` is not enabled.
-        x-examples: ["qwerty123", "foobar"]
+        x-examples: ["qwerty123"]
       allowedUserGroups:
         type: array
         items:
@@ -92,7 +92,7 @@ properties:
           clusterIssuerName:
             type: string
             default: "letsencrypt"
-            x-examples: ["letsencrypt", "letsencrypt-staging", "selfsigned"]
+            x-examples: ["letsencrypt"]
             description: |
               What ClusterIssuer to use for getting an SSL certificate (currently, `letsencrypt`, `letsencrypt-staging`, `selfsigned` are available; also, you can define your own).
       customCertificate:


### PR DESCRIPTION
## Description
Matrix tests optimizations.

## Why do we need it, and what problem does it solve?
The matrix tests take too much time to execute.

## Changelog entries

```changes
section: ci
type: chore
summary: Matrix tests optimizations.
impact: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
