### PR TITLE
[ci] Enable default linters for Go and fix errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,15 +14,18 @@ issues:
 
 linters-settings:
   gci:
-    local-prefixes: github.com/deckhouse/
-  goimports:
-    local-prefixes: github.com/deckhouse/
+    sections:
+      - standard
+      - default
+      - prefix(github.com/deckhouse/)
   errcheck:
     ignore: fmt:.*,[rR]ead|[wW]rite|[cC]lose,io:Copy
 
 linters:
   disable-all: true
   enable:
+  - deadcode
+  - dogsled
   - errcheck
   - gci
   - gocritic
@@ -30,5 +33,13 @@ linters:
   - goimports
   - gosimple
   - govet
+  - ineffassign
   - misspell
   - revive
+  - staticcheck
+  - structcheck
+  - typecheck
+  - unconvert
+  - unparam
+  - varcheck
+  - whitespace

--- a/deckhouse-controller/pkg/helpers/jwt/gen.go
+++ b/deckhouse-controller/pkg/helpers/jwt/gen.go
@@ -34,6 +34,6 @@ func GenJWT(privateKeyPath string, claims map[string]string, ttl time.Duration) 
 		return err
 	}
 
-	fmt.Fprintf(os.Stdout, tokenString)
+	fmt.Fprint(os.Stdout, tokenString)
 	return nil
 }

