### PR TITLE
[docs] Fix incorrect the `registryScheme` parameter in the getting started

### DIFF
--- a/docs/site/_includes/getting_started/bm-private/partials/config.yml.default.ce.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/config.yml.default.ce.inc
@@ -71,9 +71,9 @@ deckhouse:
   # [<en>] A special string with your token to access the Docker registry.
   # [<ru>] Строка с ключом для доступа к Docker registry.
   registryDockerCfg: <YOUR_PRIVATE_ACCESS_STRING_IS_HERE>
-  # [<en>] Registry access scheme (http or https).
-  # [<ru>] Протокол доступа к registry (http или https).
-  registryScheme: https
+  # [<en>] Registry access scheme (HTTP or HTTPS).
+  # [<ru>] Протокол доступа к registry (HTTP или HTTPS).
+  registryScheme: HTTPS
   # [<en>] Root CA certificate to validate the registry’s HTTPS certificate (if self-signed certificates are used).
   # [<ru>] Корневой сертификат, которым можно проверить сертификат registry (если registry использует самоподписанные сертификаты).
   registryCA: <REGISTRY_CA>

--- a/docs/site/js/getting-started-private.js
+++ b/docs/site/js/getting-started-private.js
@@ -111,8 +111,8 @@ $(document).ready(function () {
     update_parameter('dhctl-registry-images-repo', 'imagesRepo', '<IMAGES_REPO_URI>', null, '[config-yml]');
     update_parameter('dhctl-registry-ca', 'registryCA', '<REGISTRY_CA>', null, '[config-yml]', 4);
     if (registrySchemeHTTP && registrySchemeHTTP === 'true') {
-      update_parameter('http', 'registryScheme', 'https', null, null);
-      updateTextInSnippet('[config-yml]', /registryScheme: https.+\n---/s, "registryScheme: http\n---");
+      update_parameter('HTTP', 'registryScheme', 'HTTPS', null, null);
+      updateTextInSnippet('[config-yml]', /registryScheme: HTTPS.+\n---/s, "registryScheme: HTTP\n---");
     }
 
     if ((registrySchemeHTTP && registrySchemeHTTP === 'true') || !registryCA || (registryCA && registryCA.length < 1)) {
@@ -121,7 +121,7 @@ $(document).ready(function () {
         return (this.innerText === "registryScheme");
       }).each(function (index) {
         delete_elements($(this).next().next().next(), 3);
-        updateTextInSnippet('[config-yml]', /(registryScheme: http[s]?).+\n---/s, "$1\n---");
+        updateTextInSnippet('[config-yml]', /(registryScheme: HTTP[S]?).+\n---/s, "$1\n---");
       });
 
     }


### PR DESCRIPTION
Signed-off-by: Artem Kladov <artem.kladov@flant.com>

## Description
There was http[s] instead of HTTP[S] value for the registryScheme parameter in the getting started config.yml for private environment. The right value is HTTP[S].

## Changelog entries
```changes
section: docs
type: fix
summary: Fixed incorrect the `registryScheme` parameter in the getting started 
impact_level: low
```
