### PR TITLE
[cert-manager] bump version to 1.8.2

### DIFF
--- a/modules/101-cert-manager/crds/crd-certificaterequests.yaml
+++ b/modules/101-cert-manager/crds/crd-certificaterequests.yaml
@@ -10,7 +10,7 @@ metadata:
     module: 'cert-manager'
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/version: "v1.7.1"
+    app.kubernetes.io/version: "v1.8.2"
 spec:
   group: cert-manager.io
   names:
@@ -190,6 +190,9 @@ spec:
                       type:
                         description: Type of the condition, known values are (`Ready`, `InvalidRequest`, `Approved`, `Denied`).
                         type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
                 failureTime:
                   description: FailureTime stores the time that this CertificateRequest failed. This is used to influence garbage collection and back-off.
                   type: string

--- a/modules/101-cert-manager/crds/crd-certificates.yaml
+++ b/modules/101-cert-manager/crds/crd-certificates.yaml
@@ -100,6 +100,10 @@ spec:
                   type: array
                   items:
                     type: string
+                certificateOwnerRef:
+                  type: boolean
+                  x-doc-default: nil
+                  description: CertificateOwnerRef is whether to set the certificate resource as an owner of a secret where a TLS certificate is stored. When this option is toggled, the secret will be automatically removed when the certificate resource is deleted. A global owner reference policy will be used by default (controlled by the --enable-certificate-owner-ref flag).
                 encodeUsagesInRequest:
                   description: EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest
                   type: boolean

--- a/modules/101-cert-manager/crds/crd-certificates.yaml
+++ b/modules/101-cert-manager/crds/crd-certificates.yaml
@@ -10,7 +10,7 @@ metadata:
     module: 'cert-manager'
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/version: "v1.7.1"
+    app.kubernetes.io/version: "v1.8.2"
 spec:
   group: cert-manager.io
   names:
@@ -100,10 +100,6 @@ spec:
                   type: array
                   items:
                     type: string
-                certificateOwnerRef:
-                  type: boolean
-                  x-doc-default: nil
-                  description: CertificateOwnerRef is whether to set the certificate resource as an owner of a secret where a TLS certificate is stored. When this option is toggled, the secret will be automatically removed when the certificate resource is deleted. A global owner reference policy will be used by default (controlled by the --enable-certificate-owner-ref flag).
                 encodeUsagesInRequest:
                   description: EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest
                   type: boolean
@@ -198,6 +194,9 @@ spec:
                     rotationPolicy:
                       description: RotationPolicy controls how private keys should be regenerated when a re-issuance is being processed. If set to Never, a private key will only be generated if one does not already exist in the target `spec.secretName`. If one does exists but it does not have the correct algorithm or size, a warning will be raised to await user intervention. If set to Always, a private key matching the specified requirements will be generated whenever a re-issuance occurs. Default is 'Never' for backward compatibility.
                       type: string
+                      enum:
+                        - Never
+                        - Always
                     size:
                       description: Size is the key bit size of the corresponding private key for this certificate. If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`, and will default to `2048` if not specified. If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`, and will default to `256` if not specified. If `algorithm` is set to `Ed25519`, Size is ignored. No other values are allowed.
                       type: integer
@@ -340,6 +339,12 @@ spec:
                       type:
                         description: Type of the condition, known values are (`Ready`, `Issuing`).
                         type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                failedIssuanceAttempts:
+                  description: The number of continuous failed issuance attempts up till now. This field gets removed (if set) on a successful issuance and gets set to 1 if unset and an issuance has failed. If an issuance has failed, the delay till the next issuance will be calculated using formula time.Hour * 2 ^ (failedIssuanceAttempts - 1).
+                  type: integer
                 lastFailureTime:
                   description: LastFailureTime is the time as recorded by the Certificate controller of the most recent failure to complete a CertificateRequest for this Certificate resource. If set, cert-manager will not re-request another Certificate until 1 hour has elapsed from this time.
                   type: string

--- a/modules/101-cert-manager/crds/crd-challenges.yaml
+++ b/modules/101-cert-manager/crds/crd-challenges.yaml
@@ -10,7 +10,7 @@ metadata:
     module: 'cert-manager'
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/version: "v1.7.1"
+    app.kubernetes.io/version: "v1.8.2"
 spec:
   group: acme.cert-manager.io
   names:
@@ -304,7 +304,7 @@ spec:
                             - nameserver
                           properties:
                             nameserver:
-                              description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                              description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
                               type: string
                             tsigAlgorithm:
                               description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
@@ -379,10 +379,49 @@ spec:
                           type: object
                           properties:
                             labels:
-                              description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                              description: Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.
                               type: object
                               additionalProperties:
                                 type: string
+                            parentRefs:
+                              description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways'
+                              type: array
+                              items:
+                                description: "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object."
+                                type: object
+                                required:
+                                  - name
+                                properties:
+                                  group:
+                                    description: "Group is the group of the referent. \n Support: Core"
+                                    type: string
+                                    default: gateway.networking.k8s.io
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  kind:
+                                    description: "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)"
+                                    type: string
+                                    default: Gateway
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                  name:
+                                    description: "Name is the name of the referent. \n Support: Core"
+                                    type: string
+                                    maxLength: 253
+                                    minLength: 1
+                                  namespace:
+                                    description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                                    type: string
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  sectionName:
+                                    description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
+                                    type: string
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             serviceType:
                               description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                               type: string

--- a/modules/101-cert-manager/crds/crd-clusterissuers.yaml
+++ b/modules/101-cert-manager/crds/crd-clusterissuers.yaml
@@ -10,7 +10,7 @@ metadata:
     module: 'cert-manager'
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/version: "v1.7.1"
+    app.kubernetes.io/version: "v1.8.2"
 spec:
   group: cert-manager.io
   names:
@@ -339,7 +339,7 @@ spec:
                                   - nameserver
                                 properties:
                                   nameserver:
-                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
                                     type: string
                                   tsigAlgorithm:
                                     description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
@@ -414,10 +414,49 @@ spec:
                                 type: object
                                 properties:
                                   labels:
-                                    description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                                    description: Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.
                                     type: object
                                     additionalProperties:
                                       type: string
