### PR TITLE
[upmeter] Fix duplicating groups in alerting rules

### DIFF
--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -433,8 +433,6 @@
 
           The list of PVs: `kubectl get pv | grep disk-smoke-mini`.
 
-- name: d8.upmeter.resources
-  rules:
     - alert: D8UpmeterProbeGarbageSecretsByCertManager
       expr: |
         (


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Fix duplicating group in alerting rules.

## Why do we need it, and what problem does it solve?
Fix error:
```
level=info ts=2022-06-28T14:09:25.981513368Z caller=rules.go:340 component=prometheusoperator msg="Invalid rule" err="424:3: groupname: \"d8.upmeter.resources\" is repeated in the same file"
level=error ts=2022-06-28T14:09:25.981577258Z caller=klog.go:116 component=k8s_client_runtime func=ErrorDepth msg="sync \"d8-monitoring/main\" failed: Invalid rule"
```

## Changelog entries

```changes
section: upmeter
type: fix
summary: Fix duplicating groups in alerting rules
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
