### PR TITLE
[node-manager] change CA scale-down timing

### DIFF
--- a/modules/040-node-manager/docs/internal/CLUSTER_AUTOSCALER.md
+++ b/modules/040-node-manager/docs/internal/CLUSTER_AUTOSCALER.md
@@ -1,0 +1,26 @@
+# Cluster autoscaler logics
+
+### Scale-down timings
+
+We have 2 modified arguments for scaling down:
+ - `scale-down-delay-after-add`
+ - `scale-down-unneeded-time`
+ 
+ They respected like this:
+  - if `scale-down-delay-after-add` > `scale-down-unneeded-time` then `scale-down-delay-after-add` will be respected
+  - if `scale-down-delay-after-add` < `scale-down-unneeded-time` then `scale-down-unneeded-time` will be respected
+  
+First of all unneeded node will set timestamp
+Then `scale-down-delay-after-add` will be checked, if for current loop `lastScaleUpTS` + `scale-down-delay-after-add` < `time.Now()` - node will be skipped (cooldown reason)
+If node is not in cooldown, then `scale-down-unneeded-time` will be checked. If `nodeTS` + `scale-down-unneeded-time` > `time.Now()` - it will be removed
+
+
+
+```mermaid
+graph TD
+    A[Start CA loop] -->|Node is marked as unneeded| B(Node set scale-up-TS, unneeded-TS)
+    B -->|scale-up-TS + scale-down-delay-after-add > time.Now| C{Continue}
+    B -->|scale-up-TS + scale-down-delay-after-add < time.Now| D{Skip node removal}
+    C -->|unneeded-TS + scale-down-unneeded-time > time.Now| F{Remove node}
+    C -->|unneeded-TS + scale-down-unneeded-time < time.Now| E{Skip node removal}
+```

--- a/modules/040-node-manager/templates/cluster-autoscaler/deployment.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/deployment.yaml
@@ -88,7 +88,7 @@ spec:
         - --scale-down-delay-after-failure=1m
         - --scale-down-utilization-threshold=0.6
         - --unremovable-node-recheck-timeout=30s
-        - --scale-down-delay-after-add=2m
+        - --scale-down-delay-after-add=10m
         - --address=127.0.0.1:8085
         - --v=2
         env:


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Change scale-down-after-add timer for cluster-autoscaler to prevent node flapping

## Why do we need it, and what problem does it solve?
We have 2m scale-down-after-add parameter, node is scaling up, then some huge app is not able to become ready in time and node is scaling down. We can increase cooldown window and wait at least 10 minutes after scaling-up

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: cluster-autoscaler: increase node cooldown after scaling-up to prevent flapping (10m instead of 2m)
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
