### PR TITLE
[dhctl][ci] Do not download linter for dhctl

### DIFF
--- a/dhctl/Makefile
+++ b/dhctl/Makefile
@@ -32,7 +32,7 @@ ifndef OS
 	endif
 endif
 
-export PATH := $(abspath bin/protoc/bin/):$(abspath bin/):${PATH}
+export PATH := $(abspath bin/):${PATH}
 
 INSTALLER_IMAGE_URL=dev-registry.deckhouse.io/sys/deckhouse-oss/install:main
 
@@ -63,19 +63,19 @@ test:
 deps: bin/golangci-lint bin/gofumpt
 	go mod tidy
 
-lint: bin/golangci-lint
+lint:
 	golangci-lint run ./... -c .golangci.yaml
 
-fix: bin/golangci-lint
+fix:
 	golangci-lint run ./... -c .golangci.yaml --fix
 
-fmt: bin/golangci-lint bin/gofumpt
+fmt:
 	@# - gofumpt is not included in the .golangci.yaml because it conflicts with imports https://github.com/golangci/golangci-lint/issues/1490#issuecomment-778782810
 	@# - goimports is not turned on since it is used mostly by gofumpt internally
 	gofumpt -l -w -extra .
 	golangci-lint run ./... -c .golangci.yaml --fix
 
-ci: deps lint
+ci:
 	./hack/coverage.sh
 
 devenv:

--- a/werf.yaml
+++ b/werf.yaml
@@ -453,33 +453,6 @@ ansible:
       args:
         chdir: /dhctl
 ---
-image: dhctl-tests
-fromCacheVersion: "20220615"
-fromImage: base-for-go
-git:
-- add: /
-  to: /deckhouse
-  includePaths:
-  - dhctl
-  - candi
-  excludePaths:
-  - candi/cloud-providers/*/layouts
-  - candi/cloud-providers/*/terraform-modules
-mount:
-- fromPath: ~/go-pkg-cache
-  to: /go/pkg
-ansible:
-  beforeInstall:
-    - apk:
-        name: git,ca-certificates,curl,bash,make
-        update_cache: yes
-    - command: rm -rf /var/cache/apk/*
-
-  install:
-  - shell: make deps
-    args:
-      chdir: /deckhouse/dhctl
----
 artifact: jq
 from: {{ .Images.BASE_ALPINE }}
 fromCacheVersion: "20210527"


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
There is a linter in the deckhouse testing container. The downloading process fails from time to time which forces us to rerun tests (so annoying).

## What is the expected result?
N/A

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: chore
summary:  Do not download linter for dhctl every time
impact_level: ow
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
