### PR TITLE
[user-authn] Refactor dex probes

### DIFF
--- a/modules/150-user-authn/monitoring/prometheus-rules/dex.yaml
+++ b/modules/150-user-authn/monitoring/prometheus-rules/dex.yaml
@@ -1,7 +1,7 @@
 - name: d8.dex.availability
   rules:
-  - alert: D8DexTargetDown
-    expr: max by (job) (up{job="dex", namespace="d8-user-authn"} == 0)
+  - alert: D8DexAllTargetsDown
+    expr: sum(up{job="dex", namespace="d8-user-authn"}) == 0
     for: 5m
     labels:
       severity_level: "6"
@@ -11,8 +11,4 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_dex_unavailable: "D8DexUnavailable,tier=cluster,prometheus=deckhouse,d8_module=user-authn,db_component=dex"
-      plk_grouped_by__d8_dex_unavailable: "D8DexUnavailable,tier=cluster,prometheus=deckhouse"
-      plk_labels_as_annotations: "instance,pod"
-      plk_ignore_labels: "job"
       summary: Prometheus is unable to scrape Dex metrics.

--- a/modules/150-user-authn/monitoring/prometheus-rules/dex.yaml
+++ b/modules/150-user-authn/monitoring/prometheus-rules/dex.yaml
@@ -1,0 +1,18 @@
+- name: d8.dex.availability
+  rules:
+  - alert: D8DexTargetDown
+    expr: max by (job) (up{job="dex", namespace="d8-user-authn"} == 0)
+    for: 5m
+    labels:
+      severity_level: "6"
+      tier: cluster
+      d8_module: deckhouse
+      d8_component: dex
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_create_group_if_not_exists__d8_dex_unavailable: "D8DexUnavailable,tier=cluster,prometheus=deckhouse,d8_module=user-authn,db_component=dex"
+      plk_grouped_by__d8_dex_unavailable: "D8DexUnavailable,tier=cluster,prometheus=deckhouse"
+      plk_labels_as_annotations: "instance,pod"
+      plk_ignore_labels: "job"
+      summary: Prometheus is unable to scrape Dex metrics.

--- a/modules/150-user-authn/templates/dex/config.yaml
+++ b/modules/150-user-authn/templates/dex/config.yaml
@@ -9,6 +9,8 @@
     https: 0.0.0.0:5556
     tlsKey: /etc/dex/certs/tls.key
     tlsCert: /etc/dex/certs/tls.crt
+  telemetry:
+    http: 127.0.0.1:5558
   frontend:
     issuer: "Kubernetes Dex"
     logoUrl: "https://kubernetes.io/images/favicon.png"

--- a/modules/150-user-authn/templates/dex/deployment.yaml
+++ b/modules/150-user-authn/templates/dex/deployment.yaml
@@ -69,16 +69,14 @@ spec:
           protocol: TCP
         livenessProbe:
           httpGet:
-            path: /healthz
-            port: 5556
+            path: /healthz/live
+            port: 5559
             scheme: HTTPS
         readinessProbe:
           httpGet:
-            path: /healthz
-            port: 5556
+            path: /healthz/ready
+            port: 5559
             scheme: HTTPS
-          initialDelaySeconds: 5
-          timeoutSeconds: 1
         volumeMounts:
         - name: original-config
           mountPath: /etc/dex/config
