### PR TITLE
[log-shipper] Fix DaemonSet alerts

### DIFF
--- a/helm_lib/templates/_node_affinity.tpl
+++ b/helm_lib/templates/_node_affinity.tpl
@@ -76,6 +76,8 @@ nodeSelector:
   operator: "Exists"
 - key: dedicated
   operator: "Exists"
+- key: ToBeDeletedByClusterAutoscaler
+  operator: "Exists"
 {{ include "helm_lib_internal_node_problems_tolerations" . }}
   {{- if .Values.global.modules.placement.customTolerationKeys }}
     {{- range $key := .Values.global.modules.placement.customTolerationKeys }}

--- a/helm_lib/templates/_node_affinity.tpl
+++ b/helm_lib/templates/_node_affinity.tpl
@@ -77,7 +77,6 @@ nodeSelector:
 - key: dedicated
   operator: "Exists"
 - key: ToBeDeletedByClusterAutoscaler
-  operator: "Exists"
 {{ include "helm_lib_internal_node_problems_tolerations" . }}
   {{- if .Values.global.modules.placement.customTolerationKeys }}
     {{- range $key := .Values.global.modules.placement.customTolerationKeys }}

--- a/modules/101-cert-manager/template_tests/module_test.go
+++ b/modules/101-cert-manager/template_tests/module_test.go
@@ -191,6 +191,7 @@ var _ = Describe("Module :: cert-manager :: helm template ::", func() {
   operator: Exists
 - key: dedicated
   operator: Exists
+- key: ToBeDeletedByClusterAutoscaler
 - key: node.kubernetes.io/not-ready
 - key: node.kubernetes.io/out-of-disk
 - key: node.kubernetes.io/memory-pressure
@@ -242,6 +243,7 @@ var _ = Describe("Module :: cert-manager :: helm template ::", func() {
   operator: Exists
 - key: dedicated
   operator: Exists
+- key: ToBeDeletedByClusterAutoscaler
 - key: node.kubernetes.io/not-ready
 - key: node.kubernetes.io/out-of-disk
 - key: node.kubernetes.io/memory-pressure
@@ -316,6 +318,7 @@ podAntiAffinity:
   operator: Exists
 - key: dedicated
   operator: Exists
+- key: ToBeDeletedByClusterAutoscaler
 - key: node.kubernetes.io/not-ready
 - key: node.kubernetes.io/out-of-disk
 - key: node.kubernetes.io/memory-pressure
@@ -367,6 +370,7 @@ podAntiAffinity:
   operator: Exists
 - key: dedicated
   operator: Exists
+- key: ToBeDeletedByClusterAutoscaler
 - key: node.kubernetes.io/not-ready
 - key: node.kubernetes.io/out-of-disk
 - key: node.kubernetes.io/memory-pressure

--- a/modules/460-log-shipper/monitoring/prometheus-rules/log-shipper-agent.yaml
+++ b/modules/460-log-shipper/monitoring/prometheus-rules/log-shipper-agent.yaml
@@ -1,29 +1,12 @@
 - name: log-shipper-agent
   rules:
-  - alert: D8LogShipperNotScheduledOnNode
-    # The second part of this query counts how many nodes that allowed to not contain a daemonset pod are in the cluster.
-    # Alert will be fired if there are more nodes without vector pods than allowed.
-    expr: |
-      (
-        (
-          max by (node) (kube_node_info)
-          unless
-          max by (node) (up{job="log-shipper-agent"})
-        )
-        *
-        scalar(
-          (
-            sum(
-              max by (node) (kube_node_info)
-              unless
-              max by (node) (up{job="log-shipper-agent"})
-            )
-            >
-            sum(kube_node_info) - sum(kube_daemonset_status_desired_number_scheduled{daemonset="log-shipper-agent", namespace="d8-log-shipper"})
-          ) or vector(0)
-        )
-      ) > 0
+  - alert: D8LogShipperAgentNotScheduledInCluster
     for: 15m
+    expr: |
+      kube_daemonset_status_desired_number_scheduled{daemonset="log-shipper-agent", namespace="d8-log-shipper", job="kube-state-metrics"}
+      -
+      kube_daemonset_status_current_number_scheduled{daemonset="log-shipper-agent", namespace="d8-log-shipper", job="kube-state-metrics"}
+      > 0
     labels:
       severity_level: "7"
       d8_module: log-shipper
@@ -31,25 +14,9 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      summary: The log-shipper-agent Pod cannot schedule on Node {{ $labels.node }}
+      summary: Pods of log-shipper-agent cannot be scheduled in the cluster.
       description: |
-        The log-shipper-agent Pod cannot schedule on Node {{ $labels.node }}.
+        A number of log-shipper-agents are not scheduled.
 
         Consider checking state of the d8-log-shipper/log-shipper-agent DaemonSet.
         `kubectl -n d8-log-shipper get daemonset,pod --selector=app=log-shipper-agent`
-
-  - alert: D8LogShipperAgentNotScheduledInCluster
-    expr: |
-      count(ALERTS{alertname="D8LogShipperNotScheduledOnNode"}) > 1
-    labels:
-      d8_module: log-shipper
-      d8_component: agent
-    annotations:
-      plk_protocol_version: "1"
-      plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_log_shipper_not_scheduled_on_node: "D8LogShipperNotScheduledOnNode,prometheus=deckhouse,d8_module=log-shipper,d8_component=agent"
-      plk_group_for__d8_log_shipper_not_scheduled_on_node: "D8LogShipperNotScheduledOnNode,prometheus=deckhouse"
-      summary: Pods of log-shipper-agent cannot be scheduled in the cluster
-      description: |
-        Pods of log-shipper-agent cannot be scheduled in the cluster.
-        Additional information can be found in linked alerts.

--- a/modules/460-log-shipper/templates/daemonset.yaml
+++ b/modules/460-log-shipper/templates/daemonset.yaml
@@ -62,7 +62,7 @@ spec:
       {{- else }}
         {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- end }}
-      {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
+      {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       containers:
         - name: vector

--- a/modules/460-log-shipper/templates/namespace.yaml
+++ b/modules/460-log-shipper/templates/namespace.yaml
@@ -4,5 +4,3 @@ kind: Namespace
 metadata:
   name: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
-  annotations:
-    extended-monitoring.flant.com/enabled: ""


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
* Tolerate ToBeDeletedByClusterAutoscaler for all nodes strategy
* Change the logic of log-shipper alerts
* Remove the extended monitoring annotation from the log-shipper namespace to avoid duplicated alerts

## Why do we need it, and what problem does it solve?
1. The log-shipper module has the node selector property. It means not all nodes in the cluster carry log-shipper agents.
2. New alert uses DamonSet status data, which is more accurate and filled by Kubernetes. Kubernetes knows, that a node has tainted and should not carry a pod.
3.  ToBeDeletedByClusterAutoscaler should also be tolerated because if a system pod is restarted accidentally, it will not be able to schedule on a node back.
4. All monitoring components have the cluster-medium priority class. The log-shipper agents had the cluster-low priority class, which led to its evictions sometimes.

## What is the expected result?
Some components in kube-system and d8-system namespaces will be restarted.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: log-shipper
type: fix
summary: Fix DaemonSet alerts
impact_level: default
---
section: modules
type: fix
summary: Tolerate evictions for cluster components on node scaling
impact: All controllers with the all-node toleration strategy (master node components, system daemonsets) will be restarted.
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
