### PR TITLE
[docs] Update Makefile for building documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ FOCUS=""
 
 MDLINTER_IMAGE = ghcr.io/igorshubovych/markdownlint-cli@sha256:2e22b4979347f70e0768e3fef1a459578b75d7966e4b1a6500712b05c5139476
 
+# Explicitly set architecture on arm, since werf currently does not support building of images for any other platform
+# besides linux/amd64 (e.g. relevant for mac m1).
 PLATFORM_NAME := $(shell uname -p)
 ifneq ($(filter arm%,$(PLATFORM_NAME)),)
 	export WERF_PLATFORM=linux/amd64

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ FOCUS=""
 
 MDLINTER_IMAGE = ghcr.io/igorshubovych/markdownlint-cli@sha256:2e22b4979347f70e0768e3fef1a459578b75d7966e4b1a6500712b05c5139476
 
+PLATFORM_NAME := $(shell uname -p)
+ifneq ($(filter arm%,$(PLATFORM_NAME)),)
+	export WERF_PLATFORM=linux/amd64
+endif
+
 help:
 	@printf -- "${FORMATTING_BEGIN_BLUE}%s${FORMATTING_END}\n" \
 	"" \
@@ -110,3 +115,23 @@ cve-report: ## Generate CVE report for a Deckhouse release.
 cve-base-images: ## Check CVE in our base images.
   ##~ Options: SEVERITY=CRITICAL,HIGH
 	./tools/cve/base-images.sh
+
+##@ Documentation
+
+.PHONY: docs
+docs: ## Run containers with the documentation (werf is required to build the containers).
+	docker network inspect deckhouse 2>/dev/null 1>/dev/null || docker network create deckhouse
+	cd docs/documentation/; werf compose up --docker-compose-command-options='-d' --env local
+	cd docs/site/; werf compose up --docker-compose-command-options='-d' --env local
+	echo "Open http://localhost to access the documentation..."
+
+.PHONY: docs-dev
+docs-dev: ## Run containers with the documentation in the dev mode (allow uncommited files).
+	docker network inspect deckhouse 2>/dev/null 1>/dev/null || docker network create deckhouse
+	cd docs/documentation/; werf compose up --docker-compose-command-options='-d' --dev --env development
+	cd docs/site/; werf compose up --docker-compose-command-options='-d' --dev --env development
+	echo "Open http://localhost to access the documentation..."
+
+.PHONY: docs-down
+docs-down: ## Stop all the documentation containers.
+	docker rm -f site_site_1 site_front_1 documentation; docker network rm deckhouse

--- a/docs/documentation/Makefile
+++ b/docs/documentation/Makefile
@@ -1,19 +1,18 @@
-export BASE_NGINX_ALPINE=nginx:1.15.12-alpine@sha256:57a226fb6ab6823027c0704a9346a890ffb0cacde06bc19bbc234c8720673555
-export BASE_ALPINE=alpine:3.12.1@sha256:c0e9560cda118f9ec63ddefb4a173a2b2a0347082d7dff7dc14272e7841a5b5a
-export BASE_GOLANG_16_ALPINE=golang:1.16.3-alpine3.12@sha256:371dc6bf7e0c7ce112a29341b000c40d840aef1dbb4fdcb3ae5c0597e28f3061
-export BASE_JEKYLL=jekyll/jekyll:3.8@sha256:9521c8aae4739fcbc7137ead19f91841b833d671542f13e91ca40280e88d6e34
+PLATFORM_NAME := $(shell uname -p)
+ifneq ($(filter arm%,$(PLATFORM_NAME)),)
+	export WERF_PLATFORM=linux/amd64
+endif
 
 all: up
-
 
 network:
 		docker network inspect deckhouse 2>&1 1>/dev/null || docker network create deckhouse
 
 up: network
-		werf compose up --follow --docker-compose-command-options='-d'
+		werf compose up --follow --docker-compose-command-options='-d' --env local
 
 down:
-		werf compose down
+		docker rm -f documentation
 
 dev: network
 		werf compose up --follow --docker-compose-command-options='-d' --dev --env development

