### PR TITLE
[cloud-provider-vsphere] fix error in terraform for static nodes in s…

### DIFF
--- a/ee/candi/cloud-providers/vsphere/terraform-modules/static-node/main.tf
+++ b/ee/candi/cloud-providers/vsphere/terraform-modules/static-node/main.tf
@@ -113,6 +113,7 @@ locals {
 
 resource "vsphere_virtual_machine" "node" {
   name             = join("-", [local.prefix, local.node_group_name, var.nodeIndex])
+  resource_pool_id = data.vsphere_resource_pool.resource_pool[0].id
   resource_pool_id = length(local.resource_pool) == 0 ? null : data.vsphere_resource_pool.resource_pool[0].id
   datastore_id     = data.vsphere_datastore.datastore.id
   folder           = var.providerClusterConfiguration.vmFolderPath

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -176,12 +176,12 @@ spec:
 {{- $alertmanagers_byservice := false }}
 {{- $alertmanagers_internal := false }}
 {{- if hasKey .Values.prometheus.internal.alertmanagers "byService" }}
-  {{- if gt (len .Values.prometheus.internal.alertmanagers.byService) 0 }}
+  {{- if len .Values.prometheus.internal.alertmanagers.byService }}
     {{- $alertmanagers_byservice = true }}
   {{- end }}
 {{- end }}
 {{- if hasKey .Values.prometheus.internal.alertmanagers "internal" }}
-  {{- if gt (len .Values.prometheus.internal.alertmanagers.internal) 0 }}
+  {{- if len .Values.prometheus.internal.alertmanagers.internal }}
     {{- $alertmanagers_internal = true }}
   {{- end }}
 {{- end }}

--- a/testing/cloud_layouts/vSphere/Standard/configuration.tpl.yaml
+++ b/testing/cloud_layouts/vSphere/Standard/configuration.tpl.yaml
@@ -33,9 +33,8 @@ deckhouse:
       subnet: 172.16.25.0/24
       dns:
         servers:
-        - 10.80.100.129
-        - 10.80.100.130
-        - 10.80.101.253
+        - 8.8.8.8
+        - 8.8.4.4
         search:
         - ${VSPHERE_BASE_DOMAIN}
 ---


### PR DESCRIPTION
…etups without nested resource pools

Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix error in terraform for static nodes in setups without nested resource pools.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-vsphere
type: fix
summary: Fix error in terraform for static nodes in setups without nested resource pools
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
