### PR TITLE
[test] Add targets for documentation to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 export PATH := $(abspath bin/):${PATH}
 
+export BASE_NGINX_ALPINE=nginx:1.15.12-alpine@sha256:57a226fb6ab6823027c0704a9346a890ffb0cacde06bc19bbc234c8720673555
+export BASE_ALPINE=alpine:3.12.1@sha256:c0e9560cda118f9ec63ddefb4a173a2b2a0347082d7dff7dc14272e7841a5b5a
+export BASE_GOLANG_16_ALPINE=golang:1.16.3-alpine3.12@sha256:371dc6bf7e0c7ce112a29341b000c40d840aef1dbb4fdcb3ae5c0597e28f3061
+export BASE_JEKYLL=jekyll/jekyll:3.8@sha256:9521c8aae4739fcbc7137ead19f91841b833d671542f13e91ca40280e88d6e34
+
 FORMATTING_BEGIN_YELLOW = \033[0;33m
 FORMATTING_BEGIN_BLUE = \033[36m
 FORMATTING_END = \033[0m
@@ -81,3 +86,16 @@ lint-markdown-fix: ## Run markdown linter and fix problems automatically.
 .PHONY: generate
 generate: ## Run all generate-* jobs in bulk.
 	cd tools; go generate
+
+##@ Site up
+
+.PHONY: docs
+docs: ## Run containers with the documentation (werf is required to build the containers).
+	docker network inspect deckhouse 2>/dev/null 1>/dev/null || docker network create deckhouse; \
+	cd docs/documentation/; werf compose up --docker-compose-command-options='-d'; \
+  cd ../site/; werf compose up --docker-compose-command-options='-d'; \
+  echo "Open http://localhost to access the documentation..."
+
+.PHONY: docs-down
+docs-down: ## Stop all the documentation containers.
+	docker rm -f site_site_1 site_front_1 documentation; docker network rm deckhouse


### PR DESCRIPTION
## Description
Added two targes for building and stopping containers with the documentation.
Run:
- `make docs` — to build and run containers with the documentation ([werf](werf.io) is required). 
- `make docs-down` — to stop and remove the documentation containers. 

After building, the documentation is available on http://localhost.

Will be fixed in #1923 

## Changelog entries
```changes
section: test
type: feature
summary: Added Makefile targets for building documentation locally.
impact_level: low
```
