### PR TITLE
[cni-cilium] set as default cni

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/hooks/get_cni_secret.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/get_cni_secret.go
@@ -1,0 +1,10 @@
+/*
+Copyright 2022 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderOpenstack")

--- a/ee/modules/030-cloud-provider-openstack/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-openstack/openapi/values.yaml
@@ -103,3 +103,5 @@ properties:
         type: string
       supportsOnlineDiskResize:
         type: boolean
+      cniSecretData:
+        type: string

--- a/ee/modules/030-cloud-provider-openstack/templates/cni.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cni.yaml
@@ -6,9 +6,8 @@ metadata:
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 data:
-  cni: {{ b64enc "flannel" | quote }}
-  {{- if eq .Values.cloudProviderOpenstack.internal.podNetworkMode "VXLAN" }}
-  flannel: {{ b64enc "{\"podNetworkMode\":\"vxlan\"}" | quote }}
-  {{- else }}
-  flannel: {{ b64enc "{\"podNetworkMode\":\"host-gw\"}" | quote }}
-  {{- end }}
+{{- if hasKey .Values.cloudProviderOpenstack.internal "cniSecretData" }}
+  {{- .Values.cloudProviderOpenstack.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
+  cni: {{ b64enc "cilium" | quote }}
+{{- end }}

--- a/ee/modules/030-cloud-provider-vsphere/hooks/get_cni_secret.go
+++ b/ee/modules/030-cloud-provider-vsphere/hooks/get_cni_secret.go
@@ -1,0 +1,10 @@
+/*
+Copyright 2022 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("cloudProviderVsphere")

--- a/ee/modules/030-cloud-provider-vsphere/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/openapi/values.yaml
@@ -404,3 +404,5 @@ properties:
             type: array
             items:
               type: string
+      cniSecretData:
+        type: string

--- a/ee/modules/030-cloud-provider-vsphere/templates/cni.yaml
+++ b/ee/modules/030-cloud-provider-vsphere/templates/cni.yaml
@@ -6,5 +6,8 @@ metadata:
   namespace: kube-system
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 data:
-  cni: {{ b64enc "flannel" | quote }}
-  flannel: {{ b64enc "{\"podNetworkMode\":\"host-gw\"}" | quote }}
+{{- if hasKey .Values.cloudProviderVsphere.internal "cniSecretData" }}
+  {{- .Values.cloudProviderVsphere.internal.cniSecretData | b64dec | nindent 2 }}
+{{- else }}
+  cni: {{ b64enc "cilium" | quote }}
+{{- end }}

--- a/go_lib/hooks/get_cni_secret/hook.go
+++ b/go_lib/hooks/get_cni_secret/hook.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package get_cni_secret
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+func applyCNISecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	secret := &v1.Secret{}
+	err := sdk.FromUnstructured(obj, secret)
+	if err != nil {
+		return "", err
+	}
+
+	if _, ok := secret.Data["cni"]; !ok {
+		return "", fmt.Errorf("kube-system/d8-cni-configuration secret data field `cni` is absent: %q", secret.Data)
+	}
+
+	dataYAML, err := yaml.Marshal(secret.Data)
+	if err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(dataYAML), nil
+}
+
+func RegisterHook(moduleName string) bool {
+	return sdk.RegisterFunc(&go_hook.HookConfig{
+		OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+		Kubernetes: []go_hook.KubernetesConfig{
+			{
+				Name:       "cni_secret",
+				ApiVersion: "v1",
+				Kind:       "Secret",
+				NamespaceSelector: &types.NamespaceSelector{
+					NameSelector: &types.NameSelector{
+						MatchNames: []string{"kube-system"},
+					},
+				},
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-cni-configuration"},
+				},
+				FilterFunc: applyCNISecretFilter,
+			},
+		},
+	}, setCNISecretData(moduleName))
+}
+
+func setCNISecretData(moduleName string) func(input *go_hook.HookInput) error {
+	return func(input *go_hook.HookInput) error {
+		cniSecretSnap := input.Snapshots["cni_secret"]
+		if len(cniSecretSnap) == 0 {
+			input.LogEntry.Info("No cni secret received, skipping setting values")
+			return nil
+		}
+
+		if len(cniSecretSnap) > 1 {
+			input.LogEntry.Info("Multiple secret received, skipping setting values")
+			return nil
+		}
+
+		path := fmt.Sprintf("%s.internal.cniSecretData", moduleName)
+		input.Values.Set(path, cniSecretSnap[0].(string))
+		return nil
+	}
+}

--- a/modules/000-common/hooks/get_cni_secret.go
+++ b/modules/000-common/hooks/get_cni_secret.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/get_cni_secret"
+
+var _ = get_cni_secret.RegisterHook("common")

--- a/modules/000-common/hooks/get_cni_secret_test.go
+++ b/modules/000-common/hooks/get_cni_secret_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"encoding/base64"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: common :: hooks :: check_cni_secret ::", func() {
+	const (
+		cniSecret = `
+---
+apiVersion: v1
+data:
+  cni: Zmxhbm5lbA==
+  flannel: eyJwb2ROZXR3b3JrTW9kZSI6Imhvc3QtZ3cifQ==
+kind: Secret
+metadata:
+  name: d8-cni-configuration
+  namespace: kube-system
+type: Opaque
+`
+	)
+
+	f := HookExecutionConfigInit(`{"common":{"internal": {}}}`, `{}`)
+	Context("Empti cluster", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(``)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Hook must fail", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("common.internal.cniSecretData").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Cluster with valid secret", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(cniSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Hook must not fail", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			d := f.ValuesGet("common.internal.cniSecretData").String()
+			dataYaml, _ := base64.StdEncoding.DecodeString(d)
+			Expect(dataYaml).To(MatchYAML(`cni: Zmxhbm5lbA==
+flannel: eyJwb2ROZXR3b3JrTW9kZSI6Imhvc3QtZ3cifQ==
+`))
+		})
+	})
+
+})


### PR DESCRIPTION
Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
In existing clusters cni parameters stored in kube-system/d8-cni-configuration secret. 
We stores parameters from existing secret in module internal values, and recreate secret with this parameters.
Thus, if cluster have a configured cni (cni-flannel for example), it will continue to use configured cni.
If there is no secret (new installation, first run), we install cni-cilium as cni in the d8-cni-configuration secret.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We want to replace cni-flannel with cni-cilium for all new installations in vsphere and openstack clouds.
For existing clusters we should not change cni.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cni-cilium
type: feature
summary: cni-cilium set as default cni (replaces cni-flannel) for openstack and vsphere.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
