### PR TITLE
[kube-dns][node-local-dns] coredns v1.9.3 with patch

### DIFF
--- a/modules/042-kube-dns/hooks/legacy_metrics.go
+++ b/modules/042-kube-dns/hooks/legacy_metrics.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
+	"github.com/flant/addon-operator/sdk"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "metrics",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "service",
+			ApiVersion: "v1",
+			Kind:       "Service",
+			FilterFunc: applyLegacyServiceAnnotationFilter,
+		},
+	},
+}, legacyServiceAnnotation)
+
+const (
+	legacyServiceAnnotationGroup      = "kube_dns_legacy_service_annotation"
+	legacyServiceAnnotationMetricName = "d8_kube_dns_deprecated_service_annotation"
+)
+
+func legacyServiceAnnotation(input *go_hook.HookInput) error {
+	input.MetricsCollector.Expire(legacyServiceAnnotationGroup)
+
+	snap := input.Snapshots["service"]
+	for _, obj := range snap {
+		if obj == nil {
+			continue
+		}
+
+		svc := obj.(*Service)
+		input.MetricsCollector.Set(legacyServiceAnnotationMetricName, 1, map[string]string{"service_namespace": svc.Namespace, "service_name": svc.Name}, metrics.WithGroup(legacyServiceAnnotationGroup))
+	}
+
+	return nil
+}
+
+func applyLegacyServiceAnnotationFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	svc := &v1.Service{}
+	err := sdk.FromUnstructured(obj, svc)
+	if err != nil {
+		return nil, err
+	}
+
+	service := &Service{
+		Name:      svc.Name,
+		Namespace: svc.Namespace,
+	}
+
+	if _, ok := svc.Annotations["service.alpha.kubernetes.io/tolerate-unready-endpoints"]; ok {
+		// we'll skip Services with a proper spec field set
+		if svc.Spec.PublishNotReadyAddresses {
+			return nil, nil
+		}
+
+		return service, err
+	}
+
+	return nil, nil
+}
+
+type Service struct {
+	Name      string
+	Namespace string
+}

--- a/modules/042-kube-dns/hooks/legacy_metrics_test.go
+++ b/modules/042-kube-dns/hooks/legacy_metrics_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/shell-operator/pkg/metric_storage/operation"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const (
+	serviceWithDeprecatedAnnotation = `---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+  namespace: test
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+`
+
+	serviceWithoutDeprecatedAnnotation = `---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+  namespace: test
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+`
+
+	serviceWithDeprecatedAnnotationAndWithSpecField = `---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+  namespace: test
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  publishNotReadyAddresses: true
+`
+)
+
+var _ = Describe("kube-dns hooks :: legacy_metrics ::", func() {
+	f := HookExecutionConfigInit("", "")
+
+	Context("Empty cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("No metrics should be present in an empty custer", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(1))
+			Expect(m[0].Action).Should(Equal("expire"))
+		})
+
+		Context("Service created with the deprecated annotation", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(serviceWithDeprecatedAnnotation))
+				f.RunHook()
+			})
+
+			It("Metric should be generated", func() {
+				Expect(f).To(ExecuteSuccessfully())
+				m := f.MetricsCollector.CollectedMetrics()
+				Expect(m).To(HaveLen(2))
+				Expect(m[0].Action).Should(Equal("expire"))
+				Expect(m[1]).To(BeEquivalentTo(operation.MetricOperation{
+					Name:   legacyServiceAnnotationMetricName,
+					Group:  legacyServiceAnnotationGroup,
+					Action: "set",
+					Value:  pointer.Float64Ptr(1.0),
+					Labels: map[string]string{
+						"service_name":      "test",
+						"service_namespace": "test",
+					},
+				}))
+			})
+
+			Context("Service updated without the deprecated annotation", func() {
+				BeforeEach(func() {
+					f.BindingContexts.Set(f.KubeStateSet(serviceWithoutDeprecatedAnnotation))
+					f.RunHook()
+				})
+
+				It("Metric should be removed", func() {
+					Expect(f).To(ExecuteSuccessfully())
+					m := f.MetricsCollector.CollectedMetrics()
+					Expect(m).To(HaveLen(1))
+					Expect(m[0].Action).Should(Equal("expire"))
+				})
+			})
+
+			Context("Service updated with the proper spec field", func() {
+				BeforeEach(func() {
+					f.BindingContexts.Set(f.KubeStateSet(serviceWithDeprecatedAnnotationAndWithSpecField))
+					f.RunHook()
+				})
+
+				It("Metric should be removed", func() {
+					Expect(f).To(ExecuteSuccessfully())
+					m := f.MetricsCollector.CollectedMetrics()
+					Expect(m).To(HaveLen(1))
+					Expect(m[0].Action).Should(Equal("expire"))
+				})
+			})
+		})
+	})
+})

