### PR TITLE
[cert-manager] default ingress class for LE cluster-issuer

### DIFF
--- a/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt-staging.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt-staging.yaml
@@ -15,6 +15,9 @@ spec:
     solvers:
     - http01:
         ingress:
+          {{- if hasKey .Values.global.modules "ingressClass" -}}
+          class: {{- .Values.global.modules.ingressClass -}}
+          {{- end -}}
           podTemplate:
             spec:
               serviceAccountName: acme-solver-deckhouse-sa

--- a/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt.yaml
@@ -15,6 +15,9 @@ spec:
     solvers:
     - http01:
         ingress:
+          {{- if hasKey .Values.global.modules "ingressClass" -}}
+          class: {{- .Values.global.modules.ingressClass -}}
+          {{- end -}}
           podTemplate:
             spec:
               serviceAccountName: acme-solver-deckhouse-sa


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Respect global ingress class for LE cluster issuer

## Why do we need it, and what problem does it solve?
Now we can use LE cluster issuer only with default (unset) ingress class. It wouldn't work in some situations

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cert-manager
type: fix
summary: Respect global ingress class in the LE cluster-issuer
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