+                                  parentRefs:
+                                    description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways'
+                                    type: array
+                                    items:
+                                      description: "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object."
+                                      type: object
+                                      required:
+                                        - name
+                                      properties:
+                                        group:
+                                          description: "Group is the group of the referent. \n Support: Core"
+                                          type: string
+                                          default: gateway.networking.k8s.io
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        kind:
+                                          description: "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)"
+                                          type: string
+                                          default: Gateway
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                        name:
+                                          description: "Name is the name of the referent. \n Support: Core"
+                                          type: string
+                                          maxLength: 253
+                                          minLength: 1
+                                        namespace:
+                                          description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                                          type: string
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        sectionName:
+                                          description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
+                                          type: string
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                   serviceType:
                                     description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
@@ -1205,5 +1244,8 @@ spec:
                       type:
                         description: Type of the condition, known values are (`Ready`).
                         type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
       served: true
       storage: true

--- a/modules/101-cert-manager/crds/crd-issuers.yaml
+++ b/modules/101-cert-manager/crds/crd-issuers.yaml
@@ -10,7 +10,7 @@ metadata:
     module: 'cert-manager'
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/version: "v1.7.1"
+    app.kubernetes.io/version: "v1.8.2"
 spec:
   group: cert-manager.io
   names:
@@ -339,7 +339,7 @@ spec:
                                   - nameserver
                                 properties:
                                   nameserver:
-                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
                                     type: string
                                   tsigAlgorithm:
                                     description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
@@ -414,10 +414,49 @@ spec:
                                 type: object
                                 properties:
                                   labels:
-                                    description: The labels that cert-manager will use when creating the temporary HTTPRoute needed for solving the HTTP-01 challenge. These labels must match the label selector of at least one Gateway.
+                                    description: Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.
                                     type: object
                                     additionalProperties:
                                       type: string
+                                  parentRefs:
+                                    description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways'
+                                    type: array
+                                    items:
+                                      description: "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object."
+                                      type: object
+                                      required:
+                                        - name
+                                      properties:
+                                        group:
+                                          description: "Group is the group of the referent. \n Support: Core"
+                                          type: string
+                                          default: gateway.networking.k8s.io
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        kind:
+                                          description: "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)"
+                                          type: string
+                                          default: Gateway
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                        name:
+                                          description: "Name is the name of the referent. \n Support: Core"
+                                          type: string
+                                          maxLength: 253
+                                          minLength: 1
+                                        namespace:
+                                          description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                                          type: string
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        sectionName:
+                                          description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
+                                          type: string
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                   serviceType:
                                     description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
@@ -1205,5 +1244,8 @@ spec:
                       type:
                         description: Type of the condition, known values are (`Ready`).
                         type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
       served: true
       storage: true

--- a/modules/101-cert-manager/crds/crd-orders.yaml
+++ b/modules/101-cert-manager/crds/crd-orders.yaml
@@ -10,7 +10,7 @@ metadata:
     module: 'cert-manager'
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
-    app.kubernetes.io/version: "v1.7.1"
+    app.kubernetes.io/version: "v1.8.2"
 spec:
   group: acme.cert-manager.io
   names:

--- a/modules/101-cert-manager/images/cert-manager-acme-solver/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-acme-solver/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "1.7.1" }}
+{{- $version := "1.8.2" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ $.Images.BASE_ALPINE }}
 import:

--- a/modules/101-cert-manager/images/cert-manager-cainjector/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-cainjector/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "1.7.1" }}
+{{- $version := "1.8.2" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ $.Images.BASE_ALPINE }}
 import:

--- a/modules/101-cert-manager/images/cert-manager-controller/patches/certificate_owner_ref.patch
+++ b/modules/101-cert-manager/images/cert-manager-controller/patches/certificate_owner_ref.patch
@@ -1,12 +1,8 @@
-Index: deploy/crds/crd-certificates.yaml
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
 diff --git a/deploy/crds/crd-certificates.yaml b/deploy/crds/crd-certificates.yaml
---- a/deploy/crds/crd-certificates.yaml	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/deploy/crds/crd-certificates.yaml	(date 1653420801180)
-@@ -82,6 +82,9 @@
+index b27bef803..b1bf2f53c 100644
+--- a/deploy/crds/crd-certificates.yaml
++++ b/deploy/crds/crd-certificates.yaml
+@@ -80,6 +80,9 @@ spec:
                          enum:
                            - DER
                            - CombinedPEM
@@ -16,15 +12,11 @@ diff --git a/deploy/crds/crd-certificates.yaml b/deploy/crds/crd-certificates.ya
                  commonName:
                    description: 'CommonName is a common name to be used on the Certificate. The CommonName should have a length of 64 characters or fewer to avoid generating invalid CSRs. This value is ignored by TLS clients when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
                    type: string
-Index: internal/apis/certmanager/types_certificate.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
 diff --git a/internal/apis/certmanager/types_certificate.go b/internal/apis/certmanager/types_certificate.go
---- a/internal/apis/certmanager/types_certificate.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/internal/apis/certmanager/types_certificate.go	(date 1653420801180)
-@@ -172,6 +172,11 @@
+index 8b13b09b5..44442481f 100644
+--- a/internal/apis/certmanager/types_certificate.go
++++ b/internal/apis/certmanager/types_certificate.go
+@@ -172,6 +172,11 @@ type CertificateSpec struct {
  	// `--feature-gates=AdditionalCertificateOutputFormats=true` option on both
  	// the controller and webhook components.
  	AdditionalOutputFormats []CertificateAdditionalOutputFormat
@@ -34,142 +26,238 @@ diff --git a/internal/apis/certmanager/types_certificate.go b/internal/apis/cert
 +	// If unset (`nil`) `--enable-certificate-owner-ref` CLI parameter value is used. Default value is `nil`.
 +	CertificateOwnerRef *bool
  }
-
+ 
  // CertificatePrivateKey contains configuration options for private keys
