### PR TITLE
[Upmeter] Add basic probe for cert-manager

### DIFF
--- a/modules/500-upmeter/hooks/disabled_probes.go
+++ b/modules/500-upmeter/hooks/disabled_probes.go
@@ -113,10 +113,16 @@ func calcDisabledProbes(presence appPresence, enabledModules, disabledManually s
 	disableMonitoringAndAutoscalingProbes(enabledModules, disabledProbes)
 	disableExtensionsProbes(presence, enabledModules, disabledProbes)
 	disableLoadBalancingProbes(presence, enabledModules, disabledProbes)
+	disableControlPlaneProbes(enabledModules, disabledProbes)
 
 	return disabledProbes
 }
 
+func disableControlPlaneProbes(enabledModules, disabledProbes set.Set) {
+	if !enabledModules.Has("cert-manager") {
+		disabledProbes.Add("control-plane/cert-manager")
+	}
+}
 func disableSyntheticProbes(presence appPresence, disabledProbes set.Set) {
 	if !presence.smokeMini {
 		disabledProbes.Add("synthetic/")

--- a/modules/500-upmeter/hooks/disabled_probes_test.go
+++ b/modules/500-upmeter/hooks/disabled_probes_test.go
@@ -497,6 +497,19 @@ func Test_calcDisabledProbes(t *testing.T) {
 			expectNotDisabled: set.New("extensions/prometheus-longterm"),
 		},
 
+		// certManager -> control-plane/cert-manager
+		{
+			name:           "control-plane/cert-manager off",
+			expectDisabled: set.New("control-plane/cert-manager"),
+		},
+		{
+			name: "control-plane/cert-manager on",
+			args: args{
+				enabledModules: set.New("cert-manager"),
+			},
+			expectNotDisabled: set.New("control-plane/cert-manager"),
+		},
+
 		// Manually disabled probes are preserved
 		{
 			name: "manually disabled extensions/prometheus-longterm",

--- a/modules/500-upmeter/images/upmeter/Makefile
+++ b/modules/500-upmeter/images/upmeter/Makefile
@@ -1,5 +1,5 @@
 # https://github.com/golangci/golangci-lint
-GOLANGCI_LINT_VERSION=1.45.2
+GOLANGCI_LINT_VERSION=1.46.2
 # https://github.com/mvdan/gofumpt
 GOFUMPT_VERSION=0.3.1
 GOARCH=amd64
@@ -35,6 +35,8 @@ fmt:
 	@# - goimports is not turned on since it is used mostly by gofumpt internally
 	$(GOFUMPT_BIN) -l -w -extra .
 	$(GOLANGCILINT_BIN) run ./... -c .golangci.yaml --fix
+	gci -w -local d8.io/upmeter .
+	goimports -w -local d8.io/upmeter .
 
 test:
 	go test -race ./...

--- a/modules/500-upmeter/images/upmeter/pkg/agent/sender/client.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/sender/client.go
@@ -66,24 +66,24 @@ func NewClient(config *ClientConfig, timeout time.Duration) *Client {
 func (c *Client) Send(reqBody []byte) error {
 	req, err := http.NewRequest(http.MethodPost, c.url, bytes.NewReader(reqBody))
 	if err != nil {
-		return fmt.Errorf("cannot create POST request: %v", err)
+		return fmt.Errorf("preparing POST request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", c.UserAgent)
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("did not send to upmeter: %v", err)
+		return fmt.Errorf("sending: %v", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("cannot read upmeter response body: %v", err)
+		return fmt.Errorf("reding server response body: %v", err)
 	}
 
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("unexpected upmeter response status=%d, body=%q", resp.StatusCode, string(body))
+		return fmt.Errorf("unexpected upmeter response: status=%d, body=%q", resp.StatusCode, string(body))
 	}
 
 	return nil

--- a/modules/500-upmeter/images/upmeter/pkg/agent/sender/sender.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/sender/sender.go
@@ -81,7 +81,7 @@ func (s *Sender) sendLoop() {
 		case <-ticker.C:
 			err := s.export()
 			if err != nil {
-				log.Errorf("cannot export episodes: %v", err)
+				log.Errorf("sendLoop: %v", err)
 			}
 		case <-s.stop:
 			ticker.Stop()
@@ -143,14 +143,10 @@ func (s *Sender) send(episodes []check.Episode) error {
 
 	body, err := json.Marshal(data)
 	if err != nil {
-		return fmt.Errorf("failed to marshal payload to JSON: %v", err)
+		return fmt.Errorf("marshalling to JSON: %v", err)
 	}
 
-	err = s.client.Send(body)
-	if err != nil {
-		return fmt.Errorf("failed to send data: %v", err)
-	}
-	return nil
+	return s.client.Send(body)
 }
 
 func (s *Sender) Stop() {

--- a/modules/500-upmeter/images/upmeter/pkg/check/checker.go
+++ b/modules/500-upmeter/images/upmeter/pkg/check/checker.go
@@ -23,8 +23,4 @@ package check
 type Checker interface {
 	// Check does the actual job to determine the result. Returns nil if everything is ok.
 	Check() Error
-
-	// BusyWith describes what the check is doing. Used in logging and possibly other details of the
-	// probe flow.
-	BusyWith() string
 }

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/certificate_secret.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/certificate_secret.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package checker
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+
+	"d8.io/upmeter/pkg/check"
+	"d8.io/upmeter/pkg/kubernetes"
+	"d8.io/upmeter/pkg/probe/util"
+)
+
+// CertificateSecretLifecycle is a checker constructor and configurator
+type CertificateSecretLifecycle struct {
+	Access    kubernetes.Access
+	Namespace string
+	AgentID   string
+
+	CreationTimeout time.Duration
+	DeletionTimeout time.Duration
+
+	ControlPlaneAccessTimeout time.Duration
+}
+
+func (c CertificateSecretLifecycle) Checker() check.Checker {
+	return &CertificateSecretLifecycleChecker{
+		Access:    c.Access,
+		Namespace: c.Namespace,
+		AgentID:   c.AgentID,
+
+		CreationTimeout: c.CreationTimeout,
+		DeletionTimeout: c.DeletionTimeout,
+
+		ControlPlaneAccessTimeout: c.ControlPlaneAccessTimeout,
+	}
+}
+
+type CertificateSecretLifecycleChecker struct {
+	Access    kubernetes.Access
+	Namespace string
+	AgentID   string
+
+	CreationTimeout time.Duration
+	DeletionTimeout time.Duration
+
+	ControlPlaneAccessTimeout time.Duration
+}
+
+func (c *CertificateSecretLifecycleChecker) Check() check.Error {
+	return c.new(c.name()).Check()
+}
+
+func (c *CertificateSecretLifecycleChecker) name() string {
+	// should be new for each run in order not to get stuck with created object
+	return util.RandomIdentifier("upmeter-cm-probe")
+}
+
+func (c *CertificateSecretLifecycleChecker) new(name string) check.Checker {
+	pingControlPlane := newControlPlaneChecker(c.Access, c.ControlPlaneAccessTimeout)
+
+	createCert := doOrUnknown(
+		c.CreationTimeout,
+		&certificateCreator{
+			access:    c.Access,
+			name:      name,
+			agentID:   c.AgentID,
+			namespace: c.Namespace,
+		},
+	)
+
+	deleteCert := doOrUnknown(
+		c.CreationTimeout,
+		&certificateDeleter{
+			access:    c.Access,
+			name:      name,
+			namespace: c.Namespace,
+		},
+	)
+
+	checkSecretExists := withTimeout(
+		&secretExistenceChecker{
+			access:    c.Access,
+			name:      name,
+			namespace: c.Namespace,
+		},
+		c.ControlPlaneAccessTimeout,
+	)
+
+	checkSecretDoesNotExists := withTimeout(
+		&secretNonexistenceChecker{
+			access:    c.Access,
+			name:      name,
+			namespace: c.Namespace,
+		},
+		c.ControlPlaneAccessTimeout,
+	)
+
+	return sequence(
+		pingControlPlane,
+		createCert,
+		checkSecretExists,
+		deleteCert,
+		checkSecretDoesNotExists,
+	)
+}
+
+type certificateCreator struct {
+	access  kubernetes.Access
+	agentID string
+
+	name      string
+	namespace string
+}
+
+func (c *certificateCreator) Do(ctx context.Context) error {
+	decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+
+	obj := &unstructured.Unstructured{}
+	manifest := certificateManifest(c.agentID, c.name, c.namespace)
+
+	if _, _, err := decUnstructured.Decode([]byte(manifest), nil, obj); err != nil {
+		return err
+	}
+
+	_, err := c.access.Kubernetes().Dynamic().
+		Resource(certificateGVR).
+		Namespace(c.namespace).
+		Create(obj, metav1.CreateOptions{})
+
+	return err
+}
+
+type certificateDeleter struct {
+	access    kubernetes.Access
+	name      string
+	namespace string
+}
+
+func (c *certificateDeleter) Do(ctx context.Context) error {
+	return c.access.Kubernetes().Dynamic().
+		Resource(certificateGVR).
+		Namespace(c.namespace).
+		Delete(c.name, &metav1.DeleteOptions{})
+}
+
+type secretExistenceChecker struct {
+	access    kubernetes.Access
+	name      string
+	namespace string
+}
+
+func (c *secretExistenceChecker) Check() check.Error {
+	_, err := c.access.Kubernetes().CoreV1().Secrets(c.namespace).Get(c.name, metav1.GetOptions{})
+	if err == nil {
+		return nil
+	}
+
+	if apierrors.IsNotFound(err) {
+		return check.ErrFail("secret %s/%s is not there: %w", c.namespace, c.name, err)
+	}
+
+	return check.ErrUnknown("getting %s/%s: %w", c.namespace, c.name, err)
+}
+
+type secretNonexistenceChecker struct {
+	access    kubernetes.Access
+	name      string
+	namespace string
+}
+
+func (c *secretNonexistenceChecker) Check() check.Error {
+	_, err := c.access.Kubernetes().CoreV1().Secrets(c.namespace).Get(c.name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return check.ErrUnknown("getting %s/%s: %w", c.namespace, c.name, err)
+	}
+	return check.ErrFail("secret %s/%s is still there", c.namespace, c.name)
+}
+
+var certificateGVR = schema.GroupVersionResource{
+	Group:    "cert-manager.io",
+	Version:  "v1",
+	Resource: "certificates",
+}
+
+func certificateManifest(agentID, name, namespace string) string {
+	tpl := `
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: upmeter
+    heritage: upmeter
+    upmeter-agent: %q
+    upmeter-group: control-plane
+    upmeter-probe: cert-manager
+  name: %q
+  namespace: %q
+spec:
+  certificateOwnerRef: true
+  dnsNames:
+  - nothing-%s.example.com
+  issuerRef:
+    kind: ClusterIssuer
+    name: selfsigned
+  secretName: %q`
+
+	return fmt.Sprintf(tpl,
+		agentID,   // label
+		name,      // certificate name
+		namespace, // namespace
+		agentID,   // domain part
+		name,      // secret name
+	)
+}

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/d8_clusterconfiguration.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/d8_clusterconfiguration.go
@@ -237,10 +237,6 @@ func (c *setInitedValueChecker) create(value string) check.Error {
 	return nil
 }
 
-func (c *setInitedValueChecker) BusyWith() string {
-	return "setting inited value in object upmeterhookprobe.deckhouse.io/" + c.name
-}
-
 type hookProbeObjectGetter interface {
 	Get() *v1.HookProbe
 }
@@ -268,8 +264,4 @@ func (c *checkMirrorValueChecker) Check() check.Error {
 		)
 	}
 	return nil
-}
-
-func (c *checkMirrorValueChecker) BusyWith() string {
-	return "checking values in object upmeterhookprobe.deckhouse.io/" + c.name
 }

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/http.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/http.go
@@ -52,15 +52,6 @@ func (c *httpChecker) Check() check.Error {
 	return c.verifier.Verify(body)
 }
 
-func (c *httpChecker) BusyWith() string {
-	// It might feel that here we can be caught by a race condition.
-	// But in normal case request is always created before timeout message is used.
-	if c.req == nil {
-		return "(request not ready)"
-	}
-	return c.req.URL.String()
-}
-
 // httpVerifier defines HTTP request and body verification for an HTTP endpoint check
 type httpVerifier interface {
 	// Request to endpoint

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_configmap.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_configmap.go
@@ -17,7 +17,6 @@ limitations under the License.
 package checker
 
 import (
-	"fmt"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -57,10 +56,6 @@ type configMapLifecycleChecker struct {
 
 	// inner state
 	checker check.Checker
-}
-
-func (c *configMapLifecycleChecker) BusyWith() string {
-	return c.checker.BusyWith()
 }
 
 func (c *configMapLifecycleChecker) Check() check.Error {
@@ -119,10 +114,6 @@ type configMapCreationChecker struct {
 	configMap *v1.ConfigMap
 }
 
-func (c *configMapCreationChecker) BusyWith() string {
-	return fmt.Sprintf("creating configmap %s/%s", c.namespace, c.configMap.Name)
-}
-
 func (c *configMapCreationChecker) Check() check.Error {
 	client := c.access.Kubernetes()
 
@@ -138,10 +129,6 @@ type configMapDeletionChecker struct {
 	access    kubernetes.Access
 	configMap *v1.ConfigMap
 	namespace string
-}
-
-func (c *configMapDeletionChecker) BusyWith() string {
-	return fmt.Sprintf("deleting configmap %s/%s", c.namespace, c.configMap.Name)
 }
 
 func (c *configMapDeletionChecker) Check() check.Error {

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_controlplane.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_controlplane.go
@@ -47,10 +47,6 @@ func (c *controlPlaneChecker) Check() check.Error {
 	return nil
 }
 
-func (c *controlPlaneChecker) BusyWith() string {
-	return "fetching kubernetes /version"
-}
-
 // newControlPlaneChecker returns the checker wrapped with timeout to be use it in other checkers as precondition
 func newControlPlaneChecker(access kubernetes.Access, timeout time.Duration) check.Checker {
 	return withTimeout(&controlPlaneChecker{access}, timeout)

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_daemonset.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_daemonset.go
@@ -17,7 +17,6 @@ limitations under the License.
 package checker
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -76,10 +75,6 @@ type dsPodsReadinessChecker struct {
 	requestTimeout  time.Duration
 	creationTimeout time.Duration
 	deletionTimeout time.Duration
-}
-
-func (c *dsPodsReadinessChecker) BusyWith() string {
-	return fmt.Sprintf("getting daemonset %s/%s", c.namespace, c.name)
 }
 
 func (c *dsPodsReadinessChecker) Check() check.Error {

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_deployment.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_deployment.go
@@ -17,7 +17,6 @@ limitations under the License.
 package checker
 
 import (
-	"fmt"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -71,10 +70,6 @@ type deploymentLifecycleChecker struct {
 
 	// inner state
 	checker check.Checker
-}
-
-func (c *deploymentLifecycleChecker) BusyWith() string {
-	return c.checker.BusyWith()
 }
 
 func (c *deploymentLifecycleChecker) Check() check.Error {
@@ -156,10 +151,6 @@ type deploymentCreationChecker struct {
 	deployment *appsv1.Deployment
 }
 
-func (c *deploymentCreationChecker) BusyWith() string {
-	return fmt.Sprintf("creating deployment %s/%s", c.namespace, c.deployment.Name)
-}
-
 func (c *deploymentCreationChecker) Check() check.Error {
 	client := c.access.Kubernetes()
 
@@ -175,10 +166,6 @@ type deploymentDeletionChecker struct {
 	access    k8s.Access
 	namespace string
 	name      string
-}
-
-func (c *deploymentDeletionChecker) BusyWith() string {
-	return fmt.Sprintf("deleting deployment %s/%s", c.namespace, c.name)
 }
 
 func (c *deploymentDeletionChecker) Check() check.Error {

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_garbagecollection.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_garbagecollection.go
@@ -17,7 +17,6 @@ limitations under the License.
 package checker
 
 import (
-	"fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,10 +61,6 @@ func newGarbageCollectorCheckerByLabels(access k8s.Access, kind, namespace strin
 		// inner state
 		firstRun: true,
 	}
-}
-
-func (c *garbageCollectorChecker) BusyWith() string {
-	return fmt.Sprintf("collecting garbage of %s/%s, listOpts=%s", c.namespace, c.kind, c.listOpts)
 }
 
 func (c *garbageCollectorChecker) Check() check.Error {

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_listing.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_listing.go
@@ -35,10 +35,6 @@ type objectIsNotListedChecker struct {
 	listOpts  *metav1.ListOptions
 }
 
-func (c *objectIsNotListedChecker) BusyWith() string {
-	return fmt.Sprintf("tracking object deletion %s/%s %s", c.namespace, c.kind, c.listOpts)
-}
-
 func (c *objectIsNotListedChecker) Check() check.Error {
 	list, err := listObjects(c.access.Kubernetes(), c.kind, c.namespace, *c.listOpts)
 	if err != nil {

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_namespace.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_namespace.go
@@ -17,7 +17,6 @@ limitations under the License.
 package checker
 
 import (
-	"fmt"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -57,10 +56,6 @@ type namespaceLifeCycleChecker struct {
 
 	// inner state
 	checker check.Checker
-}
-
-func (c *namespaceLifeCycleChecker) BusyWith() string {
-	return c.checker.BusyWith()
 }
 
 func (c *namespaceLifeCycleChecker) Check() check.Error {
@@ -114,10 +109,6 @@ type namespaceCreationChecker struct {
 	namespace *v1.Namespace
 }
 
-func (c *namespaceCreationChecker) BusyWith() string {
-	return fmt.Sprintf("creating namespace %q", c.namespace.GetName())
-}
-
 func (c *namespaceCreationChecker) Check() check.Error {
 	client := c.access.Kubernetes()
 	_, err := client.CoreV1().Namespaces().Create(c.namespace)
@@ -131,10 +122,6 @@ func (c *namespaceCreationChecker) Check() check.Error {
 type namespaceDeletionChecker struct {
 	access    k8s.Access
 	namespace *v1.Namespace
-}
-
-func (c *namespaceDeletionChecker) BusyWith() string {
-	return fmt.Sprintf("deleting namespace %q", c.namespace.GetName())
 }
 
 func (c *namespaceDeletionChecker) Check() check.Error {

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_pod.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_pod.go
@@ -17,7 +17,6 @@ limitations under the License.
 package checker
 
 import (
-	"fmt"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -73,10 +72,6 @@ type podLifecycleChecker struct {
 	checker check.Checker
 }
 
-func (c *podLifecycleChecker) BusyWith() string {
-	return c.checker.BusyWith()
-}
-
 func (c *podLifecycleChecker) Check() check.Error {
 	pod := createPodObject(c.node, c.access.SchedulerProbeImage())
 	c.checker = c.new(pod)
@@ -129,10 +124,6 @@ type podCreationChecker struct {
 	pod       *v1.Pod
 }
 
-func (c *podCreationChecker) BusyWith() string {
-	return fmt.Sprintf("creating pod %s/%s", c.namespace, c.pod.Name)
-}
-
 func (c *podCreationChecker) Check() check.Error {
 	_, err := c.access.Kubernetes().CoreV1().Pods(c.namespace).Create(c.pod)
 	if err != nil {
@@ -145,10 +136,6 @@ type podScheduledChecker struct {
 	access    kubernetes.Access
 	namespace string
 	listOpts  *metav1.ListOptions
-}
-
-func (c *podScheduledChecker) BusyWith() string {
-	return fmt.Sprintf("looking for scheduled pod ns=%s listOpts=%s", c.namespace, c.listOpts)
 }
 
 func (c *podScheduledChecker) Check() check.Error {
@@ -180,10 +167,6 @@ type pendingPodChecker struct {
 	listOpts  *metav1.ListOptions
 }
 
-func (c *pendingPodChecker) BusyWith() string {
-	return fmt.Sprintf("looking for pending pod ns=%s listOpts=%s", c.namespace, c.listOpts)
-}
-
 func (c *pendingPodChecker) Check() check.Error {
 	client := c.access.Kubernetes()
 
@@ -205,10 +188,6 @@ type podDeletionChecker struct {
 	access    kubernetes.Access
 	namespace string
 	listOpts  *metav1.ListOptions
-}
-
-func (c *podDeletionChecker) BusyWith() string {
-	return fmt.Sprintf("deleting pod ns=%s listOpts=%s", c.namespace, c.listOpts)
 }
 
 func (c *podDeletionChecker) Check() check.Error {
@@ -329,10 +308,6 @@ func (c *podReadinessChecker) Check() check.Error {
 	return check.ErrFail("no ready pods found %s,%s", c.namespace, c.labelSelector)
 }
 
-func (c *podReadinessChecker) BusyWith() string {
-	return fmt.Sprintf("getting pods to check at least one is ready %s,%s", c.namespace, c.labelSelector)
-}
-
 // podRunningOrReadyChecker checks that there is a pod in Ready condition in reasonable time.
 //   - if pod is running, but not ready in the `readinessTimeout` time, the check status is considered unknown.
 //   - if pod is running, but not ready in `readinessTimeout` or more, the check status is considered failed.
@@ -370,10 +345,6 @@ func (c *podRunningOrReadyChecker) Check() check.Error {
 		cherr = err
 	}
 	return cherr
-}
-
-func (c *podRunningOrReadyChecker) BusyWith() string {
-	return fmt.Sprintf("getting pods to check if they are running or ready %s,%s", c.namespace, c.labelSelector)
 }
 
 func isPodRunning(pod *v1.Pod) bool {

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/smoke_mini.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/smoke_mini.go
@@ -85,10 +85,6 @@ type smokeMiniChecker struct {
 	logger *log.Entry
 }
 
-func (c *smokeMiniChecker) BusyWith() string {
-	return "requesting smoke-mini " + c.path
-}
-
 func (c *smokeMiniChecker) Check() check.Error {
 	ips, lookupErr := c.lookuper.Lookup()
 	if lookupErr != nil {
@@ -213,10 +209,6 @@ func (d DnsAvailable) Checker() check.Checker {
 type dnsChecker struct {
 	lookuper lookuper
 	logger   *log.Entry
-}
-
-func (c *dnsChecker) BusyWith() string {
-	return "resolving"
 }
 
 func (c *dnsChecker) Check() check.Error {

--- a/modules/500-upmeter/images/upmeter/pkg/probe/group_controlplane.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/group_controlplane.go
@@ -21,6 +21,7 @@ import (
 
 	"d8.io/upmeter/pkg/kubernetes"
 	"d8.io/upmeter/pkg/probe/checker"
+	"d8.io/upmeter/pkg/probe/util"
 )
 
 func initControlPlane(access kubernetes.Access) []runnerConfig {
@@ -93,6 +94,19 @@ func initControlPlane(access kubernetes.Access) []runnerConfig {
 				SchedulingTimeout:         20 * time.Second,
 				DeletionTimeout:           20 * time.Second,
 				GarbageCollectionTimeout:  gcTimeout,
+				ControlPlaneAccessTimeout: cpTimeout,
+			},
+		}, {
+			group:  groupControlPlane,
+			probe:  "cert-manager",
+			check:  "_",
+			period: time.Minute,
+			config: checker.CertificateSecretLifecycle{
+				Access:                    access,
+				Namespace:                 namespace,
+				AgentID:                   util.AgentUniqueId(),
+				CreationTimeout:           5 * time.Second,
+				DeletionTimeout:           20 * time.Second,
 				ControlPlaneAccessTimeout: cpTimeout,
 			},
 		},

--- a/modules/500-upmeter/images/upmeter/pkg/probe/load_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/load_test.go
@@ -86,6 +86,7 @@ func TestLoader_Probes(t *testing.T) {
 	allProbesSorted := []check.ProbeRef{
 		{Group: "control-plane", Probe: "apiserver"},
 		{Group: "control-plane", Probe: "basic-functionality"},
+		{Group: "control-plane", Probe: "cert-manager"},
 		{Group: "control-plane", Probe: "controller-manager"},
 		{Group: "control-plane", Probe: "namespace"},
 		{Group: "control-plane", Probe: "scheduler"},
@@ -122,6 +123,7 @@ func TestLoader_Probes(t *testing.T) {
 	filteredProbesSorted := []check.ProbeRef{
 		{Group: "control-plane", Probe: "apiserver"},
 		{Group: "control-plane", Probe: "basic-functionality"},
+		{Group: "control-plane", Probe: "cert-manager"},
 		{Group: "control-plane", Probe: "controller-manager"},
 		{Group: "control-plane", Probe: "namespace"},
 		{Group: "control-plane", Probe: "scheduler"},

--- a/modules/500-upmeter/images/upmeter/pkg/server/server_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/server_test.go
@@ -31,6 +31,7 @@ func Test_newProbeLister(t *testing.T) {
 	allProbesSorted := []check.ProbeRef{
 		{Group: "control-plane", Probe: "apiserver"},
 		{Group: "control-plane", Probe: "basic-functionality"},
+		{Group: "control-plane", Probe: "cert-manager"},
 		{Group: "control-plane", Probe: "controller-manager"},
 		{Group: "control-plane", Probe: "namespace"},
 		{Group: "control-plane", Probe: "scheduler"},

--- a/modules/500-upmeter/images/webui/src/app/i18n/en.ts
+++ b/modules/500-upmeter/images/webui/src/app/i18n/en.ts
@@ -137,6 +137,16 @@ const langPack: LangPack = {
           "kube-apiserver is not available or probe execution is skipped because previous probe was not yet finished",
         reasonNodata: REASON_AGENTS_STOPPED,
       },
+      "cert-manager": {
+        title: "Cert Manager",
+        description: "Every 1 minute a certificate is created and deleted to check the cert-manager handling of it",
+        reasonUp:
+          "certificate secret was created, and after the certificate was deleted, the secret disappeared",
+        reasonDown: "certificate secret was not created in 5 seconds, or was no deleted in 20 seconds",
+        reasonUnknown:
+          "error occurred during creation or deletion, or kube-apiserver is not available",
+        reasonNodata: REASON_AGENTS_STOPPED,
+      },
       "controller-manager": {
         title: "Controller Manager",
         description: "Every 1 minute a Deployment is created and deleted",

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -432,3 +432,48 @@
           These PVs have no valuable data on them an should be deleted.
 
           The list of PVs: `kubectl get pv | grep disk-smoke-mini`.
+
+- name: d8.upmeter.resources
+  rules:
+    - alert: D8UpmeterProbeGarbageSecretsByCertManager
+      expr: |
+        (
+          count (kube_secret_info{namespace="d8-upmeter", secret=~"upmeter-cm-probe.*"})
+          /
+          count (kube_pod_labels{namespace="d8-upmeter", label_app="upmeter-agent"})
+        ) >= 2
+      for: 10m
+      labels:
+        severity_level: "9"
+        tier: cluster
+        d8_module: upmeter
+        d8_component: upmeter-agent
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: "markdown"
+        plk_create_group_if_not_exists__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse"
+        plk_labels_as_annotations: "secret"
+        summary: Garbage produced by cert-manager probe is not being cleaned.
+        description: |
+          Probe secrets found.
+
+          Upmeter agents should clean certificates, and thus secrets produced by cert-manager should clean, too.
+          There should not be more secrets than master nodes (upmeter-agent is a DaemonSet with master nodeSelector).
+          Also, they should be deleted within seconds.
+
+          This might be an indication of a problem with kube-apiserver, or cert-manager, or upmeter itself.
+          It is also possible, that the secrets were left by old upmeter-agent pods due to Upmeter update.
+
+          1. Check upmeter-agent logs
+
+          `kubectl -n d8-upmeter logs ds/upmeter-agent | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "cert-manager") | [.time, .level, .msg] | @tsv'`
+
+          2. Check that control plane and cert-manager are functional.
+
+          3. Delete certificates manually, and secrets, if needed:
+
+          ```
+          kubectl -n d8-upmeter delete certificate -l upmeter-probe=cert-manager
+          kubectl -n d8-upmeter get secret -ojson | jq -r '.items[] | .metadata.name' | grep upmeter-cm-probe | xargs -n 1 -- kubectl -n d8-upmeter delete secret
+          ```

--- a/modules/500-upmeter/templates/upmeter-agent/rbac-for-us.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/rbac-for-us.yaml
@@ -38,6 +38,10 @@ rules:
   - apiGroups: [ "apps" ]
     resources: [ "daemonsets" ]
     verbs: [ "get" ]
+  # Cert-manager basic probe checking for secret creation
+  - apiGroups: [ "cert-manager.io" ]
+    resources: [ "certificates" ]
+    verbs: [ "create", "delete" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Description

Add basic probe for cert-manager

## Why do we need it, and what problem does it solve?

More availability checks in SLA by design epic

## Changelog entries


```changes
section: upmeter
type: feature
summary: Added basic probe for cert-manager in 'control-plane' availability group
```

## TODO

- [x] Probe
- [x] Disabling the probe
- [x] Alerts for garbage objects, blocked by #1648
