### PR TITLE
[prometheus] rollback disk retention size to 80%

### DIFF
--- a/modules/300-prometheus/hooks/prometheus_disk.go
+++ b/modules/300-prometheus/hooks/prometheus_disk.go
@@ -278,7 +278,7 @@ func prometheusDisk(input *go_hook.HookInput, dc dependency.Container) error {
 				}
 			}
 
-			retention = diskSize * 9 / 10 // 90%
+			retention = diskSize * 8 / 10 // 80%
 		}
 
 		diskSizePath := fmt.Sprintf("prometheus.internal.prometheus%s.diskSizeGigabytes", promNameForPath)

--- a/modules/300-prometheus/hooks/prometheus_disk_test.go
+++ b/modules/300-prometheus/hooks/prometheus_disk_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = Describe("Modules :: prometheus :: hooks :: prometheus_disk ::", func() {
+var _ = FDescribe("Modules :: prometheus :: hooks :: prometheus_disk ::", func() {
 	const (
 		prom = `
 ---
@@ -276,12 +276,12 @@ status:
 			f.RunHook()
 		})
 
-		It("must be executed successfully; main disk size must be 45, retention must be 40; longterm disk size must be 40, retention must be 36", func() {
+		It("must be executed successfully; main disk size must be 45, retention must be 36; longterm disk size must be 40, retention must be 32", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("prometheus.internal.prometheusMain.diskSizeGigabytes").String()).To(Equal("45"))
-			Expect(f.ValuesGet("prometheus.internal.prometheusMain.retentionGigabytes").String()).To(Equal("40"))
+			Expect(f.ValuesGet("prometheus.internal.prometheusMain.retentionGigabytes").String()).To(Equal("36"))
 			Expect(f.ValuesGet("prometheus.internal.prometheusLongterm.diskSizeGigabytes").String()).To(Equal("40"))
-			Expect(f.ValuesGet("prometheus.internal.prometheusLongterm.retentionGigabytes").String()).To(Equal("36"))
+			Expect(f.ValuesGet("prometheus.internal.prometheusLongterm.retentionGigabytes").String()).To(Equal("32"))
 		})
 	})
 

--- a/modules/300-prometheus/hooks/prometheus_disk_test.go
+++ b/modules/300-prometheus/hooks/prometheus_disk_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = FDescribe("Modules :: prometheus :: hooks :: prometheus_disk ::", func() {
+var _ = Describe("Modules :: prometheus :: hooks :: prometheus_disk ::", func() {
 	const (
 		prom = `
 ---


### PR DESCRIPTION
Signed-off-by: Vitaliy Snurnitsin <vitaliy.snurnitsin@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Set disk retention size to 80%.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When small disks are used in clusters with a large number of metrics, disk cleanup does not have time to complete and space runs out.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: fix
summary: Set disk retention size to 80%
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
