### PR TITLE
[snapshot-controller] Reduce amount of replicas for snapshot-controller to a maximum of 2

### DIFF
--- a/modules/045-snapshot-controller/templates/snapshot-controller/deployment.yaml
+++ b/modules/045-snapshot-controller/templates/snapshot-controller/deployment.yaml
@@ -39,7 +39,7 @@ metadata:
 spec:
   minReadySeconds: 15
   revisionHistoryLimit: 2
-  {{- include "helm_lib_deployment_on_master_strategy_and_replicas_for_ha" . | nindent 2 }}
+  {{- include "helm_lib_deployment_strategy_and_replicas_for_ha" . | nindent 2 }}
   selector:
     matchLabels:
       app: snapshot-controller

--- a/modules/045-snapshot-controller/templates/snapshot-validation-webhook/deployment.yaml
+++ b/modules/045-snapshot-controller/templates/snapshot-validation-webhook/deployment.yaml
@@ -37,8 +37,8 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "snapshot-validation-webhook" )) | nindent 2 }}
 spec:
-  {{- include "helm_lib_deployment_on_master_strategy_and_replicas_for_ha" . | nindent 2 }}
   revisionHistoryLimit: 2
+  {{- include "helm_lib_deployment_strategy_and_replicas_for_ha" . | nindent 2 }}
   selector:
     matchLabels:
       app: snapshot-validation-webhook


### PR DESCRIPTION
## Description

Reduce amount of replicas for snapshot-controller to a maximum of 2

## Why do we need it, and what problem does it solve?
If amount of system-nodes less than master-nodes, then some replicas of snapshot-controller always stuck in `Pending`

## Changelog entries

```changes
section: snapshot-controller
type: fix
summary: Reduce amount of replicas for snapshot-controller to a maximum of 2
impact: low
```
