### PR TITLE
[helm_lib] _csi_controller.tpl annotation only for CCM

### DIFF
--- a/helm_lib/templates/_csi_controller.tpl
+++ b/helm_lib/templates/_csi_controller.tpl
@@ -97,8 +97,10 @@ spec:
     metadata:
       labels:
         app: {{ $fullname }}
+    {{- if hasPrefix "cloud-provider-" $context.Chart.Name }}
       annotations:
         cloud-config-checksum: {{ include (print $context.Template.BasePath "/cloud-controller-manager/secret.yaml") $context | sha256sum }}
+    {{- end }}
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
## Description
helm_lib _csi_controller.tpl fix — checksum annotation only for CCM

## Why do we need it, and what problem does it solve?
As usual, we forgot about ceph-csi.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: helm_lib
type: fix
summary: helm_lib _csi_controller.tpl fix — checksum annotation only for CCM
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
