### PR TITLE
[monitoring-kubernetes] node-exporter: parse containerd config

### DIFF
--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_ALPINE_3_15
-FROM $BASE_ALPINE_3_15
+ARG BASE_ALPINE
+FROM $BASE_ALPINE
 ADD "https://storage.googleapis.com/kubernetes-release/release/v1.21.14/bin/linux/amd64/kubectl" /bin/
 ADD "https://github.com/flant/kube-resource-unit-converter/releases/download/0.1/kube-resource-unit-converter" /bin/
 ADD loop /bin/

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_ALPINE
-FROM $BASE_ALPINE
+ARG BASE_ALPINE_3_15
+FROM $BASE_ALPINE_3_15
 ADD "https://storage.googleapis.com/kubernetes-release/release/v1.21.14/bin/linux/amd64/kubectl" /bin/
 ADD "https://github.com/flant/kube-resource-unit-converter/releases/download/0.1/kube-resource-unit-converter" /bin/
 ADD loop /bin/

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -3,5 +3,5 @@ FROM $BASE_ALPINE_3_15
 ADD "https://storage.googleapis.com/kubernetes-release/release/v1.21.14/bin/linux/amd64/kubectl" /bin/
 ADD "https://github.com/flant/kube-resource-unit-converter/releases/download/0.1/kube-resource-unit-converter" /bin/
 ADD loop /bin/
-RUN apk add --no-cache bash grep coreutils curl bc jq dasel && chmod +x /bin/kubectl /bin/kube-resource-unit-converter
+RUN apk add --no-cache bash grep coreutils curl bc jq && chmod +x /bin/kubectl /bin/kube-resource-unit-converter
 ENTRYPOINT ["/bin/loop"]

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -3,5 +3,5 @@ FROM $BASE_ALPINE
 ADD "https://storage.googleapis.com/kubernetes-release/release/v1.20.9/bin/linux/amd64/kubectl" /bin/
 ADD "https://github.com/flant/kube-resource-unit-converter/releases/download/0.1/kube-resource-unit-converter" /bin/
 ADD loop /bin/
-RUN apk add --no-cache bash grep coreutils curl bc jq && chmod +x /bin/kubectl /bin/kube-resource-unit-converter
+RUN apk add --no-cache bash grep coreutils curl bc jq dasel && chmod +x /bin/kubectl /bin/kube-resource-unit-converter
 ENTRYPOINT ["/bin/loop"]

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_ALPINE
 FROM $BASE_ALPINE
-ADD "https://storage.googleapis.com/kubernetes-release/release/v1.20.9/bin/linux/amd64/kubectl" /bin/
+ADD "https://storage.googleapis.com/kubernetes-release/release/v1.21.14/bin/linux/amd64/kubectl" /bin/
 ADD "https://github.com/flant/kube-resource-unit-converter/releases/download/0.1/kube-resource-unit-converter" /bin/
 ADD loop /bin/
 RUN apk add --no-cache bash grep coreutils curl bc jq dasel && chmod +x /bin/kubectl /bin/kube-resource-unit-converter

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/loop
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/loop
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2021 Flant JSC
+# Copyright 2022 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/loop
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/loop
@@ -48,7 +48,11 @@ runtime_root_dir () {
     curl -sS --unix-sock /var/run/docker.sock http://system/info | jq -re '.DockerRootDir'
     ;;
   containerd)
-    dasel -f /var/run/containerd-config.toml '.root' 2>/dev/null || echo "/var/lib/containerd"
+    root_dir="$(grep "^root" /etc/containerd/config.toml | sed "s/ //g"  | sed "s/\"//g" |cut -d"=" -f2)"
+    if [ -z "${root_dir}" ]; then
+      root_dir="/var/lib/containerd"
+    fi
+    echo ${root_dir}
     ;;
   *)
     echo "Unknown container runtime detected: $(runtime). Only \"docker\" and \"containerd\" are supported"

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/loop
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/loop
@@ -30,7 +30,7 @@ runtime_root_dir () {
     curl -sS --unix-sock /var/run/docker.sock http://system/info | jq -re '.DockerRootDir'
     ;;
   containerd)
-    crictl --runtime-endpoint unix:/var/run/containerd/containerd.sock info | jq -r '.config.containerdRootDir'
+    dasel -f /var/run/containerd-config.toml '.root' 2>/dev/null || echo "/var/lib/containerd"
     ;;
   *)
     echo "Unknown container runtime detected: $(runtime). Only \"docker\" and \"containerd\" are supported"

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/loop
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/loop
@@ -16,6 +16,10 @@
 
 set -euf -o pipefail
 
+if [ x"${DEBUG}" == "xtrue" ]; then
+  set -x
+fi
+
 runtime () {
   # We use external binary instead of the option `--request-timeout 60s` because the option does not work in-cluster mode.
   # ref: https://github.com/kubernetes/kubernetes/issues/49343/

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/loop
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/loop
@@ -16,7 +16,7 @@
 
 set -euf -o pipefail
 
-if [ x"${DEBUG}" == "xtrue" ]; then
+if [ x"${DEBUG:-}" == "xtrue" ]; then
   set -x
 fi
 

--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/loop
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/loop
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2021 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -euf -o pipefail
 
 runtime () {

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -87,10 +87,8 @@ spec:
           mountPath: /var/run/node-exporter-textfile
         - name: dockersock
           mountPath: /var/run/docker.sock
-        - name: containerdsock
-          mountPath: /var/run/containerd/containerd.sock
-        - name: crictl
-          mountPath: /usr/local/bin/crictl
+        - name: containerdconfig
+          mountPath: /var/run/containerd-config.toml
         - name: kube
           mountPath: /root/.kube
         resources:
@@ -140,12 +138,10 @@ spec:
       - name: dockersock
         hostPath:
           path: /var/run/docker.sock
-      - name: containerdsock
+      - name: containerdconfig
         hostPath:
-          path: /var/run/containerd/containerd.sock
-      - name: crictl
-        hostPath:
-          path: /usr/local/bin/crictl
+          path: /etc/containerd/config.toml
+          type: FileOrCreate
       - emptyDir:
           medium: Memory
         name: kube

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -88,7 +88,7 @@ spec:
         - name: dockersock
           mountPath: /var/run/docker.sock
         - name: containerdconfig
-          mountPath: /var/run/containerd-config.toml
+          mountPath: /etc/containerd/config.toml
         - name: kube
           mountPath: /root/.kube
         resources:


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Managed clusters (EKS, Yandex, GKE) with deckhouse as module couldn't work with kubelet-eviction-threshold-exporter because they don't have crictl and also socket can have different passes. But all of them have /etc/containerd/config.toml, so we can parse it and extract root direction

## Why do we need it, and what problem does it solve?
kubelet-eviction-threshold-exporter doesn't work in platform managed kubernetes.
```
kubelet-eviction-threshold-exporter /bin/loop: line 33: crictl: command not found      
```

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring-kubernetes
type: fix
summary: Make `kubelet-eviction-threshold-exporter` workable in managed kubernetes platforms (AWS, GKE, Yandex, etc)
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