--- a/docs/documentation/werf.yaml
+++ b/docs/documentation/werf.yaml
@@ -9,6 +9,9 @@ configVersion: 1
 {{ $_ := set . "Images" (.Files.Get "../../candi/image_versions.yml" | fromYaml) }}
   {{- range $k, $v := .Images }}
     {{ $baseImagePath := (printf "%s%s" $.Images.REGISTRY_PATH (trimSuffix "/" $v)) }}
+    {{- if or (eq $.Env "development") (eq $.Env "local") }}
+      {{ $baseImagePath = trimSuffix "/" $v }}
+    {{- end }}
     {{- if ne $k "REGISTRY_PATH" }}
       {{- $_ := set $.Images $k $baseImagePath }}
     {{- end }}
@@ -155,9 +158,9 @@ git:
   excludePaths:
     - '**/werf*.yaml'
     - '**/docker-compose.yml'
+    - '**/Makefile'
     - '**/.werf'
     - '**/.helm'
-    - Makefile
     - documentation/pages/internal
     - documentation/config
   stageDependencies:

--- a/docs/site/Makefile
+++ b/docs/site/Makefile
@@ -1,21 +1,20 @@
-export BASE_NGINX_ALPINE=nginx:1.15.12-alpine@sha256:57a226fb6ab6823027c0704a9346a890ffb0cacde06bc19bbc234c8720673555
-export BASE_ALPINE=alpine:3.12.1@sha256:c0e9560cda118f9ec63ddefb4a173a2b2a0347082d7dff7dc14272e7841a5b5a
-export BASE_GOLANG_16_ALPINE=golang:1.16.3-alpine3.12@sha256:371dc6bf7e0c7ce112a29341b000c40d840aef1dbb4fdcb3ae5c0597e28f3061
-export BASE_JEKYLL=jekyll/jekyll:3.8@sha256:9521c8aae4739fcbc7137ead19f91841b833d671542f13e91ca40280e88d6e34
+PLATFORM_NAME := $(shell uname -p)
+ifneq ($(filter arm%,$(PLATFORM_NAME)),)
+	export WERF_PLATFORM=linux/amd64
+endif
 
 all: up
-
 
 network:
 		docker network inspect deckhouse 2>&1 1>/dev/null || docker network create deckhouse
 
 up: network
-		werf compose up --follow --docker-compose-command-options='-d'
+		werf compose up --follow --docker-compose-command-options='-d' --env local
 
 down:
-		werf compose down
+		docker rm -f site_site_1 site_front_1; docker network rm deckhouse
 
 dev: network
-		werf compose up --follow --docker-compose-command-options='-d' --dev
+		werf compose up --follow --docker-compose-command-options='-d' --dev --env development
 
 .PHONY: up dev

--- a/docs/site/werf.yaml
+++ b/docs/site/werf.yaml
@@ -20,6 +20,9 @@ gitWorktree:
 {{ $_ := set . "Images" (.Files.Get "../../candi/image_versions.yml" | fromYaml) }}
   {{- range $k, $v := .Images }}
     {{ $baseImagePath := (printf "%s%s" $.Images.REGISTRY_PATH (trimSuffix "/" $v)) }}
+    {{- if or (eq $.Env "development") (eq $.Env "local") }}
+      {{ $baseImagePath = trimSuffix "/" $v }}
+    {{- end }}
     {{- if ne $k "REGISTRY_PATH" }}
       {{- $_ := set $.Images $k $baseImagePath }}
     {{- end }}


### PR DESCRIPTION
## Description
Added targes for building and stopping containers with the documentation:
- `make docs` — to build and run containers with the documentation ([werf](werf.io) is required). 
- `make docs-dev` — to build and run containers with the documentation in dev mode (allow uncommitted files). 
- `make docs-down` — to stop and remove the documentation containers. 

Fix Makefile to build documentation on mac.

Use public images when building through Makefiles.

## What is the expected result?
Working:
- `make docs`
- `make docs-dev`
- `make docs-down`

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests are passed.
- [X] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: feature
summary: Add targets for documentation to the Makefile.
impact_level: low
```