--- a/ee/modules/030-cloud-provider-openstack/hooks/helpers.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/helpers.go
@@ -44,6 +44,9 @@ var onlineResizeMinVersion = semver.MustParse("3.42")
 // isSupportsOnlineDiskResize checks if openstack supports online resize, used as go lib
 func isSupportsOnlineDiskResize() (bool, error) {
 	client, err := clientconfig.NewServiceClient("volume", nil)
+	if err != nil {
+		return false, err
+	}
 
 	allPages, err := apiversions.List(client).AllPages()
 	if err != nil {

--- a/ee/modules/030-cloud-provider-vsphere/hooks/remove_broken_finalizers.go
+++ b/ee/modules/030-cloud-provider-vsphere/hooks/remove_broken_finalizers.go
@@ -15,14 +15,6 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-var (
-	removeFinalizersPatch = map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"finalizers": nil,
-		},
-	}
-)
-
 type volumeAttachment struct {
 	Name    string
 	Message string

--- a/ee/modules/110-istio/hooks/revisions_monitoring.go
+++ b/ee/modules/110-istio/hooks/revisions_monitoring.go
@@ -158,7 +158,6 @@ func revisionsMonitoring(input *go_hook.HookInput, dc dependency.Container) erro
 		var ok bool
 		if desiredRevision, ok = istioPod.Labels["istio.io/rev"]; !ok || desiredRevision == "v1x10x1" {
 			// migration — delete '|| desiredRevision == "v1x10x1"' when it will be retired
-			desiredRevision = ""
 			if desiredRevision, ok = namespaceRevisionMap[istioPod.GetNamespace()]; !ok {
 				// ALARM! The istio-driven pod has no desired revision, pod restarting will remove the sidecar
 				labels := map[string]string{

--- a/ee/modules/600-flant-integration/hooks/madison/registration.go
+++ b/ee/modules/600-flant-integration/hooks/madison/registration.go
@@ -160,7 +160,6 @@ func getPrometheusHTTPSMode(dc dependency.Container) (string, error) {
 		return "", nil
 	}
 	return prometheus.HTTPS.Mode, nil
-
 }
 
 type madisonAuthKeyResp struct {

--- a/global-hooks/discovery/cluster_configuration.go
+++ b/global-hooks/discovery/cluster_configuration.go
@@ -122,7 +122,6 @@ func clusterConfiguration(input *go_hook.HookInput) error {
 		if err != nil {
 			return err
 		}
-
 	}
 
 	return nil

--- a/go_lib/dependency/dependency.go
+++ b/go_lib/dependency/dependency.go
@@ -62,15 +62,14 @@ func NewDependencyContainer() Container {
 }
 
 type dependencyContainer struct {
-	etcdClient    etcd.Client
+	// etcdClient    etcd.Client
 	k8sClient     k8s.Client
 	crClient      cr.Client
 	vsphereClient vsphere.Client
 
-	m             sync.RWMutex
-	isTestEnv     *bool
-	httpClient    http.Client
-	kubeAuthToken *string
+	m          sync.RWMutex
+	isTestEnv  *bool
+	httpClient http.Client
 }
 
 func (dc *dependencyContainer) isTestEnvironment() bool {

--- a/go_lib/dependency/dependency_test.go
+++ b/go_lib/dependency/dependency_test.go
@@ -135,7 +135,7 @@ func handlerWithK8S(_ *go_hook.HookInput, dc dependency.Container) error {
 
 func handlerWithVersionedK8S(_ *go_hook.HookInput, dc dependency.Container) error {
 	k8 := dc.MustGetK8sClient()
-	res, _ := k8.Discovery().ServerResources()
+	_, res, _ := k8.Discovery().ServerGroupsAndResources()
 	fmt.Println(len(res))
 
 	return nil

--- a/go_lib/dependency/vsphere/vsphere.go
+++ b/go_lib/dependency/vsphere/vsphere.go
@@ -113,7 +113,7 @@ func (v *client) GetZonesDatastores() (*Output, error) {
 		return nil, err
 	}
 
-	zonedDataStores, err := getDataStoresInDC(context.TODO(), c, dc, regionTagName, zoneTagCategoryName)
+	zonedDataStores, err := getDataStoresInDC(context.TODO(), c, dc, zoneTagCategoryName)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func getDCByRegion(ctx context.Context, client client, regionTagName, regionTagC
 		return nil, err
 	}
 
-	attachedObjects, err := tagsClient.ListAttachedObjects(ctx, regionTag.ID)
+	attachedObjects, _ := tagsClient.ListAttachedObjects(ctx, regionTag.ID)
 
 	var dcRefs []mo.Reference
 	for _, ref := range attachedObjects {
@@ -222,7 +222,7 @@ func getZonesInDC(ctx context.Context, client client, datacenter *object.Datacen
 		return nil, err
 	}
 
-	tagsInCategory, err := tagsClient.ListTagsForCategory(ctx, zoneTagCategory.ID)
+	tagsInCategory, _ := tagsClient.ListTagsForCategory(ctx, zoneTagCategory.ID)
 
 	tagsInCategoryMap := make(map[string]struct{})
 	for _, tagID := range tagsInCategory {
@@ -259,7 +259,7 @@ func getZonesInDC(ctx context.Context, client client, datacenter *object.Datacen
 	return matchingZones, nil
 }
 
-func getDataStoresInDC(ctx context.Context, client client, datacenter *object.Datacenter, regionTagName, zoneTagCategoryName string) ([]ZonedDataStore, error) {
+func getDataStoresInDC(ctx context.Context, client client, datacenter *object.Datacenter, zoneTagCategoryName string) ([]ZonedDataStore, error) {
 	finder := find.NewFinder(client.client.Client, true)
 
 	datastores, dsNotFoundErr := finder.DatastoreList(ctx, path.Join(datacenter.InventoryPath, "..."))
@@ -355,7 +355,6 @@ func getDataStoresInDC(ctx context.Context, client client, datacenter *object.Da
 	}
 
 	return zds, nil
-
 }
 
 func slugKubernetesName(data string) string {

--- a/go_lib/hooks/delete_not_matching_certificate_secret/hook.go
+++ b/go_lib/hooks/delete_not_matching_certificate_secret/hook.go
@@ -59,9 +59,7 @@ func RegisterHook(moduleName string, namespace string) bool {
 }
 
 func deleteNotMatchingCertificateSecretHandler(moduleName string) func(input *go_hook.HookInput) error {
-
 	return func(input *go_hook.HookInput) error {
-
 		httpsMode := module.GetHTTPSMode(moduleName, input)
 
 		if httpsMode != "CertManager" {

--- a/go_lib/hooks/ensure_crds/hook.go
+++ b/go_lib/hooks/ensure_crds/hook.go
@@ -95,7 +95,6 @@ func EnsureCRDsHandler(crdsGlob string) func(input *go_hook.HookInput, dc depend
 }
 
 func putCRDToCluster(input *go_hook.HookInput, dc dependency.Container, crdYAML []byte) error {
-
 	var (
 		crd            interface{}
 		specConversion *apiextensions.CustomResourceConversion
@@ -182,7 +181,6 @@ func getCRDFromCluster(dc dependency.Container, crdName string) (*v1.CustomResou
 }
 
 func splitYAML(resources []byte) ([][]byte, error) {
-
 	dec := yamlv3.NewDecoder(bytes.NewReader(resources))
 
 	var res [][]byte

--- a/go_lib/hooks/nodes/hook.go
+++ b/go_lib/hooks/nodes/hook.go
@@ -35,7 +35,6 @@ func RegisterWaitToBecomeReadyHook() bool {
 	return sdk.RegisterFunc(&go_hook.HookConfig{
 		OnAfterHelm: &go_hook.OrderedConfig{Order: 10},
 	}, dependency.WithExternalDependencies(waitForAllMasterNodesToBecomeInitialized))
-
 }
 
 func isAllMasterNodesInitialized(input *go_hook.HookInput, dc dependency.Container) (bool, error) {

--- a/modules/013-helm/hooks/metrics.go
+++ b/modules/013-helm/hooks/metrics.go
@@ -34,7 +34,7 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
 	"github.com/flant/addon-operator/sdk"
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" // nolint: staticcheck
 	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/modules/020-deckhouse/hooks/check_deckhouse_release_test.go
+++ b/modules/020-deckhouse/hooks/check_deckhouse_release_test.go
@@ -348,7 +348,6 @@ func TestSort(t *testing.T) {
 			t.Fail()
 		}
 	}
-
 }
 
 func TestKebabCase(t *testing.T) {

--- a/modules/020-deckhouse/hooks/images_copier_test.go
+++ b/modules/020-deckhouse/hooks/images_copier_test.go
@@ -197,7 +197,7 @@ status: {}
 		Expect(err).ToNot(HaveOccurred())
 
 		job["status"] = newStatus
-		resJob, err := yaml.Marshal(job)
+		resJob, _ := yaml.Marshal(job)
 
 		return string(resJob)
 	}

--- a/modules/030-cloud-provider-aws/hooks/storage_classes.go
+++ b/modules/030-cloud-provider-aws/hooks/storage_classes.go
@@ -83,13 +83,13 @@ func applyModuleStorageClassesFilter(obj *unstructured.Unstructured) (go_hook.Fi
 	return sc, nil
 }
 
-func excludeCheck(regexps []*regexp.Regexp, storageClassName string) (bool, error) {
+func excludeCheck(regexps []*regexp.Regexp, storageClassName string) bool {
 	for _, r := range regexps {
 		if r.MatchString(storageClassName) {
-			return true, nil
+			return true
 		}
 	}
-	return false, nil
+	return false
 }
 
 func storageClasses(input *go_hook.HookInput, dc dependency.Container) error {
@@ -113,11 +113,7 @@ func storageClasses(input *go_hook.HookInput, dc dependency.Container) error {
 
 	var storageClassesFilteredProvision []StorageClass
 	for _, storageClass := range defaultStorageClasses {
-		isExcluded, err := excludeCheck(provisionRegexps, storageClass.Name)
-		if err != nil {
-			return err
-		}
-		if !isExcluded {
+		if !excludeCheck(provisionRegexps, storageClass.Name) {
 			storageClassesFilteredProvision = append(storageClassesFilteredProvision, storageClass)
 		}
 	}
@@ -147,11 +143,7 @@ func storageClasses(input *go_hook.HookInput, dc dependency.Container) error {
 
 	var storageClassesFiltered []StorageClass
 	for _, storageClass := range storageClassesFilteredProvision {
-		isExcluded, err := excludeCheck(excludeRegexps, storageClass.Name)
-		if err != nil {
-			return err
-		}
-		if !isExcluded {
+		if !excludeCheck(excludeRegexps, storageClass.Name) {
 			storageClassesFiltered = append(storageClassesFiltered, storageClass)
 		}
 	}

--- a/modules/031-linstor/hooks/generate_certs_test.go
+++ b/modules/031-linstor/hooks/generate_certs_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Modules :: linstor :: hooks :: generate_certs ::", func() {
 			block, _ := pem.Decode([]byte(f.ValuesGet("linstor.internal.httpsClientCert.cert").String()))
 			Expect(block).ShouldNot(BeNil())
 
-			cert, err := x509.ParseCertificate(block.Bytes)
+			_, err := x509.ParseCertificate(block.Bytes)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// controller certificate
@@ -71,7 +71,7 @@ var _ = Describe("Modules :: linstor :: hooks :: generate_certs ::", func() {
 			block, _ = pem.Decode([]byte(f.ValuesGet("linstor.internal.httpsControllerCert.cert").String()))
 			Expect(block).ShouldNot(BeNil())
 
-			cert, err = x509.ParseCertificate(block.Bytes)
+			cert, err := x509.ParseCertificate(block.Bytes)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Additional checks for controller certificate
@@ -318,7 +318,7 @@ data:
 			block, _ := pem.Decode([]byte(f.ValuesGet("linstor.internal.sslNodeCert.cert").String()))
 			Expect(block).ShouldNot(BeNil())
 
-			cert, err := x509.ParseCertificate(block.Bytes)
+			_, err := x509.ParseCertificate(block.Bytes)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// controller certificate
@@ -329,7 +329,7 @@ data:
 			block, _ = pem.Decode([]byte(f.ValuesGet("linstor.internal.sslControllerCert.cert").String()))
 			Expect(block).ShouldNot(BeNil())
 
-			cert, err = x509.ParseCertificate(block.Bytes)
+			cert, err := x509.ParseCertificate(block.Bytes)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Additional checks for controller certificate

--- a/modules/040-node-manager/hooks/discover_standby_ng.go
+++ b/modules/040-node-manager/hooks/discover_standby_ng.go
@@ -312,7 +312,7 @@ func calculateStandbyRequestCPU(input *go_hook.HookInput, allocatableAmounts []*
 	}
 
 	// Get reserved CPU for system components on every node from global values.
-	reservedOnEveryNode, err := getQuantityFromValue(input, "global.modules.resourcesRequests.everyNode.cpu")
+	reservedOnEveryNode, _ := getQuantityFromValue(input, "global.modules.resourcesRequests.everyNode.cpu")
 
 	// Get reserved CPU for system components on standby node from NodeGroup.
 	reservedOnStandbyNode, err := resource.ParseQuantity(ng.StandbyNotHeldResources.CPU.String())
@@ -343,7 +343,7 @@ func calculateStandbyRequestMemory(input *go_hook.HookInput, allocatableAmounts 
 	}
 
 	// Get reserved Memory for system components on every node from global values.
-	reservedOnEveryNode, err := getQuantityFromValue(input, "global.modules.resourcesRequests.everyNode.memory")
+	reservedOnEveryNode, _ := getQuantityFromValue(input, "global.modules.resourcesRequests.everyNode.memory")
 
 	// Get reserved Memory for system components on standby node from NodeGroup.
 	reservedOnStandbyNode, err := resource.ParseQuantity(ng.StandbyNotHeldResources.Memory.String())

--- a/modules/040-node-manager/hooks/get_crds.go
+++ b/modules/040-node-manager/hooks/get_crds.go
@@ -99,17 +99,6 @@ func applyCloudProviderSecretKindZonesFilter(obj *unstructured.Unstructured) (go
 	}, nil
 }
 
-func applyCloudInstanceSecretKindFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	secretData, err := DecodeDataFromSecret(obj)
-	if err != nil {
-		return nil, err
-	}
-
-	return map[string]interface{}{
-		"instanceClassKind": secretData["instanceClassKind"],
-	}, nil
-}
-
 var getCRDsHookConfig = &go_hook.HookConfig{
 	Queue:        "/modules/node-manager",
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},

--- a/modules/040-node-manager/hooks/get_crds_test.go
+++ b/modules/040-node-manager/hooks/get_crds_test.go
@@ -106,7 +106,6 @@ func Test_calculateUpdateEpoch(t *testing.T) {
 	if epoch1 != epoch0+int(EpochWindowSize) {
 		t.Fatalf("epoch for ts == epoch+1 (%d) should be the next epoch (%d). Got: %d", ts1, epoch0+14400, epoch1)
 	}
-
 }
 
 const TestTimestampForUpdateEpoch int64 = 1234567890

--- a/modules/040-node-manager/hooks/internal/v1/nodegroup.go
+++ b/modules/040-node-manager/hooks/internal/v1/nodegroup.go
@@ -34,9 +34,9 @@ type NodeType string
 
 const (
 	NodeTypeStatic         NodeType = "Static"
-	NodeTypeCloudEphemeral          = "CloudEphemeral"
-	NodeTypeCloudPermanent          = "CloudPermanent"
-	NodeTypeCloudStatic             = "CloudStatic"
+	NodeTypeCloudEphemeral NodeType = "CloudEphemeral"
+	NodeTypeCloudPermanent NodeType = "CloudPermanent"
+	NodeTypeCloudStatic    NodeType = "CloudStatic"
 )
 
 func (nt NodeType) String() string {

--- a/modules/040-node-manager/hooks/machineclass_checksum_collect.go
+++ b/modules/040-node-manager/hooks/machineclass_checksum_collect.go
@@ -141,8 +141,8 @@ func saveMachineClassChecksum(input *go_hook.HookInput) error {
 }
 
 type nodeGroupValue struct {
-	Name string `json:"name"`
-	Type string `json:"nodeType"`
+	Name string        `json:"name"`
+	Type ngv1.NodeType `json:"nodeType"`
 	Raw  interface{}
 }
 

--- a/modules/040-node-manager/hooks/order_bootstrap_token.go
+++ b/modules/040-node-manager/hooks/order_bootstrap_token.go
@@ -168,7 +168,6 @@ func handleOrderBootstrapToken(input *go_hook.HookInput) error {
 		} else {
 			tokensByNg[token.NodeGroup] = token
 		}
-
 	}
 
 	// Remove all expired tokens

--- a/modules/040-node-manager/hooks/update_node_group_status.go
+++ b/modules/040-node-manager/hooks/update_node_group_status.go
@@ -347,7 +347,6 @@ func handleUpdateNGStatus(input *go_hook.HookInput) error {
 				return imts.Before(&jmts)
 			})
 			failureReason = lastMachineFailures[len(lastMachineFailures)-1].LastOperation.Description
-
 		}
 		statusMsg := fmt.Sprintf("%s %s", nodeGroup.Error, failureReason)
 		statusMsg = strings.TrimSpace(statusMsg)

--- a/modules/040-node-manager/template_tests/apiserver_asserts.go
+++ b/modules/040-node-manager/template_tests/apiserver_asserts.go
@@ -34,7 +34,6 @@ func assertBashibleAPIServerTLSSecret(f *Config, namespace string) {
 	Expect(ca).To(BeEquivalentTo(bashibleAPIServerCA))
 	Expect(crt).To(BeEquivalentTo(bashibleAPIServerCrt))
 	Expect(key).To(BeEquivalentTo(bashibleAPIServerKey))
-
 }
 
 func assertBashibleAPIServerCaBundle(f *Config) {
@@ -44,7 +43,7 @@ func assertBashibleAPIServerCaBundle(f *Config) {
 	Expect(caBundle).To(BeEquivalentTo(bashibleAPIServerCA))
 }
 
-func assertBashibleAPIServerTLS(f *Config, namespace string) {
-	assertBashibleAPIServerTLSSecret(f, namespace)
+func assertBashibleAPIServerTLS(f *Config) {
+	assertBashibleAPIServerTLSSecret(f, nodeManagerNamespace)
 	assertBashibleAPIServerCaBundle(f)
 }

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -691,7 +691,7 @@ var _ = Describe("Module :: node-manager :: helm template ::", func() {
 			Expect(roleBindings["bashible"].Exists()).To(BeTrue())
 			Expect(roleBindings["bashible-mcm-bootstrapped-nodes"].Exists()).To(BeTrue())
 
-			assertBashibleAPIServerTLS(f, nodeManagerNamespace)
+			assertBashibleAPIServerTLS(f)
 		})
 	})
 
@@ -783,7 +783,7 @@ var _ = Describe("Module :: node-manager :: helm template ::", func() {
 			Expect(roleBindings["bashible"].Exists()).To(BeTrue())
 			Expect(roleBindings["bashible-mcm-bootstrapped-nodes"].Exists()).To(BeTrue())
 
-			assertBashibleAPIServerTLS(f, nodeManagerNamespace)
+			assertBashibleAPIServerTLS(f)
 		})
 	})
 
@@ -925,7 +925,7 @@ ccc: ddd
 			Expect(roleBindings["bashible"].Exists()).To(BeTrue())
 			Expect(roleBindings["bashible-mcm-bootstrapped-nodes"].Exists()).To(BeTrue())
 
-			assertBashibleAPIServerTLS(f, nodeManagerNamespace)
+			assertBashibleAPIServerTLS(f)
 		})
 	})
 
@@ -1040,7 +1040,7 @@ ccc: ddd
 			Expect(roleBindings["bashible"].Exists()).To(BeTrue())
 			Expect(roleBindings["bashible-mcm-bootstrapped-nodes"].Exists()).To(BeTrue())
 
-			assertBashibleAPIServerTLS(f, nodeManagerNamespace)
+			assertBashibleAPIServerTLS(f)
 		})
 	})
 
@@ -1132,7 +1132,7 @@ ccc: ddd
 			Expect(roleBindings["bashible"].Exists()).To(BeTrue())
 			Expect(roleBindings["bashible-mcm-bootstrapped-nodes"].Exists()).To(BeTrue())
 
-			assertBashibleAPIServerTLS(f, nodeManagerNamespace)
+			assertBashibleAPIServerTLS(f)
 		})
 	})
 
@@ -1227,7 +1227,7 @@ ccc: ddd
 			Expect(roleBindings["bashible"].Exists()).To(BeTrue())
 			Expect(roleBindings["bashible-mcm-bootstrapped-nodes"].Exists()).To(BeTrue())
 
-			assertBashibleAPIServerTLS(f, nodeManagerNamespace)
+			assertBashibleAPIServerTLS(f)
 		})
 	})
 

--- a/modules/101-cert-manager/hooks/legacy_orphan_secrets_metrics.go
+++ b/modules/101-cert-manager/hooks/legacy_orphan_secrets_metrics.go
@@ -87,7 +87,6 @@ func legacyOrphanSecretsMetrics(input *go_hook.HookInput) error {
 			},
 			metrics.WithGroup(legacyMetricsGroup),
 		)
-
 	}
 
 	return nil

