### PR TITLE
[docs] Fix misspelling in the YandexInstanceClass resource

### DIFF
--- a/candi/cloud-providers/yandex/openapi/doc-ru-instance_class.yaml
+++ b/candi/cloud-providers/yandex/openapi/doc-ru-instance_class.yaml
@@ -32,7 +32,7 @@ spec:
                     ID платформы. [Список существующих платформ](https://cloud.yandex.com/docs/compute/concepts/vm-platforms).
                 preemptible:
                   description: |
-                    Необходимость заказа preemptible instance.
+                    Необходимость заказа preemptible-инстансов.
                 diskType:
                   description: |
                     Тип диска у инстансов. [Типы дисков](https://cloud.yandex.com/docs/compute/concepts/disk#disks_types).
@@ -88,7 +88,7 @@ spec:
                     ID платформы. [Список существующих платформ](https://cloud.yandex.com/docs/compute/concepts/vm-platforms).
                 preemptible:
                   description: |
-                    Необходимость заказа preemptible instance.
+                    Необходимость заказа preemptible-инстансов.
                 diskType:
                   description: |
                     Тип диска у инстансов. [Типы дисков](https://cloud.yandex.com/docs/compute/concepts/disk#disks_types).

--- a/candi/cloud-providers/yandex/openapi/instance_class.yaml
+++ b/candi/cloud-providers/yandex/openapi/instance_class.yaml
@@ -64,7 +64,7 @@ spec:
                   x-doc-default: standard-v2
                   type: string
                 preemptible:
-                  description: Should a provisioned Yandex Compute Instance be preemtible.
+                  description: Should a provisioned Yandex Compute Instance be preemptible.
                   type: boolean
                   x-doc-default: false
                 diskType:
@@ -180,7 +180,7 @@ spec:
                   type: string
                 preemptible:
                   description: |
-                    Should a provisioned Yandex Compute Instance be preemtible.
+                    Should a provisioned Yandex Compute Instance be preemptible.
                   type: boolean
                   x-doc-default: false
                 diskType:


### PR DESCRIPTION
## Description
There was a misspelling in the preemptible parameter in the YandexInstanceClass resource, which led to the search on the site for the word preemptible not giving the correct results.

## Changelog entries
```changes
section: cloud-provider-yandex
type: fix
summary: Fixed misspelling in the YandexInstanceClass resource
impact_level: low
```
