### PR TITLE
[dhctl] Do not try remove label dhctl.deckhouse.io/node-for-converge if node object was deleted during converge

### DIFF
--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/hook.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/hook.go
@@ -179,6 +179,7 @@ func (h *Hook) AfterAction() error {
 	return retry.NewLoop(title, 10, 3*time.Second).Run(func() error {
 		err := h.convergeLabelToNode(false)
 		if err != nil && errors.IsNotFound(err) {
+			log.InfoLn("Converged node was not found. Skip remove label.")
 			// node object was removed while converge
 			// we do not need to remove label, because label added to removed object
 			// and new object will create without label

--- a/dhctl/pkg/operations/converge/infra/hook/controlplane/hook.go
+++ b/dhctl/pkg/operations/converge/infra/hook/controlplane/hook.go
@@ -19,9 +19,8 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/deckhouse"


### PR DESCRIPTION
…

Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Do not try remove label dhctl.deckhouse.io/node-for-converge if node object was deleted during converge

## Why do we need it, and what problem does it solve?
Close #1927

## What is the expected result?
If converged node contains deckhouse pod and converged node has destructive converge has not errors

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: fix
summary: Do not try remove label dhctl.deckhouse.io/node-for-converge if node object was deleted during converge
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
