### PR TITLE
[linstor] fix: spatch not recent enough

### DIFF
--- a/modules/031-linstor/images/drbd-driver-loader/Dockerfile
+++ b/modules/031-linstor/images/drbd-driver-loader/Dockerfile
@@ -1,6 +1,6 @@
-ARG BASE_DEBIAN
+ARG BASE_DEBIAN_BULLSEYE
 
-FROM $BASE_DEBIAN as builder
+FROM $BASE_DEBIAN_BULLSEYE as builder
 ARG DRBD_GITREPO=https://github.com/LINBIT/drbd
 ARG DRBD_VERSION=9.1.6
 
@@ -17,9 +17,7 @@ RUN git clone ${DRBD_GITREPO} /drbd \
  && mv ./docker/entry.sh /entry.sh \
  && chmod +x /entry.sh
 
-ARG BASE_DEBIAN
-
-FROM $BASE_DEBIAN
+FROM $BASE_DEBIAN_BULLSEYE
 
 RUN apt-get update \
  && apt-get install -y kmod gnupg wget make gcc patch curl coccinelle \


### PR DESCRIPTION
## Description

DRBD requires newer spatch version:

```
INFO: spatch not recent enough, need spatch version >= 1.0.8
```

## Why do we need it, and what problem does it solve?

Latest cherry-pick https://github.com/deckhouse/deckhouse/pull/1726#issuecomment-1151173849 made inposible the drbd module building on Deckhouse <1.33:



## Changelog entries

```changes
section: linstor
type: fix
summary: Fix drbd module building.
```