-Index: internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go b/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
---- a/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go	(date 1653420801180)
-@@ -834,6 +834,7 @@
+diff --git a/internal/apis/certmanager/v1/zz_generated.conversion.go b/internal/apis/certmanager/v1/zz_generated.conversion.go
+index 733ae713e..66adb7d33 100644
+--- a/internal/apis/certmanager/v1/zz_generated.conversion.go
++++ b/internal/apis/certmanager/v1/zz_generated.conversion.go
+@@ -834,6 +834,7 @@ func autoConvert_v1_CertificateSpec_To_certmanager_CertificateSpec(in *v1.Certif
  	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
  	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
  	out.AdditionalOutputFormats = *(*[]certmanager.CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
 +	out.CertificateOwnerRef = (*bool)(unsafe.Pointer(in.CertificateOwnerRef))
  	return nil
  }
-
-@@ -882,6 +883,7 @@
+ 
+@@ -866,6 +867,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1_CertificateSpec(in *certmanag
+ 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
+ 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
+ 	out.AdditionalOutputFormats = *(*[]v1.CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
++	out.CertificateOwnerRef = (*bool)(unsafe.Pointer(in.CertificateOwnerRef))
+ 	return nil
+ }
+ 
+diff --git a/internal/apis/certmanager/v1alpha2/types_certificate.go b/internal/apis/certmanager/v1alpha2/types_certificate.go
+index 6fb736ebf..53b8e629d 100644
+--- a/internal/apis/certmanager/v1alpha2/types_certificate.go
++++ b/internal/apis/certmanager/v1alpha2/types_certificate.go
+@@ -217,6 +217,11 @@ type CertificateSpec struct {
+ 	// the controller and webhook components.
+ 	// +optional
+ 	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
++
++	// CertificateOwnerRef is whether to set the certificate resource as an owner of secret where the tls certificate is stored.
++	// When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.
++	// If unset (`nil`) `--enable-certificate-owner-ref` CLI parameter value is used. Default value is `nil`.
++	CertificateOwnerRef *bool
+ }
+ 
+ // CertificatePrivateKey contains configuration options for private keys
+diff --git a/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go b/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
+index b06143355..f0888a038 100644
+--- a/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
++++ b/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
+@@ -834,6 +834,7 @@ func autoConvert_v1alpha2_CertificateSpec_To_certmanager_CertificateSpec(in *Cer
+ 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
+ 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
+ 	out.AdditionalOutputFormats = *(*[]certmanager.CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
++	out.CertificateOwnerRef = (*bool)(unsafe.Pointer(in.CertificateOwnerRef))
+ 	return nil
+ }
+ 
+@@ -882,6 +883,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1alpha2_CertificateSpec(in *cer
  	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
  	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
  	out.AdditionalOutputFormats = *(*[]CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
 +	out.CertificateOwnerRef = (*bool)(unsafe.Pointer(in.CertificateOwnerRef))
  	return nil
  }
-
-Index: pkg/controller/certificates/internal/secretsmanager/secret_test.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/pkg/controller/certificates/internal/secretsmanager/secret_test.go b/pkg/controller/certificates/internal/secretsmanager/secret_test.go
---- a/pkg/controller/certificates/internal/secretsmanager/secret_test.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/pkg/controller/certificates/internal/secretsmanager/secret_test.go	(date 1653420801184)
-@@ -24,9 +24,6 @@
- 	"testing"
- 	"time"
-
--	"github.com/jetstack/cert-manager/internal/controller/feature"
--	testpkg "github.com/jetstack/cert-manager/pkg/controller/test"
--	utilfeature "github.com/jetstack/cert-manager/pkg/util/feature"
- 	"github.com/stretchr/testify/assert"
- 	corev1 "k8s.io/api/core/v1"
- 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-@@ -39,6 +36,10 @@
- 	fakeclock "k8s.io/utils/clock/testing"
- 	"k8s.io/utils/pointer"
-
-+	"github.com/jetstack/cert-manager/internal/controller/feature"
-+	testpkg "github.com/jetstack/cert-manager/pkg/controller/test"
-+	utilfeature "github.com/jetstack/cert-manager/pkg/util/feature"
+ 
+diff --git a/internal/apis/certmanager/v1alpha2/zz_generated.deepcopy.go b/internal/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
+index e8a6f74ee..653324ee0 100644
+--- a/internal/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
++++ b/internal/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
+@@ -472,6 +472,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
+ 		*out = make([]CertificateAdditionalOutputFormat, len(*in))
+ 		copy(*out, *in)
+ 	}
++	if in.CertificateOwnerRef != nil {
++		in, out := &in.CertificateOwnerRef, &out.CertificateOwnerRef
++		*out = new(bool)
++		**out = **in
++	}
+ 	return
+ }
+ 
+diff --git a/internal/apis/certmanager/v1alpha3/types_certificate.go b/internal/apis/certmanager/v1alpha3/types_certificate.go
+index 4de139b2a..1817fbb07 100644
+--- a/internal/apis/certmanager/v1alpha3/types_certificate.go
++++ b/internal/apis/certmanager/v1alpha3/types_certificate.go
+@@ -215,6 +215,11 @@ type CertificateSpec struct {
+ 	// the controller and webhook components.
+ 	// +optional
+ 	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
 +
- 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
- 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
- 	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
-@@ -73,6 +74,30 @@
- 		gen.SetCertificateDNSNames("example.com"),
- 	), fixedClock)
-
-+	baseCertWithCertificateOwnerRefEnabled := gen.Certificate("test",
-+		gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: "ca-issuer", Kind: "Issuer", Group: "foo.io"}),
-+		gen.SetCertificateSecretName("output"),
-+		gen.SetCertificateRenewBefore(time.Hour*36),
-+		gen.SetCertificateDNSNames("example.com"),
-+		gen.SetCertificateUID(apitypes.UID("test-uid")),
-+		gen.SetCertificateOwnerRef(true),
-+	)
-+	baseCertBundleWithCertificateOwnerRefEnabled := internaltest.MustCreateCryptoBundle(t, gen.CertificateFrom(baseCertWithCertificateOwnerRefEnabled,
-+		gen.SetCertificateDNSNames("example.com"),
-+	), fixedClock)
++	// CertificateOwnerRef is whether to set the certificate resource as an owner of secret where the tls certificate is stored.
++	// When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.
++	// If unset (`nil`) `--enable-certificate-owner-ref` CLI parameter value is used. Default value is `nil`.
++	CertificateOwnerRef *bool
+ }
+ 
+ // CertificatePrivateKey contains configuration options for private keys
+diff --git a/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go b/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
+index 4196fd32d..67a2806a0 100644
+--- a/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
++++ b/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
+@@ -833,6 +833,7 @@ func autoConvert_v1alpha3_CertificateSpec_To_certmanager_CertificateSpec(in *Cer
+ 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
+ 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
+ 	out.AdditionalOutputFormats = *(*[]certmanager.CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
++	out.CertificateOwnerRef = (*bool)(unsafe.Pointer(in.CertificateOwnerRef))
+ 	return nil
+ }
+ 
+@@ -881,6 +882,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1alpha3_CertificateSpec(in *cer
+ 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
+ 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
+ 	out.AdditionalOutputFormats = *(*[]CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
++	out.CertificateOwnerRef = (*bool)(unsafe.Pointer(in.CertificateOwnerRef))
+ 	return nil
+ }
+ 
+diff --git a/internal/apis/certmanager/v1alpha3/zz_generated.deepcopy.go b/internal/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
+index c85c797c5..ce31d9c95 100644
+--- a/internal/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
++++ b/internal/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
+@@ -467,6 +467,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
+ 		*out = make([]CertificateAdditionalOutputFormat, len(*in))
+ 		copy(*out, *in)
+ 	}
++	if in.CertificateOwnerRef != nil {
++		in, out := &in.CertificateOwnerRef, &out.CertificateOwnerRef
++		*out = new(bool)
++		**out = **in
++	}
+ 	return
+ }
+ 
+diff --git a/internal/apis/certmanager/v1beta1/types_certificate.go b/internal/apis/certmanager/v1beta1/types_certificate.go
+index e89bc0b25..ed575a76a 100644
+--- a/internal/apis/certmanager/v1beta1/types_certificate.go
++++ b/internal/apis/certmanager/v1beta1/types_certificate.go
+@@ -192,6 +192,11 @@ type CertificateSpec struct {
+ 	// the controller and webhook components.
+ 	// +optional
+ 	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
 +
-+	baseCertWithCertificateOwnerRefDisabled := gen.Certificate("test",
-+		gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: "ca-issuer", Kind: "Issuer", Group: "foo.io"}),
-+		gen.SetCertificateSecretName("output"),
-+		gen.SetCertificateRenewBefore(time.Hour*36),
-+		gen.SetCertificateDNSNames("example.com"),
-+		gen.SetCertificateUID(apitypes.UID("test-uid")),
-+		gen.SetCertificateOwnerRef(false),
-+	)
-+	baseCertBundleWithCertificateOwnerRefDisabled := internaltest.MustCreateCryptoBundle(t, gen.CertificateFrom(baseCertWithCertificateOwnerRefDisabled,
-+		gen.SetCertificateDNSNames("example.com"),
-+	), fixedClock)
++	// CertificateOwnerRef is whether to set the certificate resource as an owner of secret where the tls certificate is stored.
++	// When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.
++	// If unset (`nil`) `--enable-certificate-owner-ref` CLI parameter value is used. Default value is `nil`.
++	CertificateOwnerRef *bool
+ }
+ 
+ // CertificatePrivateKey contains configuration options for private keys
+diff --git a/internal/apis/certmanager/v1beta1/zz_generated.conversion.go b/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
+index 24caa2838..07c71dadc 100644
+--- a/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
++++ b/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
+@@ -832,6 +832,7 @@ func autoConvert_v1beta1_CertificateSpec_To_certmanager_CertificateSpec(in *Cert
+ 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
+ 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
+ 	out.AdditionalOutputFormats = *(*[]certmanager.CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
++	out.CertificateOwnerRef = (*bool)(unsafe.Pointer(in.CertificateOwnerRef))
+ 	return nil
+ }
+ 
+@@ -869,6 +870,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1beta1_CertificateSpec(in *cert
+ 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
+ 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
+ 	out.AdditionalOutputFormats = *(*[]CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
++	out.CertificateOwnerRef = (*bool)(unsafe.Pointer(in.CertificateOwnerRef))
+ 	return nil
+ }
+ 
+diff --git a/internal/apis/certmanager/v1beta1/zz_generated.deepcopy.go b/internal/apis/certmanager/v1beta1/zz_generated.deepcopy.go
+index 67a66f922..889886348 100644
+--- a/internal/apis/certmanager/v1beta1/zz_generated.deepcopy.go
++++ b/internal/apis/certmanager/v1beta1/zz_generated.deepcopy.go
+@@ -467,6 +467,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
+ 		*out = make([]CertificateAdditionalOutputFormat, len(*in))
+ 		copy(*out, *in)
+ 	}
++	if in.CertificateOwnerRef != nil {
++		in, out := &in.CertificateOwnerRef, &out.CertificateOwnerRef
++		*out = new(bool)
++		**out = **in
++	}
+ 	return
+ }
+ 
+diff --git a/internal/apis/certmanager/zz_generated.deepcopy.go b/internal/apis/certmanager/zz_generated.deepcopy.go
+index c5780a2b0..654173431 100644
+--- a/internal/apis/certmanager/zz_generated.deepcopy.go
++++ b/internal/apis/certmanager/zz_generated.deepcopy.go
+@@ -467,6 +467,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
+ 		*out = make([]CertificateAdditionalOutputFormat, len(*in))
+ 		copy(*out, *in)
+ 	}
++	if in.CertificateOwnerRef != nil {
++		in, out := &in.CertificateOwnerRef, &out.CertificateOwnerRef
++		*out = new(bool)
++		**out = **in
++	}
+ 	return
+ }
+ 
+diff --git a/pkg/apis/certmanager/v1/types_certificate.go b/pkg/apis/certmanager/v1/types_certificate.go
+index dcf967bd7..1edeb8736 100644
+--- a/pkg/apis/certmanager/v1/types_certificate.go
++++ b/pkg/apis/certmanager/v1/types_certificate.go
+@@ -196,6 +196,12 @@ type CertificateSpec struct {
+ 	// the controller and webhook components.
+ 	// +optional
+ 	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
 +
- 	baseCertWithSecretTemplate := gen.CertificateFrom(baseCertBundle.Certificate,
- 		gen.SetCertificateSecretTemplate(map[string]string{
- 			"template":  "annotation",
-@@ -156,6 +181,48 @@
- 			expectedErr: false,
- 		},
-
-+		"if secret does not exist, but certificateOwnerRef is set to true, create new Secret, with owner disabled": {
-+			certificateOptions: controllerpkg.CertificateOptions{EnableOwnerRef: false},
-+			certificate:        baseCertBundleWithCertificateOwnerRefEnabled.Certificate,
-+			existingSecret:     nil,
-+			secretData:         SecretData{Certificate: baseCertBundle.CertBytes, CA: []byte("test-ca"), PrivateKey: []byte("test-key")},
-+			applyFn: func(t *testing.T) testcoreclients.ApplyFn {
-+				return func(_ context.Context, gotCnf *applycorev1.SecretApplyConfiguration, gotOpts metav1.ApplyOptions) (*corev1.Secret, error) {
-+					expUID := apitypes.UID("test-uid")
-+					expCnf := applycorev1.Secret("output", gen.DefaultTestNamespace).
-+						WithAnnotations(
-+							map[string]string{
-+								cmapi.CertificateNameKey: "test", cmapi.IssuerGroupAnnotationKey: "foo.io",
-+								cmapi.IssuerKindAnnotationKey: "Issuer", cmapi.IssuerNameAnnotationKey: "ca-issuer",
-+
-+								cmapi.CommonNameAnnotationKey: baseCertBundle.Cert.Subject.CommonName, cmapi.AltNamesAnnotationKey: strings.Join(baseCertBundle.Cert.DNSNames, ","),
-+								cmapi.IPSANAnnotationKey:  strings.Join(utilpki.IPAddressesToString(baseCertBundle.Cert.IPAddresses), ","),
-+								cmapi.URISANAnnotationKey: strings.Join(utilpki.URLsToString(baseCertBundle.Cert.URIs), ","),
-+							}).
-+						WithLabels(make(map[string]string)).
-+						WithData(map[string][]byte{
-+							corev1.TLSCertKey:       baseCertBundle.CertBytes,
-+							corev1.TLSPrivateKeyKey: []byte("test-key"),
-+							cmmeta.TLSCAKey:         []byte("test-ca"),
-+						}).
-+						WithType(corev1.SecretTypeTLS).
-+						WithOwnerReferences(&applymetav1.OwnerReferenceApplyConfiguration{
-+							APIVersion: pointer.String("cert-manager.io/v1"), Kind: pointer.String("Certificate"),
-+							Name: pointer.String("test"), UID: &expUID,
-+							Controller: pointer.Bool(true), BlockOwnerDeletion: pointer.Bool(true),
-+						})
-+
-+					assert.Equal(t, expCnf, gotCnf)
-+
-+					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test"}
-+					assert.Equal(t, expOpts, gotOpts)
-+
-+					return nil, nil
-+				}
-+			},
-+			expectedErr: false,
-+		},
-+
- 		"if secret does not exist, create new Secret, with owner enabled": {
- 			certificateOptions: controllerpkg.CertificateOptions{EnableOwnerRef: true},
- 			certificate:        baseCertBundle.Certificate,
-@@ -164,7 +231,6 @@
++	// CertificateOwnerRef is whether to set the certificate resource as an owner of secret where the tls certificate is stored.
++	// When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.
++	// If unset (`nil`) `--enable-certificate-owner-ref` CLI parameter value is used. Default value is `nil`.
++	// +optional
++	CertificateOwnerRef *bool `json:"certificateOwnerRef,omitempty"`
+ }
+ 
+ // CertificatePrivateKey contains configuration options for private keys
+diff --git a/pkg/apis/certmanager/v1/zz_generated.deepcopy.go b/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
+index 287750339..32d320413 100644
+--- a/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
++++ b/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
+@@ -467,6 +467,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
+ 		*out = make([]CertificateAdditionalOutputFormat, len(*in))
+ 		copy(*out, *in)
+ 	}
++	if in.CertificateOwnerRef != nil {
++		in, out := &in.CertificateOwnerRef, &out.CertificateOwnerRef
++		*out = new(bool)
++		**out = **in
++	}
+ 	return
+ }
+ 
+diff --git a/pkg/controller/certificates/issuing/internal/secret_test.go b/pkg/controller/certificates/issuing/internal/secret_test.go
+index 56caf0def..818c647ac 100644
+--- a/pkg/controller/certificates/issuing/internal/secret_test.go
++++ b/pkg/controller/certificates/issuing/internal/secret_test.go
+@@ -163,7 +163,6 @@ func Test_SecretsManager(t *testing.T) {
  			applyFn: func(t *testing.T) testcoreclients.ApplyFn {
  				return func(_ context.Context, gotCnf *applycorev1.SecretApplyConfiguration, gotOpts metav1.ApplyOptions) (*corev1.Secret, error) {
  					expUID := apitypes.UID("test-uid")
@@ -177,43 +265,7 @@ diff --git a/pkg/controller/certificates/internal/secretsmanager/secret_test.go 
  					expCnf := applycorev1.Secret("output", gen.DefaultTestNamespace).
  						WithAnnotations(
  							map[string]string{
-@@ -182,6 +248,35 @@
- 							Controller: pointer.Bool(true), BlockOwnerDeletion: pointer.Bool(true),
- 						})
- 					assert.Equal(t, expCnf, gotCnf)
-+
-+					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test"}
-+					assert.Equal(t, expOpts, gotOpts)
-+
-+					return nil, nil
-+				}
-+			},
-+			expectedErr: false,
-+		},
-+
-+		"if secret does not exist, but certificateOwnerRef is set to false, create new Secret, with owner enabled": {
-+			certificateOptions: controllerpkg.CertificateOptions{EnableOwnerRef: true},
-+			certificate:        baseCertBundleWithCertificateOwnerRefDisabled.Certificate,
-+			existingSecret:     nil,
-+			secretData:         SecretData{Certificate: baseCertBundle.CertBytes, CA: []byte("test-ca"), PrivateKey: []byte("test-key")},
-+			applyFn: func(t *testing.T) testcoreclients.ApplyFn {
-+				return func(_ context.Context, gotCnf *applycorev1.SecretApplyConfiguration, gotOpts metav1.ApplyOptions) (*corev1.Secret, error) {
-+					expCnf := applycorev1.Secret("output", gen.DefaultTestNamespace).
-+						WithAnnotations(
-+							map[string]string{
-+								cmapi.CertificateNameKey: "test", cmapi.IssuerGroupAnnotationKey: "foo.io", cmapi.IssuerKindAnnotationKey: "Issuer",
-+								cmapi.IssuerNameAnnotationKey: "ca-issuer", cmapi.CommonNameAnnotationKey: baseCertBundle.Cert.Subject.CommonName,
-+								cmapi.AltNamesAnnotationKey: strings.Join(baseCertBundle.Cert.DNSNames, ","), cmapi.IPSANAnnotationKey: strings.Join(utilpki.IPAddressesToString(baseCertBundle.Cert.IPAddresses), ","),
-+								cmapi.URISANAnnotationKey: strings.Join(utilpki.URLsToString(baseCertBundle.Cert.URIs), ","),
-+							}).
-+						WithLabels(make(map[string]string)).
-+						WithData(map[string][]byte{corev1.TLSCertKey: baseCertBundle.CertBytes, corev1.TLSPrivateKeyKey: []byte("test-key"), cmmeta.TLSCAKey: []byte("test-ca")}).
-+						WithType(corev1.SecretTypeTLS)
-+					assert.Equal(t, expCnf, gotCnf)
-
- 					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test"}
- 					assert.Equal(t, expOpts, gotOpts)
-@@ -236,6 +331,59 @@
+@@ -235,6 +234,59 @@ func Test_SecretsManager(t *testing.T) {
  			},
  			expectedErr: false,
  		},
@@ -273,11 +325,46 @@ diff --git a/pkg/controller/certificates/internal/secretsmanager/secret_test.go 
  		"if secret does exist, update existing Secret and leave custom annotations, with owner enabled": {
  			certificateOptions: controllerpkg.CertificateOptions{EnableOwnerRef: true},
  			certificate:        baseCertBundle.Certificate,
-@@ -277,6 +425,51 @@
- 							Controller: pointer.Bool(true), BlockOwnerDeletion: pointer.Bool(true),
+@@ -277,6 +329,35 @@ func Test_SecretsManager(t *testing.T) {
  						})
  					assert.Equal(t, expCnf, gotCnf)
+ 
++					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test"}
++					assert.Equal(t, expOpts, gotOpts)
 +
++					return nil, nil
++				}
++			},
++			expectedErr: false,
++		},
++
++		"if secret does not exist, but certificateOwnerRef is set to false, create new Secret, with owner enabled": {
++			certificateOptions: controllerpkg.CertificateOptions{EnableOwnerRef: true},
++			certificate:        baseCertBundleWithCertificateOwnerRefDisabled.Certificate,
++			existingSecret:     nil,
++			secretData:         SecretData{Certificate: baseCertBundle.CertBytes, CA: []byte("test-ca"), PrivateKey: []byte("test-key")},
++			applyFn: func(t *testing.T) testcoreclients.ApplyFn {
++				return func(_ context.Context, gotCnf *applycorev1.SecretApplyConfiguration, gotOpts metav1.ApplyOptions) (*corev1.Secret, error) {
++					expCnf := applycorev1.Secret("output", gen.DefaultTestNamespace).
++						WithAnnotations(
++							map[string]string{
++								cmapi.CertificateNameKey: "test", cmapi.IssuerGroupAnnotationKey: "foo.io", cmapi.IssuerKindAnnotationKey: "Issuer",
++								cmapi.IssuerNameAnnotationKey: "ca-issuer", cmapi.CommonNameAnnotationKey: baseCertBundle.Cert.Subject.CommonName,
++								cmapi.AltNamesAnnotationKey: strings.Join(baseCertBundle.Cert.DNSNames, ","), cmapi.IPSANAnnotationKey: strings.Join(utilpki.IPAddressesToString(baseCertBundle.Cert.IPAddresses), ","),
++								cmapi.URISANAnnotationKey: strings.Join(utilpki.URLsToString(baseCertBundle.Cert.URIs), ","),
++							}).
++						WithLabels(make(map[string]string)).
++						WithData(map[string][]byte{corev1.TLSCertKey: baseCertBundle.CertBytes, corev1.TLSPrivateKeyKey: []byte("test-key"), cmmeta.TLSCAKey: []byte("test-ca")}).
++						WithType(corev1.SecretTypeTLS)
++					assert.Equal(t, expCnf, gotCnf)
++
+ 					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
+ 					assert.Equal(t, expOpts, gotOpts)
+ 
+@@ -368,6 +449,51 @@ func Test_SecretsManager(t *testing.T) {
+ 						})
+ 					assert.Equal(t, expCnf, gotCnf)
+ 
 +					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test"}
 +					assert.Equal(t, expOpts, gotOpts)
 +
@@ -322,84 +409,15 @@ diff --git a/pkg/controller/certificates/internal/secretsmanager/secret_test.go 
 +						}).
 +						WithType(corev1.SecretTypeTLS)
 +					assert.Equal(t, expCnf, gotCnf)