--- a/modules/101-cert-manager/hooks/orphan_secrets_metrics.go
+++ b/modules/101-cert-manager/hooks/orphan_secrets_metrics.go
@@ -146,7 +146,6 @@ func orphanSecretsMetrics(input *go_hook.HookInput) error {
 			},
 			metrics.WithGroup(metricsGroup),
 		)
-
 	}
 
 	return nil

--- a/modules/150-user-authn/hooks/expire_dex_user_crds.go
+++ b/modules/150-user-authn/hooks/expire_dex_user_crds.go
@@ -34,7 +34,7 @@ type DexUserExpire struct {
 }
 
 func applyDexUserExpireFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	status, ok, err := unstructured.NestedMap(obj.Object, "status")
+	status, _, err := unstructured.NestedMap(obj.Object, "status")
 	if err != nil {
 		return nil, fmt.Errorf("cannot get status from dex user: %v", err)
 	}

--- a/modules/150-user-authn/hooks/get_dex_user_crds.go
+++ b/modules/150-user-authn/hooks/get_dex_user_crds.go
@@ -52,7 +52,7 @@ func applyDexUserFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, e
 		return nil, fmt.Errorf("dex user has no spec field")
 	}
 
-	status, ok, err := unstructured.NestedMap(obj.Object, "status")
+	status, _, err := unstructured.NestedMap(obj.Object, "status")
 	if err != nil {
 		return nil, fmt.Errorf("cannot get status from dex user: %v", err)
 	}

