### PR TITLE
[snapshot-controller] Fix CRDs

### DIFF
--- a/modules/010-snapshot-controller-crd/crds/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+++ b/modules/010-snapshot-controller-crd/crds/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
@@ -114,6 +114,15 @@ spec:
   - name: v1alpha1
     served: false
     storage: false
+    # This indicates the v1alpha1 version of the custom resource is deprecated.
+    # API requests to this version receive a warning in the server response.
+    deprecated: true
+    # This overrides the default warning returned to clients making v1alpha1 API requests.
+    deprecationWarning: "snapshot.storage.k8s.io/v1alpha1 VolumeSnapshot is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshot"
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
 status:
   acceptedNames:
     kind: ""

--- a/modules/010-snapshot-controller-crd/crds/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+++ b/modules/010-snapshot-controller-crd/crds/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
@@ -303,6 +303,15 @@ spec:
   - name: v1alpha1
     served: false
     storage: false
+    # This indicates the v1alpha1 version of the custom resource is deprecated.
+    # API requests to this version receive a warning in the server response.
+    deprecated: true
+    # This overrides the default warning returned to clients making v1alpha1 API requests.
+    deprecationWarning: "snapshot.storage.k8s.io/v1alpha1 VolumeSnapshot is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshot"
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
 status:
   acceptedNames:
     kind: ""

--- a/modules/010-snapshot-controller-crd/crds/snapshot.storage.k8s.io_volumesnapshots.yaml
+++ b/modules/010-snapshot-controller-crd/crds/snapshot.storage.k8s.io_volumesnapshots.yaml
@@ -228,6 +228,15 @@ spec:
   - name: v1alpha1
     served: false
     storage: false
+    # This indicates the v1alpha1 version of the custom resource is deprecated.
+    # API requests to this version receive a warning in the server response.
+    deprecated: true
+    # This overrides the default warning returned to clients making v1alpha1 API requests.
+    deprecationWarning: "snapshot.storage.k8s.io/v1alpha1 VolumeSnapshot is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshot"
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
## Description
snapshot-controller does not allow install crd until `v1alpha1` is preserved in cluster.

## Why do we need it, and what problem does it solve?

```
ModuleRun task for module 'snapshot-controller-crd', phase 'Startup' with doModuleStartup, trigger is OperatorStartup
Module hook start snapshot-controller-crd/010-snapshot-controller-crd/hooks/ensure_crds.go
ModuleRun failed in phase 'Startup'. Requeue task to retry after delay. Failed count is 13. Error: 3 errors occurred:
	* Create object: apiextensions.k8s.io/v1/CustomResourceDefinition//volumesnapshotclasses.snapshot.storage.k8s.io: CustomResourceDefinition.apiextensions.k8s.io "volumesnapshotclasses.snapshot.storage.k8s.io" is invalid: spec.versions[2].schema.openAPIV3Schema: Required value: schemas are required
	* Create object: apiextensions.k8s.io/v1/CustomResourceDefinition//volumesnapshotcontents.snapshot.storage.k8s.io: CustomResourceDefinition.apiextensions.k8s.io "volumesnapshotcontents.snapshot.storage.k8s.io" is invalid: spec.versions[2].schema.openAPIV3Schema: Required value: schemas are required
	* Create object: apiextensions.k8s.io/v1/CustomResourceDefinition//volumesnapshots.snapshot.storage.k8s.io: CustomResourceDefinition.apiextensions.k8s.io "volumesnapshots.snapshot.storage.k8s.io" is invalid: spec.versions[2].schema.openAPIV3Schema: Required value: schemas are required
```

## Changelog entries


```changes
section: snapshot-controller
type: fix
summary: The `snapshot-controller` does not allow install CRD until `v1alpha1` is preserved in cluster.
```
