### PR TITLE
[linstor] listen on IPv4 address

### DIFF
--- a/modules/031-linstor/templates/linstor-controller/linstorcontroller.yaml
+++ b/modules/031-linstor/templates/linstor-controller/linstorcontroller.yaml
@@ -62,6 +62,7 @@ spec:
     Autoplacer/Weights/MaxThroughput: "0"
   logLevel: info
   httpBindAddress: "127.0.0.1"
+  httpsBindAddress: "0.0.0.0"
   sidecars:
   - name: kube-rbac-proxy
     {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 4 }}


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

## Description

Make linstor-controller listen on IPv4-only address.

## Why do we need it, and what problem does it solve?

Fixes https://github.com/deckhouse/deckhouse/issues/1804.

## Changelog entries


```changes
section: linstor
type: fix
summary: Make the `linstor-controller` listen on IPv4-only address.
```