### PR TITLE
[ingress-nginx] Refactor startup hook

### DIFF
--- a/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version.go
+++ b/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// this hook figure out minimal ingress controller version at the beginning and on IngressNginxController creation
+// Deckhouse would not update minor version before pod is ready, so this hook will execute at least once (on sync)
+
 package hooks
 
 import (
@@ -19,16 +22,19 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	OnStartup: &go_hook.OrderedConfig{Order: 20},
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
-			Name:       "ingressControllers",
-			ApiVersion: "deckhouse.io/v1",
-			Kind:       "IngressNginxController",
-			FilterFunc: applySpecControllerFilter,
+			Name:                         "ingressControllers",
+			ApiVersion:                   "deckhouse.io/v1",
+			Kind:                         "IngressNginxController",
+			WaitForSynchronization:       pointer.BoolPtr(true),
+			ExecuteHookOnEvents:          pointer.BoolPtr(true),
+			ExecuteHookOnSynchronization: pointer.BoolPtr(true),
+			FilterFunc:                   applySpecControllerFilter,
 		},
 	},
 }, discoverMinimalNginxVersion)

--- a/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version.go
+++ b/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // this hook figure out minimal ingress controller version at the beginning and on IngressNginxController creation
+// this version is used on requirements check on Deckhouse update
 // Deckhouse would not update minor version before pod is ready, so this hook will execute at least once (on sync)
 
 package hooks


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Refactor startup hook, use kubeclient instead of snapshots

## Why do we need it, and what problem does it solve?
Snopshots don't work at startup phase. We have an extra run of the hook without any usefulness

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ingress-nginx
type: fix
summary: Refactor startup hook
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
