### PR TITLE
[dhctl] Prevent to break already bootstrapped cluster when bootstrap new cluster

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -307,11 +307,11 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *Config) erro
 				return manifests.ClusterUUIDConfigMap(cfg.UUID)
 			},
 			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().ConfigMaps("kube-system").Create(context.TODO(), manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})
+				_, err := kubeCl.CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).Create(context.TODO(), manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})
 				return err
 			},
 			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().ConfigMaps("kube-system").Update(context.TODO(), manifest.(*apiv1.ConfigMap), metav1.UpdateOptions{})
+				_, err := kubeCl.CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).Update(context.TODO(), manifest.(*apiv1.ConfigMap), metav1.UpdateOptions{})
 				return err
 			},
 		})

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -590,13 +590,19 @@ func SecretMasterDevicePath(nodeName string, devicePath []byte) *apiv1.Secret {
 	)
 }
 
+const (
+	ClusterUUIDCmKey       = "cluster-uuid"
+	ClusterUUIDCm          = "d8-cluster-uuid"
+	ClusterUUIDCmNamespace = "kube-system"
+)
+
 func ClusterUUIDConfigMap(uuid string) *apiv1.ConfigMap {
 	return &apiv1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "d8-cluster-uuid",
-			Namespace: "kube-system",
+			Name:      ClusterUUIDCm,
+			Namespace: ClusterUUIDCmNamespace,
 		},
-		Data: map[string]string{"cluster-uuid": uuid},
+		Data: map[string]string{ClusterUUIDCmKey: uuid},
 	}
 }
 

