### PR TITLE
[candi] Automatic patchversions update makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,16 +13,15 @@ MDLINTER_IMAGE = ghcr.io/igorshubovych/markdownlint-cli@sha256:2e22b4979347f70e0
 # besides linux/amd64 (e.g. relevant for mac m1).
 PLATFORM_NAME := $(shell uname -p)
 OS_NAME := $(shell uname)
-LBITS := $(shell getconf LONG_BIT)
 ifneq ($(filter arm%,$(PLATFORM_NAME)),)
 	export WERF_PLATFORM=linux/amd64
 endif
 
 # Set platform for jq
 ifeq ($(OS_NAME), Linux)
-	JQ_PLATFORM = linux
+	JQ_PLATFORM = linux64
 else ifeq ($(OS_NAME), Darwin)
-	JQ_PLATFORM = osx-amd
+	JQ_PLATFORM = osx-amd64
 endif
 
 # Set platform for yq
@@ -174,10 +173,10 @@ docs-down: ## Stop all the documentation containers.
 ##@ Update kubernetes control-plane patchversions
 
 bin/jq: ## Install jq deps for update-patchversion script.
-	curl -sSfL https://github.com/stedolan/jq/releases/download/jq-1.6/jq-$(JQ_PLATFORM)$(LBITS) -o $(PWD)/bin/jq && chmod +x $(PWD)/bin/jq
+	curl -sSfL https://github.com/stedolan/jq/releases/download/jq-1.6/jq-$(JQ_PLATFORM) -o $(PWD)/bin/jq && chmod +x $(PWD)/bin/jq
 
 bin/yq: ## Install yq deps for update-patchversion script.
-	curl -sSfL https://github.com/mikefarah/yq/releases/download/v4.25.3/yq_$(YQ_PLATFORM)_$(YQ_ARCH) -o $(PWD)/bin/yq
+	curl -sSfL https://github.com/mikefarah/yq/releases/download/v4.25.3/yq_$(YQ_PLATFORM)_$(YQ_ARCH) -o $(PWD)/bin/yq && chmod +x $(PWD)/bin/yq
 
 bin/crane: ## Install crane deps for update-patchversion script.
 	curl -sSfL https://github.com/google/go-containerregistry/releases/download/v0.10.0/go-containerregistry_$(OS_NAME)_$(CRANE_ARCH).tar.gz | tar -xzf - crane && mv crane $(PWD)/bin/crane && chmod +x $(PWD)/bin/crane

--- a/Makefile
+++ b/Makefile
@@ -141,3 +141,25 @@ docs-dev: ## Run containers with the documentation in the dev mode (allow uncomm
 .PHONY: docs-down
 docs-down: ## Stop all the documentation containers.
 	docker rm -f site_site_1 site_front_1 documentation; docker network rm deckhouse
+
+##@ Update kubernetes control-plane patchversions
+
+.PHONY: update-k8s-patch-versions-deps
+update-k8s-patch-versions-deps: ## Install jq,yq,crane deps for update-patchversion script.
+	make install-jq && make install-yq && make install-crane
+
+.PHONY: install-jq
+install-jq: ## Install jq deps for update-patchversion script.
+	cd candi/tools; bash update_kubernetes_patchversions.sh install-jq
+
+.PHONY: install-yq
+install-yq: ## Install yq deps for update-patchversion script.
+	cd candi/tools; bash update_kubernetes_patchversions.sh install-yq
+
+.PHONY: install-crane
+install-crane: ## Install crane deps for update-patchversion script.
+	cd candi/tools; bash update_kubernetes_patchversions.sh install-crane
+
+.PHONY: update-k8s-patch-versions
+update-k8s-patch-versions: ## Run update-patchversion script to generate new version_map.yml.
+	cd candi/tools; bash update_kubernetes_patchversions.sh

--- a/candi/tools/discover_new_kubernetes_patchversions.sh
+++ b/candi/tools/discover_new_kubernetes_patchversions.sh
@@ -16,10 +16,29 @@
 
 set -Eeo pipefail
 
-. /deckhouse/candi/tools/functions.sh
+. functions.sh
+
+CREATE_PR=false
+PR_TITLE="New kubernetes patchversions"
+PR_BODY=$(cat <<"EOF"
+## Description
+New Kubernetes control-plane components patchversions.
+## Why do we need it, and what problem does it solve?
+Kubernetes control-plane components should be up to date.
+## Changelog entries
+```changes
+section: candi
+type: feature
+summary: New Kubernetes control-plane components patchversions.
+impact: Restart Kubernetes control-plane components.
+impact_level: default
+```
+EOF
+)
 
 function check_requirements() {
     check_jq
+    check_gh
     check_crane
     check_yq
 }
