### PR TITLE
[dhctl] fix: detect events from new log messages from latest addon-operator

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/log.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log.go
@@ -87,10 +87,7 @@ func isErrorLine(line *logLine) bool {
 
 	// Consider stderr messages are errors too.
 	if line.Output == "stderr" {
-		// Skip possible messages from tiller.
-		if line.Component != "tiller" {
-			return true
-		}
+		return true
 	}
 
 	return false
@@ -100,14 +97,7 @@ func isErrorLine(line *logLine) bool {
 func isModuleSuccess(line *logLine) bool {
 	// Message about successful ModuleRun since PR#126 in flant/addon-operator.
 	// https://github.com/flant/addon-operator/blob/7e814fbe92fb12af79c67c4226b4c2781d959f3c/pkg/addon-operator/operator.go#L1376
-	if line.Message == "ModuleRun success, module is ready" {
-		return true
-	}
-	// Message about successful ModuleRun prior PR#126 in flant/addon-operator.
-	if line.Message == "Module run success" {
-		return true
-	}
-	return false
+	return line.Message == "ModuleRun success, module is ready"
 }
 
 // isConvergeDone returns true when ConvergeModules task is done reloading all modules.

--- a/dhctl/pkg/kubernetes/actions/deckhouse/log.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log.go
@@ -87,12 +87,10 @@ func isErrorLine(line *logLine) bool {
 
 	// Consider stderr messages are errors too.
 	if line.Output == "stderr" {
-		// skip tiller output
-		if line.Component == "tiller" {
-			return false
+		// Skip possible messages from tiller.
+		if line.Component != "tiller" {
+			return true
 		}
-
-		return true
 	}
 
 	return false

--- a/dhctl/pkg/kubernetes/actions/deckhouse/log.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log.go
@@ -98,9 +98,12 @@ func isErrorLine(line *logLine) bool {
 
 // isModuleSuccess returns true on message about successful module run.
 func isModuleSuccess(line *logLine) bool {
+	// Message about successful ModuleRun since PR#126 in flant/addon-operator.
+	// https://github.com/flant/addon-operator/blob/7e814fbe92fb12af79c67c4226b4c2781d959f3c/pkg/addon-operator/operator.go#L1376
 	if line.Message == "ModuleRun success, module is ready" {
 		return true
 	}
+	// Message about successful ModuleRun prior PR#126 in flant/addon-operator.
 	if line.Message == "Module run success" {
 		return true
 	}
@@ -110,9 +113,12 @@ func isModuleSuccess(line *logLine) bool {
 // isConvergeDone returns true when ConvergeModules task is done reloading all modules.
 // Consider the first occurrence is the first converge success.
 func isConvergeDone(line *logLine) bool {
+	// Message about successful converge since PR#315 in flant/addon-operator.
+	// https://github.com/flant/addon-operator/blob/7e814fbe92fb12af79c67c4226b4c2781d959f3c/pkg/addon-operator/operator.go#L588
 	if line.Message == "ConvergeModules task done" {
 		return true
 	}
+	// Message about successful converge prior PR#315 in flant/addon-operator.
 	if line.Message == "Queue 'main' contains 0 converge tasks after handle 'ModuleHookRun'" {
 		return true
 	}

--- a/dhctl/pkg/kubernetes/actions/deckhouse/log_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package deckhouse
 
 import (

--- a/dhctl/pkg/kubernetes/actions/deckhouse/log_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package deckhouse
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_is_error_line(t *testing.T) {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/log_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log_test.go
@@ -50,11 +50,6 @@ func Test_is_error_line(t *testing.T) {
 			`{"level":"info","output":"stdout","binding":"kubernetes","binding.name":"secrets","event.type":"OperatorStartup","hook":"300-prometheus/hooks/additional_configs_render","hook.type":"module","module":"prometheus","msg":"secret/prometheus-main-additional-configs unchanged","queue":"/modules/prometheus","task.id":"ba36269b-6699-42a0-9337-dce59b48f68b","time":"2022-06-17T08:53:27Z"}`,
 			false,
 		},
-		{
-			"stderr from tiller",
-			`{"operator.component":"tiller","msg":"some error message","level":"info","output":"stderr","time":"2022-06-17T08:53:27Z"}`,
-			false,
-		},
 	}
 
 	for _, tt := range tests {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/log_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log_test.go
@@ -1,0 +1,61 @@
+package deckhouse
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_is_error_line(t *testing.T) {
+	tests := []struct {
+		name    string
+		logLine string
+		result  bool
+	}{
+		// Positive cases.
+		{
+			"level=error",
+			`{"level":"error","msg":"Global hook failed, requeue task to retry after delay ... ","binding":"onStartup","event.type":"OperatorStartup","hook":"module-config/startup_sync.go","hook.type":"global","queue":"main","task.id":"6d685def-ad8e-4961-a14b-a422e1f76a31","time":"2022-06-17T08:51:32Z"}`,
+			true,
+		},
+		{
+			"stderr",
+			`{"level":"info","output":"stderr","binding":"kubernetes","binding.name":"secrets","event.type":"OperatorStartup","hook":"300-prometheus/hooks/additional_configs_render","hook.type":"module","module":"prometheus","msg":"secret/prometheus-main-additional-configs unchanged","queue":"/modules/prometheus","task.id":"ba36269b-6699-42a0-9337-dce59b48f68b","time":"2022-06-17T08:53:27Z"}`,
+			true,
+		},
+		// Negative cases.
+		{
+			"level=info",
+			`{"level":"info","msg":"Module hook start deckhouse-web/810-deckhouse-web/hooks/https/copy_custom_certificate.go","binding":"beforeHelm","event.type":"OperatorStartup","hook":"810-deckhouse-web/hooks/https/copy_custom_certificate.go","hook.type":"module","module":"deckhouse-web","queue":"main","task.id":"e7f06e0c-2304-421a-a856-2684f5cd4914","time":"2022-06-17T08:54:22Z"}`,
+			false,
+		},
+		{
+			"stdout",
+			`{"level":"info","output":"stdout","binding":"kubernetes","binding.name":"secrets","event.type":"OperatorStartup","hook":"300-prometheus/hooks/additional_configs_render","hook.type":"module","module":"prometheus","msg":"secret/prometheus-main-additional-configs unchanged","queue":"/modules/prometheus","task.id":"ba36269b-6699-42a0-9337-dce59b48f68b","time":"2022-06-17T08:53:27Z"}`,
+			false,
+		},
+		{
+			"stderr from tiller",
+			`{"operator.component":"tiller","msg":"some error message","level":"info","output":"stderr","time":"2022-06-17T08:53:27Z"}`,
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result bool
+			var lines int
+			parseLogByLine([]byte(tt.logLine), func(line *logLine) bool {
+				result = isErrorLine(line)
+				lines++
+				// Stop on first line.
+				return false
+			})
+			require.Equal(t, 1, lines, "Should parse log line")
+			if tt.result {
+				require.True(t, result, "Should detect error message")
+			} else {
+				require.False(t, result, "Should not detect error message")
+			}
+		})
+	}
+}


### PR DESCRIPTION

Signed-off-by: Ivan Mikheykin <ivan.mikheykin@flant.com>

## Description

- fix: detect Converge ends from new log messages from latest addon-operator
- fix: detect stderr as error
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Dhctl parses deckhouse logs and detect events. Latest addon-operator change messages, so update is needed.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: fix
summary: Detect events from latest addon-operator log messages.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