--- a/modules/042-kube-dns/images/coredns/Dockerfile
+++ b/modules/042-kube-dns/images/coredns/Dockerfile
@@ -1,7 +1,18 @@
 # Based on https://github.com/coredns/coredns/blob/master/Dockerfile
 ARG BASE_ALPINE
-FROM coredns/coredns:1.9.1@sha256:d5a7db9ab4cb3efc22a08707385c54c328db3df32841d6c4a8ae78f102f1f49a as artifact
+ARG BASE_GOLANG_17_ALPINE
 
-FROM $BASE_ALPINE
-COPY --from=artifact /coredns /coredns
+
+FROM $BASE_GOLANG_17_ALPINE as artifact
+WORKDIR /src
+RUN apk add patch
+RUN wget https://github.com/coredns/coredns/archive/refs/tags/v1.9.3.tar.gz -O - | tar -xzv --strip-components=1 -C /src/
+COPY patches/support-alpha-tolerate-unready-endpoints-annotation.patch /src/
+RUN patch -p1 < support-alpha-tolerate-unready-endpoints-annotation.patch
+RUN CGO_ENABLED=0 go build -ldflags="-s -w -X github.com/coredns/coredns/coremain.GitCommit=v1.9.3-flant.1" -o coredns
+
+
+FROM $BASE_GOLANG_17_ALPINE
+RUN apk add --no-cache ca-certificates
+COPY --from=artifact /src/coredns /coredns
 ENTRYPOINT [ "/coredns" ]

