### PR TITLE
[linstor] Document default StorageClass

### DIFF
--- a/modules/031-linstor/docs/FAQ.md
+++ b/modules/031-linstor/docs/FAQ.md
@@ -63,9 +63,6 @@ Mark a StorageClass as default:
 ```bash
 kubectl annotate storageclass linstor-data-r2 storageclass.kubernetes.io/is-default-class=true
 ```
-
-
-
 ## How to add existing LVM or LVMThin pool?
 
 Example of adding an existing LVM pool:

--- a/modules/031-linstor/docs/FAQ.md
+++ b/modules/031-linstor/docs/FAQ.md
@@ -44,6 +44,28 @@ Depending on the task, choose one of the following:
 - DRBD + LVM — faster (x2) and more reliable (LVM is simpler);
 - DRBD + LVMThin — support for snapshots and the possibility of overcommitment.
 
+## Changing the default StorageClass
+
+List the StorageClasses in your cluster:
+
+```bash
+kubectl get storageclass
+```
+
+Mark the default StorageClass as non-default:
+
+```bash
+kubectl annotate storageclass local-path storageclass.kubernetes.io/is-default-class-
+```
+
+Mark a StorageClass as default:
+
+```bash
+kubectl annotate storageclass linstor-data-r2 storageclass.kubernetes.io/is-default-class=true
+```
+
+
+
 ## How to add existing LVM or LVMThin pool?
 
 Example of adding an existing LVM pool:

--- a/modules/031-linstor/docs/FAQ_RU.md
+++ b/modules/031-linstor/docs/FAQ_RU.md
@@ -44,6 +44,27 @@ title: "Модуль linstor: FAQ"
 - DRBD + LVM — быстрей (в два раза) и надежней (LVM — проще);
 - DRBD + LVMThin — поддержка snapshot'ов и возможность overprovisioning.
 
+
+## Как назначить StorageClass по умолчанию
+
+Отоброзить список всех StorageClasses:
+
+```bash
+kubectl get storageclass
+```
+
+Снимите аннотацию с предыдущего StorageClass по умолчанию
+
+```bash
+kubectl annotate storageclass local-path storageclass.kubernetes.io/is-default-class-
+```
+
+Добавьте аннотацию для назначения нового StorageClass по умолчанию
+
+```bash
+kubectl annotate storageclass linstor-data-r2 storageclass.kubernetes.io/is-default-class=true
+```
+
 ## Как добавить существующий LVM или LVMThin-пул?
 
 Пример добавления LVM-пула:

--- a/modules/031-linstor/docs/FAQ_RU.md
+++ b/modules/031-linstor/docs/FAQ_RU.md
@@ -43,23 +43,21 @@ title: "Модуль linstor: FAQ"
 В зависимости от задачи нужно выбрать один из следующих вариантов:
 - DRBD + LVM — быстрей (в два раза) и надежней (LVM — проще);
 - DRBD + LVMThin — поддержка snapshot'ов и возможность overprovisioning.
-
-
 ## Как назначить StorageClass по умолчанию
 
-Отоброзить список всех StorageClasses:
+Отобразите список всех StorageClass'ов:
 
 ```bash
 kubectl get storageclass
 ```
 
-Снимите аннотацию с предыдущего StorageClass по умолчанию
+Снимите аннотацию с предыдущего StorageClass по умолчанию:
 
 ```bash
 kubectl annotate storageclass local-path storageclass.kubernetes.io/is-default-class-
 ```
 
-Добавьте аннотацию для назначения нового StorageClass по умолчанию
+Добавьте аннотацию для назначения нового StorageClass по умолчанию:
 
 ```bash
 kubectl annotate storageclass linstor-data-r2 storageclass.kubernetes.io/is-default-class=true


### PR DESCRIPTION
## Description

Document how to set StorageClass by default

## Why do we need it, and what problem does it solve?

Since SotrageClasses generated dynamically we need to explain how to specify StorageClass by default.

## Changelog entries


```changes
section: linstor
type: chore
summary: document how to set StorageClass by default
impact_level: low
```