### PR TITLE
[node-manager][docs] Add node reboot step in clean up node FAQ

### DIFF
--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -189,6 +189,8 @@ This is only needed if you have to move a static node from one cluster to anothe
    systemctl daemon-reload
    systemctl reset-failed
    ```
+   
+1. Reboot the node.
 
 1. Start CRI:
 

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -190,6 +190,8 @@ kubectl label node <node_name> node-role.kubernetes.io/<old_node_group_name>-
    systemctl reset-failed
    ```
 
+1. Перезагрузите узел.
+
 1. Запустите обратно CRI:
 
    ```shell


### PR DESCRIPTION
Signed-off-by: Konstantin Aksenov <konstantin.aksenov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add node reboot step in clean up node FAQ.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Reboot helps to remove existing CNI interface. It helps to avoid problems with network configuration.
```
 Warning  FailedCreatePodSandBox  0s               kubelet            (combined from similar events): Failed to create pod sandbox: rpc error: code = Unknown desc = failed to set up sandbox container "ab1ffcf6c6b4ae067799d20cd6bc8aba44f675e5600d4106086f6d4b9f058f5d" network for pod "early-oom-wrnm7": networkPlugin cni failed to set up pod "early-oom-wrnm7_d8-cloud-instance-manager" network: failed to set bridge addr: "cni0" already has an IP address different from 10.123.97.1/24
 
  10: cni0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    inet 10.123.81.1/24 brd 10.123.81.255 scope global cni0
       valid_lft forever preferred_lft forever
 ```

 

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: chore
summary: Add node reboot step in clean up node FAQ
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
