### PR TITLE
[linstor] listen on IPv4 address (#1830)

### DIFF
--- a/modules/031-linstor/templates/linstor-controller/linstorcontroller.yaml
+++ b/modules/031-linstor/templates/linstor-controller/linstorcontroller.yaml
@@ -62,6 +62,7 @@ spec:
     Autoplacer/Weights/MaxThroughput: "0"
   logLevel: info
   httpBindAddress: "127.0.0.1"
+  httpsBindAddress: "0.0.0.0"
   sidecars:
   - name: kube-rbac-proxy
     {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 4 }}


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>
(cherry picked from commit 11f7ee5e09c09dc2d1cde94d4bdeb1a0ed283923)

Ref: #1830

## Description
Make linstor-controller listen on IPv4-only address.

Fixes https://github.com/deckhouse/deckhouse/issues/1804.

## Changelog entries
```changes
section: linstor
type: fix
summary: Make the `linstor-controller` listen on IPv4-only address.
```