### PR TITLE
[node-manager] Fix unbound variable bootstrap_job_log_pid when bootstrap static-node

### DIFF
--- a/modules/040-node-manager/templates/node-group/_bootstrap_script.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap_script.tpl
@@ -1,4 +1,5 @@
 {{- define "node_group_bashible_bootstrap_script" -}}
+  bootstrap_job_log_pid=""
   {{- $context := . -}}
 
   {{- include "node_group_bashible_bootstrap_script_base_bootstrap" $context }}
@@ -38,7 +39,6 @@ while [ "$patch_pending" = true ] ; do
 done
 
 # Start output bootstrap logs
-bootstrap_job_log_pid=""
 if type socat >/dev/null 2>&1; then
   socat -u FILE:/var/log/cloud-init-output.log,ignoreeof TCP4-LISTEN:8000,fork,reuseaddr &
   bootstrap_job_log_pid=$!
@@ -58,8 +58,8 @@ until /var/lib/bashible/bashible.sh; do
 done;
 
 # Stop output bootstrap logs
-if [ -n "$bootstrap_job_log_pid" ] && kill -s 0 "$bootstrap_job_log_pid" 2>/dev/null; then
-  kill -9 "$bootstrap_job_log_pid"
+if [ -n "${bootstrap_job_log_pid-}" ] && kill -s 0 "${bootstrap_job_log_pid-}" 2>/dev/null; then
+  kill -9 "${bootstrap_job_log_pid-}"
 fi
 
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Fix unbound variable bootstrap_job_log_pid when bootstrap static-node

## Why do we need it, and what problem does it solve?
Fix error while bootstrap static node:
```
/var/lib/bashible/bootstrap.sh: line 255: bootstrap_job_log_pid: unbound variable
```

and node can not reboot

## What is the expected result?
Node MUST reboot after bootstrap static-node if kernel was installed.
Error `/var/lib/bashible/bootstrap.sh: line 255: bootstrap_job_log_pid: unbound variable` must gone when bootstrap static-node.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Fix unbound variable bootstrap_job_log_pid when bootstrap static-node
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
