### PR TITLE
[cilium-hubble] hook for copying custom cert

### DIFF
--- a/modules/500-cilium-hubble/hooks/https/copy_custom_certificate.go
+++ b/modules/500-cilium-hubble/hooks/https/copy_custom_certificate.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2021 Flant CJSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/deckhouse/deckhouse/go_lib/hooks/copy_custom_certificate"
+)
+
+var _ = copy_custom_certificate.RegisterHook("ciliumHubble")

--- a/modules/500-cilium-hubble/hooks/https/delete_not_matching_certificate_secret.go
+++ b/modules/500-cilium-hubble/hooks/https/delete_not_matching_certificate_secret.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2021 Flant CJSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import "github.com/deckhouse/deckhouse/go_lib/hooks/delete_not_matching_certificate_secret"
+
+var _ = delete_not_matching_certificate_secret.RegisterHook("ciliumHubble", "d8-cni-cilium")


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Copy custom certificate for ingress resources

## Why do we need it, and what problem does it solve?
Template respects custom certificate but it's not copied

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cilium-hubble
type: fix 
summary: copy custom certificate into d8-cni-cilium is used
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
