### PR TITLE
[helm] Fix release namespace detection and add helm_version to metric

### DIFF
--- a/modules/013-helm/hooks/metrics.go
+++ b/modules/013-helm/hooks/metrics.go
@@ -196,6 +196,8 @@ func getHelm3Releases(ctx context.Context, client k8s.Client, releasesC chan<- *
 			if err != nil {
 				return 0, err
 			}
+			// release can contains wrong namespace (set by helm and werf) and confuse user wit hwrong metric
+			// fetch namespace from secret is more reliable
 			release.Namespace = secret.Namespace
 			release.HelmVersion = "3"
 
@@ -238,6 +240,8 @@ func getHelm2Releases(ctx context.Context, client k8s.Client, releasesC chan<- *
 			if err != nil {
 				return 0, err
 			}
+			// release can contains wrong namespace (set by helm and werf) and confuse user wit hwrong metric
+			// fetch namespace from secret is more reliable
 			release.Namespace = secret.Namespace
 			release.HelmVersion = "2"
 

--- a/modules/013-helm/hooks/metrics.go
+++ b/modules/013-helm/hooks/metrics.go
@@ -296,7 +296,7 @@ type release struct {
 	Manifest  string `json:"manifest,omitempty" protobuf:"bytes,5,opt,name=manifest,proto3"`
 
 	// set helm version manually
-	HelmVersion string
+	HelmVersion string `json:"-"`
 }
 
 type manifest struct {

--- a/modules/013-helm/hooks/metrics.go
+++ b/modules/013-helm/hooks/metrics.go
@@ -65,6 +65,9 @@ const unsupportedVersionsYAML = `
   "networking.k8s.io/v1beta1": ["Ingress"]
   "extensions/v1beta1": ["Ingress"]
 
+"1.24":
+  "snapshot.storage.k8s.io/v1beta1": ["VolumeSnapshot"]
+
 "1.25":
   "batch/v1beta1": ["CronJob"]
   "discovery.k8s.io/v1beta1": ["EndpointSlice"]
@@ -193,6 +196,8 @@ func getHelm3Releases(ctx context.Context, client k8s.Client, releasesC chan<- *
 			if err != nil {
 				return 0, err
 			}
+			release.Namespace = secret.Namespace
+			release.HelmVersion = "3"
 
 			releasesC <- release
 			totalReleases++
@@ -233,6 +238,8 @@ func getHelm2Releases(ctx context.Context, client k8s.Client, releasesC chan<- *
 			if err != nil {
 				return 0, err
 			}
+			release.Namespace = secret.Namespace
+			release.HelmVersion = "2"
 
 			releasesC <- release
 			totalReleases++
@@ -270,6 +277,7 @@ func runReleaseProcessor(k8sCurrentVersion *semver.Version, input *go_hook.HookI
 				input.MetricsCollector.Set("resource_versions_compatibility", float64(incompatibility), map[string]string{
 					"helm_release_name":      rel.Name,
 					"helm_release_namespace": rel.Namespace,
+					"helm_version":           rel.HelmVersion,
 					"k8s_version":            k8sCompatibilityVersion,
 					"resource_name":          resource.Metadata.Name,
 					"resource_namespace":     resource.Metadata.Namespace,
@@ -285,7 +293,10 @@ func runReleaseProcessor(k8sCurrentVersion *semver.Version, input *go_hook.HookI
 type release struct {
 	Name      string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name,proto3"`
 	Namespace string `json:"namespace,omitempty" protobuf:"bytes,8,opt,name=namespace,proto3"`
-	Manifest  string `json:"manifest,omitempty" protobuf:"bytes,5,opt,name=manifest,proto3" `
+	Manifest  string `json:"manifest,omitempty" protobuf:"bytes,5,opt,name=manifest,proto3"`
+
+	// set helm version manually
+	HelmVersion string
 }
 
 type manifest struct {

--- a/modules/013-helm/hooks/metrics_test.go
+++ b/modules/013-helm/hooks/metrics_test.go
@@ -67,6 +67,7 @@ var _ = Describe("helm :: hooks :: deprecated_versions ::", func() {
 					case "resource_versions_compatibility":
 						Expect(*metric.Value).To(Equal(float64(1))) // 1 means deprecated
 						Expect(metric.Labels["k8s_version"]).To(Equal("1.22"))
+						Expect(metric.Labels["helm_release_namespace"]).To(Equal("appns")) // we check namespace injection, because the release contains 'defau;t' namespace
 
 						switch metric.Labels["api_version"] {
 						case "networking.k8s.io/v1beta1":

--- a/modules/013-helm/hooks/startup_metrics.go
+++ b/modules/013-helm/hooks/startup_metrics.go
@@ -61,6 +61,7 @@ func handleDeprecatedAPIStartup(input *go_hook.HookInput, dc dependency.Containe
 		input.MetricsCollector.Set("resource_versions_compatibility", value, map[string]string{
 			"helm_release_name":      metricRecord.Metric.HelmReleaseName,
 			"helm_release_namespace": metricRecord.Metric.HelmReleaseNamespace,
+			"helm_version":           metricRecord.Metric.HelmVersion,
 			"k8s_version":            metricRecord.Metric.K8sVersion,
 			"resource_name":          metricRecord.Metric.ResourceName,
 			"resource_namespace":     metricRecord.Metric.ResourceNamespace,
@@ -109,6 +110,7 @@ type promMetrics struct {
 				Kind                 string `json:"kind"`
 				HelmReleaseName      string `json:"helm_release_name"`
 				HelmReleaseNamespace string `json:"helm_release_namespace"`
+				HelmVersion          string `json:"helm_version"`
 				K8sVersion           string `json:"k8s_version"`
 				ResourceName         string `json:"resource_name"`
 				ResourceNamespace    string `json:"resource_namespace"`

--- a/modules/013-helm/monitoring/prometheus-rules/deprecated-versions.yaml
+++ b/modules/013-helm/monitoring/prometheus-rules/deprecated-versions.yaml
@@ -14,7 +14,7 @@
       plk_group_for__helm_release_resource_versions_deprecated: HelmReleaseHasResourcesWithDeprecatedVersions,prometheus=deckhouse
       summary: At least one HELM release contains resources with deprecated apiVersion, which will be removed in Kubernetes v{{ $labels.k8s_version }}.
       description: |
-        To observe all resources use the expr `max by (helm_release_namespace, helm_release_name, resource_namespace, resource_name, api_version, kind, k8s_version) (resource_versions_compatibility) == 1` in Prometheus.
+        To observe all resources use the expr `max by (helm_release_namespace, helm_release_name, helm_version, resource_namespace, resource_name, api_version, kind, k8s_version) (resource_versions_compatibility) == 1` in Prometheus.
 
         You can find more details for migration in the deprecation guide: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v{{ $labels.k8s_version | reReplaceAll "\\." "-" }}.
 
@@ -33,6 +33,6 @@
       summary:
         At least one HELM release contains resources with unsupported apiVersion for Kubernetes v{{ $labels.k8s_version }}.
       description: |
-        To observe all resources use the expr `max by (helm_release_namespace, helm_release_name, resource_namespace, resource_name, api_version, kind, k8s_version) (resource_versions_compatibility) == 2` in Prometheus.
+        To observe all resources use the expr `max by (helm_release_namespace, helm_release_name, helm_version, resource_namespace, resource_name, api_version, kind, k8s_version) (resource_versions_compatibility) == 2` in Prometheus.
 
         You can find more details for migration in the deprecation guide: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v{{ $labels.k8s_version | reReplaceAll "\\." "-" }}.


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Fix release namespace detection.
Add helm_version to the metric.
Add 1.24 k8s unsupported APIs.

## Why do we need it, and what problem does it solve?
Helm release namespace unmarshalling from resource sometimes gives wierd results. Getting namespace from secret/cm is more predictable.
Adding `helm_version` value to metrics makes the process of figuring out a deprecated release easier.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: helm
type: fix 
summary: Fix namespace detection for helm releases with unsupported/deprecated resources.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
