### PR TITLE
[chore] Add CVE report scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,17 @@ help:
 	"" \
 	"-----------------------------------------------------------------------------------" \
 	""
-	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make ${FORMATTING_BEGIN_YELLOW}<target>${FORMATTING_END}\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  ${FORMATTING_BEGIN_BLUE}%-46s${FORMATTING_END} %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@awk 'BEGIN {\
+	    FS = ":.*##"; \
+	    printf                "Usage: ${FORMATTING_BEGIN_BLUE}OPTION${FORMATTING_END}=<value> make ${FORMATTING_BEGIN_YELLOW}<target>${FORMATTING_END}\n"\
+	  } \
+	  /^[a-zA-Z0-9_-]+:.*?##/ { printf "  ${FORMATTING_BEGIN_BLUE}%-46s${FORMATTING_END} %s\n", $$1, $$2 } \
+	  /^.?.?##~/              { printf "   %-46s${FORMATTING_BEGIN_YELLOW}%-46s${FORMATTING_END}\n", "", substr($$1, 6) } \
+	  /^##@/                  { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 
 GOLANGCI_VERSION = 1.46.2
+TRIVY_VERSION= 0.28.1
 TESTS_TIMEOUT="15m"
 
 ##@ General
@@ -37,7 +44,8 @@ deps: bin/golangci-lint bin/trivy ## Install dev dependencies.
 tests-modules: ## Run unit tests for modules hooks and templates.
 	go test -timeout=${TESTS_TIMEOUT} -vet=off ./modules/... ./global-hooks/... ./ee/modules/... ./ee/fe/modules/...
 
-tests-matrix: ## Test how helm templates are rendered with different input values generated from values examples. Use 'FOCUS' environment variable to run tests for a particular module.
+tests-matrix: ## Test how helm templates are rendered with different input values generated from values examples.
+  ##~ Options: $FOCUS=module-name
 	go test ./testing/matrix/ -v
 
 tests-openapi: ## Run tests against modules openapi values schemas.
@@ -92,11 +100,13 @@ render-workflow: ## Generate CI workflow instructions.
 ##@ Reports
 
 bin/trivy:
-	curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ./bin v0.28.1
+	curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ./bin v${TRIVY_VERSION}
 
 .PHONY: cve-report
 cve-report: ## Generate CVE report for a Deckhouse release.
+  ##~ Options: $SEVERITY=CRITICAL,HIGH $REPO=registry.deckhouse.io $TAG=v1.30.0
 	./tools/cve/release.sh
 
 cve-base-images: ## Check CVE in our base images.
+  ##~ Options: $SEVERITY=CRITICAL,HIGH
 	./tools/cve/base-images.sh

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ tests-modules: ## Run unit tests for modules hooks and templates.
 	go test -timeout=${TESTS_TIMEOUT} -vet=off ./modules/... ./global-hooks/... ./ee/modules/... ./ee/fe/modules/...
 
 tests-matrix: ## Test how helm templates are rendered with different input values generated from values examples.
-  ##~ Options: $FOCUS=module-name
+  ##~ Options: FOCUS=module-name
 	go test ./testing/matrix/ -v
 
 tests-openapi: ## Run tests against modules openapi values schemas.
@@ -104,9 +104,9 @@ bin/trivy:
 
 .PHONY: cve-report
 cve-report: ## Generate CVE report for a Deckhouse release.
-  ##~ Options: $SEVERITY=CRITICAL,HIGH $REPO=registry.deckhouse.io $TAG=v1.30.0
+  ##~ Options: SEVERITY=CRITICAL,HIGH REPO=registry.deckhouse.io TAG=v1.30.0
 	./tools/cve/release.sh
 
 cve-base-images: ## Check CVE in our base images.
-  ##~ Options: $SEVERITY=CRITICAL,HIGH
+  ##~ Options: SEVERITY=CRITICAL,HIGH
 	./tools/cve/base-images.sh