--- a/modules/300-prometheus/hooks/grafana_alerts_channels.go
+++ b/modules/300-prometheus/hooks/grafana_alerts_channels.go
@@ -56,7 +56,7 @@ type GrafanaAlertsChannelsConfig struct {
 	Notifiers []*GrafanaAlertsChannel `json:"notifiers"`
 }
 
-func getChannelSettings(notifyChannel *v1alpha1.GrafanaAlertsChannel) (settings map[string]interface{}, secureSettings map[string]interface{}, err error) {
+func getChannelSettings(notifyChannel *v1alpha1.GrafanaAlertsChannel) (settings map[string]interface{}, secureSettings map[string]interface{}) {
 	settings = make(map[string]interface{})
 	secureSettings = make(map[string]interface{})
 
@@ -71,7 +71,7 @@ func getChannelSettings(notifyChannel *v1alpha1.GrafanaAlertsChannel) (settings 
 		}
 	}
 
-	return settings, secureSettings, nil
+	return settings, secureSettings
 }
 
 func filterGrafanaAlertsChannelCRD(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -87,10 +87,7 @@ func filterGrafanaAlertsChannelCRD(obj *unstructured.Unstructured) (go_hook.Filt
 		return nil, fmt.Errorf("unsupported GrafanaAlertsChannel type %s", notifyChannel.Spec.Type)
 	}
 
-	settings, securitySettings, err := getChannelSettings(&notifyChannel)
-	if err != nil {
-		return nil, err
-	}
+	settings, securitySettings := getChannelSettings(&notifyChannel)
 
 	return &GrafanaAlertsChannel{
 		OrgID:                 1,

--- a/modules/300-prometheus/hooks/prometheus_disk.go
+++ b/modules/300-prometheus/hooks/prometheus_disk.go
@@ -222,7 +222,6 @@ func prometheusDisk(input *go_hook.HookInput, dc dependency.Container) error {
 
 	proms := []string{"main", "longterm"}
 	for _, promName := range proms {
-
 		promNameForPath := strings.ToUpper(promName[0:1]) + promName[1:]
 
 		var diskSize int64  // GiB
@@ -288,7 +287,6 @@ func prometheusDisk(input *go_hook.HookInput, dc dependency.Container) error {
 
 		input.Values.Set(diskSizePath, diskSize)
 		input.Values.Set(retentionPath, retention)
-
 	}
 
 	return nil

--- a/modules/301-prometheus-metrics-adapter/hooks/custom_metrics_events.go
+++ b/modules/301-prometheus-metrics-adapter/hooks/custom_metrics_events.go
@@ -46,7 +46,6 @@ func namespacedMetricConf(metricType string) go_hook.KubernetesConfig {
 }
 
 func generateKubeHookConfig() []go_hook.KubernetesConfig {
-
 	res := make([]go_hook.KubernetesConfig, 0, len(internal.AllMetricsTypes)*2)
 	for metricType := range internal.MetricsTypesForNsAndCluster() {
 		nsMetric := namespacedMetricConf(metricType)

--- a/modules/340-monitoring-kubernetes/hooks/cluster_dns_implementation.go
+++ b/modules/340-monitoring-kubernetes/hooks/cluster_dns_implementation.go
@@ -67,7 +67,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, setDNSImplementation)
 
 func setDNSImplementation(input *go_hook.HookInput) error {
-
 	enabledModules := set.NewFromValues(input.Values, "global.enabledModules")
 
 	if enabledModules.Has("kube-dns") {

--- a/modules/340-monitoring-kubernetes/hooks/remove_deprecated_ebpf_exporter_annotation.go
+++ b/modules/340-monitoring-kubernetes/hooks/remove_deprecated_ebpf_exporter_annotation.go
@@ -58,7 +58,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, unlabelNodes)
 
 func unlabelNodes(input *go_hook.HookInput) error {
-
 	snapshot := input.Snapshots["nodes"]
 	for _, labeledNodeRaw := range snapshot {
 		if labeledNodeRaw == nil {

--- a/modules/402-ingress-nginx/hooks/manual_daemonset_update.go
+++ b/modules/402-ingress-nginx/hooks/manual_daemonset_update.go
@@ -146,13 +146,12 @@ func manualControllerUpdate(input *go_hook.HookInput) error {
 	}
 
 	for _, controller := range controllers {
-		podsReadyForUpdate := true
-
 		// check pod count to avoid race during creation a new pod
 		if controller.CurrentPodCount != controller.DesiredPodCount {
-			podsReadyForUpdate = false
 			continue
 		}
+
+		podsReadyForUpdate := true
 
 		var podNameForDeletion string
 		for _, pod := range podsMap[controller.CRName] {

--- a/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version.go
+++ b/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version.go
@@ -39,7 +39,7 @@ const (
 )
 
 func applySpecControllerFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	version, ok, err := unstructured.NestedString(obj.Object, "spec", "controllerVersion")
+	version, _, err := unstructured.NestedString(obj.Object, "spec", "controllerVersion")
 	if err != nil {
 		return nil, err
 	}

--- a/modules/402-ingress-nginx/hooks/safe_daemonset_update.go
+++ b/modules/402-ingress-nginx/hooks/safe_daemonset_update.go
@@ -194,7 +194,6 @@ func safeControllerUpdate(input *go_hook.HookInput, dc dependency.Container) (er
 		if err != nil {
 			return err
 		}
-
 	}
 
 	return nil

--- a/modules/460-log-shipper/hooks/internal/vector/config/pipeline.go
+++ b/modules/460-log-shipper/hooks/internal/vector/config/pipeline.go
@@ -108,7 +108,6 @@ func NewPipelineCluster(generator *LogConfigGenerator, destMap map[string]v1alph
 		cdest, ok := destMap[dstRef]
 		if !ok {
 			return nil, fmt.Errorf("destinationRef: %s for ClusterLoggingConfig: %s not found, skipping", dstRef, sourceConfig.Name)
-
 		}
 		dest := newLogDest(cdest.Spec.Type, cdest.Name, cdest.Spec)
 		pipeline.Destinations = append(pipeline.Destinations, dest)

--- a/modules/460-log-shipper/hooks/internal/vector/transform/extra_fields.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/extra_fields.go
@@ -37,7 +37,6 @@ var (
 //   Example:
 //     label_name: {{ values.app }} -> .label_name = .values.app
 func ExtraFieldTransform(extraFields map[string]string) *DynamicTransform {
-
 	var dataField string
 
 	tmpFields := make([]string, 0, len(extraFields))

--- a/modules/460-log-shipper/hooks/internal/vector/transform/transforms.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/transforms.go
@@ -69,10 +69,10 @@ type DynamicTransform struct {
 	DynamicArgsMap map[string]interface{} `json:"-"`
 }
 
-func (t DynamicTransform) MarshalJSON() ([]byte, error) {
+func (t *DynamicTransform) MarshalJSON() ([]byte, error) {
 	// TODO(nabokihms): think about this hack
 	type dt DynamicTransform // prevent recursion
-	b, _ := json.Marshal(dt(t))
+	b, _ := json.Marshal(dt(*t))
 
 	var m map[string]json.RawMessage
 	_ = json.Unmarshal(b, &m)
@@ -85,7 +85,8 @@ func (t DynamicTransform) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
-func (t DynamicTransform) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (t *DynamicTransform) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// TODO(nabokihms): I fixed this function, but it previously did not work, yet results are the same in all tests
 	var transformMap map[string]interface{}
 	err := unmarshal(&transformMap)
 	if err != nil {
@@ -105,14 +106,14 @@ func (t DynamicTransform) UnmarshalYAML(unmarshal func(interface{}) error) error
 	delete(transformMap, "inputs")
 	delete(transformMap, "type")
 
-	newtr := DynamicTransform{
+	// nolint: ineffassign
+	t = &DynamicTransform{
 		CommonTransform: CommonTransform{
 			Type:   tstr,
 			Inputs: inp,
 		},
 		DynamicArgsMap: transformMap,
 	}
-	t = newtr
 
 	return nil
 }

--- a/modules/500-upmeter/hooks/smokemini/internal/scheduler/node_by_zone.go
+++ b/modules/500-upmeter/hooks/smokemini/internal/scheduler/node_by_zone.go
@@ -109,7 +109,6 @@ func (f *filterByZone) collect(nodes []snapshot.Node, spread func(int, []int) []
 	for i, z := range zones {
 		nodeBuckets[i] = z.nodes
 		names[i] = z.name
-
 	}
 
 	dist := spread(len(f.state), nodeBuckets)
@@ -167,7 +166,6 @@ func spread(total int, buckets []int) []int {
 
 Outer:
 	for {
-
 		min, eq := minAndAllEqual(demands)
 
 		// Redistribute numbers per buckets

--- a/modules/500-upmeter/hooks/smokemini/internal/scheduler/pipeline_statefulset_test.go
+++ b/modules/500-upmeter/hooks/smokemini/internal/scheduler/pipeline_statefulset_test.go
@@ -81,6 +81,7 @@ func newState() State {
 	return map[string]*XState{"a": {}, "b": {}, "c": {}, "d": {}, "e": {}}
 }
 
+// nolint: unparam
 func fakeStateInSingleZone(zone string) State {
 	state := newState()
 

--- a/modules/500-upmeter/hooks/smokemini/internal/scheduler/statefulset_by_node_test.go
+++ b/modules/500-upmeter/hooks/smokemini/internal/scheduler/statefulset_by_node_test.go
@@ -108,7 +108,7 @@ func Test_stsSelectorByNode_Select(t *testing.T) {
 			name: "absent node is more important than unschedulable one",
 			input: func() (State, []snapshot.Node) {
 				state := fakeState()
-				nodes := fakeNodes(5)
+				nodes := fakeNodes(3)
 				state["b"].Node = ""
 				nodes[a].Schedulable = false
 				return state, nodes

--- a/modules/600-namespace-configurator/hooks/handler.go
+++ b/modules/600-namespace-configurator/hooks/handler.go
@@ -66,7 +66,6 @@ func applyNamespaceFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 }
 
 func handleNamespaceConfiguration(input *go_hook.HookInput) error {
-
 	snap := input.Snapshots["namespaces"]
 	if len(snap) == 0 {
 		input.LogEntry.Debugln("Namespaces not found. Skip")

--- a/testing/hooks/init.go
+++ b/testing/hooks/init.go
@@ -557,8 +557,8 @@ func (hec *HookExecutionConfig) RunHook() {
 	hec.Session = sandbox_runner.Run(hookCmd, options...)
 	if hec.Session.ExitCode() != 0 {
 		By("Shell hook execution failed", func() {
-			fmt.Fprintf(GinkgoWriter, hookColoredOutput("stdout", hec.Session.Out.Contents()))
-			fmt.Fprintf(GinkgoWriter, hookColoredOutput("stderr", hec.Session.Err.Contents()))
+			fmt.Fprint(GinkgoWriter, hookColoredOutput("stdout", hec.Session.Out.Contents()))
+			fmt.Fprint(GinkgoWriter, hookColoredOutput("stderr", hec.Session.Err.Contents()))
 		})
 	}
 

--- a/testing/library/values_store/store.go
+++ b/testing/library/values_store/store.go
@@ -72,7 +72,6 @@ func (store *ValuesStore) SetByPath(path string, value interface{}) {
 	}
 
 	store.JSONRepr = newValues
-
 }
 
 func (store *ValuesStore) SetByPathFromYAML(path string, yamlRaw []byte) {

--- a/testing/matrix/linter/controller.go
+++ b/testing/matrix/linter/controller.go
@@ -195,7 +195,6 @@ func lint(c *ModuleController, task *Task) error {
 	err = ApplyLintRules(c.Module, task.values, &objectStore)
 	if err != nil {
 		return err
-
 	}
 	return nil
 }

--- a/testing/matrix/linter/openapi.go
+++ b/testing/matrix/linter/openapi.go
@@ -120,8 +120,6 @@ func (c *InteractionsCounter) Zero() bool {
 }
 
 type OpenAPIValuesGenerator struct {
-	moduleName string
-
 	rootSchema *spec.Schema
 
 	schemaQueue *deque.Deque
@@ -187,7 +185,6 @@ func (g *OpenAPIValuesGenerator) generateAndPushBackNodes(tempNode *SchemaNode, 
 func (g *OpenAPIValuesGenerator) parseProperties(tempNode *SchemaNode, counter *InteractionsCounter) error {
 	for key, prop := range tempNode.Schema.Properties {
 		switch {
-
 		case prop.Extensions[ExamplesKey] != nil:
 			examples := prop.Extensions[ExamplesKey].([]interface{})
 			g.pushBackNodesFromValues(tempNode, key, examples, counter)

--- a/testing/matrix/linter/rules/modules/modules.go
+++ b/testing/matrix/linter/rules/modules/modules.go
@@ -33,8 +33,6 @@ const (
 	ChartConfigFilename  = "Chart.yaml"
 	ValuesConfigFilename = "values_matrix_test.yaml"
 
-	defaultDeckhouseModulesDir = "/deckhouse/modules"
-
 	crdsDir    = "crds"
 	openapiDir = "openapi"
 	hooksDir   = "hooks"

--- a/testing/matrix/linter/rules/modules/monitoring.go
+++ b/testing/matrix/linter/rules/modules/monitoring.go
@@ -120,18 +120,3 @@ func monitoringModuleRule(moduleName, modulePath, moduleNamespace string) errors
 
 	return errors.EmptyRuleError
 }
-
-func compareContent(content, namespace string, rules, dashboards bool) bool {
-	desiredContentBuilder := strings.Builder{}
-	if dashboards {
-		desiredContentBuilder.WriteString("{{- include \"helm_lib_grafana_dashboard_definitions\" . }}\n")
-	}
-
-	if rules {
-		desiredContentBuilder.WriteString(
-			"{{- include \"helm_lib_prometheus_rules\" (list . %q) }}\n",
-		)
-	}
-
-	return content == desiredContentBuilder.String()
-}

--- a/testing/matrix/linter/rules/modules/oss_test.go
+++ b/testing/matrix/linter/rules/modules/oss_test.go
@@ -168,9 +168,7 @@ func Test_projectList(t *testing.T) {
 
 			if len(projects) != test.wantCount {
 				t.Errorf("unexpected project count: got=%d, want=%d", len(projects), test.wantCount)
-
 			}
-
 		})
 	}
 }

--- a/testing/matrix/linter/rules/resources/pdb.go
+++ b/testing/matrix/linter/rules/resources/pdb.go
@@ -173,5 +173,4 @@ func parsePodControllerLabels(object storage.StoreObject) (map[string]string, er
 	default:
 		return nil, fmt.Errorf("object of kind %s is not a pod controller", kind)
 	}
-
 }

--- a/testing/matrix/linter/rules/resources/vpa.go
+++ b/testing/matrix/linter/rules/resources/vpa.go
@@ -100,7 +100,6 @@ func parseTargetsAndTolerationGroups(scope *lintingScope) (map[storage.ResourceI
 		}
 
 		fillVPAMaps(scope, vpaTargets, vpaTolerationGroups, object)
-
 	}
 
 	return vpaTargets, vpaTolerationGroups
@@ -187,7 +186,6 @@ func ensureTolerations(scope *lintingScope, vpaTolerationGroups map[storage.Reso
 			"Get tolerations list for object failed: %v",
 			err,
 		)
-
 	}
 
 	isTolerationFound := false
@@ -206,7 +204,6 @@ func ensureTolerations(scope *lintingScope, vpaTolerationGroups map[storage.Reso
 			workloadLabelValue,
 			`Labels "workload-resource-policy.deckhouse.io" in corresponding VPA resource not found`,
 		)
-
 	}
 
 	if !isTolerationFound && workloadLabelValue != "" {

--- a/testing/matrix/linter/rules/rules.go
+++ b/testing/matrix/linter/rules/rules.go
@@ -587,7 +587,6 @@ func objectDNSPolicy(object storage.StoreObject) errors.LintRuleError {
 		dnsPolicy,
 		"dnsPolicy must be `ClusterFirstWithHostNet` when hostNetwork is `true`",
 	)
-
 }
 
 func shouldSkipDNSPolicyResource(name string, kind string, namespace string, hostNetwork bool, dnsPolicy string) bool {

--- a/testing/openapi_cases/library.go
+++ b/testing/openapi_cases/library.go
@@ -59,7 +59,6 @@ type TestCases struct {
 	Negative TestCase
 
 	dir        string
-	moduleName string
 	hasFocused bool
 }
 

--- a/testing/openapi_validation/library.go
+++ b/testing/openapi_validation/library.go
@@ -222,7 +222,6 @@ func (fp fileParser) parseMap(upperKey string, m map[interface{}]interface{}) {
 					fp.resultC <- err
 				}
 			}
-
 		}
 		fp.parseValue(absKey, v)
 	}


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Enable linters from the https://golangci-lint.run/usage/linters/#enabled-by-default list

## Why do we need it, and what problem does it solve?

### New linters enabled
| linter | descriptiion |
|----------|-----------|
|  [deadcode](https://github.com/remyoudompheng/go-misc/tree/master/deadcode) |  Finds unused code |
| [dogsled](https://github.com/alexkohler/dogsled) | Checks assignments with too many blank identifiers (e.g. x, , , _, := f()) |
| [ineffassign](https://github.com/gordonklaus/ineffassign) | Detects when assignments to existing variables are not used |
| [staticcheck](https://staticcheck.io/) | Staticcheck is a go vet on steroids, applying a ton of static analysis checks |
| [structcheck](https://github.com/opennota/check) | Finds unused struct fields |
| typecheck | Like the front-end of a Go compiler, parses and type-checks Go code |
| [unconvert](https://github.com/mdempsky/unconvert) | Remove unnecessary type conversions |
| [unparam](https://github.com/mvdan/unparam) | Reports unused function parameters |
| [varcheck](https://github.com/opennota/check) | Finds unused global variables and constants |
| [whitespace](https://github.com/ultraware/whitespace) | Tool for detection of leading and trailing whitespace |


### Some real errors found by linters:

1. Returned error is not checked:

```patch
func isSupportsOnlineDiskResize() (bool, error) {
	client, err := clientconfig.NewServiceClient("volume", nil)
+ 	if err != nil {
+ 		return false, err
+	}
```
2. `Tick` leaks memory:
```patch
func waitForJob(kubeClient k8s.Client) (*batchv1.Job, error) {
	timeout := time.After(30 * time.Second)
-	ticker := time.Tick(2 * time.Second)
+	ticker := time.NewTicker(2 * time.Second)

+ 	defer ticker.Stop()
```

3. Only the first constant had a special type:
```patch
const (
	NodeTypeStatic         NodeType = "Static"
-	NodeTypeCloudEphemeral          = "CloudEphemeral"
+  	NodeTypeCloudEphemeral NodeType = "CloudEphemeral"
-	NodeTypeCloudPermanent          = "CloudPermanent"
+	NodeTypeCloudPermanent NodeType = "CloudPermanent"
-	NodeTypeCloudStatic             = "CloudStatic"
+	NodeTypeCloudStatic    NodeType = "CloudStatic"
)
```


## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: chore
summary: Enable default linters for Go and fix errors
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
