### PR TITLE
[deckhouse] image-copier one-liner to detect if there are Pods with irrelevant registry

### DIFF
--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -208,6 +208,10 @@ To switch the Deckhouse cluster to using a third-party registry, follow these st
 * Wait for the Deckhouse Pod to become `Ready`. Restart Deckhouse Pod if it will be in `ImagePullBackoff` state.
 * Wait for bashible to apply the new settings on the master node. The bashible log on the master node (`journalctl -u bashible`) should contain the message `Configuration is in sync, nothing to do`.
 * Only if Deckhouse won't be updated using a third-party registry, then you have to remove `releaseChannel` setting from configmap `d8-system/deckhouse`.
+* Check if there are pods with original registry in cluster (if there are — restart them):
+```
+kubectl get pods -A -o json | jq '.items[] | select(.spec.containers[] | select((.image | contains("deckhouse.io")))) | .metadata.namespace + "\t" + .metadata.name' -r
+```
 
 ## How do I change the configuration of a cluster?
 

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -207,11 +207,12 @@ To switch the Deckhouse cluster to using a third-party registry, follow these st
   * If necessary, change or add the `ca` field with the root CA certificate that validates the third-party registry's https certificate (if the third-party registry uses self-signed certificates).
 * Wait for the Deckhouse Pod to become `Ready`. Restart Deckhouse Pod if it will be in `ImagePullBackoff` state.
 * Wait for bashible to apply the new settings on the master node. The bashible log on the master node (`journalctl -u bashible`) should contain the message `Configuration is in sync, nothing to do`.
-* Only if Deckhouse won't be updated using a third-party registry, then you have to remove `releaseChannel` setting from configmap `d8-system/deckhouse`.
-* Check if there are pods with original registry in cluster (if there are — restart them):
-```
-kubectl get pods -A -o json | jq '.items[] | select(.spec.containers[] | select((.image | contains("deckhouse.io")))) | .metadata.namespace + "\t" + .metadata.name' -r
-```
+* If you want to disable Deckhouse automatic updates, remove the `releaseChannel` parameter from the `d8-system/deckhouse` ConfigMap.
+* Check if there are Pods with original registry in cluster (if there are — restart them):
+
+  ```shell
+  kubectl get pods -A -o json | jq '.items[] | select(.spec.containers[] | select((.image | contains("deckhouse.io")))) | .metadata.namespace + "\t" + .metadata.name' -r
+  ```
 
 ## How do I change the configuration of a cluster?
 

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -212,6 +212,10 @@ chmod 700 d8-push.sh
 * Дождаться перехода Pod'а Deckhouse в статус `Ready`. Если Pod будет находиться в статусе `ImagePullBackoff`, то перезапустите его.
 * Дождаться применения bashible новых настроек на master-узле. В журнале bashible на master-узле (`journalctl -u bashible`) должно появится сообщение `Configuration is in sync, nothing to do`.
 * Только если обновление Deckhouse через сторонний registry не планируется, то следует удалить `releaseChannel` из ConfigMap `d8-system/deckhouse`.
+* Проверить, не осталось ли в кластере подов с оригинальным реджистри:
+```
+kubectl get pods -A -o json | jq '.items[] | select(.spec.containers[] | select((.image | contains("deckhouse.io")))) | .metadata.namespace + "\t" + .metadata.name' -r
+```
 
 ## Как изменить конфигурацию кластера
 

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -200,22 +200,23 @@ chmod 700 d8-push.sh
 
 ## Как переключить работающий кластер Deckhouse на использование стороннего registry?
 
-Для переключения кластера Deckhouse на использование стороннего registry необходимо выполнить следующие действия:
+Для переключения кластера Deckhouse на использование стороннего registry выполните следующие действия:
 