--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -189,7 +189,7 @@ This is only needed if you have to move a static node from one cluster to anothe
    systemctl daemon-reload
    systemctl reset-failed
    ```
-   
+
 1. Reboot the node.
 
 1. Start CRI:

--- a/tools/cve/base-images.sh
+++ b/tools/cve/base-images.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Copyright 2022 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeo pipefail
+shopt -s failglob
+
+if [[ "x$SEVERITY" == "x" ]]; then
+  SEVERITY="CRITICAL,HIGH"
+fi
+
+function __base_images_tags__ {
+  docker run -i --rm \
+    -e TARGET_UID=$(id -u) \
+    -e TARGET_GID=$(id -g) \
+    -e TARGET_UMASK=$(umask) \
+    -e TARGET_OSTYPE=${OSTYPE} \
+    -v $(pwd)/.github/ci_includes:/in/ci_includes \
+    hairyhenderson/gomplate:v3.10.0-alpine \
+      --left-delim '{!{' \
+      --right-delim '}!}' \
+      --plugin echo=/bin/echo \
+      --template /in/ci_includes \
+      -i '{!{ tmpl.Exec "image_versions_envs" . }!}'
+}
+
+function __main__() {
+  echo "Severity: $SEVERITY"
+  echo ""
+
+  base_images=$(__base_images_tags__)
+  base_images=$(grep -v "#" <<< "$base_images") # remove comments
+  base_images=$(grep -v "BASE_GOLANG" <<< "$base_images") # golang images are used for multistage builds
+  base_images=$(grep -v "BASE_RUST" <<< "$base_images") # rust images are used for multistage builds
+  base_images=$(awk '{ print $2 }' <<< "$base_images") # pick an actual images address
+  base_images=$(jq -sr '.[]' <<< "$base_images") # unwrap quotes "string" -> string
+
+  for image in $base_images ; do
+    echo "----------------------------------------------"
+    echo "👾 Image: $image"
+    echo ""
+
+    trivy image --timeout 10m --severity=$SEVERITY "$image"
+  done
+}
+
+__main__

--- a/tools/cve/release.sh
+++ b/tools/cve/release.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Copyright 2022 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeo pipefail
+shopt -s failglob
+
+if [[ "x$REPO" == "x" ]]; then
+  REPO="registry.deckhouse.io/deckhouse/ce"
+fi
+
+if [[ "x$TAG" == "x" ]]; then
+  TAG="$(git tag --list "v*" | tail -1)"
+fi
+
+if [[ "x$SEVERITY" == "x" ]]; then
+  SEVERITY="CRITICAL,HIGH"
+fi
+
+function __main__() {
+  echo "Deckhouse image to check: $REPO:$TAG"
+  echo "Severity: $SEVERITY"
+  echo "----------------------------------------------"
+  echo ""
+
+  docker pull "$REPO:$TAG"
+  tags=$(docker run --rm "$REPO:$TAG" cat /deckhouse/modules/images_tags.json)
+
+  for module in $(jq -rc 'to_entries[]' <<< "$tags"); do
+    echo "=============================================="
+    echo "🛰 Module: $(jq -rc '.key' <<< "$module")"
+
+    for image in $(jq -rc '.value | to_entries[]' <<< "$module"); do
+      echo "----------------------------------------------"
+      echo "👾 Image: $(jq -rc '.key' <<< "$image")"
+      echo ""
+
+      trivy image --timeout 10m --severity=$SEVERITY "$REPO:$(jq -rc '.value' <<< "$image")"
+    done
+  done
+}
+
+__main__

--- a/tools/cve/release.sh
+++ b/tools/cve/release.sh
@@ -17,6 +17,15 @@
 set -Eeo pipefail
 shopt -s failglob
 
+# This script makes full CVE scan for a Deckhouse release.
+#
+# Usage: OPTION=<value> release.sh
+#
+# $REPO - Deckhouse images repo
+# $TAG - Deckhouse image tag (by default: the latest tag)
+# $SEVERITY - output only entries with specified severity levels (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)
+
+
 if [[ "x$REPO" == "x" ]]; then
   REPO="registry.deckhouse.io/deckhouse/ce"
 fi


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Add two commands to generate Deckhouse CVE reports

## Why do we need it, and what problem does it solve?
This PR allows us to easily generate reports using one of the most popular tools - [trivy](https://github.com/aquasecurity/trivy).
With these reports, developers can check that there are no new critical dependencies introduced.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: chore
summary: Add CVE report scripts
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
