### PR TITLE
[Ceph-csi] add registry secret 

### DIFF
--- a/modules/099-ceph-csi/templates/registry.yaml
+++ b/modules/099-ceph-csi/templates/registry.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: deckhouse-registry
+  namespace: d8-{{ $.Chart.Name }}
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ $.Values.global.modulesImages.registryDockercfg }}


### PR DESCRIPTION
## Description

Add registry secret to d8-ceph-csi namespace

## Why do we need it, and what problem does it solve?

Automates the access to images, fixes the secret absence which is references in the ceph-csi daemonset.

## Changelog entries

```changes
section: ceph-csi
type: fix
summary: Fixed missing registry secret
```
