### PR TITLE
[ingress-nginx] Add patch for ingress-controller 0.33

### DIFF
--- a/modules/402-ingress-nginx/images/controller-0-33/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-0-33/patches/README.md
@@ -48,3 +48,6 @@ There is a problem, that when you set an invalid URL as a value for the nginx.in
 Thus, this is considered a security hole. Users can accidentally set an invalid URL by hand or because of an error in helm templates.
 
 https://github.com/kubernetes/ingress-nginx/pull/8256
+
+### Ingress class
+If ingress class annotation or spec field is not set, fallback to default class("nginx") and check it

--- a/modules/402-ingress-nginx/images/controller-0-33/patches/ingress-class.patch
+++ b/modules/402-ingress-nginx/images/controller-0-33/patches/ingress-class.patch
@@ -1,0 +1,16 @@
+diff --git a/internal/ingress/annotations/class/main.go b/internal/ingress/annotations/class/main.go
+index 8c0684af3..36f8baaee 100644
+--- a/internal/ingress/annotations/class/main.go
++++ b/internal/ingress/annotations/class/main.go
+@@ -62,6 +62,11 @@ func IsValid(ing *networking.Ingress) bool {
+ 		return IngressClass == DefaultClass
+ 	}
+ 
++	// without annotation and IngressClass in spec, fallback to default
++	if ing.Spec.IngressClassName == nil {
++		return IngressClass == DefaultClass
++	}
++
+ 	// 4. with IngressClass
+ 	return k8s.IngressClass.Name == *ing.Spec.IngressClassName
+ }


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Add patch for working with ingress class resource

## Why do we need it, and what problem does it solve?
If ingress class resource exists but ingress object does not have neither annotation nor spec field IngressClassName, then controller panics

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ingress-nginx
type: fix
summary: Fix workability of 0.33 controller with IngressClass resource.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