-
- 					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test"}
- 					assert.Equal(t, expOpts, gotOpts)
-Index: pkg/controller/certificates/internal/secretsmanager/secret.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/pkg/controller/certificates/internal/secretsmanager/secret.go b/pkg/controller/certificates/internal/secretsmanager/secret.go
---- a/pkg/controller/certificates/internal/secretsmanager/secret.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/pkg/controller/certificates/internal/secretsmanager/secret.go	(date 1653420828288)
-@@ -107,10 +107,16 @@
- 		WithAnnotations(secret.Annotations).WithLabels(secret.Labels).
- 		WithData(secret.Data).WithType(secret.Type)
-
-+	certificateOwnerRef := s.enableSecretOwnerReferences
-+	// Check the CertificateOwnerRef field of the certificate, and if it is not nil, override enableSecretOwnerReferences with the CertificateOwnerRef value.
-+	if crt.Spec.CertificateOwnerRef != nil {
-+		certificateOwnerRef = *crt.Spec.CertificateOwnerRef
-+	}
 +
- 	// If Secret owner reference is enabled, set it on the Secret. This results
- 	// in a no-op if the Secret already exists and has the owner reference set,
- 	// and visa-versa.
--	if s.enableSecretOwnerReferences {
-+	if certificateOwnerRef {
- 		ref := *metav1.NewControllerRef(crt, certificateGvk)
- 		applyCnf = applyCnf.WithOwnerReferences(&applymetav1.OwnerReferenceApplyConfiguration{
- 			APIVersion: &ref.APIVersion, Kind: &ref.Kind,
-Index: pkg/apis/certmanager/v1/zz_generated.deepcopy.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/pkg/apis/certmanager/v1/zz_generated.deepcopy.go b/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
---- a/pkg/apis/certmanager/v1/zz_generated.deepcopy.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/pkg/apis/certmanager/v1/zz_generated.deepcopy.go	(date 1653420801184)
-@@ -467,6 +467,11 @@
- 		*out = make([]CertificateAdditionalOutputFormat, len(*in))
- 		copy(*out, *in)
- 	}
-+	if in.CertificateOwnerRef != nil {
-+		in, out := &in.CertificateOwnerRef, &out.CertificateOwnerRef
-+		*out = new(bool)
-+		**out = **in
-+	}
- 	return
- }
-
-Index: internal/apis/certmanager/zz_generated.deepcopy.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/internal/apis/certmanager/zz_generated.deepcopy.go b/internal/apis/certmanager/zz_generated.deepcopy.go
---- a/internal/apis/certmanager/zz_generated.deepcopy.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/internal/apis/certmanager/zz_generated.deepcopy.go	(date 1653420801184)
-@@ -467,6 +467,11 @@
- 		*out = make([]CertificateAdditionalOutputFormat, len(*in))
- 		copy(*out, *in)
- 	}
-+	if in.CertificateOwnerRef != nil {
-+		in, out := &in.CertificateOwnerRef, &out.CertificateOwnerRef
-+		*out = new(bool)
-+		**out = **in
-+	}
- 	return
- }
-
-Index: test/unit/gen/certificate.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
+ 					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
+ 					assert.Equal(t, expOpts, gotOpts)
+ 
 diff --git a/test/unit/gen/certificate.go b/test/unit/gen/certificate.go
