### PR TITLE
[deckhouse-controller] fix: display help when deckhouse-controller is invoked without arguments

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/main.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/main.go
@@ -82,7 +82,6 @@ func main() {
 
 	// start main loop
 	startCmd := kpApp.Command("start", "Start deckhouse.").
-		Default().
 		Action(func(c *kingpin.ParseContext) error {
 			// Force separate port for hook metrics.
 			if sh_app.HookMetricsListenPort == "" {

--- a/deckhouse-controller/entrypoint.sh
+++ b/deckhouse-controller/entrypoint.sh
@@ -17,6 +17,12 @@
 set -o pipefail
 set -e
 
+# Prevent starting another instance.
+if [[ -n "$DEBUG_UNIX_SOCKET" && -e "$DEBUG_UNIX_SOCKET" ]] ; then
+  echo "deckhouse-controller already started"
+  exit 1
+fi
+
 declare -A bundles_map; bundles_map=( ["Default"]="default" ["Minimal"]="minimal" ["Managed"]="managed" )
 
 bundle=${DECKHOUSE_BUNDLE:-Default}

--- a/deckhouse-controller/entrypoint.sh
+++ b/deckhouse-controller/entrypoint.sh
@@ -34,4 +34,4 @@ EOF
 
 cat ${MODULES_DIR}/values-${bundles_map[$bundle]}.yaml >> ${MODULES_DIR}/values.yaml
 
-exec /sbin/tini -- /usr/bin/deckhouse-controller "$@"
+exec /sbin/tini -- /usr/bin/deckhouse-controller start


### PR DESCRIPTION
## Description

Remove default for start command to prevent starting second instance of operator.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Accidental invoking deckhouse-controller without arguments starts an operator. This behaviour complicates diagnostics.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse-controller
type: fix
summary: Display help when deckhouse-controller is invoked without arguments.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
