### PR TITLE
[control-plane-manager] Fix link to quota-backend-bytes

### DIFF
--- a/modules/040-control-plane-manager/openapi/config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/config-values.yaml
@@ -215,7 +215,7 @@ properties:
     properties:
       maxDbSize:
         description: |
-          (quota-backend-bytes)[https://etcd.io/docs/v3.5/dev-guide/limit/#storage-size-limit] parameter.
+          [quota-backend-bytes](https://etcd.io/docs/v3.5/dev-guide/limit/#storage-size-limit) parameter.
           Deckhouse automatically manages the `quota-backend-bytes` parameter.
           If the `maxDbSize` parameter is set, deckhouse will use this value for the `quota-backend-bytes` etcd parameter.
 

--- a/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
@@ -127,7 +127,7 @@ properties:
     properties:
       maxDbSize:
         description: |
-          (quota-backend-bytes)[https://etcd.io/docs/v3.5/dev-guide/limit/#storage-size-limit] параметр.
+          [quota-backend-bytes](https://etcd.io/docs/v3.5/dev-guide/limit/#storage-size-limit) параметр.
           Deckhouse автоматически управляет `quota-backend-bytes` параметром.
           Если параметр `maxDbSize` установлен, то Deckhouse будет использовать это значение для параметра `quota-backend-bytes` etcd.
 


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Fix link to quota-backend-bytes in openapi spec

## Why do we need it, and what problem does it solve?
Incorrect link view in documentation

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: control-plane-manager
type:chore
summary: Fix link to quota-backend-bytes
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