--- a/dhctl/pkg/operations/bootstrap.go
+++ b/dhctl/pkg/operations/bootstrap.go
@@ -34,6 +34,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/deckhouse"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/bootstrap"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/cache"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/ssh"
@@ -223,7 +224,12 @@ func WaitForSSHConnectionOnMaster(sshClient *ssh.Client) error {
 
 func InstallDeckhouse(kubeCl *client.KubernetesClient, config *deckhouse.Config) error {
 	return log.Process("bootstrap", "Install Deckhouse", func() error {
-		err := deckhouse.CreateDeckhouseManifests(kubeCl, config)
+		err := bootstrap.CheckPreventBreakAnotherBootstrappedCluster(kubeCl, config)
+		if err != nil {
+			return err
+		}
+
+		err = deckhouse.CreateDeckhouseManifests(kubeCl, config)
 		if err != nil {
 			return fmt.Errorf("deckhouse create manifests: %v", err)
 		}

--- a/dhctl/pkg/operations/bootstrap/checks.go
+++ b/dhctl/pkg/operations/bootstrap/checks.go
@@ -34,9 +34,8 @@ func CheckPreventBreakAnotherBootstrappedCluster(kubeCl *client.KubernetesClient
 	}
 
 	if err == nil {
-		var ok bool
-		uuidInCluster, ok = cmInCluster.Data[manifests.ClusterUUIDCmKey]
-		if !ok || uuidInCluster == "" {
+		uuidInCluster = cmInCluster.Data[manifests.ClusterUUIDCmKey]
+		if uuidInCluster == "" {
 			return fmt.Errorf("Cluster UUID config map found, but UUID is empty")
 		}
 	}

--- a/dhctl/pkg/operations/bootstrap/checks.go
+++ b/dhctl/pkg/operations/bootstrap/checks.go
@@ -1,0 +1,55 @@
+// Copyright 2022 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/deckhouse"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/manifests"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+)
+
+func CheckPreventBreakAnotherBootstrappedCluster(kubeCl *client.KubernetesClient, config *deckhouse.Config) error {
+	var uuidInCluster string
+	cmInCluster, err := kubeCl.CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).Get(context.TODO(), manifests.ClusterUUIDCm, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	if err == nil {
+		var ok bool
+		uuidInCluster, ok = cmInCluster.Data[manifests.ClusterUUIDCmKey]
+		if !ok || uuidInCluster == "" {
+			return fmt.Errorf("Cluster UUID config map found, but UUID is empty")
+		}
+	}
+
+	if uuidInCluster == "" {
+		return nil
+	}
+
+	if uuidInCluster != config.UUID {
+		return fmt.Errorf(`Cluster UUID's not equal in the cluster (%s) and in the cache (%s).
+Probably you are trying bootstrap cluster on nede with previous created cluster.
+Please check hostname.`, uuidInCluster, config.UUID)
+	}
+
+	return nil
+}

--- a/dhctl/pkg/operations/bootstrap/checks.go
+++ b/dhctl/pkg/operations/bootstrap/checks.go
@@ -46,7 +46,7 @@ func CheckPreventBreakAnotherBootstrappedCluster(kubeCl *client.KubernetesClient
 
 	if uuidInCluster != config.UUID {
 		return fmt.Errorf(`Cluster UUID's not equal in the cluster (%s) and in the cache (%s).
-Probably you are trying bootstrap cluster on nede with previous created cluster.
+Probably you are trying bootstrap cluster on node with previous created cluster.
 Please check hostname.`, uuidInCluster, config.UUID)
 	}
 

--- a/dhctl/pkg/operations/bootstrap_test.go
+++ b/dhctl/pkg/operations/bootstrap_test.go
@@ -162,7 +162,7 @@ func TestInstallDeckhouse(t *testing.T) {
 		})
 	})
 
-	t.Run("Has cluster uuid config map", func(t *testing.T) {
+	t.Run("Cluster has uuid config map", func(t *testing.T) {
 		t.Run("with empty uuid", func(t *testing.T) {
 			t.Run("should not install deckhouse", func(t *testing.T) {
 				fakeClient := client.NewFakeKubernetesClient()

--- a/dhctl/pkg/operations/bootstrap_test.go
+++ b/dhctl/pkg/operations/bootstrap_test.go
@@ -150,13 +150,13 @@ func TestInstallDeckhouse(t *testing.T) {
 	}
 
 	t.Run("Does not have cluster uuid config map", func(t *testing.T) {
-		t.Run("should install deckhouse", func(t *testing.T) {
+		t.Run("should install Deckhouse", func(t *testing.T) {
 			fakeClient := client.NewFakeKubernetesClient()
 			createReadyDeckhousePod(fakeClient)
 
 			err := InstallDeckhouse(fakeClient, conf)
 
-			require.NoError(t, err, "Deckhouse should installed")
+			require.NoError(t, err, "Should install Deckhouse")
 
 			assertDeploymentAndUUIDCmCreated(t, fakeClient)
 		})
@@ -164,7 +164,7 @@ func TestInstallDeckhouse(t *testing.T) {
 
 	t.Run("Cluster has uuid config map", func(t *testing.T) {
 		t.Run("with empty uuid", func(t *testing.T) {
-			t.Run("should not install deckhouse", func(t *testing.T) {
+			t.Run("should not install Deckhouse", func(t *testing.T) {
 				fakeClient := client.NewFakeKubernetesClient()
 				curUUID := ""
 
@@ -173,14 +173,14 @@ func TestInstallDeckhouse(t *testing.T) {
 
 				err := InstallDeckhouse(fakeClient, conf)
 
-				require.Error(t, err, "Deckhouse should not install")
+				require.Error(t, err, "Should not install Deckhouse")
 
 				assertNotDeploymentCreatedAndUUIDCmIsSame(t, fakeClient, curUUID)
 			})
 		})
 
 		t.Run("with another uuid", func(t *testing.T) {
-			t.Run("should not install deckhouse", func(t *testing.T) {
+			t.Run("should not install Deckhouse", func(t *testing.T) {
 				fakeClient := client.NewFakeKubernetesClient()
 
 				curUUID := uuid.New().String()
@@ -190,7 +190,7 @@ func TestInstallDeckhouse(t *testing.T) {
 
 				err := InstallDeckhouse(fakeClient, conf)
 
-				require.Error(t, err, "Deckhouse should not install")
+				require.Error(t, err, "Should not install Deckhouse")
 
 				assertNotDeploymentCreatedAndUUIDCmIsSame(t, fakeClient, curUUID)
 			})
@@ -204,7 +204,7 @@ func TestInstallDeckhouse(t *testing.T) {
 
 				err := InstallDeckhouse(fakeClient, conf)
 
-				require.NoError(t, err, "Deckhouse should not install")
+				require.NoError(t, err, "Should not install Deckhouse")
 
 				assertDeploymentAndUUIDCmCreated(t, fakeClient)
 			})

--- a/dhctl/pkg/operations/bootstrap_test.go
+++ b/dhctl/pkg/operations/bootstrap_test.go
@@ -204,7 +204,7 @@ func TestInstallDeckhouse(t *testing.T) {
 
 				err := InstallDeckhouse(fakeClient, conf)
 
-				require.NoError(t, err, "Should not install Deckhouse")
+				require.NoError(t, err, "Should install Deckhouse")
 
 				assertDeploymentAndUUIDCmCreated(t, fakeClient)
 			})


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Prevent to break already bootstrapped cluster when bootstrap new cluster.

Before apply deckhouse manifests, we check cluster UUID now, and if we will get different uuid (none empty) from cache and from cluster, we will return error. 

## Why do we need it, and what problem does it solve?
Close #1657

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: feature
summary: Prevent to break already bootstrapped cluster when bootstrap new cluster
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
