### PR TITLE
[openvpn] fix set_search_domains hook

### DIFF
--- a/modules/500-openvpn/hooks/set_search_domains.go
+++ b/modules/500-openvpn/hooks/set_search_domains.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Flant CJSC
+Copyright 2021 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/500-openvpn/hooks/set_search_domains.go
+++ b/modules/500-openvpn/hooks/set_search_domains.go
@@ -28,7 +28,9 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 func setSearchDomain(input *go_hook.HookInput) error {
 	clusterDomain := input.Values.Get("global.discovery.clusterDomain").String()
 
-	input.ConfigValues.Set("openvpn.pushToClientSearchDomains", []string{clusterDomain})
+	if !input.ConfigValues.Exists("openvpn.pushToClientSearchDomains") {
+		input.ConfigValues.Set("openvpn.pushToClientSearchDomains", []string{clusterDomain})
+	}
 
 	return nil
 }

--- a/modules/500-openvpn/hooks/set_search_domains_test.go
+++ b/modules/500-openvpn/hooks/set_search_domains_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Flant CJSC
+Copyright 2021 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/500-openvpn/hooks/set_search_domains_test.go
+++ b/modules/500-openvpn/hooks/set_search_domains_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2021 Flant CJSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: openvpn :: hooks :: set_search_domains ", func() {
+	f := HookExecutionConfigInit(`{"global": {"discovery":{"clusterDomain":"test.test"}},"openvpn":{"internal":{}, "auth": {}}}`, `{"openvpn":{}}`)
+	Context("openvpn.pushToClientSearchDomains not set", func() {
+		BeforeEach(func() {
+			f.KubeStateSet("")
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("domain should be set to test.test", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ConfigValuesGet("openvpn.pushToClientSearchDomains.0").String()).Should(Equal("test.test"))
+		})
+	})
+
+	Context("openvpn.pushToClientSearchDomains is set", func() {
+		BeforeEach(func() {
+			f.KubeStateSet("")
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ConfigValuesSet("openvpn.pushToClientSearchDomains.0", "example.example")
+			f.RunHook()
+		})
+
+		It("domain should be set to example.example", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ConfigValuesGet("openvpn.pushToClientSearchDomains.0").String()).Should(Equal("example.example"))
+		})
+	})
+})


### PR DESCRIPTION
Signed-off-by: Vitaliy Snurnitsin <vitaliy.snurnitsin@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added check for the existence of the pushToClientSearchDomains parameter in the config.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This fixes a bug that does not allow you to set additional domains.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: openvpn
type: fix
summary: Fixes a bug that does not allow you to set additional domains.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
