### PR TITLE
[ingress-nginx] Delete ingressClass objects on ingress migration to > 1.0

### DIFF
--- a/modules/402-ingress-nginx/hooks/migrate_ingress_class.go
+++ b/modules/402-ingress-nginx/hooks/migrate_ingress_class.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	v1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+)
+
+// migration from 0.33 to 1.1 have to change ingress class but it's controller field is immutable
+// we have to handle this situation manually - delete old IngressClass resources
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 30},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                         "ingressClasses",
+			ApiVersion:                   "networking.k8s.io/v1",
+			Kind:                         "IngressClass",
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"heritage": "deckhouse",
+					"module":   "ingress-nginx",
+				}},
+			FilterFunc: applyIngressClassFilter,
+		},
+	},
+}, handleIngressClasses)
+
+func applyIngressClassFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var ic v1.IngressClass
+
+	err := sdk.FromUnstructured(obj, &ic)
+	if err != nil {
+		return nil, err
+	}
+
+	return d8IngressClass{
+		Name:       ic.Name,
+		Controller: ic.Spec.Controller,
+	}, nil
+}
+
+func handleIngressClasses(input *go_hook.HookInput) error {
+	snap := input.Snapshots["ingressClasses"]
+	if len(snap) == 0 {
+		return nil
+	}
+
+	existingClasses := make(map[string]string, len(snap))
+	for _, s := range snap {
+		class := s.(d8IngressClass)
+		existingClasses[class.Name] = class.Controller
+	}
+
+	conArray := input.Values.Get("ingressNginx.internal.ingressControllers").Array()
+	edgeVersion, _ := semver.NewVersion("v1.0.0")
+
+	for _, con := range conArray {
+		var controller Controller
+
+		err := json.Unmarshal([]byte(con.String()), &controller)
+		if err != nil {
+			return err
+		}
+
+		controllerName := "k8s.io/ingress-nginx"
+
+		ingressClass, _, err := unstructured.NestedString(controller.Spec, "ingressClass")
+		if err != nil {
+			return err
+		}
+
+		version, ok, err := unstructured.NestedString(controller.Spec, "controllerVersion")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			version = input.Values.Get("ingressNginx.defaultControllerVersion").String()
+		}
+		semV := semver.MustParse(version)
+		if semV.GreaterThan(edgeVersion) {
+			controllerName = fmt.Sprintf("ingress-nginx.deckhouse.io/%s", ingressClass)
+		}
+
+		existingController, ok := existingClasses[ingressClass]
+		if !ok {
+			continue
+		}
+
+		if existingController != controllerName {
+			input.PatchCollector.Delete("networking.k8s.io/v1", "IngressClass", "", ingressClass)
+		}
+	}
+
+	return nil
+}
+
+type d8IngressClass struct {
+	Name       string
+	Controller string
+}

--- a/modules/402-ingress-nginx/hooks/migrate_ingress_class_test.go
+++ b/modules/402-ingress-nginx/hooks/migrate_ingress_class_test.go
@@ -1,0 +1,156 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Global hooks :: discovery :: minimal_ingress_version ", func() {
+	initValuesString := `{"ingressNginx":{"defaultControllerVersion": "0.33", "internal": {"ingressControllers": []}}}`
+	globalValuesString := `{}`
+	f := HookExecutionConfigInit(initValuesString, globalValuesString)
+	f.RegisterCRD("deckhouse.io", "v1", "IngressNginxController", false)
+
+	Context("No existing ingress classes", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("ingressNginx.internal.ingressControllers", []byte(`
+[
+	{
+		"name": "test",
+		"spec": {
+		  "ingressClass": "nginx",
+		  "controllerVersion": "0.33"
+		}
+	}
+]
+`))
+			f.KubeStateSet("")
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should run successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+
+	Context("Cluster has up to date IngressClass", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("ingressNginx.internal.ingressControllers", []byte(`
+[
+	{
+		"name": "test",
+		"spec": {
+		  "ingressClass": "nginx",
+		  "controllerVersion": "0.33"
+		}
+	}
+]
+`))
+			f.KubeStateSet(`
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    heritage: deckhouse
+    module: ingress-nginx
+  name: nginx
+spec:
+  controller: k8s.io/ingress-nginx
+`)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should have kept IngressClass", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ingC := f.KubernetesGlobalResource("IngressClass", "nginx")
+			Expect(ingC.Exists()).To(BeTrue())
+		})
+	})
+
+	Context("Cluster has outdated IngressClass", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("ingressNginx.internal.ingressControllers", []byte(`
+[
+	{
+		"name": "test",
+		"spec": {
+		  "ingressClass": "nginx",
+		  "controllerVersion": "1.1"
+		}
+	}
+]
+`))
+			f.KubeStateSet(`
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    heritage: deckhouse
+    module: ingress-nginx
+  name: nginx
+spec:
+  controller: k8s.io/ingress-nginx
+`)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should delete IngressClass", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ingC := f.KubernetesGlobalResource("IngressClass", "nginx")
+			Expect(ingC.Exists()).To(BeFalse())
+		})
+	})
+
+	Context("controller version not set. Rollback to 0.33", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("ingressNginx.internal.ingressControllers", []byte(`
+[
+	{
+		"name": "test",
+		"spec": {
+		  "ingressClass": "nginx"
+		}
+	}
+]
+`))
+			f.KubeStateSet(`
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    heritage: deckhouse
+    module: ingress-nginx
+  name: nginx
+spec:
+  controller: ingress-nginx.deckhouse.io/nginx
+`)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Should delete IngressClass", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			ingC := f.KubernetesGlobalResource("IngressClass", "nginx")
+			Expect(ingC.Exists()).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Delete IngressClass object when we migrate from controller < 1.0 to controller > 1.0 version

## Why do we need it, and what problem does it solve?
IngressClassesfor controller > 1.0 and < 1.0 have different controller spec field. This field is immutable, so we have to delete all this object and recreate it. Without this hook D8 will stuck if you just edit the version of a IngressNginxController

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ingress-nginx
type: fix 
summary: Handle IngressClass resources when migrating from controller < 1.0 version to > 1.0 version
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
