### PR TITLE
[deckhouse] improve deckhouse update process

### DIFF
--- a/modules/020-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/020-deckhouse/hooks/check_deckhouse_release.go
@@ -137,17 +137,15 @@ releaseLoop:
 
 		case release.Version.Equal(newSemver):
 			input.LogEntry.Debugf("Release with version %s already exists", release.Version)
-			if releaseChecker.releaseMetadata.Suspend {
-				if release.Phase == v1alpha1.PhasePending {
-					p := map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"annotations": map[string]string{
-								"release.deckhouse.io/suspended": "true",
-							},
+			if releaseChecker.releaseMetadata.Suspend && release.Phase == v1alpha1.PhasePending {
+				p := map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]string{
+							"release.deckhouse.io/suspended": "true",
 						},
-					}
-					input.PatchCollector.MergePatch(p, "deckhouse.io/v1alpha1", "DeckhouseRelease", "", release.Name)
+					},
 				}
+				input.PatchCollector.MergePatch(p, "deckhouse.io/v1alpha1", "DeckhouseRelease", "", release.Name)
 			}
 			return nil
 

--- a/modules/020-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/020-deckhouse/hooks/check_deckhouse_release.go
@@ -138,14 +138,16 @@ releaseLoop:
 		case release.Version.Equal(newSemver):
 			input.LogEntry.Debugf("Release with version %s already exists", release.Version)
 			if releaseChecker.releaseMetadata.Suspend {
-				p := map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"annotations": map[string]string{
-							"release.deckhouse.io/suspended": "true",
+				if release.Phase == v1alpha1.PhasePending {
+					p := map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"annotations": map[string]string{
+								"release.deckhouse.io/suspended": "true",
+							},
 						},
-					},
+					}
+					input.PatchCollector.MergePatch(p, "deckhouse.io/v1alpha1", "DeckhouseRelease", "", release.Name)
 				}
-				input.PatchCollector.MergePatch(p, "deckhouse.io/v1alpha1", "DeckhouseRelease", "", release.Name)
 			}
 			return nil
 

--- a/modules/020-deckhouse/hooks/update_deckhouse_image.go
+++ b/modules/020-deckhouse/hooks/update_deckhouse_image.go
@@ -108,6 +108,9 @@ type deckhousePodInfo struct {
 	Ready     bool   `json:"ready"`
 }
 
+// while cluster bootstrapping we have the tag for deckhouse image like: alpha, beta, early-access, stable, rock-solid
+// it is set via dhctl, which does not know anything about releases and tags
+// We can use this bootstrap image for applying first release without any requirements (like update windows, canary, etc)
 func (dpi deckhousePodInfo) isBootstrapImage() bool {
 	colonIndex := strings.LastIndex(dpi.Image, ":")
 	if colonIndex == -1 {

--- a/modules/020-deckhouse/hooks/update_deckhouse_image.go
+++ b/modules/020-deckhouse/hooks/update_deckhouse_image.go
@@ -109,12 +109,18 @@ type deckhousePodInfo struct {
 }
 
 func (dpi deckhousePodInfo) isBootstrapImage() bool {
-	arr := strings.Split(dpi.Image, ":")
-	if len(arr) != 2 {
+	colonIndex := strings.LastIndex(dpi.Image, ":")
+	if colonIndex == -1 {
 		return false
 	}
 
-	switch strings.ToLower(arr[1]) {
+	tag := dpi.Image[colonIndex+1:]
+
+	if tag == "" {
+		return false
+	}
+
+	switch strings.ToLower(tag) {
 	case "alpha", "beta", "early-access", "stable", "rock-solid":
 		return true
 

--- a/modules/020-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/020-deckhouse/hooks/update_deckhouse_image_test.go
@@ -262,6 +262,23 @@ var _ = Describe("Modules :: deckhouse :: hooks :: update deckhouse image ::", f
 		})
 	})
 
+	Context("First Release with manual mode", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("deckhouse.update.mode", []byte(`"Manual"`))
+			f.ValuesDelete("deckhouse.update.windows")
+			f.KubeStateSet(deckhouseBootstrapPod + deckhouseDeployment + deckhousePatchRelease)
+			f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
+			f.RunHook()
+		})
+
+		It("Should update deckhouse deployment", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-1").Field("status.phase").String()).To(Equal("Deployed"))
+			dep := f.KubernetesResource("Deployment", "d8-system", "deckhouse")
+			Expect(dep.Field("spec.template.spec.containers").Array()[0].Get("image").String()).To(BeEquivalentTo("my.registry.com/deckhouse:v1.25.1"))
+		})
+	})
+
 	Context("Few patch releases", func() {
 		BeforeEach(func() {
 			f.KubeStateSet(deckhousePodYaml + fewPatchReleases)
@@ -415,7 +432,26 @@ metadata:
 spec:
   containers:
     - name: deckhouse
-      image: dev-registry.deckhouse.io/sys/deckhouse-oss:test-me
+      image: dev-registry.deckhouse.io/sys/deckhouse-oss:v1.2.3
+status:
+  containerStatuses:
+    - containerID: containerd://9990d3eccb8657d0bfe755672308831b6d0fab7f3aac553487c60bf0f076b2e3
+      imageID: dev-registry.deckhouse.io/sys/deckhouse-oss/dev@sha256:d57f01a88e54f863ff5365c989cb4e2654398fa274d46389e0af749090b862d1
+      ready: true
+`
+	deckhouseBootstrapPod = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: deckhouse-6f46df5bd7-nk4j7
+  namespace: d8-system
+  labels:
+    app: deckhouse
+spec:
+  containers:
+    - name: deckhouse
+      image: dev-registry.deckhouse.io/sys/deckhouse-oss:alpha
 status:
   containerStatuses:
     - containerID: containerd://9990d3eccb8657d0bfe755672308831b6d0fab7f3aac553487c60bf0f076b2e3

--- a/modules/020-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/020-deckhouse/hooks/update_deckhouse_image_test.go
@@ -451,11 +451,11 @@ metadata:
 spec:
   containers:
     - name: deckhouse
-      image: dev-registry.deckhouse.io/sys/deckhouse-oss:alpha
+      image: dev-registry.deckhouse.io:5000/sys/deckhouse-oss:alpha
 status:
   containerStatuses:
     - containerID: containerd://9990d3eccb8657d0bfe755672308831b6d0fab7f3aac553487c60bf0f076b2e3
-      imageID: dev-registry.deckhouse.io/sys/deckhouse-oss/dev@sha256:d57f01a88e54f863ff5365c989cb4e2654398fa274d46389e0af749090b862d1
+      imageID: dev-registry.deckhouse.io:5000/sys/deckhouse-oss/dev@sha256:d57f01a88e54f863ff5365c989cb4e2654398fa274d46389e0af749090b862d1
       ready: true
 `
 	deckhouseNotReadyPod = `


### PR DESCRIPTION
## Description
Suspend only pending releases. Apply first release automatically on deckhouse bootstrap

## Why do we need it, and what problem does it solve?
Improve update process. Suspending deployed release leads to implicit behavior. Also as first pending release

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse
type: feature
summary: Automatically apply first release on deckhouse bootstrap
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
