### PR TITLE
[user-authn] Make kubelogin tab active by default

### DIFF
--- a/modules/150-user-authn/images/kubeconfig-generator/already_logged.patch
+++ b/modules/150-user-authn/images/kubeconfig-generator/already_logged.patch
@@ -232,7 +232,7 @@ index c6ab1b1..893a163 100644
 +	})
 +}
 diff --git a/templates/kubeconfig.html b/templates/kubeconfig.html
-index 35763de..51bde8d 100644
+index 35763de..e942d27 100644
 --- a/templates/kubeconfig.html
 +++ b/templates/kubeconfig.html
 @@ -26,7 +26,7 @@
@@ -244,15 +244,23 @@ index 35763de..51bde8d 100644
        </div>
        <h2 class="theme-heading">Generated Kubernetes Token - {{ .ShortDescription }}</h2>
 
-@@ -44,21 +44,31 @@
-           <button class="tablinks active" onclick="openTab(event, 'Linux')">Linux</button>
+@@ -41,24 +41,34 @@
+         </div>
+
+         <div class="tab">
+-          <button class="tablinks active" onclick="openTab(event, 'Linux')">Linux</button>
++          <button class="tablinks active" onclick="openTab(event, 'Kubelogin')">Kubelogin</button>
++          <button class="tablinks" onclick="openTab(event, 'Linux')">Linux</button>
            <button class="tablinks" onclick="openTab(event, 'MacOS')">MacOS</button>
            <button class="tablinks" onclick="openTab(event, 'Windows')">Windows</button>
-+          <button class="tablinks" onclick="openTab(event, 'Kubelogin')">Kubelogin</button>
 +          <button class="tablinks" onclick="openTab(event, 'RawConfig')">Raw Config</button>
            <button class="tablinks" onclick="openTab(event, 'IDToken')">ID Token</button>
          </div>
 
++        <div id="Kubelogin" class="tabcontent">
++          {{ template "kubelogin-tab-content" . }}
++        </div>
++
          <div id="Linux" class="tabcontent" style="display: block">
            {{ template "linux-tab-content" . }}
          </div>
@@ -267,10 +275,6 @@ index 35763de..51bde8d 100644
            {{ template "windows-tab-content" . }}
          </div>
 
-+        <div id="Kubelogin" class="tabcontent">
-+          {{ template "kubelogin-tab-content" . }}
-+        </div>
-+
 +        <div id="RawConfig" class="tabcontent">
 +          {{ template "raw-config-tab-content" . }}
 +        </div>


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
Kubelogin is a recommended way to authenticate with a kubectl because of https://github.com/deckhouse/deckhouse/issues/1151

Let's make the kubelogin tab active by default in attempt to improve UX.
![image](https://user-images.githubusercontent.com/32434187/174610328-61347b22-349a-45b4-8479-3861f225fe47.png)


## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: user-authn
type: feature
summary: Make kubelogin tab active by default
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
