### PR TITLE
New kubernetes patchversions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,9 @@ lint-fix: bin/golangci-lint ## Fix lint violations.
 .PHONY: generate
 generate: ## Run all generate-* jobs in bulk.
 	cd tools; go generate
+
+##@ New kubernetes control-plane patchversions
+
+.PHONY: update-patchversions
+update-patchversions: ## Run update-patchversion script to generate new PR.
+	cd candi/tools; bash update_kubernetes_patchversions.sh

--- a/candi/tools/discover_new_kubernetes_patchversions.sh
+++ b/candi/tools/discover_new_kubernetes_patchversions.sh
@@ -16,10 +16,29 @@
 
 set -Eeo pipefail
 
-. /deckhouse/candi/tools/functions.sh
+. functions.sh
+
+CREATE_PR=false
+PR_TITLE="New kubernetes patchversions"
+PR_BODY=$(cat <<"EOF"
+## Description
+New Kubernetes control-plane components patchversions.
+## Why do we need it, and what problem does it solve?
+Kubernetes control-plane components should be up to date.
+## Changelog entries
+```changes
+section: candi
+type: feature
+summary: New Kubernetes control-plane components patchversions.
+impact: Restart Kubernetes control-plane components.
+impact_level: default
+```
+EOF
+)
 
 function check_requirements() {
     check_jq
+    check_gh
     check_crane
     check_yq
 }
