### PR TITLE
[docs][namespace-configurator] Fix the configuration page.

### DIFF
--- a/modules/600-namespace-configurator/docs/CONFIGURATION.md
+++ b/modules/600-namespace-configurator/docs/CONFIGURATION.md
@@ -2,11 +2,11 @@
 title: "The namespace-configurator module: configuration"
 ---
 
-This module is **disabled** by default. To enable it, add the following lines to the `deckhouse` ConfigMap:
+This module is **enabled** by default. To disable it, add the following lines to the `deckhouse` ConfigMap:
 
 ```yaml
 data:
-  namespaceConfiguratorEnabled: "true"
+  namespaceConfiguratorEnabled: "false"
 ```
 
 ## Parameters

--- a/modules/600-namespace-configurator/docs/CONFIGURATION_RU.md
+++ b/modules/600-namespace-configurator/docs/CONFIGURATION_RU.md
@@ -2,11 +2,11 @@
 title: "Модуль namespace-configurator: настройки"
 ---
 
-Модуль по умолчанию **выключен**. Для включения добавьте в ConfigMap `deckhouse`:
+Модуль по умолчанию **включен**. Для выключения добавьте в ConfigMap `deckhouse`:
 
 ```yaml
 data:
-  namespaceConfiguratorEnabled: "true"
+  namespaceConfiguratorEnabled: "false"
 ```
 
 ## Параметры


### PR DESCRIPTION
Signed-off-by: Artem Kladov <artem.kladov@flant.com>

## Description
The namespace-configurator module was mistakenly listed as disabled by default.

## Changelog entries
```changes
section: namespace-configurator
type: fix
summary: The namespace-configurator module was mistakenly listed as disabled by default in the documentation.
impact_level: low
```
