### PR TITLE
[ingress-nginx] add patch apply to dockerfile

### DIFF
--- a/modules/402-ingress-nginx/images/controller-0-33/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-0-33/Dockerfile
@@ -8,6 +8,7 @@ COPY patches/omit-helm-secrets.patch /
 COPY patches/healthcheck.patch /
 COPY patches/pod-ip.patch /
 COPY patches/deny-invalid-auth-locations.patch /
+COPY patches/ingress-class.patch /
 ENV GOARCH=amd64
 RUN apt-get update && apt-get install -y --no-install-recommends git mercurial patch && \
     git clone --branch controller-0.33.0 --depth 1 https://github.com/kubernetes/ingress-nginx.git /src && \

--- a/modules/402-ingress-nginx/images/controller-0-33/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-0-33/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git mercurial p
     patch -p1 < /omit-helm-secrets.patch && \
     patch -p1 < /healthcheck.patch && \
     patch -p1 < /deny-invalid-auth-locations.patch && \
+    patch -p1 < /ingress-class.patch && \
     make GO111MODULE=on USE_DOCKER=false build
 
 # luarocks assets for luajit artifact


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Forgot to add patch to Dockerfile

## Why do we need it, and what problem does it solve?
It doesn' work :)

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ingress-nginx
type: fix 
summary: Fix build of the ingress-nginx 0.33 controller.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
