### PR TITLE
[deckhouse-controller] fix: 'already started' error on container restart

### DIFF
--- a/deckhouse-controller/entrypoint.sh
+++ b/deckhouse-controller/entrypoint.sh
@@ -17,12 +17,6 @@
 set -o pipefail
 set -e
 
-# Prevent starting another instance.
-if [[ -n "$DEBUG_UNIX_SOCKET" && -e "$DEBUG_UNIX_SOCKET" ]] ; then
-  echo "deckhouse-controller already started"
-  exit 1
-fi
-
 declare -A bundles_map; bundles_map=( ["Default"]="default" ["Minimal"]="minimal" ["Managed"]="managed" )
 
 bundle=${DECKHOUSE_BUNDLE:-Default}


### PR DESCRIPTION
## Description

Remove precautions from entrypoint.sh to make it compatible with container restarts.

## Why do we need it, and what problem does it solve?

Socket file checking precaution not works properly on container restart. Previous deckhouse-controller execution left UNIX socket file and deploy/deckhouse hangs in CrashLoopBack state.

## What is the expected result?

1. Edit cm/deckhouse with error config values
2. Restart deploy/deckhouse
3. Run kubectl -n d8-system logs deploy/deckhouse
4. Currently it will print a single line "deckhouse-controller is already started"
5. With changes it should print error about config values.

<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse-controller
type: fix
summary: Remove precautions from entrypoint.sh to make it compatible with container restarts.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