@@ -28,36 +47,39 @@ function check_requirements() {
 # update_version_map VERSION PATCH
 function update_version_map() {
   local NEW_DIGEST
-  yq -i e ".k8s.\"${1}\".patch = ${2}" /deckhouse/candi/version_map.yml
+  yq -i e ".k8s.\"${1}\".patch = ${2}" ../version_map.yml
   # Kube-proxy
-  if yq -e e "select(.k8s.\"${1}\".controlPlane | has(\"kubeProxy\"))" /deckhouse/candi/version_map.yml >/dev/null 2>/dev/null; then
+  if yq -e e "select(.k8s.\"${1}\".controlPlane | has(\"kubeProxy\"))" ../version_map.yml >/dev/null 2>/dev/null; then
     NEW_DIGEST="$(crane digest "registry.k8s.io/kube-proxy:v${1}.${2}")"
-    yq -i e ".k8s.\"${1}\".controlPlane.kubeProxy = \"${NEW_DIGEST}\"" /deckhouse/candi/version_map.yml
+    yq -i e ".k8s.\"${1}\".controlPlane.kubeProxy = \"${NEW_DIGEST}\"" ../version_map.yml
   fi
   # Kube-scheduler
   NEW_DIGEST=""
-  if yq -e e "select(.k8s.\"${1}\".controlPlane | has(\"kubeScheduler\"))" /deckhouse/candi/version_map.yml >/dev/null 2>/dev/null; then
+  if yq -e e "select(.k8s.\"${1}\".controlPlane | has(\"kubeScheduler\"))" ../version_map.yml >/dev/null 2>/dev/null; then
     NEW_DIGEST="$(crane digest "registry.k8s.io/kube-scheduler:v${1}.${2}")"
-    yq -i e ".k8s.\"${1}\".controlPlane.kubeScheduler = \"${NEW_DIGEST}\"" /deckhouse/candi/version_map.yml
+    yq -i e ".k8s.\"${1}\".controlPlane.kubeScheduler = \"${NEW_DIGEST}\"" ../version_map.yml
   fi
 }
 
 check_requirements
 
-TMPDIR="$(mktemp -du)"
-mkdir -p "${TMPDIR}"
-cd "${TMPDIR}"
-
-for VERSION in $(yq e /deckhouse/candi/version_map.yml -j | jq -r '.k8s | keys[]'); do
-  for PATCH in $(yq e /deckhouse/candi/version_map.yml -j | jq -r --arg version "${VERSION}" '.k8s."\($version)".patch'); do
+for VERSION in $(yq e ../version_map.yml -o json | jq -r '.k8s | keys[]'); do
+  for PATCH in $(yq e ../version_map.yml -o json | jq -r --arg version "${VERSION}" '.k8s."\($version)".patch'); do
     # Get last patch version from github CHANGELOG.md
     NEW_FULL_VERSION="$(curl -s "https://raw.githubusercontent.com/kubernetes/kubernetes/master/CHANGELOG/CHANGELOG-${VERSION}.md" | grep '## Downloads for v' | head -n 1 | grep -Eo "${VERSION}.[0-9]+")"
     NEW_PATCH="$(awk -F "." '{print $3}' <<< "${NEW_FULL_VERSION}")"
     if [[ "${NEW_PATCH}" -ne "${PATCH}" ]]; then
-      echo "New kubernetes patch version ${NEW_PATCH} found for ${VERSION}"
+      echo "New kubernetes patch version ${VERSION}.${NEW_PATCH} "
+      CREATE_PR=true
       update_version_map "${VERSION}" "${NEW_PATCH}"
     fi
   done
 done
 
-cd -
+if [[ "${CREATE_PR}" -eq "true" ]]; then
+  git checkout -b "kubernetes-patchversions-$(date +"%y-%m-%d-%H-%M")"
+  git add .
+  git commit -m "[candi] New kubernetes control-plane components patchversions"
+  git push
+  gh -B main -b "${PR_BODY}" -t "${PR_TITLE}"
+fi

--- a/candi/tools/functions.sh
+++ b/candi/tools/functions.sh
@@ -18,21 +18,28 @@ set -Eeo pipefail
 
 function check_jq() {
     if ! jq --version &>/dev/null; then
-      >&2 echo "ERROR: jq is not installed"
+      >&2 echo "ERROR: jq is not installed. Please install it from https://stedolan.github.io/jq/download"
+      return 1
+    fi
+}
+
+function check_gh() {
+    if ! gh --version &>/dev/null; then
+      >&2 echo "ERROR: gh is not installed. Please install it from https://cli.github.com"
       return 1
     fi
 }
 
 function check_crane() {
     if ! crane version &>/dev/null; then
-      >&2 echo "ERROR: crane is not installed"
+      >&2 echo "ERROR: crane is not installed. Please install it from https://github.com/google/go-containerregistry/tree/main/cmd/crane"
       return 1
     fi
 }
 
 function check_yq() {
     if ! yq --version &>/dev/null; then
-      >&2 echo "ERROR: yq is not installed"
+      >&2 echo "ERROR: yq is not installed. Please install it from https://github.com/mikefarah/yq/releases"
       return 1
     fi
 

--- a/candi/tools/update_kubernetes_patchversions.sh
+++ b/candi/tools/update_kubernetes_patchversions.sh
@@ -82,6 +82,6 @@ if [[ "${CREATE_PR}" -eq "true" ]]; then
   git checkout -b "${BRANCH}"
   git add .
   git commit -m "[candi] New kubernetes control-plane components patchversions"
-  git push
+  git push --set-upstream origin "${BRANCH}"
 #  gh -B main -b "${PR_BODY}" -t "${PR_TITLE}"
 fi

--- a/candi/tools/update_kubernetes_patchversions.sh
+++ b/candi/tools/update_kubernetes_patchversions.sh
@@ -19,23 +19,6 @@ set -Eeo pipefail
 . functions.sh
 
 CREATE_PR=false
-PR_TITLE="New kubernetes patchversions"
-PR_BODY=$(cat <<"EOF"
-## Description
-New Kubernetes control-plane components patchversions.
-## Why do we need it, and what problem does it solve?
-Kubernetes control-plane components should be up to date.
-## Changelog entries
-```changes
-section: candi
-type: feature
-summary: New Kubernetes control-plane components patchversions.
-impact: Restart Kubernetes control-plane components.
-impact_level: default
-```
-EOF
-)
-
 function check_requirements() {
     check_jq
     check_gh
@@ -69,19 +52,33 @@ for VERSION in $(yq e ../version_map.yml -o json | jq -r '.k8s | keys[]'); do
     NEW_FULL_VERSION="$(curl -s "https://raw.githubusercontent.com/kubernetes/kubernetes/master/CHANGELOG/CHANGELOG-${VERSION}.md" | grep '## Downloads for v' | head -n 1 | grep -Eo "${VERSION}.[0-9]+")"
     NEW_PATCH="$(awk -F "." '{print $3}' <<< "${NEW_FULL_VERSION}")"
     if [[ "${NEW_PATCH}" -ne "${PATCH}" ]]; then
-      echo "New kubernetes patch version ${VERSION}.${NEW_PATCH} "
+      PR_DESCRIPTION="${PR_DESCRIPTION}$(echo -e "\n* New kubernetes patch version ${VERSION}.${NEW_PATCH}.")"
       CREATE_PR=true
       update_version_map "${VERSION}" "${NEW_PATCH}"
     fi
   done
 done
 
-cd ../../
 if [[ "${CREATE_PR}" == "true" ]]; then
+  cd ../../
   BRANCH="kubernetes-patchversions-$(date +"%y-%m-%d-%H-%M")"
   git checkout -b "${BRANCH}"
   git add .
   git commit -m "[candi] New kubernetes control-plane components patchversions"
   git push --set-upstream origin "${BRANCH}"
-#  gh -B main -b "${PR_BODY}" -t "${PR_TITLE}"
+  cat <<EOF | gh pr create -d -B main -F - -t "New kubernetes patchversions"
+## Description
+New Kubernetes control-plane components patchversions.
+${PR_DESCRIPTION}
+## Why do we need it, and what problem does it solve?
+Kubernetes control-plane components should be up to date.
+## Changelog entries
+\`\`\`changes
+section: candi
+type: feature
+summary: New Kubernetes control-plane components patchversions.
+impact: Restart Kubernetes control-plane components.
+impact_level: default
+\`\`\`
+EOF
 fi

--- a/candi/tools/update_kubernetes_patchversions.sh
+++ b/candi/tools/update_kubernetes_patchversions.sh
@@ -76,6 +76,7 @@ for VERSION in $(yq e ../version_map.yml -o json | jq -r '.k8s | keys[]'); do
   done
 done
 
+cd ../../
 if [[ "${CREATE_PR}" -eq "true" ]]; then
   BRANCH="kubernetes-patchversions-$(date +"%y-%m-%d-%H-%M")"
   git checkout -b "${BRANCH}"

--- a/candi/tools/update_kubernetes_patchversions.sh
+++ b/candi/tools/update_kubernetes_patchversions.sh
@@ -77,7 +77,7 @@ for VERSION in $(yq e ../version_map.yml -o json | jq -r '.k8s | keys[]'); do
 done
 
 cd ../../
-if [[ "${CREATE_PR}" -eq "true" ]]; then
+if [[ "${CREATE_PR}" == "true" ]]; then
   BRANCH="kubernetes-patchversions-$(date +"%y-%m-%d-%H-%M")"
   git checkout -b "${BRANCH}"
   git add .

--- a/candi/tools/update_kubernetes_patchversions.sh
+++ b/candi/tools/update_kubernetes_patchversions.sh
@@ -77,9 +77,10 @@ for VERSION in $(yq e ../version_map.yml -o json | jq -r '.k8s | keys[]'); do
 done
 
 if [[ "${CREATE_PR}" -eq "true" ]]; then
-  git checkout -b "kubernetes-patchversions-$(date +"%y-%m-%d-%H-%M")"
+  BRANCH="kubernetes-patchversions-$(date +"%y-%m-%d-%H-%M")"
+  git checkout -b "${BRANCH}"
   git add .
   git commit -m "[candi] New kubernetes control-plane components patchversions"
   git push
-  gh -B main -b "${PR_BODY}" -t "${PR_TITLE}"
+#  gh -B main -b "${PR_BODY}" -t "${PR_TITLE}"
 fi

--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -236,7 +236,7 @@ k8s:
       kubeProxy: sha256:4b6c25521c58d7b7968b85f1f7dd9db30719b3565af97250442f5df91aece29d
   '1.21':
     status: available
-    patch: 13
+    patch: 14
     cniVersion: 0.8.7
     bashible: *bashible_k8s_ge_1_19
     ccm:
@@ -258,11 +258,11 @@ k8s:
       # etcd: sha256 digest isn't needed because this component is compiled from source
       # kubeApiServer: sha256 digest isn't needed because this component is compiled from source
       # kubeControllerManager: sha256 digest isn't needed because this component is compiled from source
-      kubeScheduler: sha256:31fcb7186443a295160d33b35053de599419554fead24fafa3b2b11559e84f84
+      kubeScheduler: sha256:67d226ce629ef439d8e1e1b401a6f828cc4558abd6d9e5e3717d188dc7ce4ba1
       # kubeProxy: sha256 digest isn't needed for this version of kubernetes because this component is compiled as a module image with a special patch
   '1.22':
     status: available
-    patch: 10
+    patch: 11
     cniVersion: 0.8.7
     bashible: *bashible_k8s_ge_1_19
     ccm:
@@ -284,11 +284,11 @@ k8s:
       # etcd: sha256 digest isn't needed because this component is compiled from source
       # kubeApiServer: sha256 digest isn't needed because this component is compiled from source
       # kubeControllerManager: sha256 digest isn't needed because this component is compiled from source
-      kubeScheduler: sha256:3cf4645e7711d24edbd763047a46eb072b77c4795d0bbef807620e1923466bbe
-      kubeProxy: sha256:a64e8600862c14ca15b4e228abe5061e6fe5b6dd008e669739fb0e4098c0d0e9
+      kubeScheduler: sha256:0d281ae79168aefcb11678431a1eb0cf8faeb424a73e35c20af36534c107d2f2
+      kubeProxy: sha256:d17e9639c3b4c483c4cd435457f35ec12b57bfea1a8d5c17dc52e27656aed1e3
   '1.23':
     status: available
-    patch: 7
+    patch: 8
     cniVersion: 0.8.7
     bashible: *bashible_k8s_ge_1_19
     ccm:
@@ -310,5 +310,5 @@ k8s:
       # etcd: sha256 digest isn't needed because this component is compiled from source
       # kubeApiServer: sha256 digest isn't needed because this component is compiled from source
       # kubeControllerManager: sha256 digest isn't needed because this component is compiled from source
-      kubeScheduler: sha256:5b0fc360fb9abd0a33e31c3ed37c713d40dc5d3089b38e4092495510d45dcafe
-      kubeProxy: sha256:26d9bc653f99e54163685a93f440a774802c3ce00eea16d46147bb8dc4d88663
+      kubeScheduler: sha256:cf1842e377fa32a72dab549e203dbb51c20189f9321d2d2b5e7f96214f60ab05
+      kubeProxy: sha256:71e8db32908c9db3ecbf48cf22af3b366c8a07b66f86b2cb553874402f8f068c


### PR DESCRIPTION
## Description
New Kubernetes control-plane components patchversions.

* New kubernetes patch version 1.21.14.
* New kubernetes patch version 1.22.11.
* New kubernetes patch version 1.23.8.
## Why do we need it, and what problem does it solve?
Kubernetes control-plane components should be up to date.
## Changelog entries
```changes
section: candi
type: feature
summary: New Kubernetes control-plane components patchversions.
impact: Restart Kubernetes control-plane components.
impact_level: default
```
