### PR TITLE
Change k8s registry

### DIFF
--- a/candi/bashible/bundles/ubuntu-lts/node-group/035_pull_pause.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/node-group/035_pull_pause.sh.tpl
@@ -17,7 +17,7 @@ if [[ "${FIRST_BASHIBLE_RUN}" != "yes" ]]; then
   exit 0
 fi
 
-pause_container="k8s.gcr.io/pause:3.2"
+pause_container="registry.k8s.io/pause:3.2"
 if [[ "$(docker image ls -q "${pause_container}" | wc -l)" -eq "0" ]]; then
   if ! docker pull "${pause_container}" >/dev/null 2>/dev/null; then
     docker pull registry.deckhouse.io/deckhouse/ce:pause-3.2

--- a/candi/bashible/common-steps/node-group/050_configure_and_start_containerd.sh.tpl
+++ b/candi/bashible/common-steps/node-group/050_configure_and_start_containerd.sh.tpl
@@ -24,7 +24,7 @@ _on_containerd_config_changed() {
   {{- if hasKey .nodeGroup.cri "containerd" }}
     {{- $max_concurrent_downloads = .nodeGroup.cri.containerd.maxConcurrentDownloads | default $max_concurrent_downloads }}
   {{- end }}
-  {{- $sandbox_image := "k8s.gcr.io/pause:3.2" }}
+  {{- $sandbox_image := "registry.k8s.io/pause:3.2" }}
   {{- if .images }}
     {{- if .images.common.pause }}
       {{- $sandbox_image = printf "%s%s:%s" .registry.address .registry.path .images.common.pause }}

--- a/candi/tools/discover_new_kubernetes_patchversions.sh
+++ b/candi/tools/discover_new_kubernetes_patchversions.sh
@@ -31,13 +31,13 @@ function update_version_map() {
   yq -i e ".k8s.\"${1}\".patch = ${2}" /deckhouse/candi/version_map.yml
   # Kube-proxy
   if yq -e e "select(.k8s.\"${1}\".controlPlane | has(\"kubeProxy\"))" /deckhouse/candi/version_map.yml >/dev/null 2>/dev/null; then
-    NEW_DIGEST="$(crane digest "k8s.gcr.io/kube-proxy:v${1}.${2}")"
+    NEW_DIGEST="$(crane digest "registry.k8s.io/kube-proxy:v${1}.${2}")"
     yq -i e ".k8s.\"${1}\".controlPlane.kubeProxy = \"${NEW_DIGEST}\"" /deckhouse/candi/version_map.yml
   fi
   # Kube-scheduler
   NEW_DIGEST=""
   if yq -e e "select(.k8s.\"${1}\".controlPlane | has(\"kubeScheduler\"))" /deckhouse/candi/version_map.yml >/dev/null 2>/dev/null; then
-    NEW_DIGEST="$(crane digest "k8s.gcr.io/kube-scheduler:v${1}.${2}")"
+    NEW_DIGEST="$(crane digest "registry.k8s.io/kube-scheduler:v${1}.${2}")"
     yq -i e ".k8s.\"${1}\".controlPlane.kubeScheduler = \"${NEW_DIGEST}\"" /deckhouse/candi/version_map.yml
   fi
 }

--- a/dhctl/pkg/template/testdata/resources/order.yaml
+++ b/dhctl/pkg/template/testdata/resources/order.yaml
@@ -368,7 +368,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: k8s.gcr.io/nginx-slim:0.8
+          image: registry.k8s.io/nginx-slim:0.8
           ports:
             - containerPort: 80
               name: web

--- a/modules/000-common/images/csi-external-attacher/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-attacher/werf.inc.yaml
@@ -16,6 +16,6 @@ docker:
   ENTRYPOINT: ["/csi-attacher"]
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-from: k8s.gcr.io/sig-storage/csi-attacher:{{ $value.csi.attacher }}
+from: registry.k8s.io/sig-storage/csi-attacher:{{ $value.csi.attacher }}
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-external-provisioner/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-provisioner/werf.inc.yaml
@@ -16,6 +16,6 @@ docker:
   ENTRYPOINT: ["/csi-provisioner"]
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-from: k8s.gcr.io/sig-storage/csi-provisioner:{{ $value.csi.provisioner }}
+from: registry.k8s.io/sig-storage/csi-provisioner:{{ $value.csi.provisioner }}
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-external-resizer/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-resizer/werf.inc.yaml
@@ -16,6 +16,6 @@ docker:
   ENTRYPOINT: ["/csi-resizer"]
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-from: k8s.gcr.io/sig-storage/csi-resizer:{{ $value.csi.resizer }}
+from: registry.k8s.io/sig-storage/csi-resizer:{{ $value.csi.resizer }}
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
@@ -16,6 +16,6 @@ docker:
   ENTRYPOINT: ["/csi-snapshotter"]
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-from: k8s.gcr.io/sig-storage/csi-snapshotter:{{ $value.csi.snapshotter }}
+from: registry.k8s.io/sig-storage/csi-snapshotter:{{ $value.csi.snapshotter }}
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-livenessprobe/werf.inc.yaml
+++ b/modules/000-common/images/csi-livenessprobe/werf.inc.yaml
@@ -16,6 +16,6 @@ docker:
   ENTRYPOINT: ["/livenessprobe"]
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-from: k8s.gcr.io/sig-storage/livenessprobe:{{ $value.csi.livenessprobe }}
+from: registry.k8s.io/sig-storage/livenessprobe:{{ $value.csi.livenessprobe }}
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
+++ b/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
@@ -16,6 +16,6 @@ docker:
   ENTRYPOINT: ["/csi-node-driver-registrar"]
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-from: k8s.gcr.io/sig-storage/csi-node-driver-registrar:{{ $value.csi.registrar }}
+from: registry.k8s.io/sig-storage/csi-node-driver-registrar:{{ $value.csi.registrar }}
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/pause/werf.inc.yaml
+++ b/modules/000-common/images/pause/werf.inc.yaml
@@ -1,2 +1,2 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-from: k8s.gcr.io/pause:3.1@sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea
+from: registry.k8s.io/pause:3.1@sha256:f78411e19d84a252e53bff71a4407a5686c46983a2c2eeed83929b888179acea

--- a/modules/021-kube-proxy/images/kube-proxy/werf.inc.yaml
+++ b/modules/021-kube-proxy/images/kube-proxy/werf.inc.yaml
@@ -54,6 +54,6 @@ shell:
   - for patchfile in /patches/{{ $version }}/*.patch ; do patch -p1 < ${patchfile}; done
   - make all WHAT=cmd/kube-proxy
   {{- else }}
-from: k8s.gcr.io/kube-proxy:v{{ printf "%s.%s" $version $patch }}@{{ $value.controlPlane.kubeProxy }}
+from: registry.k8s.io/kube-proxy:v{{ printf "%s.%s" $version $patch }}@{{ $value.controlPlane.kubeProxy }}
   {{- end }}
 {{- end }}

--- a/modules/040-control-plane-manager/images/kube-scheduler/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/kube-scheduler/werf.inc.yaml
@@ -19,5 +19,5 @@ docker:
   ENTRYPOINT: ["/usr/bin/kube-scheduler"]
 ---
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
-from: k8s.gcr.io/kube-scheduler:v{{ printf "%s.%s" $version $patch }}@{{ $value.controlPlane.kubeScheduler }}
+from: registry.k8s.io/kube-scheduler:v{{ printf "%s.%s" $version $patch }}@{{ $value.controlPlane.kubeScheduler }}
 {{- end }}

--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -654,7 +654,7 @@ spec:
     }
     
       {{- $max_concurrent_downloads := 3 }}
-      {{- $sandbox_image := "k8s.gcr.io/pause:3.2" }}
+      {{- $sandbox_image := "registry.k8s.io/pause:3.2" }}
       {{- if .images }}
         {{- if .images.common.pause }}
           {{- $sandbox_image = printf "%s%s:%s" .registry.address .registry.path .images.common.pause }}
@@ -982,7 +982,7 @@ spec:
     }
     
       {{- $max_concurrent_downloads := 3 }}
-      {{- $sandbox_image := "k8s.gcr.io/pause:3.2" }}
+      {{- $sandbox_image := "registry.k8s.io/pause:3.2" }}
       {{- if .images }}
         {{- if .images.common.pause }}
           {{- $sandbox_image = printf "%s%s:%s" .registry.address .registry.path .images.common.pause }}

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -658,7 +658,7 @@ spec:
     }
     
       {{- $max_concurrent_downloads := 3 }}
-      {{- $sandbox_image := "k8s.gcr.io/pause:3.2" }}
+      {{- $sandbox_image := "registry.k8s.io/pause:3.2" }}
       {{- if .images }}
         {{- if .images.common.pause }}
           {{- $sandbox_image = printf "%s%s:%s" .registry.address .registry.path .images.common.pause }}
@@ -986,7 +986,7 @@ spec:
     }
     
       {{- $max_concurrent_downloads := 3 }}
-      {{- $sandbox_image := "k8s.gcr.io/pause:3.2" }}
+      {{- $sandbox_image := "registry.k8s.io/pause:3.2" }}
       {{- if .images }}
         {{- if .images.common.pause }}
           {{- $sandbox_image = printf "%s%s:%s" .registry.address .registry.path .images.common.pause }}

--- a/modules/042-kube-dns/hooks/sts_discovery_test.go
+++ b/modules/042-kube-dns/hooks/sts_discovery_test.go
@@ -62,7 +62,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.8
 `, 1))
 			f.RunHook()
 		})
@@ -110,7 +110,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.8
 ---
 apiVersion: v1
 kind: Service
@@ -144,7 +144,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.8
 ---
 apiVersion: v1
 kind: Service
@@ -178,7 +178,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: k8s.gcr.io/nginx-slim:0.8
+        image: registry.k8s.io/nginx-slim:0.8
 `, 1))
 			f.RunHook()
 		})

--- a/modules/045-snapshot-controller/images/snapshot-controller/Dockerfile
+++ b/modules/045-snapshot-controller/images/snapshot-controller/Dockerfile
@@ -1,6 +1,6 @@
 # Based on https://github.com/kubernetes-csi/external-snapshotter/blob/master/cmd/snapshot-controller/Dockerfile
 ARG BASE_ALPINE
-FROM k8s.gcr.io/sig-storage/snapshot-controller:v5.0.1@sha256:cc9f25f394a50acd54df580458e0470b1b804dfc8ada59924d51667da9efb165 as artifact
+FROM registry.k8s.io/sig-storage/snapshot-controller:v5.0.1@sha256:cc9f25f394a50acd54df580458e0470b1b804dfc8ada59924d51667da9efb165 as artifact
 
 FROM $BASE_ALPINE
 COPY --from=artifact /snapshot-controller /snapshot-controller

--- a/modules/045-snapshot-controller/images/snapshot-validation-webhook/Dockerfile
+++ b/modules/045-snapshot-controller/images/snapshot-validation-webhook/Dockerfile
@@ -1,6 +1,6 @@
 # Based on https://github.com/kubernetes-csi/external-snapshotter/blob/master/cmd/snapshot-validation-webhook/Dockerfile
 ARG BASE_ALPINE
-FROM k8s.gcr.io/sig-storage/snapshot-validation-webhook:v5.0.1@sha256:78b3784b6fcb96b9f1806040fbb55f72bf55c5a1f599db451ef9ff3c7b282310 as artifact
+FROM registry.k8s.io/sig-storage/snapshot-validation-webhook:v5.0.1@sha256:78b3784b6fcb96b9f1806040fbb55f72bf55c5a1f599db451ef9ff3c7b282310 as artifact
 
 FROM $BASE_ALPINE
 COPY --from=artifact /snapshot-validation-webhook /snapshot-validation-webhook

--- a/modules/301-prometheus-metrics-adapter/images/k8s-prometheus-adapter/Dockerfile
+++ b/modules/301-prometheus-metrics-adapter/images/k8s-prometheus-adapter/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_ALPINE
-FROM k8s.gcr.io/prometheus-adapter/prometheus-adapter:v0.9.1@sha256:d025d1a109234c28b4a97f5d35d759943124be8885a5bce22a91363025304e9d as artifact
+FROM registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.9.1@sha256:d025d1a109234c28b4a97f5d35d759943124be8885a5bce22a91363025304e9d as artifact
 
 FROM $BASE_ALPINE
 COPY --from=artifact /adapter /adapter

--- a/modules/302-vertical-pod-autoscaler/images/admission-controller/Dockerfile
+++ b/modules/302-vertical-pod-autoscaler/images/admission-controller/Dockerfile
@@ -1,6 +1,6 @@
 # Based on https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler-0.9.0/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
 ARG BASE_ALPINE
-FROM k8s.gcr.io/autoscaling/vpa-admission-controller:0.9.0@sha256:690e8d48fb6e11fac2be2cfe3f699bd864ae5e961e35b8dd292102104ecae521 as artifact
+FROM registry.k8s.io/autoscaling/vpa-admission-controller:0.9.0@sha256:690e8d48fb6e11fac2be2cfe3f699bd864ae5e961e35b8dd292102104ecae521 as artifact
 
 FROM $BASE_ALPINE
 COPY --from=artifact /admission-controller /

--- a/modules/302-vertical-pod-autoscaler/images/updater/Dockerfile
+++ b/modules/302-vertical-pod-autoscaler/images/updater/Dockerfile
@@ -1,6 +1,6 @@
 # Based on https://github.com/kubernetes/autoscaler/blob/vertical-pod-autoscaler-0.9.0/vertical-pod-autoscaler/pkg/updater/Dockerfile
 ARG BASE_ALPINE
-FROM k8s.gcr.io/autoscaling/vpa-updater:0.9.0@sha256:f2f85053098e957b28e4b4fe8ec60354ce4073ab9a7822c7a2ef18e5a0614a28 as artifact
+FROM registry.k8s.io/autoscaling/vpa-updater:0.9.0@sha256:f2f85053098e957b28e4b4fe8ec60354ce4073ab9a7822c7a2ef18e5a0614a28 as artifact
 
 FROM $BASE_ALPINE
 COPY --from=artifact /updater /

--- a/modules/340-monitoring-kubernetes-control-plane/hooks/discovery_test.go
+++ b/modules/340-monitoring-kubernetes-control-plane/hooks/discovery_test.go
@@ -42,7 +42,7 @@ spec:
     - --key-file=/etc/kubernetes/pki/etcd/server.key
     - --listen-client-urls=https://127.0.0.1:2379,https://10.0.3.240:2379
     - --listen-peer-urls=https://10.0.3.240:2380
-    image: k8s.gcr.io/etcd:3.3.10
+    image: registry.k8s.io/etcd:3.3.10
 `
 
 	etcdByManager = `

--- a/modules/402-ingress-nginx/images/controller-0-46/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-0-46/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
   && luarocks install lua-iconv 7-3
 
 # IngressNginxController docker image
-FROM k8s.gcr.io/ingress-nginx/controller:v0.46.0@sha256:52f0058bed0a17ab0fb35628ba97e8d52b5d32299fbc03cc0f6c7b9ff036b61a as controller_0_46_0
+FROM registry.k8s.io/ingress-nginx/controller:v0.46.0@sha256:52f0058bed0a17ab0fb35628ba97e8d52b5d32299fbc03cc0f6c7b9ff036b61a as controller_0_46_0
 
 # Final image
 FROM $BASE_ALPINE

--- a/modules/402-ingress-nginx/images/controller-0-48/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-0-48/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
   && luarocks install lua-iconv 7-3
 
 # IngressNginxController docker image
-FROM k8s.gcr.io/ingress-nginx/controller:v0.48.1@sha256:e9fb216ace49dfa4a5983b183067e97496e7a8b307d2093f4278cd550c303899 as controller_0_48_1
+FROM registry.k8s.io/ingress-nginx/controller:v0.48.1@sha256:e9fb216ace49dfa4a5983b183067e97496e7a8b307d2093f4278cd550c303899 as controller_0_48_1
 
 # Final image
 FROM $BASE_ALPINE

--- a/modules/402-ingress-nginx/images/controller-0-49/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-0-49/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
   && luarocks install lua-iconv 7-3
 
 # IngressNginxController docker image
-FROM k8s.gcr.io/ingress-nginx/controller:v0.49.1@sha256:4080849490fd4f61416ad7bdba6fdd0ee58164f2e13df1128b407ce82d5f3986 as controller_0_49_1
+FROM registry.k8s.io/ingress-nginx/controller:v0.49.1@sha256:4080849490fd4f61416ad7bdba6fdd0ee58164f2e13df1128b407ce82d5f3986 as controller_0_49_1
 
 # Final image
 FROM $BASE_ALPINE

--- a/modules/402-ingress-nginx/images/controller-1-1/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-1/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
   && luarocks install lua-iconv 7-3
 
 # IngressNginxController docker image
-FROM k8s.gcr.io/ingress-nginx/controller:v1.1.3@sha256:31f47c1e202b39fadecf822a9b76370bd4baed199a005b3e7d4d1455f4fd3fe2 as controller_image
+FROM registry.k8s.io/ingress-nginx/controller:v1.1.3@sha256:31f47c1e202b39fadecf822a9b76370bd4baed199a005b3e7d4d1455f4fd3fe2 as controller_image
 
 # Final image
 FROM $BASE_ALPINE

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_deployment.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_deployment.go
@@ -233,7 +233,7 @@ func createDeploymentObject(agentId string) *appsv1.Deployment {
 					Containers: []v1.Container{
 						{
 							Name:  "pause",
-							Image: "k8s.gcr.io/upmeter-nonexistent:3.1415",
+							Image: "registry.k8s.io/upmeter-nonexistent:3.1415",
 							Command: []string{
 								"/pause",
 							},


### PR DESCRIPTION
## Description

Change kubernetes registry as it changes in the upstream

- https://groups.google.com/a/kubernetes.io/g/dev/c/DYZYNQ_A6_c/m/FpHqeVR2BAAJ
- https://github.com/kubernetes/enhancements/tree/master/keps/sig-release/3000-artifact-distribution
- https://github.com/kubernetes/kubernetes/pull/109938

## Why do we need it, and what problem does it solve?

Keep upstream components available

## Changelog entries

```changes
section: ingress-nginx
type: chore
summary: Switched to new official kubernetes registry
impact_level: high
impact: All nginx ingress pods of controllers >=0.46 will be restarted
---
section: candi
type: chore
summary: Switched to new official kubernetes registry
---
section: control-plane-manager
type: chore
summary: Switched to new official kubernetes registry
impact: All control plane pods will be restarted
---
section: dhctl
type: chore
summary: Switched to new official kubernetes registry
---
section: kube-dns
type: chore
summary: Switched to new official kubernetes registry
impact: kube-dns pods will be restarted
---
section: kube-proxy
type: chore
summary: Switched to new official kubernetes registry
impact: kube-proxy pods will be restarted
---
section: monitoring-kubernetes-control-plane
type: chore
summary: Switched to new official kubernetes registry
---
section: node-manager
type: chore
summary: Switched to new official kubernetes registry
---
section: prometheus-metrics-adapter
type: chore
summary: Switched to new official kubernetes registry
---
section: snapshot-controller
type: chore
summary: Switched to new official kubernetes registry
---
section: upmeter
type: chore
summary: Switched to new official kubernetes registry
---
section: vertical-pod-autoscaler
type: chore
summary: Switched to new official kubernetes registry
```