--- a/modules/042-kube-dns/images/coredns/patches/README.md
+++ b/modules/042-kube-dns/images/coredns/patches/README.md
@@ -1,0 +1,5 @@
+# Patches
+
+## support-alpha-tolerate-unready-endpoints-annotation.patch
+
+CoreDNS [relies](https://github.com/coredns/coredns/blob/5534625c75a0ae1f84e1f715eaddb257de4166eb/plugin/kubernetes/object/endpoint.go#L182-L184) on Ready status of an endpoint in an EndpointSlice. Make sure that coredns respects the deprecated `service.alpha.kubernetes.io/tolerate-unready-endpoints` annotation.

--- a/modules/042-kube-dns/images/coredns/patches/README.md
+++ b/modules/042-kube-dns/images/coredns/patches/README.md
@@ -3,3 +3,5 @@
 ## support-alpha-tolerate-unready-endpoints-annotation.patch
 
 CoreDNS [relies](https://github.com/coredns/coredns/blob/5534625c75a0ae1f84e1f715eaddb257de4166eb/plugin/kubernetes/object/endpoint.go#L182-L184) on Ready status of an endpoint in an EndpointSlice. Make sure that coredns respects the deprecated `service.alpha.kubernetes.io/tolerate-unready-endpoints` annotation.
+
+Upstream [PR](https://github.com/coredns/coredns/pull/5491).

--- a/modules/042-kube-dns/images/coredns/patches/support-alpha-tolerate-unready-endpoints-annotation.patch
+++ b/modules/042-kube-dns/images/coredns/patches/support-alpha-tolerate-unready-endpoints-annotation.patch
@@ -1,0 +1,215 @@
+Index: plugin/kubernetes/kubernetes.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/plugin/kubernetes/kubernetes.go b/plugin/kubernetes/kubernetes.go
+--- a/plugin/kubernetes/kubernetes.go	(revision 45b0a11294c59bfd806a57807aaa2a185f761cd5)
++++ b/plugin/kubernetes/kubernetes.go	(date 1657053155625)
+@@ -540,6 +540,10 @@
+ 					continue
+ 				}
+
++				if !ep.Ready && !svc.HasAlphaPublishUnreadyAddressesAnnotation {
++					continue
++				}
++
+ 				for _, eps := range ep.Subsets {
+ 					for _, addr := range eps.Addresses {
+
+Index: plugin/kubernetes/kubernetes_test.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/plugin/kubernetes/kubernetes_test.go b/plugin/kubernetes/kubernetes_test.go
+--- a/plugin/kubernetes/kubernetes_test.go	(revision 45b0a11294c59bfd806a57807aaa2a185f761cd5)
++++ b/plugin/kubernetes/kubernetes_test.go	(date 1657053548158)
+@@ -135,6 +135,7 @@
+ 			Name:      "svc1-slice1",
+ 			Namespace: "testns",
+ 			Index:     object.EndpointsKey("svc1", "testns"),
++			Ready:     true,
+ 		},
+ 		{
+ 			Subsets: []object.EndpointSubset{
+@@ -150,6 +151,7 @@
+ 			Name:      "hdls1-slice1",
+ 			Namespace: "testns",
+ 			Index:     object.EndpointsKey("hdls1", "testns"),
++			Ready:     true,
+ 		},
+ 		{
+ 			Subsets: []object.EndpointSubset{
+@@ -159,6 +161,7 @@
+ 					},
+ 				},
+ 			},
++			Ready: true,
+ 		},
+ 	}
+ 	return eps
+@@ -180,6 +183,7 @@
+ 			Name:      "svc1-slice1",
+ 			Namespace: "testns",
+ 			Index:     object.EndpointsKey("svc1", "testns"),
++			Ready:     true,
+ 		},
+ 		{
+ 			Subsets: []object.EndpointSubset{
+@@ -195,6 +199,7 @@
+ 			Name:      "hdls1-slice1",
+ 			Namespace: "testns",
+ 			Index:     object.EndpointsKey("hdls1", "testns"),
++			Ready:     true,
+ 		},
+ 		{
+ 			Subsets: []object.EndpointSubset{
+@@ -210,6 +215,7 @@
+ 			Name:      "hdls1-slice2",
+ 			Namespace: "testns",
+ 			Index:     object.EndpointsKey("hdls1", "testns"),
++			Ready:     true,
+ 		},
+ 		{
+ 			Subsets: []object.EndpointSubset{
+@@ -219,6 +225,7 @@
+ 					},
+ 				},
+ 			},
++			Ready: true,
+ 		},
+ 	}
+ 	return eps
+Index: plugin/kubernetes/object/service.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/plugin/kubernetes/object/service.go b/plugin/kubernetes/object/service.go
+--- a/plugin/kubernetes/object/service.go	(revision 45b0a11294c59bfd806a57807aaa2a185f761cd5)
++++ b/plugin/kubernetes/object/service.go	(date 1657053244201)
+@@ -2,6 +2,7 @@
+
+ import (
+ 	"fmt"
++	"strconv"
+
+ 	api "k8s.io/api/core/v1"
+ 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+@@ -20,6 +21,8 @@
+ 	ExternalName string
+ 	Ports        []api.ServicePort
+
++	HasAlphaPublishUnreadyAddressesAnnotation bool
++
+ 	// ExternalIPs we may want to export.
+ 	ExternalIPs []string
+
+@@ -46,6 +49,10 @@
+ 		ExternalIPs: make([]string, len(svc.Status.LoadBalancer.Ingress)+len(svc.Spec.ExternalIPs)),
+ 	}
+
++	if v, ok := obj.GetAnnotations()["service.alpha.kubernetes.io/tolerate-unready-endpoints"]; ok {
++		s.HasAlphaPublishUnreadyAddressesAnnotation, _ = strconv.ParseBool(v)
++	}
++
+ 	if len(svc.Spec.ClusterIPs) > 0 {
+ 		s.ClusterIPs = make([]string, len(svc.Spec.ClusterIPs))
+ 		copy(s.ClusterIPs, svc.Spec.ClusterIPs)
+@@ -94,7 +101,8 @@
+ 		ExternalName: s.ExternalName,
+ 		ClusterIPs:   make([]string, len(s.ClusterIPs)),
+ 		Ports:        make([]api.ServicePort, len(s.Ports)),
+-		ExternalIPs:  make([]string, len(s.ExternalIPs)),
++		HasAlphaPublishUnreadyAddressesAnnotation: s.HasAlphaPublishUnreadyAddressesAnnotation,
++		ExternalIPs: make([]string, len(s.ExternalIPs)),
+ 	}
+ 	copy(s1.ClusterIPs, s.ClusterIPs)
+ 	copy(s1.Ports, s.Ports)
+Index: plugin/kubernetes/object/endpoint.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/plugin/kubernetes/object/endpoint.go b/plugin/kubernetes/object/endpoint.go
+--- a/plugin/kubernetes/object/endpoint.go	(revision 45b0a11294c59bfd806a57807aaa2a185f761cd5)
++++ b/plugin/kubernetes/object/endpoint.go	(date 1657053075388)
+@@ -19,6 +19,7 @@
+ 	Index     string
+ 	IndexIP   []string
+ 	Subsets   []EndpointSubset
++	Ready     bool
+
+ 	*Empty
+ }
+@@ -128,9 +129,7 @@
+ 	}
+
+ 	for _, end := range ends.Endpoints {
+-		if !endpointsliceReady(end.Conditions.Ready) {
+-			continue
+-		}
++		e.Ready = endpointsliceReady(end.Conditions.Ready)
+ 		for _, a := range end.Addresses {
+ 			ea := EndpointAddress{IP: a}
+ 			if end.Hostname != nil {
+@@ -179,9 +178,7 @@
+ 	}
+
+ 	for _, end := range ends.Endpoints {
+-		if !endpointsliceReady(end.Conditions.Ready) {
+-			continue
+-		}
++		e.Ready = endpointsliceReady(end.Conditions.Ready)
+ 		for _, a := range end.Addresses {
+ 			ea := EndpointAddress{IP: a}
+ 			if end.Hostname != nil {
+Index: plugin/kubernetes/handler_test.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/plugin/kubernetes/handler_test.go b/plugin/kubernetes/handler_test.go
+--- a/plugin/kubernetes/handler_test.go	(revision 45b0a11294c59bfd806a57807aaa2a185f761cd5)
++++ b/plugin/kubernetes/handler_test.go	(date 1657053548142)
+@@ -684,6 +684,7 @@
+ 		Name:      "kubedns",
+ 		Namespace: "kube-system",
+ 		Index:     object.EndpointsKey("kubedns", "kube-system"),
++		Ready:     true,
+ 	}},
+ 	"svc1.testns": {{
+ 		Subsets: []object.EndpointSubset{
+@@ -699,6 +700,7 @@
+ 		Name:      "svc1-slice1",
+ 		Namespace: "testns",
+ 		Index:     object.EndpointsKey("svc1", "testns"),
++		Ready:     true,
+ 	}},
+ 	"svcempty.testns": {{
+ 		Subsets: []object.EndpointSubset{
+@@ -712,6 +714,7 @@
+ 		Name:      "svcempty-slice1",
+ 		Namespace: "testns",
+ 		Index:     object.EndpointsKey("svcempty", "testns"),
++		Ready:     true,
+ 	}},
+ 	"hdls1.testns": {{
+ 		Subsets: []object.EndpointSubset{
+@@ -732,6 +735,7 @@
+ 		Name:      "hdls1-slice1",
+ 		Namespace: "testns",
+ 		Index:     object.EndpointsKey("hdls1", "testns"),
++		Ready:     true,
+ 	}},
+ 	"hdlsprtls.testns": {{
+ 		Subsets: []object.EndpointSubset{
+@@ -745,6 +749,7 @@
+ 		Name:      "hdlsprtls-slice1",
+ 		Namespace: "testns",
+ 		Index:     object.EndpointsKey("hdlsprtls", "testns"),
++		Ready:     true,
+ 	}},
+ }
+

--- a/modules/042-kube-dns/monitoring/prometheus-rules/kubernetes/dns.yaml
+++ b/modules/042-kube-dns/monitoring/prometheus-rules/kubernetes/dns.yaml
@@ -15,3 +15,26 @@
         CoreDNS pod {{$labels.pod}} has at least one critical error.
         To debug the problem, look into container logs: `kubectl -n kube-system logs {{$labels.pod}}`
       summary: CoreDNS has critical errors.
+
+- name: deckhouse.kube-dns.legacy-services
+  rules:
+  - alert: D8KubeDnsServiceWithDeprecatedAnnotation
+    expr: max by (service_namespace, service_name) (d8_kube_dns_deprecated_service_annotation) == 1
+    for: 5m
+    labels:
+      severity_level: "7"
+    annotations:
+      plk_markup_format: markdown
+      plk_protocol_version: "1"
+      plk_create_group_if_not_exists__d8_kube_dns_deprecated_resources: D8KubeDnsDeprecatedResources,tier=~tier,d8_module=kube-dns,d8_component=kube-dns
+      plk_grouped_by__d8_kube_dns_deprecated_resources: D8KubeDnsDeprecatedResources,tier=~tier,d8_module=kube-dns,d8_component=kube-dns
+      summary: Deprecated Service annotation found.
+      description: |
+        Replace deprecated Service annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints` with `spec.publishNotReadyAddresses: true`.
+        This installation is running a patched version of coredns that respects this annotation. This may change in the future.
+
+        You can get the service with deprecated annotation with the following command:
+
+            ```
+            kubectl -n {{$labels.namespace}} get svc {{$labels.name}} -o yaml
+            ```


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

1. Patched coredns v1.9.3.
2. Alert that informs user about the required migration from a deprecated annotation.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Contains patch that persuades coredns to respect deprecated `service.alpha.kubernetes.io/tolerate-unready-endpoints` annotation.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests are passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
---
section: kube-dns
type: fix
summary: Updated CoreDNS to v1.9.3. With patches to persuade coredns to respect deprecated Service annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints`. Alerts the user to the need for migrating from deprecated annotation.
impact_level: default
---
section: node-local-dns
type: fix
summary: Updated CoreDNS to v1.9.3.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
