### PR TITLE
[linstor] Add failed cases when drbd module cannot be loaded

### DIFF
--- a/modules/031-linstor/docs/FAQ.md
+++ b/modules/031-linstor/docs/FAQ.md
@@ -74,6 +74,30 @@ To configure Prometheus to use LINSTOR for storing data:
 
 - Wait for the restart of Prometheus Pods.
 
+## linstor-node cannot start because the drbd module cannot be loaded
+
+Check the status of the `linstor-node` Pods:
+
+```shell
+kubectl get pod -n d8-linstor -l app.kubernetes.io/instance=linstor,\
+app.kubernetes.io/managed-by=piraeus-operator,app.kubernetes.io/name=piraeus-node
+```
+
+If you see that some of them get stuck in `Init:CrashLoopBackOff` state, check the logs of `kernel-module-injector` container:
+
+```shell
+kubectl logs -n d8-linstor linstor-node-xxwf9 -c kernel-module-injector
+```
+
+The most likely reasons why it cannot load the kernel module:
+
+- You may already have an in-tree kernel version of the DRBDv8 module loaded when LINSTOR requires DRBDv9.
+  Check loaded module version: `cat /proc/drbd`. If the file is missing, then the module is not loaded and this is not your case.
+
+- You have Secure Boot enabled.
+  Since the DRBD module we provide is compiled dynamically for your kernel (similar to dkms), it has no digital sign.
+  We do not currently support running the DRBD module with a Secure Boot configuration.
+
 ## Pod cannot start with the `FailedMount` error
 
 ### Pod is stuck in the `ContainerCreating` phase

--- a/modules/031-linstor/docs/FAQ_RU.md
+++ b/modules/031-linstor/docs/FAQ_RU.md
@@ -74,7 +74,7 @@ linstor storage-pool create lvmthin node01 lvmthin linstor_data/data
 
 - Дождаться перезапуска Pod'ов Prometheus.
 
-## linstor-node не может запуститься из-за невозможности загрузить drbd-модуля
+## linstor-node не может запуститься из-за невозможности загрузки drbd-модуля
 
 Проверьте состояние Pod'ов `linstor-node`:
 


### PR DESCRIPTION
## Description

Describe some failed cases when linstor-node can't load drbd module.

## Why do we need it, and what problem does it solve?

Sometimes users could face with problems of loading DRBD module.
This doc trying to cover some of those cases

## Changelog entries


```changes
section: linstor
type: fix
summary: Add failed cases when drbd module cannot be loaded
impact_level: low
```