@@ -87,3 +85,50 @@ spec:
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
+      - name: kube-rbac-proxy
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+        image: "{{ $.Values.global.modulesImages.registry }}:{{ $.Values.global.modulesImages.tags.common.kubeRbacProxy }}"
+        args:
+          - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):5559"
+          - "--client-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+          - "--v=2"
+          - "--logtostderr=true"
+          - "--stale-cache-interval=1h30m"
+          - "--livez-path=/livez"
+        env:
+        - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: KUBE_RBAC_PROXY_CONFIG
+          value: |
+            excludePaths:
+            - /healthz/live
+            - /healthz/ready
+            upstreams:
+            - upstream: http://127.0.0.1:5558/
+              path: /
+              authorization:
+                resourceAttributes:
+                  namespace: d8-user-authn
+                  apiGroup: apps
+                  apiVersion: v1
+                  resource: deployments
+                  subresource: prometheus-metrics
+                  name: dex
+        ports:
+        - containerPort: 5559
+          name: https-metrics
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
+        livenessProbe:
+          httpGet:
+            path: /healthz/live
+            port: 5559
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 5559
+            scheme: HTTPS

--- a/modules/150-user-authn/templates/dex/podmonitor.yaml
+++ b/modules/150-user-authn/templates/dex/podmonitor.yaml
@@ -1,0 +1,31 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dex
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main")) | nindent 2 }}
+spec:
+  jobLabel: app
+  selector:
+    matchLabels:
+      app: dex
+  namespaceSelector:
+    matchNames:
+    - d8-{{ $.Chart.Name }}
+  podMetricsEndpoints:
+  - port: https-metrics
+    scheme: https
+    bearerTokenSecret:
+      name: "prometheus-token"
+      key: "token"
+    tlsConfig:
+      insecureSkipVerify: true
+    relabelings:
+    - targetLabel: tier
+      replacement: cluster
+    - sourceLabels: [__meta_kubernetes_pod_ready]
+      regex: "true"
+      action: keep
+{{- end }}

--- a/modules/150-user-authn/templates/dex/rbac-for-us.yaml
+++ b/modules/150-user-authn/templates/dex/rbac-for-us.yaml
@@ -66,3 +66,17 @@ subjects:
 - kind: ServiceAccount
   name: dex
   namespace: d8-{{ .Chart.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: d8:user-authn:dex:rbac-proxy
+  {{- include "helm_lib_module_labels" (list . (dict "app" "dex")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: d8:rbac-proxy
+subjects:
+  - kind: ServiceAccount
+    name: dex
+    namespace: d8-{{ $.Chart.Name }}

--- a/modules/150-user-authn/templates/dex/rbac-to-us.yaml
+++ b/modules/150-user-authn/templates/dex/rbac-to-us.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: access-to-dex-prometheus-metrics
+  namespace: d8-{{ $.Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "dex")) | nindent 2 }}
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments/prometheus-metrics"]
+  resourceNames: ["dex"]
+  verbs: ["get"]
+{{- if (.Values.global.enabledModules | has "prometheus") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: access-to-dex-prometheus-metrics
+  namespace: d8-{{ $.Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "dex")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: access-to-dex-prometheus-metrics
+subjects:
+- kind: User
+  name: d8-monitoring:scraper
+- kind: ServiceAccount
+  name: prometheus
+  namespace: d8-monitoring
+{{- end }}

--- a/modules/150-user-authn/templates/monitoring.yaml
+++ b/modules/150-user-authn/templates/monitoring.yaml
@@ -1,0 +1,1 @@
+{{- include "helm_lib_prometheus_rules" (list . "d8-monitoring") }}


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
* Refactor liveness and readiness probes align with the [official Dex helm chart](https://github.com/dexidp/helm-charts/blob/da8d7fe3369b2c9cf89a59ae7f86a6f1cf449cf7/charts/dex/templates/deployment.yaml#L95-L102). The liveness probe endpoint returns an ok message without checking database connectivity.
* Collect metrics from Dex (there are approximately 40 metrics). 
* Add a simple alert that Prometheus can scrape one of Dex targets.

## Why do we need it, and what problem does it solve?
1. Previous Dex liveness probes led to container restarts, which was a cause of pods lying in the backoff loop status
2. At least simple monitoring is required to detect problems with Dex

## What is the expected result?
Dex pod will be restarted.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: user-authn
type: fix
summary: Refactor Dex probes, and collect metrics from Dex.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