---- a/test/unit/gen/certificate.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/test/unit/gen/certificate.go	(date 1653420801184)
-@@ -267,3 +267,9 @@
+index 39ed79593..2356b7b99 100644
+--- a/test/unit/gen/certificate.go
++++ b/test/unit/gen/certificate.go
+@@ -278,3 +278,9 @@ func SetCertificateAdditionalOutputFormats(additionalOutputFormats ...v1.Certifi
  		crt.Spec.AdditionalOutputFormats = additionalOutputFormats
  	}
  }
@@ -409,216 +427,3 @@ diff --git a/test/unit/gen/certificate.go b/test/unit/gen/certificate.go
 +		crt.Spec.CertificateOwnerRef = &ownerRef
 +	}
 +}
-Index: internal/apis/certmanager/v1/zz_generated.conversion.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/internal/apis/certmanager/v1/zz_generated.conversion.go b/internal/apis/certmanager/v1/zz_generated.conversion.go
---- a/internal/apis/certmanager/v1/zz_generated.conversion.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/internal/apis/certmanager/v1/zz_generated.conversion.go	(date 1653420801180)
-@@ -834,6 +834,7 @@
- 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
- 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
- 	out.AdditionalOutputFormats = *(*[]certmanager.CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
-+	out.CertificateOwnerRef = (*bool)(unsafe.Pointer(in.CertificateOwnerRef))
- 	return nil
- }
-
-@@ -866,6 +867,7 @@
- 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
- 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
- 	out.AdditionalOutputFormats = *(*[]v1.CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
-+	out.CertificateOwnerRef = (*bool)(unsafe.Pointer(in.CertificateOwnerRef))
- 	return nil
- }
-
-Index: internal/apis/certmanager/v1alpha2/types_certificate.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/internal/apis/certmanager/v1alpha2/types_certificate.go b/internal/apis/certmanager/v1alpha2/types_certificate.go
---- a/internal/apis/certmanager/v1alpha2/types_certificate.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/internal/apis/certmanager/v1alpha2/types_certificate.go	(date 1653420801180)
-@@ -217,6 +217,11 @@
- 	// the controller and webhook components.
- 	// +optional
- 	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
-+
-+	// CertificateOwnerRef is whether to set the certificate resource as an owner of secret where the tls certificate is stored.
-+	// When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.
-+	// If unset (`nil`) `--enable-certificate-owner-ref` CLI parameter value is used. Default value is `nil`.
-+	CertificateOwnerRef *bool
- }
-
- // CertificatePrivateKey contains configuration options for private keys
-Index: pkg/apis/certmanager/v1/types_certificate.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/pkg/apis/certmanager/v1/types_certificate.go b/pkg/apis/certmanager/v1/types_certificate.go
---- a/pkg/apis/certmanager/v1/types_certificate.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/pkg/apis/certmanager/v1/types_certificate.go	(date 1653420801184)
-@@ -196,6 +196,12 @@
- 	// the controller and webhook components.
- 	// +optional
- 	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
-+
-+	// CertificateOwnerRef is whether to set the certificate resource as an owner of secret where the tls certificate is stored.
-+	// When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.
-+	// If unset (`nil`) `--enable-certificate-owner-ref` CLI parameter value is used. Default value is `nil`.
-+	// +optional
-+	CertificateOwnerRef *bool `json:"certificateOwnerRef,omitempty"`
- }
-
- // CertificatePrivateKey contains configuration options for private keys
-Index: internal/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/internal/apis/certmanager/v1alpha2/zz_generated.deepcopy.go b/internal/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
---- a/internal/apis/certmanager/v1alpha2/zz_generated.deepcopy.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/internal/apis/certmanager/v1alpha2/zz_generated.deepcopy.go	(date 1653420801180)
-@@ -472,6 +472,11 @@
- 		*out = make([]CertificateAdditionalOutputFormat, len(*in))
- 		copy(*out, *in)
- 	}
-+	if in.CertificateOwnerRef != nil {
-+		in, out := &in.CertificateOwnerRef, &out.CertificateOwnerRef
-+		*out = new(bool)
-+		**out = **in
-+	}
- 	return
- }
-
-Index: internal/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/internal/apis/certmanager/v1alpha3/zz_generated.deepcopy.go b/internal/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
---- a/internal/apis/certmanager/v1alpha3/zz_generated.deepcopy.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/internal/apis/certmanager/v1alpha3/zz_generated.deepcopy.go	(date 1653420801184)
-@@ -467,6 +467,11 @@
- 		*out = make([]CertificateAdditionalOutputFormat, len(*in))
- 		copy(*out, *in)
- 	}
-+	if in.CertificateOwnerRef != nil {
-+		in, out := &in.CertificateOwnerRef, &out.CertificateOwnerRef
-+		*out = new(bool)
-+		**out = **in
-+	}
- 	return
- }
-
-Index: internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go b/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
---- a/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go	(date 1653420801184)
-@@ -833,6 +833,7 @@
- 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
- 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
- 	out.AdditionalOutputFormats = *(*[]certmanager.CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
-+	out.CertificateOwnerRef = (*bool)(unsafe.Pointer(in.CertificateOwnerRef))
- 	return nil
- }
-
-@@ -881,6 +882,7 @@
- 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
- 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
- 	out.AdditionalOutputFormats = *(*[]CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
-+	out.CertificateOwnerRef = (*bool)(unsafe.Pointer(in.CertificateOwnerRef))
- 	return nil
- }
-
-Index: internal/apis/certmanager/v1beta1/types_certificate.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/internal/apis/certmanager/v1beta1/types_certificate.go b/internal/apis/certmanager/v1beta1/types_certificate.go
---- a/internal/apis/certmanager/v1beta1/types_certificate.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/internal/apis/certmanager/v1beta1/types_certificate.go	(date 1653420801184)
-@@ -192,6 +192,11 @@
- 	// the controller and webhook components.
- 	// +optional
- 	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
-+
-+	// CertificateOwnerRef is whether to set the certificate resource as an owner of secret where the tls certificate is stored.
-+	// When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.
-+	// If unset (`nil`) `--enable-certificate-owner-ref` CLI parameter value is used. Default value is `nil`.
-+	CertificateOwnerRef *bool
- }
-
- // CertificatePrivateKey contains configuration options for private keys
-Index: internal/apis/certmanager/v1beta1/zz_generated.deepcopy.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/internal/apis/certmanager/v1beta1/zz_generated.deepcopy.go b/internal/apis/certmanager/v1beta1/zz_generated.deepcopy.go
---- a/internal/apis/certmanager/v1beta1/zz_generated.deepcopy.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/internal/apis/certmanager/v1beta1/zz_generated.deepcopy.go	(date 1653420801184)
-@@ -467,6 +467,11 @@
- 		*out = make([]CertificateAdditionalOutputFormat, len(*in))
- 		copy(*out, *in)
- 	}
-+	if in.CertificateOwnerRef != nil {
-+		in, out := &in.CertificateOwnerRef, &out.CertificateOwnerRef
-+		*out = new(bool)
-+		**out = **in
-+	}
- 	return
- }
-
-Index: internal/apis/certmanager/v1beta1/zz_generated.conversion.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/internal/apis/certmanager/v1beta1/zz_generated.conversion.go b/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
---- a/internal/apis/certmanager/v1beta1/zz_generated.conversion.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/internal/apis/certmanager/v1beta1/zz_generated.conversion.go	(date 1653420801184)
-@@ -832,6 +832,7 @@
- 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
- 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
- 	out.AdditionalOutputFormats = *(*[]certmanager.CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
-+	out.CertificateOwnerRef = (*bool)(unsafe.Pointer(in.CertificateOwnerRef))
- 	return nil
- }
-
-@@ -869,6 +870,7 @@
- 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
- 	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
- 	out.AdditionalOutputFormats = *(*[]CertificateAdditionalOutputFormat)(unsafe.Pointer(&in.AdditionalOutputFormats))
-+	out.CertificateOwnerRef = (*bool)(unsafe.Pointer(in.CertificateOwnerRef))
- 	return nil
- }
-
-Index: internal/apis/certmanager/v1alpha3/types_certificate.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/internal/apis/certmanager/v1alpha3/types_certificate.go b/internal/apis/certmanager/v1alpha3/types_certificate.go
---- a/internal/apis/certmanager/v1alpha3/types_certificate.go	(revision 527537d0354f731ed0fa9ae91c82d1088ee00f7c)
-+++ b/internal/apis/certmanager/v1alpha3/types_certificate.go	(date 1653420801180)
-@@ -215,6 +215,11 @@
- 	// the controller and webhook components.
- 	// +optional
- 	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
-+
-+	// CertificateOwnerRef is whether to set the certificate resource as an owner of secret where the tls certificate is stored.
-+	// When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.
-+	// If unset (`nil`) `--enable-certificate-owner-ref` CLI parameter value is used. Default value is `nil`.
-+	CertificateOwnerRef *bool
- }
-
- // CertificatePrivateKey contains configuration options for private keys

