### PR TITLE
[cni-cilium] Fixed enable_node_routes hook

### DIFF
--- a/modules/021-cni-cilium/hooks/enable_node_routes.go
+++ b/modules/021-cni-cilium/hooks/enable_node_routes.go
@@ -38,9 +38,9 @@ func enableNodeRoutes(input *go_hook.HookInput) error {
 
 func shouldEnableNodeRoutes(input *go_hook.HookInput) bool {
 	// if value is set directly - skip this hook
-	_, ok := input.ConfigValues.GetOk("cniCilium.createNodeRoutes")
+	value, ok := input.ConfigValues.GetOk("cniCilium.createNodeRoutes")
 	if ok {
-		return false
+		return value.Bool()
 	}
 
 	providerRaw, ok := input.Values.GetOk("global.clusterConfiguration.cloud.provider")

--- a/modules/021-cni-cilium/hooks/enable_node_routes_test.go
+++ b/modules/021-cni-cilium/hooks/enable_node_routes_test.go
@@ -54,6 +54,18 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: enable-node-routes", func() 
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("cniCilium.createNodeRoutes").Bool()).To(BeTrue())
 		})
+
+		Context("with directly set value in config", func() {
+			BeforeEach(func() {
+				f.ConfigValuesSet("cniCilium.createNodeRoutes", false)
+				f.RunHook()
+			})
+
+			It("should be false", func() {
+				Expect(f).To(ExecuteSuccessfully())
+				Expect(f.ValuesGet("cniCilium.createNodeRoutes").Bool()).To(BeFalse())
+			})
+		})
 	})
 
 	Context("Openstack cluster with directly node-routes set", func() {


### PR DESCRIPTION
## Description
The hook now bails if a value is present in a config.

## Why do we need it, and what problem does it solve?
Previously it erroneously set the value to `false` no matter what was set in config.

## Changelog entries
```changes
section: cni-cilium
type: fix
summary: The `enable_node_routes` hook now bails if a value is present in config.
```
