### PR TITLE
[monitoring-kubernetes] handle absent containerd directory

### DIFF
--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -87,6 +87,8 @@ spec:
           mountPath: /var/run/node-exporter-textfile
         - name: dockersock
           mountPath: /var/run/docker.sock
+        - name: containerddir
+          mountPath: /etc/containerd
         - name: containerdconfig
           mountPath: /etc/containerd/config.toml
         - name: kube
@@ -138,6 +140,10 @@ spec:
       - name: dockersock
         hostPath:
           path: /var/run/docker.sock
+      - name: containerddir
+        hostPath:
+          path: /etc/containerd
+          type: DirectoryOrCreate
       - name: containerdconfig
         hostPath:
           path: /etc/containerd/config.toml

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -89,8 +89,6 @@ spec:
           mountPath: /var/run/docker.sock
         - name: containerddir
           mountPath: /etc/containerd
-        - name: containerdconfig
-          mountPath: /etc/containerd/config.toml
         - name: kube
           mountPath: /root/.kube
         resources:
@@ -144,10 +142,6 @@ spec:
         hostPath:
           path: /etc/containerd
           type: DirectoryOrCreate
-      - name: containerdconfig
-        hostPath:
-          path: /etc/containerd/config.toml
-          type: FileOrCreate
       - emptyDir:
           medium: Memory
         name: kube


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Create containerd directory if it does not exist.

## Why do we need it, and what problem does it solve?
Pod could run if host does not contain containerd directory (docker runtime for example). FileOrCreate does not create parent directory

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring-kubernetes
type: fix 
summary: Fixed handling absent containerd directory
```