--- a/modules/101-cert-manager/images/cert-manager-controller/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-controller/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "1.7.1" }}
+{{- $version := "1.8.2" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ $.Images.BASE_ALPINE }}
 import:
@@ -32,7 +32,7 @@ shell:
   - cd /build
   - git clone -b "v{{ $version }}" --single-branch https://github.com/jetstack/cert-manager.git
   - cd /build/cert-manager
-  - curl -sSfL https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64 -o /usr/local/bin/bazel
+  - curl -sSfL https://github.com/bazelbuild/bazelisk/releases/download/v1.12.0/bazelisk-linux-amd64 -o /usr/local/bin/bazel
   - chmod +x /usr/local/bin/bazel
   - test -d /patches && for patchfile in /patches/*.patch ; do patch -p1 < ${patchfile}; done
   - export APP_VERSION="v{{ $version }}-flant"

--- a/modules/101-cert-manager/images/cert-manager-webhook/werf.inc.yaml
+++ b/modules/101-cert-manager/images/cert-manager-webhook/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "1.7.1" }}
+{{- $version := "1.8.2" }}
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ $.Images.BASE_ALPINE }}
 import:


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Bump cert-manager version from 1.7.1 to 1.8.2

## Why do we need it, and what problem does it solve?
- cert-manager v1.8.2 introduces [exponential backoff after failed certificate issuance](https://github.com/cert-manager/cert-manager/blob/f8900ad1d8cc9b7c3697d7554911e2959fa56480/design/20220118.certificate-issuance-exponential-backoff.md).
Previously, a failed issuance was retried every hour which — especially in larger cert-manager installations — could cause rate limits to be hit as well as overwhelm external services. Failed attempts
are now retried with a binary exponential backoff starting with 1h then 2h, 4h up to a maximum of 32h. As part of the new backoff behavior, a new failedIssuanceAttempts field was added to the
Certificate spec to track the number of currently failed issuances.

- Use multivalue records instead of simple records for the AWS Route53 ACME DNS challenge solver.
When using simple records, it would be impossible to create a second record in a Route53 hosted zone with the same name/type.

- Increase timeouts for issuer and clusterissuer controllers to 2 minutes and increase ACME client HTTP timeouts to 90 seconds, in order to enable the use of slower ACME issuers which take a long time to process certain requests.
- other minor fixes, you can find the full list [here](https://github.com/cert-manager/cert-manager/releases/tag/v1.8.0)

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cert-manager
type: chore
summary: Bump version to 1.8.2
impact: |
  The field spec.privateKey.rotationPolicy on Certificate resources is now validated. Valid options are Never and Always. If you are using a GitOps flow and one of your YAML manifests contains a Certificate with an invalid value, you will need to update it with a valid value to prevent your GitOps tool from failing on the new validation. 
  You can find certificates with an invalid rotationPolicy value with the next command: `kubectl get certificate -A -ojson | jq -r '.items[] | select(.spec.privateKey.rotationPolicy | strings | . != "Always" and . != "Never") | "\(.metadata.name) in namespace \(.metadata.namespace) has rotationPolicy=\(.spec.privateKey.rotationPolicy)"'`
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
