### PR TITLE
[linstor] fix monitoring of piraeus-operator

### DIFF
--- a/modules/031-linstor/templates/piraeus-operator/deployment.yaml
+++ b/modules/031-linstor/templates/piraeus-operator/deployment.yaml
@@ -62,6 +62,16 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - --create-monitoring=false
+        - --metrics-bind-address=127.0.0.1:8383
+        - --health-probe-bind-address=:8081
+        readinessProbe:
+          httpGet:
+            port: 8081
+            path: /readyz
+        livenessProbe:
+          httpGet:
+            port: 8081
+            path: /healthz
         env:
         - name: WATCH_NAMESPACE
           valueFrom:
@@ -100,16 +110,6 @@ spec:
               upstreams:
               - upstream: http://127.0.0.1:8383/metrics
                 path: /metrics
-                authorization:
-                  resourceAttributes:
-                    namespace: d8-{{ .Chart.Name }}
-                    apiGroup: apps
-                    apiVersion: v1
-                    resource: deployments
-                    subresource: prometheus-metrics
-                    name: piraeus-operator
-              - upstream: http://127.0.0.1:8686/metrics
-                path: /metrics-cr
                 authorization:
                   resourceAttributes:
                     namespace: d8-{{ .Chart.Name }}

--- a/modules/031-linstor/templates/piraeus-operator/podmonitor.yaml
+++ b/modules/031-linstor/templates/piraeus-operator/podmonitor.yaml
@@ -28,26 +28,6 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
-  - targetPort: 8383
-    scheme: https
-    path: /metrics-cr
-    bearerTokenSecret:
-      name: "prometheus-token"
-      key: "token"
-    tlsConfig:
-      insecureSkipVerify: true
-    relabelings:
-    - regex: endpoint|namespace|pod|container
-      action: labeldrop
-    - targetLabel: job
-      replacement: piraeus-operator
-    - sourceLabels: [__meta_kubernetes_pod_node_name]
-      targetLabel: node
-    - targetLabel: tier
-      replacement: cluster
-    - sourceLabels: [__meta_kubernetes_pod_ready]
-      regex: "true"
-      action: keep
   selector:
     matchLabels:
       app: piraeus-operator


### PR DESCRIPTION
## Description

Remove `/metrics-cr` endpoint

## Why do we need it, and what problem does it solve?

There was a regression after updating piraeus-operator to 1.8 https://github.com/deckhouse/deckhouse/pull/1559
Piraeus-operator does not export `/metrics-cr` endpoint anymore.

## Changelog entries


```changes
section: linstor
type: fix
summary: fix monitoring of piraeus-operator
impact_level: low
```