### PR TITLE
[cilium] Changed ports to not clash with Ingress Nginx Controller's protobuf-exporter

### DIFF
--- a/modules/021-cni-cilium/templates/agent/daemonset.yaml
+++ b/modules/021-cni-cilium/templates/agent/daemonset.yaml
@@ -120,8 +120,8 @@ spec:
               - /cni-uninstall.sh
         ports:
         - name: prometheus
-          containerPort: 9090
-          hostPort: 9090
+          containerPort: 9092
+          hostPort: 9092
           protocol: TCP
         securityContext:
           privileged: true
@@ -168,7 +168,7 @@ spec:
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             upstreams:
-            - upstream: http://127.0.0.1:9090/metrics
+            - upstream: http://127.0.0.1:9092/metrics
               path: /metrics
               authorization:
                 resourceAttributes:

--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -14,8 +14,8 @@ data:
   metrics: "+cilium_bpf_map_pressure"
 
   agent-health-port: "9876"
-  prometheus-serve-addr: "127.0.0.1:9090"
-  operator-prometheus-serve-addr: "127.0.0.1:9092"
+  prometheus-serve-addr: "127.0.0.1:9092"
+  operator-prometheus-serve-addr: "127.0.0.1:9094"
   operator-api-serve-addr: "127.0.0.1:9234"
   enable-metrics: "true"
 

--- a/modules/021-cni-cilium/templates/operator/deployment.yaml
+++ b/modules/021-cni-cilium/templates/operator/deployment.yaml
@@ -66,8 +66,7 @@ spec:
         name: operator
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         ports:
-        - containerPort: 9092
-          hostPort: 9092
+        - containerPort: 9094
           name: prometheus
           protocol: TCP
         livenessProbe:
@@ -105,7 +104,7 @@ spec:
         - name: KUBE_RBAC_PROXY_CONFIG
           value: |
             upstreams:
-            - upstream: http://127.0.0.1:9092/metrics
+            - upstream: http://127.0.0.1:9094/metrics
               path: /metrics
               authorization:
                 resourceAttributes:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Cilium's port were colliding with protobuf-exporter.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Moved metric ports.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cilium
type: fix
summary: Changed metrics ports so they won't clash with protobuf-exporter
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
