### PR TITLE
[chrony] Refactor alerts

### DIFF
--- a/modules/470-chrony/monitoring/prometheus-rules/chrony.yaml
+++ b/modules/470-chrony/monitoring/prometheus-rules/chrony.yaml
@@ -4,8 +4,8 @@
     expr: abs(node_ntp_offset_seconds)
 
   - alert: NTPDaemonOnNodeDoesNotSynchronizeTime
-    expr: (min by (node) (node_ntp_sanity)) == 0
-    for: 2h
+    expr: (min by (node) (node_timex_sync_status)) == 0
+    for: 30m
     labels:
       severity_level: "5"
       tier: cluster
@@ -25,8 +25,8 @@
       summary: NTP daemon on node {{$labels.node}} have not synchronized time for too long.
 
   - alert: NodeTimeOutOfSync
-    expr: max by (node) (abs(node_time_seconds - timestamp(node_time_seconds)) > 10)
-    for: 5m
+    expr: abs(node_ntp_offset_seconds:abs - (node_ntp_rtt_seconds/2)) > 0.05
+    for: 30m
     labels:
       severity_level: "5"
       tier: cluster
@@ -34,5 +34,5 @@
       plk_protocol_version: "1"
       plk_markup_format: markdown
       description: |
-        Node's {{$labels.node}} time is out of sync from Prometheus Node by {{ $value }} seconds.
+        Node's {{$labels.node}} time is out of sync from ntp server by {{ $value }} seconds.
       summary: Node's {{$labels.node}} clock is drifting.


### PR DESCRIPTION
Signed-off-by: Konstantin Aksenov <konstantin.aksenov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- Replace metric `node_ntp_sanity metrics` with `node_timex_sync_status`
- Calculate node's clock drift using metric `node_ntp_offset_seconds`
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Alert `NTPDaemonOnNodeDoesNotSynchronizeTime` was triggered if difference between node time and chrony server time was bigger than 1ms. But chrony doesn't act as ntpd that just instantly corrects time.

> In normal operation, chronyd slews the time when it needs to adjust the system clock. For example, to correct a system clock which is 1 second slow, chronyd slightly increases the amount by which the system clock is advanced on each clock interrupt, until the error is removed. Note that at no time does time run backwards with this method.
> On most Unix systems it is not desirable to step the system clock, because many programs rely on time advancing monotonically forwards.
> When the chronyd daemon is initially started, it is possible that the system clock is considerably in error. Attempting to correct such an error by slewing might not be sensible, since it might take several hours to correct the error by this means.

Instead of it, we just check that chrony is working using metric `node_timex_sync_status`. And to check the results of chrony work, we check `node_ntp_offset_seconds` in NodeTimeOutOfSync alert.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: chrony
type: fix
summary: Refactored alerts.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