@@ -28,36 +47,39 @@ function check_requirements() {
 # update_version_map VERSION PATCH
 function update_version_map() {
   local NEW_DIGEST
-  yq -i e ".k8s.\"${1}\".patch = ${2}" /deckhouse/candi/version_map.yml
+  yq -i e ".k8s.\"${1}\".patch = ${2}" ../version_map.yml
   # Kube-proxy
-  if yq -e e "select(.k8s.\"${1}\".controlPlane | has(\"kubeProxy\"))" /deckhouse/candi/version_map.yml >/dev/null 2>/dev/null; then
+  if yq -e e "select(.k8s.\"${1}\".controlPlane | has(\"kubeProxy\"))" ../version_map.yml >/dev/null 2>/dev/null; then
     NEW_DIGEST="$(crane digest "registry.k8s.io/kube-proxy:v${1}.${2}")"
-    yq -i e ".k8s.\"${1}\".controlPlane.kubeProxy = \"${NEW_DIGEST}\"" /deckhouse/candi/version_map.yml
+    yq -i e ".k8s.\"${1}\".controlPlane.kubeProxy = \"${NEW_DIGEST}\"" ../version_map.yml
   fi
   # Kube-scheduler
   NEW_DIGEST=""
-  if yq -e e "select(.k8s.\"${1}\".controlPlane | has(\"kubeScheduler\"))" /deckhouse/candi/version_map.yml >/dev/null 2>/dev/null; then
+  if yq -e e "select(.k8s.\"${1}\".controlPlane | has(\"kubeScheduler\"))" ../version_map.yml >/dev/null 2>/dev/null; then
     NEW_DIGEST="$(crane digest "registry.k8s.io/kube-scheduler:v${1}.${2}")"
-    yq -i e ".k8s.\"${1}\".controlPlane.kubeScheduler = \"${NEW_DIGEST}\"" /deckhouse/candi/version_map.yml
+    yq -i e ".k8s.\"${1}\".controlPlane.kubeScheduler = \"${NEW_DIGEST}\"" ../version_map.yml
   fi
 }
 
 check_requirements
 
-TMPDIR="$(mktemp -du)"
-mkdir -p "${TMPDIR}"
-cd "${TMPDIR}"
-
-for VERSION in $(yq e /deckhouse/candi/version_map.yml -j | jq -r '.k8s | keys[]'); do
-  for PATCH in $(yq e /deckhouse/candi/version_map.yml -j | jq -r --arg version "${VERSION}" '.k8s."\($version)".patch'); do
+for VERSION in $(yq e ../version_map.yml -o json | jq -r '.k8s | keys[]'); do
+  for PATCH in $(yq e ../version_map.yml -o json | jq -r --arg version "${VERSION}" '.k8s."\($version)".patch'); do
     # Get last patch version from github CHANGELOG.md
     NEW_FULL_VERSION="$(curl -s "https://raw.githubusercontent.com/kubernetes/kubernetes/master/CHANGELOG/CHANGELOG-${VERSION}.md" | grep '## Downloads for v' | head -n 1 | grep -Eo "${VERSION}.[0-9]+")"
     NEW_PATCH="$(awk -F "." '{print $3}' <<< "${NEW_FULL_VERSION}")"
     if [[ "${NEW_PATCH}" -ne "${PATCH}" ]]; then
-      echo "New kubernetes patch version ${NEW_PATCH} found for ${VERSION}"
+      echo "New kubernetes patch version ${VERSION}.${NEW_PATCH} "
+      CREATE_PR=true
       update_version_map "${VERSION}" "${NEW_PATCH}"
     fi
   done
 done
 
-cd -
+if [[ "${CREATE_PR}" -eq "true" ]]; then
+  git checkout -b "kubernetes-patchversions-$(date +"%y-%m-%d-%H-%M")"
+  git add .
+  git commit -m "[candi] New kubernetes control-plane components patchversions"
+  git push
+  gh -B main -b "${PR_BODY}" -t "${PR_TITLE}"
+fi

--- a/candi/tools/functions.sh
+++ b/candi/tools/functions.sh
@@ -23,10 +23,13 @@ function check_jq() {
     fi
 }
 
-function check_gh() {
-    if ! gh --version &>/dev/null; then
-      >&2 echo "ERROR: gh is not installed. Please install it from https://cli.github.com"
-      return 1
+function install_jq() {
+    # Mac OS
+    if brew --version >/dev/null; then
+      brew install jq
+    # Linux
+    else
+      curl curl -sSfL https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/local/bin/jq && chmod +x /usr/local/bin/jq
     fi
 }
 
@@ -34,6 +37,16 @@ function check_crane() {
     if ! crane version &>/dev/null; then
       >&2 echo "ERROR: crane is not installed. Please install it from https://github.com/google/go-containerregistry/tree/main/cmd/crane"
       return 1
+    fi
+}
+
+function install_crane() {
+    # Mac OS
+    if brew --version >/dev/null; then
+      brew install crane
+    # Linux
+    else
+      curl curl -sSfL https://github.com/google/go-containerregistry/releases/download/v0.10.0/go-containerregistry_Linux_x86_64.tar.gz | tar -xzf - crane && mv crane /usr/local/bin && chmod +x /usr/local/bin/crane
     fi
 }
 
@@ -46,6 +59,16 @@ function check_yq() {
     if ! yq --version | grep -q ".*4\.[0-9]*.*"; then
       >&2 echo "ERROR: yq version should be equal 4"
       return 1
+    fi
+}
+
+function install_yq() {
+    # Mac OS
+    if brew --version >/dev/null; then
+      brew install yq
+    # Linux
+    else
+      curl curl -sSfL https://github.com/mikefarah/yq/releases/download/v4.25.3/yq_linux_amd64 -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
     fi
 }
 

--- a/candi/tools/functions.sh
+++ b/candi/tools/functions.sh
@@ -30,16 +30,6 @@ function check_crane() {
     fi
 }
 
-function install_crane() {
-    # Mac OS
-    if brew --version >/dev/null; then
-      brew install crane
-    # Linux
-    else
-      curl curl -sSfL https://github.com/google/go-containerregistry/releases/download/v0.10.0/go-containerregistry_Linux_x86_64.tar.gz | tar -xzf - crane && mv crane /usr/local/bin && chmod +x /usr/local/bin/crane
-    fi
-}
-
 function check_yq() {
     if ! yq --version &>/dev/null; then
       >&2 echo "ERROR: yq is not installed. Please install it from https://github.com/mikefarah/yq/releases"
@@ -49,16 +39,6 @@ function check_yq() {
     if ! yq --version | grep -q ".*4\.[0-9]*.*"; then
       >&2 echo "ERROR: yq version should be equal 4"
       return 1
-    fi
-}
-
-function install_yq() {
-    # Mac OS
-    if brew --version >/dev/null; then
-      brew install yq
-    # Linux
-    else
-      curl curl -sSfL https://github.com/mikefarah/yq/releases/download/v4.25.3/yq_linux_amd64 -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
     fi
 }
 

--- a/candi/tools/functions.sh
+++ b/candi/tools/functions.sh
@@ -18,21 +18,28 @@ set -Eeo pipefail
 
 function check_jq() {
     if ! jq --version &>/dev/null; then
-      >&2 echo "ERROR: jq is not installed"
+      >&2 echo "ERROR: jq is not installed. Please install it from https://stedolan.github.io/jq/download"
+      return 1
+    fi
+}
+
+function check_gh() {
+    if ! gh --version &>/dev/null; then
+      >&2 echo "ERROR: gh is not installed. Please install it from https://cli.github.com"
       return 1
     fi
 }
 
 function check_crane() {
     if ! crane version &>/dev/null; then
-      >&2 echo "ERROR: crane is not installed"
+      >&2 echo "ERROR: crane is not installed. Please install it from https://github.com/google/go-containerregistry/tree/main/cmd/crane"
       return 1
     fi
 }
 
 function check_yq() {
     if ! yq --version &>/dev/null; then
-      >&2 echo "ERROR: yq is not installed"
+      >&2 echo "ERROR: yq is not installed. Please install it from https://github.com/mikefarah/yq/releases"
       return 1
     fi
 

--- a/candi/tools/functions.sh
+++ b/candi/tools/functions.sh
@@ -23,16 +23,6 @@ function check_jq() {
     fi
 }
 
-function install_jq() {
-    # Mac OS
-    if brew --version >/dev/null; then
-      brew install jq
-    # Linux
-    else
-      curl curl -sSfL https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/local/bin/jq && chmod +x /usr/local/bin/jq
-    fi
-}
-
 function check_crane() {
     if ! crane version &>/dev/null; then
       >&2 echo "ERROR: crane is not installed. Please install it from https://github.com/google/go-containerregistry/tree/main/cmd/crane"

--- a/candi/tools/update_kubernetes_patchversions.sh
+++ b/candi/tools/update_kubernetes_patchversions.sh
@@ -19,11 +19,17 @@ set -Eeo pipefail
 . functions.sh
 
 # install dependencies
-if [[ $1 == "install-deps" ]]; then
-    install_jq
-    install_crane
-    install_yq
-fi
+case "$1" in
+install-jq)
+  install_jq
+  ;;
+install-yq)
+  install_yq
+  ;;
+install-crane)
+  install_crane
+  ;;
+esac
 
 function check_requirements() {
     check_jq

--- a/candi/tools/update_kubernetes_patchversions.sh
+++ b/candi/tools/update_kubernetes_patchversions.sh
@@ -82,6 +82,6 @@ if [[ "${CREATE_PR}" -eq "true" ]]; then
   git checkout -b "${BRANCH}"
   git add .
   git commit -m "[candi] New kubernetes control-plane components patchversions"
-  git push
+  git push --set-upstream origin "${BRANCH}"
 #  gh -B main -b "${PR_BODY}" -t "${PR_TITLE}"
 fi

--- a/candi/tools/update_kubernetes_patchversions.sh
+++ b/candi/tools/update_kubernetes_patchversions.sh
@@ -19,23 +19,6 @@ set -Eeo pipefail
 . functions.sh
 
 CREATE_PR=false
-PR_TITLE="New kubernetes patchversions"
-PR_BODY=$(cat <<"EOF"
-## Description
-New Kubernetes control-plane components patchversions.
-## Why do we need it, and what problem does it solve?
-Kubernetes control-plane components should be up to date.
-## Changelog entries
-```changes
-section: candi
-type: feature
-summary: New Kubernetes control-plane components patchversions.
-impact: Restart Kubernetes control-plane components.
-impact_level: default
-```
-EOF
-)
-
 function check_requirements() {
     check_jq
     check_gh
@@ -69,19 +52,33 @@ for VERSION in $(yq e ../version_map.yml -o json | jq -r '.k8s | keys[]'); do
     NEW_FULL_VERSION="$(curl -s "https://raw.githubusercontent.com/kubernetes/kubernetes/master/CHANGELOG/CHANGELOG-${VERSION}.md" | grep '## Downloads for v' | head -n 1 | grep -Eo "${VERSION}.[0-9]+")"
     NEW_PATCH="$(awk -F "." '{print $3}' <<< "${NEW_FULL_VERSION}")"
     if [[ "${NEW_PATCH}" -ne "${PATCH}" ]]; then
-      echo "New kubernetes patch version ${VERSION}.${NEW_PATCH} "
+      PR_DESCRIPTION="${PR_DESCRIPTION}$(echo -e "\n* New kubernetes patch version ${VERSION}.${NEW_PATCH}.")"
       CREATE_PR=true
       update_version_map "${VERSION}" "${NEW_PATCH}"
     fi
   done
 done
 
-cd ../../
 if [[ "${CREATE_PR}" == "true" ]]; then
+  cd ../../
   BRANCH="kubernetes-patchversions-$(date +"%y-%m-%d-%H-%M")"
   git checkout -b "${BRANCH}"
   git add .
   git commit -m "[candi] New kubernetes control-plane components patchversions"
   git push --set-upstream origin "${BRANCH}"
-#  gh -B main -b "${PR_BODY}" -t "${PR_TITLE}"
+  cat <<EOF | gh pr create -d -B main -F - -t "New kubernetes patchversions"
+## Description
+New Kubernetes control-plane components patchversions.
+${PR_DESCRIPTION}
+## Why do we need it, and what problem does it solve?
+Kubernetes control-plane components should be up to date.
+## Changelog entries
+\`\`\`changes
+section: candi
+type: feature
+summary: New Kubernetes control-plane components patchversions.
+impact: Restart Kubernetes control-plane components.
+impact_level: default
+\`\`\`
+EOF
 fi

--- a/candi/tools/update_kubernetes_patchversions.sh
+++ b/candi/tools/update_kubernetes_patchversions.sh
@@ -76,6 +76,7 @@ for VERSION in $(yq e ../version_map.yml -o json | jq -r '.k8s | keys[]'); do
   done
 done
 
+cd ../../
 if [[ "${CREATE_PR}" -eq "true" ]]; then
   BRANCH="kubernetes-patchversions-$(date +"%y-%m-%d-%H-%M")"
   git checkout -b "${BRANCH}"

--- a/candi/tools/update_kubernetes_patchversions.sh
+++ b/candi/tools/update_kubernetes_patchversions.sh
@@ -18,19 +18,6 @@ set -Eeo pipefail
 
 . functions.sh
 
-# install dependencies
-case "$1" in
-install-jq)
-  install_jq
-  ;;
-install-yq)
-  install_yq
-  ;;
-install-crane)
-  install_crane
-  ;;
-esac
-
 function check_requirements() {
     check_jq
     check_crane

--- a/candi/tools/update_kubernetes_patchversions.sh
+++ b/candi/tools/update_kubernetes_patchversions.sh
@@ -77,7 +77,7 @@ for VERSION in $(yq e ../version_map.yml -o json | jq -r '.k8s | keys[]'); do
 done
 
 cd ../../
-if [[ "${CREATE_PR}" -eq "true" ]]; then
+if [[ "${CREATE_PR}" == "true" ]]; then
   BRANCH="kubernetes-patchversions-$(date +"%y-%m-%d-%H-%M")"
   git checkout -b "${BRANCH}"
   git add .

--- a/candi/tools/update_kubernetes_patchversions.sh
+++ b/candi/tools/update_kubernetes_patchversions.sh
@@ -77,9 +77,10 @@ for VERSION in $(yq e ../version_map.yml -o json | jq -r '.k8s | keys[]'); do
 done
 
 if [[ "${CREATE_PR}" -eq "true" ]]; then
-  git checkout -b "kubernetes-patchversions-$(date +"%y-%m-%d-%H-%M")"
+  BRANCH="kubernetes-patchversions-$(date +"%y-%m-%d-%H-%M")"
+  git checkout -b "${BRANCH}"
   git add .
   git commit -m "[candi] New kubernetes control-plane components patchversions"
   git push
-  gh -B main -b "${PR_BODY}" -t "${PR_TITLE}"
+#  gh -B main -b "${PR_BODY}" -t "${PR_TITLE}"
 fi

--- a/candi/tools/update_kubernetes_patchversions.sh
+++ b/candi/tools/update_kubernetes_patchversions.sh
@@ -18,10 +18,15 @@ set -Eeo pipefail
 
 . functions.sh
 
-CREATE_PR=false
+# install dependencies
+if [[ $1 == "install-deps" ]]; then
+    install_jq
+    install_crane
+    install_yq
+fi
+
 function check_requirements() {
     check_jq
-    check_gh
     check_crane
     check_yq
 }
@@ -58,27 +63,3 @@ for VERSION in $(yq e ../version_map.yml -o json | jq -r '.k8s | keys[]'); do
     fi
   done
 done
-
-if [[ "${CREATE_PR}" == "true" ]]; then
-  cd ../../
-  BRANCH="kubernetes-patchversions-$(date +"%y-%m-%d-%H-%M")"
-  git checkout -b "${BRANCH}"
-  git add .
-  git commit -m "[candi] New kubernetes control-plane components patchversions"
-  git push --set-upstream origin "${BRANCH}"
-  cat <<EOF | gh pr create -d -B main -F - -t "New kubernetes patchversions"
-## Description
-New Kubernetes control-plane components patchversions.
-${PR_DESCRIPTION}
-## Why do we need it, and what problem does it solve?
-Kubernetes control-plane components should be up to date.
-## Changelog entries
-\`\`\`changes
-section: candi
-type: feature
-summary: New Kubernetes control-plane components patchversions.
-impact: Restart Kubernetes control-plane components.
-impact_level: default
-\`\`\`
-EOF
-fi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Automatic patchversions update makefile target.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This PR adds Makefile targets to update versions_map file to latest versions of kubernetes control-plane components patchversions. Later we should add GA, to periodically run auto-update and generate PRs for updated versions.
## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: chore
summary: Automatic patchversions update makefile target.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