-* Изменить поле `image` в Deployment `d8-system/deckhouse` на адрес образа Deckhouse в новом registry;
-* Изменить Secret `d8-system/deckhouse-registry` (все параметры хранятся в кодировке Base64):
-  * Исправить `.dockerconfigjson` с учетом авторизации в новом registry.
-  * Исправить `address` на адрес нового registry (например, `registry.example.com`).
-  * Исправить `path` на путь к репозиторию Deckhouse в новом registry (например, `/deckhouse/ee`).
-  * При необходимости изменить `scheme` на `http` (если используется HTTP registry).
-  * Если registry использует самоподписные сертификаты, то изменить или добавить поле `ca`, куда внести корневой сертификат соответствующего сертификата registry;
-* Дождаться перехода Pod'а Deckhouse в статус `Ready`. Если Pod будет находиться в статусе `ImagePullBackoff`, то перезапустите его.
-* Дождаться применения bashible новых настроек на master-узле. В журнале bashible на master-узле (`journalctl -u bashible`) должно появится сообщение `Configuration is in sync, nothing to do`.
-* Только если обновление Deckhouse через сторонний registry не планируется, то следует удалить `releaseChannel` из ConfigMap `d8-system/deckhouse`.
-* Проверить, не осталось ли в кластере подов с оригинальным реджистри:
-```
-kubectl get pods -A -o json | jq '.items[] | select(.spec.containers[] | select((.image | contains("deckhouse.io")))) | .metadata.namespace + "\t" + .metadata.name' -r
-```
+* Измените поле `image` в Deployment `d8-system/deckhouse` на адрес образа Deckhouse в новом registry;
+* Измените Secret `d8-system/deckhouse-registry` (все параметры хранятся в кодировке Base64):
+  * Исправьте `.dockerconfigjson` с учетом авторизации в новом registry.
+  * Исправьте `address` на адрес нового registry (например, `registry.example.com`).
+  * Исправьте `path` на путь к репозиторию Deckhouse в новом registry (например, `/deckhouse/ee`).
+  * При необходимости измените `scheme` на `http` (если используется HTTP registry).
+  * Если registry использует самоподписные сертификаты, то измените или добавьте поле `ca`, куда внесите корневой сертификат соответствующего сертификата registry;
+* Дождитесь перехода Pod'а Deckhouse в статус `Ready`. Если Pod будет находиться в статусе `ImagePullBackoff`, то перезапустите его.
+* Дождитесь применения bashible новых настроек на master-узле. В журнале bashible на master-узле (`journalctl -u bashible`) должно появится сообщение `Configuration is in sync, nothing to do`.
+* Если необходимо отключить автоматическое обновление Deckhouse через сторонний registry, то удалите параметр `releaseChannel` из ConfigMap `d8-system/deckhouse`.
+* Проверьте, не осталось ли в кластере Pod'ов с оригинальным адресом registry:
+
+  ```shell
+  kubectl get pods -A -o json | jq '.items[] | select(.spec.containers[] | select((.image | contains("deckhouse.io")))) | .metadata.namespace + "\t" + .metadata.name' -r
+  ```
 
 ## Как изменить конфигурацию кластера
 

--- a/modules/020-deckhouse/docs/internal/IMAGE_COPIER.md
+++ b/modules/020-deckhouse/docs/internal/IMAGE_COPIER.md
@@ -62,10 +62,10 @@ Execute commands another commands from `generate-copier-secret.sh` output:
 * Wait for Deckhouse pod ready (restart pod if it is in ImagePullBackoff state).
 * Check bashible on master node restart correctly.
 * If you use the istio module, it is recommended to restart all the application pods with istio sidecar.
-* Check if there are pods with original registry:
+* Check if there are Pods with original registry:
 
