### PR TITLE
[cloud-provider-openstack] Support for volume type with spaces in name

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/hooks/discover_volume_types.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/discover_volume_types.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -96,9 +97,9 @@ func getStorageClassName(value string) string {
 			r >= 'A' && r <= 'Z' ||
 			r >= '0' && r <= '9' ||
 			r == '-' || r == '.' {
-			return r
+			return unicode.ToLower(r)
 		}
-		return rune(0)
+		return rune(-1)
 	}
 
 	// a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.'

--- a/ee/modules/030-cloud-provider-openstack/hooks/discover_volume_types.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/discover_volume_types.go
@@ -38,7 +38,7 @@ func handleDiscoverVolumeTypes(input *go_hook.HookInput) error {
 
 	var openstackVolumeTypes []string
 	if os.Getenv("D8_IS_TESTS_ENVIRONMENT") != "" {
-		openstackVolumeTypes = []string{"__DEFAULT__", "some-foo", "bar", "other-bar"}
+		openstackVolumeTypes = []string{"__DEFAULT__", "some-foo", "bar", "other-bar", "SSD R1"}
 	} else {
 		openstackVolumeTypes, err = getVolumeTypesArray()
 		if err != nil {
@@ -49,7 +49,7 @@ func handleDiscoverVolumeTypes(input *go_hook.HookInput) error {
 	storageClassesMap := make(map[string]string, len(openstackVolumeTypes))
 
 	for _, vt := range openstackVolumeTypes {
-		storageClassesMap[strings.ToLower(strings.ReplaceAll(vt, "_", ""))] = vt
+		storageClassesMap[strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(vt, "_", ""), " ", "-"))] = vt
 	}
 
 	excludes, ok := input.Values.GetOk("cloudProviderOpenstack.storageClass.exclude")

--- a/ee/modules/030-cloud-provider-openstack/hooks/discover_volume_types.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/discover_volume_types.go
@@ -39,7 +39,7 @@ func handleDiscoverVolumeTypes(input *go_hook.HookInput) error {
 
 	var openstackVolumeTypes []string
 	if os.Getenv("D8_IS_TESTS_ENVIRONMENT") != "" {
-		openstackVolumeTypes = []string{"__DEFAULT__", "some-foo", "bar", "other-bar", "SSD R1", "-Xx$&? -foo", " YY fast SSD -foo."}
+		openstackVolumeTypes = []string{"__DEFAULT__", "some-foo", "bar", "other-bar", "SSD R1", "-Xx__$()? -foo-", "  YY fast SSD-foo."}
 	} else {
 		openstackVolumeTypes, err = getVolumeTypesArray()
 		if err != nil {
@@ -98,6 +98,8 @@ func getStorageClassName(value string) string {
 			r >= '0' && r <= '9' ||
 			r == '-' || r == '.' {
 			return unicode.ToLower(r)
+		} else if r == ' ' {
+			return '-'
 		}
 		return rune(-1)
 	}

--- a/ee/modules/030-cloud-provider-openstack/hooks/discover_volume_types_test.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/discover_volume_types_test.go
@@ -74,12 +74,12 @@ cloudProviderOpenstack:
 	"type": "SSD R1"
   },
   {
-	"name": "xx-foo",
-	"type": "-Xx$&? -foo"
+	"name": "xx--foo",
+	"type": "-Xx__$()? -foo-"
   },
   {
-	"name": "yyfastssd-foo",
-	"type": " YY fast SSD -foo"
+	"name": "yy-fast-ssd-foo",
+	"type": "  YY fast SSD-foo."
   }
 ]
 `))

--- a/ee/modules/030-cloud-provider-openstack/hooks/discover_volume_types_test.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/discover_volume_types_test.go
@@ -72,6 +72,14 @@ cloudProviderOpenstack:
   {
 	"name": "ssd-r1",
 	"type": "SSD R1"
+  },
+  {
+	"name": "xx-foo",
+	"type": "-Xx$&? -foo"
+  },
+  {
+	"name": "yyfastssd-foo",
+	"type": " YY fast SSD -foo"
   }
 ]
 `))

--- a/ee/modules/030-cloud-provider-openstack/hooks/discover_volume_types_test.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/discover_volume_types_test.go
@@ -99,6 +99,10 @@ cloudProviderOpenstack:
   {
 	"name": "other-bar",
 	"type": "other-bar"
+  },
+  {
+	"name": "ssd-r1",
+	"type": "SSD R1"
   }
 ]
 `))

--- a/ee/modules/030-cloud-provider-openstack/hooks/discover_volume_types_test.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/discover_volume_types_test.go
@@ -68,6 +68,10 @@ cloudProviderOpenstack:
   {
 	"name": "some-foo",
 	"type": "some-foo"
+  },
+  {
+	"name": "ssd-r1",
+	"type": "SSD R1"
   }
 ]
 `))


### PR DESCRIPTION
Signed-off-by: Konstantin Aksenov <konstantin.aksenov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
If volume type name has spaces, replace spaces with dashes for StorageClass name

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Some OpenStack clouds have volumes with spaces in names
```
+--------------------------------------+---------+-----------+
| ID                                   | Name    | Is Public |
+--------------------------------------+---------+-----------+
| bb49fb86-7279-44ed-ae1f-7a55e1771754 | SSD R1  | True      |
```
For such volume type name Deckhouse tries to create StorageClass with name `ssd r1` but this is forbidden.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-openstack
type: fix
summary: Support for volume type with spaces in name
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
