### PR TITLE
[CI] add version to changelog commit message 

### DIFF
--- a/.github/actions/milestone-changelog/action.yml
+++ b/.github/actions/milestone-changelog/action.yml
@@ -62,6 +62,8 @@ runs:
         filename='./CHANGELOG/CHANGELOG-${{ steps.args.outputs.milestone_title }}.yml'
         cat > "$filename" <<"EOF"
         ${{ steps.changelog.outputs.release_yaml }}
+
+        See [CHANGELOG ${{ steps.changelog.outputs.minor_version }}](https://github.com/deckhouse/deckhouse/blob/main/CHANGELOG/CHANGELOG-${{ steps.changelog.outputs.minor_version }}.md) for more details.
         EOF
 
     # Cumulative markdown changelog

--- a/.github/actions/milestone-changelog/action.yml
+++ b/.github/actions/milestone-changelog/action.yml
@@ -79,7 +79,7 @@ runs:
       uses: peter-evans/create-pull-request@v3.10.1
       with:
         commit-message: |
-          Re-generate changelog
+          Re-generate changelog ${{ steps.args.outputs.milestone_title }}
 
           Signed-off-by: deckhouse-BOaTswain <89150800+deckhouse-boatswain@users.noreply.github.com>
         base: main


### PR DESCRIPTION
## Description

- Add version to commit message
- Add link to full changelog in PR body

## Why do we need it, and what problem does it solve?

- Identify to see merged changelog commit
- Simplify the creation of release message

## Changelog entries

```changes
section: ci
type: chore
summary: Added release version to chengelog commit message and full changelog link to PR body
```