-```
-kubectl get pods -A -o json | jq '.items[] | select(.spec.containers[] | select((.image | contains("deckhouse.io")))) | .metadata.namespace + "\t" + .metadata.name' -r
-```
+  ```shell
+  kubectl get pods -A -o json | jq '.items[] | select(.spec.containers[] | select((.image | contains("deckhouse.io")))) | .metadata.namespace + "\t" + .metadata.name' -r
+  ```
 
 Or use this [instruction](https://deckhouse.io/en/documentation/v1/deckhouse-faq.html#how-do-i-switch-a-running-deckhouse-cluster-to-use-a-third-party-registry)

--- a/modules/020-deckhouse/docs/internal/IMAGE_COPIER.md
+++ b/modules/020-deckhouse/docs/internal/IMAGE_COPIER.md
@@ -62,7 +62,7 @@ Execute commands another commands from `generate-copier-secret.sh` output:
 * Wait for Deckhouse pod ready (restart pod if it is in ImagePullBackoff state).
 * Check bashible on master node restart correctly.
 * If you use the istio module, it is recommended to restart all the application pods with istio sidecar.
-* Check if there are pods with irrelevant registry:
+* Check if there are pods with original registry:
 
 ```
 kubectl get pods -A -o json | jq '.items[] | select(.spec.containers[] | select((.image | contains("deckhouse.io")))) | .metadata.namespace + "\t" + .metadata.name' -r

--- a/modules/020-deckhouse/docs/internal/IMAGE_COPIER.md
+++ b/modules/020-deckhouse/docs/internal/IMAGE_COPIER.md
@@ -61,5 +61,11 @@ Execute commands another commands from `generate-copier-secret.sh` output:
 * Change `d8-system/deckhouse-registry secret.
 * Wait for Deckhouse pod ready (restart pod if it is in ImagePullBackoff state).
 * Check bashible on master node restart correctly.
+* If you use the istio module, it is recommended to restart all the application pods with istio sidecar.
+* Check if there are pods with irrelevant registry:
+
+```
+kubectl get pods -A -o json | jq '.items[] | select(.spec.containers[] | select((.image | contains("deckhouse.io")))) | .metadata.namespace + "\t" + .metadata.name' -r
+```
 
 Or use this [instruction](https://deckhouse.io/en/documentation/v1/deckhouse-faq.html#how-do-i-switch-a-running-deckhouse-cluster-to-use-a-third-party-registry)

--- a/modules/020-deckhouse/images/images-copier/generate-copier-secret.sh
+++ b/modules/020-deckhouse/images/images-copier/generate-copier-secret.sh
@@ -132,6 +132,6 @@ kubectl -n d8-system rollout restart deployment deckhouse
 # The bashible log on the master node (journalctl -u bashible) should contain the message Configuration is in sync, nothing to do.
 # If you use the istio module, it is recommended to restart all the application pods with istio sidecar.
 
-# Check if there are pods with irrelevant registry:
+# Check if there are pods with original registry:
 kubectl get pods -A -o json | jq '.items[] | select(.spec.containers[] | select((.image | contains(\"deckhouse.io\")))) | .metadata.namespace + \"\\\\t\" + .metadata.name' -r
 "

--- a/modules/020-deckhouse/images/images-copier/generate-copier-secret.sh
+++ b/modules/020-deckhouse/images/images-copier/generate-copier-secret.sh
@@ -130,5 +130,8 @@ kubectl -n d8-system rollout restart deployment deckhouse
 # Wait for the Deckhouse Pod to become Ready.
 # Wait for bashible to apply the new settings on the master node.
 # The bashible log on the master node (journalctl -u bashible) should contain the message Configuration is in sync, nothing to do.
-"
+# If you use the istio module, it is recommended to restart all the application pods with istio sidecar.
 
+# Check if there are pods with irrelevant registry:
+kubectl get pods -A -o json | jq '.items[] | select(.spec.containers[] | select((.image | contains(\"deckhouse.io\")))) | .metadata.namespace + \"\\\\t\" + .metadata.name' -r
+"


### PR DESCRIPTION
## Description
image-copier one-liner to detect if there are Pods with irrelevant registry.

## Why do we need it, and what problem does it solve?
It is handy to check if all the pods were updated after re(over?)push.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse
type: chore
summary: image-copier one-liner to detect if there are Pods with irrelevant registry.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
