### PR TITLE
[cloud-provider-aws] Fix LoadBalancer type none target group creation

### DIFF
--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.20/002-non-type-lb.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.20/002-non-type-lb.patch
@@ -65,7 +65,7 @@ index c74eef1..da40e86 100644
 +	if isNone(annotations) {
 +		if path, healthCheckNodePort := servicehelpers.GetServiceHealthCheckPathPort(apiService); path != "" {
 +			for i := range v2Mappings {
-+				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(healthCheckNodePort)
++				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(int64(healthCheckNodePort))
 +				v2Mappings[i].HealthCheckConfig.Path = path
 +				v2Mappings[i].HealthCheckConfig.Protocol = elbv2.ProtocolEnumHttp
 +			}

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.20/002-non-type-lb.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.20/002-non-type-lb.patch
@@ -65,7 +65,7 @@ index c74eef1..da40e86 100644
 +	if isNone(annotations) {
 +		if path, healthCheckNodePort := servicehelpers.GetServiceHealthCheckPathPort(apiService); path != "" {
 +			for i := range v2Mappings {
-+				v2Mappings[i].HealthCheckConfig.Port = string(healthCheckNodePort)
++				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(healthCheckNodePort)
 +				v2Mappings[i].HealthCheckConfig.Path = path
 +				v2Mappings[i].HealthCheckConfig.Protocol = elbv2.ProtocolEnumHttp
 +			}

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.20/002-non-type-lb.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.20/002-non-type-lb.patch
@@ -5,7 +5,7 @@ index c74eef1..da40e86 100644
 @@ -293,6 +293,13 @@ var backendProtocolMapping = map[string]string{
  	"tcp":   "ssl",
  }
- 
+
 +var backendProtocolToAwsEnumMapping = map[string]string{
 +	"tcp":   elbv2.ProtocolEnumTcp,
 +	"tls":   elbv2.ProtocolEnumTls,
@@ -19,7 +19,7 @@ index c74eef1..da40e86 100644
 @@ -3811,7 +3818,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
  			continue
  		}
- 
+
 -		if isNLB(annotations) {
 +		if isNLB(annotations) || isNone(annotations) {
  			portMapping := nlbPortMapping{
@@ -61,11 +61,11 @@ index c74eef1..da40e86 100644
 @@ -3867,6 +3889,59 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
  		internalELB = true
  	}
- 
+
 +	if isNone(annotations) {
 +		if path, healthCheckNodePort := servicehelpers.GetServiceHealthCheckPathPort(apiService); path != "" {
 +			for i := range v2Mappings {
-+				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(int64(healthCheckNodePort))
++				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(int(healthCheckNodePort))
 +				v2Mappings[i].HealthCheckConfig.Path = path
 +				v2Mappings[i].HealthCheckConfig.Protocol = elbv2.ProtocolEnumHttp
 +			}
@@ -150,7 +150,7 @@ index c74eef1..da40e86 100644
 +			}, true, nil
 +		}
 +	}
- 
+
  	if isNLB(service.Annotations) {
  		lb, err := c.describeLoadBalancerv2(loadBalancerName)
 @@ -4447,6 +4550,25 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
@@ -176,7 +176,7 @@ index c74eef1..da40e86 100644
 +
 +		return nil
 +	}
- 
+
  	if isNLB(service.Annotations) {
  		lb, err := c.describeLoadBalancerv2(loadBalancerName)
 @@ -4638,6 +4760,10 @@ func (c *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, serv
@@ -206,7 +206,7 @@ index 0fa0115..de77f3d 100644
 @@ -74,6 +74,13 @@ func isNLB(annotations map[string]string) bool {
  	return false
  }
- 
+
 +func isNone(annotations map[string]string) bool {
 +	if annotations[ServiceAnnotationLoadBalancerType] == "none" {
 +		return true
@@ -220,7 +220,7 @@ index 0fa0115..de77f3d 100644
 @@ -131,6 +138,21 @@ func getKeyValuePropertiesFromAnnotation(annotations map[string]string, annotati
  	return additionalTags
  }
- 
+
 +func (c *Cloud) describeTargetGroup(tgName string) (*elbv2.TargetGroup, error) {
 +	response, err := c.elbv2.DescribeTargetGroups(&elbv2.DescribeTargetGroupsInput{})
 +	if err != nil {
@@ -241,7 +241,7 @@ index 0fa0115..de77f3d 100644
  	loadBalancer, err := c.describeLoadBalancerv2(loadBalancerName)
 @@ -561,7 +583,7 @@ func (c *Cloud) deleteListenerV2(listener *elbv2.Listener) error {
  }
- 
+
  // ensureTargetGroup creates a target group with a set of instances.
 -func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName types.NamespacedName, mapping nlbPortMapping, instances []string, vpcID string, tags map[string]string) (*elbv2.TargetGroup, error) {
 +func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName types.NamespacedName, mapping nlbPortMapping, instances []string, vpcID string, tags map[string]string, tgName ...string) (*elbv2.TargetGroup, error) {
@@ -251,7 +251,7 @@ index 0fa0115..de77f3d 100644
 @@ -581,6 +603,10 @@ func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName ty
  			// HealthCheckTimeoutSeconds:  Currently not configurable, 6 seconds for HTTP, 10 for TCP/HTTPS
  		}
- 
+
 +		if len(tgName) > 0 {
 +			input.Name = aws.String(tgName[0])
 +		}
@@ -262,7 +262,7 @@ index 0fa0115..de77f3d 100644
 @@ -628,6 +654,20 @@ func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName ty
  		return result.TargetGroups[0], nil
  	}
- 
+
 +	{
 +		if *targetGroup.Protocol != mapping.TrafficProtocol {
 +			_, err := c.elbv2.DeleteTargetGroup(&elbv2.DeleteTargetGroupInput{TargetGroupArn: targetGroup.TargetGroupArn})

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.21/002-non-type-lb.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.21/002-non-type-lb.patch
@@ -65,7 +65,7 @@ index c74eef1..da40e86 100644
 +	if isNone(annotations) {
 +		if path, healthCheckNodePort := servicehelpers.GetServiceHealthCheckPathPort(apiService); path != "" {
 +			for i := range v2Mappings {
-+				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(healthCheckNodePort)
++				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(int64(healthCheckNodePort))
 +				v2Mappings[i].HealthCheckConfig.Path = path
 +				v2Mappings[i].HealthCheckConfig.Protocol = elbv2.ProtocolEnumHttp
 +			}

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.21/002-non-type-lb.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.21/002-non-type-lb.patch
@@ -65,7 +65,7 @@ index c74eef1..da40e86 100644
 +	if isNone(annotations) {
 +		if path, healthCheckNodePort := servicehelpers.GetServiceHealthCheckPathPort(apiService); path != "" {
 +			for i := range v2Mappings {
-+				v2Mappings[i].HealthCheckConfig.Port = string(healthCheckNodePort)
++				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(healthCheckNodePort)
 +				v2Mappings[i].HealthCheckConfig.Path = path
 +				v2Mappings[i].HealthCheckConfig.Protocol = elbv2.ProtocolEnumHttp
 +			}

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.21/002-non-type-lb.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.21/002-non-type-lb.patch
@@ -5,7 +5,7 @@ index c74eef1..da40e86 100644
 @@ -293,6 +293,13 @@ var backendProtocolMapping = map[string]string{
  	"tcp":   "ssl",
  }
- 
+
 +var backendProtocolToAwsEnumMapping = map[string]string{
 +	"tcp":   elbv2.ProtocolEnumTcp,
 +	"tls":   elbv2.ProtocolEnumTls,
@@ -19,7 +19,7 @@ index c74eef1..da40e86 100644
 @@ -3811,7 +3818,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
  			continue
  		}
- 
+
 -		if isNLB(annotations) {
 +		if isNLB(annotations) || isNone(annotations) {
  			portMapping := nlbPortMapping{
@@ -61,11 +61,11 @@ index c74eef1..da40e86 100644
 @@ -3867,6 +3889,59 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
  		internalELB = true
  	}
- 
+
 +	if isNone(annotations) {
 +		if path, healthCheckNodePort := servicehelpers.GetServiceHealthCheckPathPort(apiService); path != "" {
 +			for i := range v2Mappings {
-+				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(int64(healthCheckNodePort))
++				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(int(healthCheckNodePort))
 +				v2Mappings[i].HealthCheckConfig.Path = path
 +				v2Mappings[i].HealthCheckConfig.Protocol = elbv2.ProtocolEnumHttp
 +			}
@@ -150,7 +150,7 @@ index c74eef1..da40e86 100644
 +			}, true, nil
 +		}
 +	}
- 
+
  	if isNLB(service.Annotations) {
  		lb, err := c.describeLoadBalancerv2(loadBalancerName)
 @@ -4447,6 +4550,25 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
@@ -176,7 +176,7 @@ index c74eef1..da40e86 100644
 +
 +		return nil
 +	}
- 
+
  	if isNLB(service.Annotations) {
  		lb, err := c.describeLoadBalancerv2(loadBalancerName)
 @@ -4638,6 +4760,10 @@ func (c *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, serv
@@ -206,7 +206,7 @@ index 0fa0115..de77f3d 100644
 @@ -74,6 +74,13 @@ func isNLB(annotations map[string]string) bool {
  	return false
  }
- 
+
 +func isNone(annotations map[string]string) bool {
 +	if annotations[ServiceAnnotationLoadBalancerType] == "none" {
 +		return true
@@ -220,7 +220,7 @@ index 0fa0115..de77f3d 100644
 @@ -131,6 +138,21 @@ func getKeyValuePropertiesFromAnnotation(annotations map[string]string, annotati
  	return additionalTags
  }
- 
+
 +func (c *Cloud) describeTargetGroup(tgName string) (*elbv2.TargetGroup, error) {
 +	response, err := c.elbv2.DescribeTargetGroups(&elbv2.DescribeTargetGroupsInput{})
 +	if err != nil {
@@ -241,7 +241,7 @@ index 0fa0115..de77f3d 100644
  	loadBalancer, err := c.describeLoadBalancerv2(loadBalancerName)
 @@ -561,7 +583,7 @@ func (c *Cloud) deleteListenerV2(listener *elbv2.Listener) error {
  }
- 
+
  // ensureTargetGroup creates a target group with a set of instances.
 -func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName types.NamespacedName, mapping nlbPortMapping, instances []string, vpcID string, tags map[string]string) (*elbv2.TargetGroup, error) {
 +func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName types.NamespacedName, mapping nlbPortMapping, instances []string, vpcID string, tags map[string]string, tgName ...string) (*elbv2.TargetGroup, error) {
@@ -251,7 +251,7 @@ index 0fa0115..de77f3d 100644
 @@ -581,6 +603,10 @@ func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName ty
  			// HealthCheckTimeoutSeconds:  Currently not configurable, 6 seconds for HTTP, 10 for TCP/HTTPS
  		}
- 
+
 +		if len(tgName) > 0 {
 +			input.Name = aws.String(tgName[0])
 +		}
@@ -262,7 +262,7 @@ index 0fa0115..de77f3d 100644
 @@ -628,6 +654,20 @@ func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName ty
  		return result.TargetGroups[0], nil
  	}
- 
+
 +	{
 +		if *targetGroup.Protocol != mapping.TrafficProtocol {
 +			_, err := c.elbv2.DeleteTargetGroup(&elbv2.DeleteTargetGroupInput{TargetGroupArn: targetGroup.TargetGroupArn})

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.22/002-non-type-lb.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.22/002-non-type-lb.patch
@@ -69,7 +69,7 @@ diff --git a/pkg/providers/v1/aws.go b/pkg/providers/v1/aws.go
 +	if isNone(annotations) {
 +		if path, healthCheckNodePort := servicehelpers.GetServiceHealthCheckPathPort(apiService); path != "" {
 +			for i := range v2Mappings {
-+				v2Mappings[i].HealthCheckConfig.Port = string(healthCheckNodePort)
++				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(healthCheckNodePort)
 +				v2Mappings[i].HealthCheckConfig.Path = path
 +				v2Mappings[i].HealthCheckConfig.Protocol = elbv2.ProtocolEnumHttp
 +			}

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.22/002-non-type-lb.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.22/002-non-type-lb.patch
@@ -69,7 +69,7 @@ diff --git a/pkg/providers/v1/aws.go b/pkg/providers/v1/aws.go
 +	if isNone(annotations) {
 +		if path, healthCheckNodePort := servicehelpers.GetServiceHealthCheckPathPort(apiService); path != "" {
 +			for i := range v2Mappings {
-+				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(int64(healthCheckNodePort))
++				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(int(healthCheckNodePort))
 +				v2Mappings[i].HealthCheckConfig.Path = path
 +				v2Mappings[i].HealthCheckConfig.Protocol = elbv2.ProtocolEnumHttp
 +			}

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.22/002-non-type-lb.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.22/002-non-type-lb.patch
@@ -69,7 +69,7 @@ diff --git a/pkg/providers/v1/aws.go b/pkg/providers/v1/aws.go
 +	if isNone(annotations) {
 +		if path, healthCheckNodePort := servicehelpers.GetServiceHealthCheckPathPort(apiService); path != "" {
 +			for i := range v2Mappings {
-+				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(healthCheckNodePort)
++				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(int64(healthCheckNodePort))
 +				v2Mappings[i].HealthCheckConfig.Path = path
 +				v2Mappings[i].HealthCheckConfig.Protocol = elbv2.ProtocolEnumHttp
 +			}

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.23/002-non-type-lb.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.23/002-non-type-lb.patch
@@ -65,7 +65,7 @@ index 39dab8f..af8217e 100644
 +	if isNone(annotations) {
 +		if path, healthCheckNodePort := servicehelpers.GetServiceHealthCheckPathPort(apiService); path != "" {
 +			for i := range v2Mappings {
-+				v2Mappings[i].HealthCheckConfig.Port = string(healthCheckNodePort)
++				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(healthCheckNodePort)
 +				v2Mappings[i].HealthCheckConfig.Path = path
 +				v2Mappings[i].HealthCheckConfig.Protocol = elbv2.ProtocolEnumHttp
 +			}

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.23/002-non-type-lb.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.23/002-non-type-lb.patch
@@ -65,7 +65,7 @@ index 39dab8f..af8217e 100644
 +	if isNone(annotations) {
 +		if path, healthCheckNodePort := servicehelpers.GetServiceHealthCheckPathPort(apiService); path != "" {
 +			for i := range v2Mappings {
-+				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(healthCheckNodePort)
++				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(int64(healthCheckNodePort))
 +				v2Mappings[i].HealthCheckConfig.Path = path
 +				v2Mappings[i].HealthCheckConfig.Protocol = elbv2.ProtocolEnumHttp
 +			}

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.23/002-non-type-lb.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.23/002-non-type-lb.patch
@@ -5,7 +5,7 @@ index 39dab8f..af8217e 100644
 @@ -310,6 +310,13 @@ var backendProtocolMapping = map[string]string{
  	"tcp":   "ssl",
  }
- 
+
 +var backendProtocolToAwsEnumMapping = map[string]string{
 +	"tcp":   elbv2.ProtocolEnumTcp,
 +	"tls":   elbv2.ProtocolEnumTls,
@@ -19,7 +19,7 @@ index 39dab8f..af8217e 100644
 @@ -3992,7 +3999,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
  			continue
  		}
- 
+
 -		if isNLB(annotations) {
 +		if isNLB(annotations) || isNone(annotations) {
  			portMapping := nlbPortMapping{
@@ -65,7 +65,7 @@ index 39dab8f..af8217e 100644
 +	if isNone(annotations) {
 +		if path, healthCheckNodePort := servicehelpers.GetServiceHealthCheckPathPort(apiService); path != "" {
 +			for i := range v2Mappings {
-+				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(int64(healthCheckNodePort))
++				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(int(healthCheckNodePort))
 +				v2Mappings[i].HealthCheckConfig.Path = path
 +				v2Mappings[i].HealthCheckConfig.Protocol = elbv2.ProtocolEnumHttp
 +			}
@@ -73,7 +73,7 @@ index 39dab8f..af8217e 100644
 +
 +		loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, apiService)
 +		serviceName := types.NamespacedName{Namespace: apiService.Namespace, Name: apiService.Name}
- 
+
 +		instanceIDs := []string{}
 +		for id := range instances {
 +			instanceIDs = append(instanceIDs, string(id))
@@ -130,7 +130,7 @@ index 39dab8f..af8217e 100644
 +			if err != nil {
 +				return nil, false, err
 +			}
- 
+
 +			if tg != nil {
 +				tgCount++
 +			}
@@ -155,7 +155,7 @@ index 39dab8f..af8217e 100644
 @@ -4629,6 +4729,25 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
  	}
  	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
- 
+
 +	if isNone(service.Annotations) {
 +		for i, _ := range service.Spec.Ports {
 +			tgNameWithSuffix := generateTgName(loadBalancerName, strconv.Itoa(i))
@@ -192,7 +192,7 @@ index 39dab8f..af8217e 100644
 @@ -5183,6 +5306,10 @@ func getInitialAttachDetachDelay(status string) time.Duration {
  	return volumeAttachmentStatusInitialDelay
  }
- 
+
 +func generateTgName(prefix, suffix string) string {
 +	return prefix[0:32-1-len(suffix)] + "-" + suffix
 +}
@@ -207,7 +207,7 @@ index 8f9884c..280caf1 100644
 @@ -87,6 +87,13 @@ func isLBExternal(annotations map[string]string) bool {
  	return false
  }
- 
+
 +func isNone(annotations map[string]string) bool {
 +	if annotations[ServiceAnnotationLoadBalancerType] == "none" {
 +		return true
@@ -221,7 +221,7 @@ index 8f9884c..280caf1 100644
 @@ -137,6 +144,21 @@ func getKeyValuePropertiesFromAnnotation(annotations map[string]string, annotati
  	return additionalTags
  }
- 
+
 +func (c *Cloud) describeTargetGroup(tgName string) (*elbv2.TargetGroup, error) {
 +	response, err := c.elbv2.DescribeTargetGroups(&elbv2.DescribeTargetGroupsInput{})
 +	if err != nil {
@@ -242,7 +242,7 @@ index 8f9884c..280caf1 100644
  	loadBalancer, err := c.describeLoadBalancerv2(loadBalancerName)
 @@ -576,7 +598,7 @@ func (c *Cloud) deleteListenerV2(listener *elbv2.Listener) error {
  }
- 
+
  // ensureTargetGroup creates a target group with a set of instances.
 -func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName types.NamespacedName, mapping nlbPortMapping, instances []string, vpcID string, tags map[string]string) (*elbv2.TargetGroup, error) {
 +func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName types.NamespacedName, mapping nlbPortMapping, instances []string, vpcID string, tags map[string]string, tgName ...string) (*elbv2.TargetGroup, error) {
@@ -252,7 +252,7 @@ index 8f9884c..280caf1 100644
 @@ -597,6 +619,10 @@ func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName ty
  			// HealthCheckTimeoutSeconds:  Currently not configurable, 6 seconds for HTTP, 10 for TCP/HTTPS
  		}
- 
+
 +		if len(tgName) > 0 {
 +			input.Name = aws.String(tgName[0])
 +		}
@@ -263,7 +263,7 @@ index 8f9884c..280caf1 100644
 @@ -622,6 +648,21 @@ func (c *Cloud) ensureTargetGroup(targetGroup *elbv2.TargetGroup, serviceName ty
  		return tg, nil
  	}
- 
+
 +	{
 +		if *targetGroup.Protocol != mapping.TrafficProtocol {
 +			_, err := c.elbv2.DeleteTargetGroup(&elbv2.DeleteTargetGroupInput{TargetGroupArn: targetGroup.TargetGroupArn})


### PR DESCRIPTION
Signed-off-by: Konstantin Aksenov <konstantin.aksenov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Correct conversion from int to string.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fixes wrong request
```
I0608 16:35:48.701512       1 log_handler.go:34] AWS API Send: elasticloadbalancing CreateTargetGroup &{CreateTargetGroup POST / <nil> <nil>} {
  HealthCheckIntervalSeconds: 10,
  HealthCheckPath: "/healthz",
  HealthCheckPort: "盞",
```
That leads to an error
```
failed to ensure load balancer: error creating load balancer target group: "ValidationError: Health check port '绔' must be within '1-65535'
```

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-aws
type: fix
summary: Fix LoadBalancer type none target group creation
impact_level: default
```
<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
