### PR TITLE
[deckhouse] Possibility to resume suspended release

### DIFF
--- a/modules/020-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/020-deckhouse/hooks/check_deckhouse_release.go
@@ -437,7 +437,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 }
 
 func buildSuspendAnnotation(suspend bool) map[string]interface{} {
-	var annotationValue interface{} = nil
+	var annotationValue interface{}
 
 	if suspend {
 		annotationValue = "true"

--- a/modules/020-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/020-deckhouse/hooks/check_deckhouse_release.go
@@ -149,7 +149,6 @@ releaseLoop:
 					patch := buildSuspendAnnotation(releaseChecker.releaseMetadata.Suspend)
 					input.PatchCollector.MergePatch(patch, "deckhouse.io/v1alpha1", "DeckhouseRelease", "", release.Name)
 				}
-
 			}
 
 			return nil

--- a/modules/020-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/020-deckhouse/hooks/check_deckhouse_release.go
@@ -137,16 +137,21 @@ releaseLoop:
 
 		case release.Version.Equal(newSemver):
 			input.LogEntry.Debugf("Release with version %s already exists", release.Version)
-			if releaseChecker.releaseMetadata.Suspend && release.Phase == v1alpha1.PhasePending {
-				p := map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"annotations": map[string]string{
-							"release.deckhouse.io/suspended": "true",
-						},
-					},
+			switch release.Phase {
+			case v1alpha1.PhasePending, "":
+				if releaseChecker.releaseMetadata.Suspend {
+					patch := buildSuspendAnnotation(releaseChecker.releaseMetadata.Suspend)
+					input.PatchCollector.MergePatch(patch, "deckhouse.io/v1alpha1", "DeckhouseRelease", "", release.Name)
 				}
-				input.PatchCollector.MergePatch(p, "deckhouse.io/v1alpha1", "DeckhouseRelease", "", release.Name)
+
+			case v1alpha1.PhaseSuspended:
+				if !releaseChecker.releaseMetadata.Suspend {
+					patch := buildSuspendAnnotation(releaseChecker.releaseMetadata.Suspend)
+					input.PatchCollector.MergePatch(patch, "deckhouse.io/v1alpha1", "DeckhouseRelease", "", release.Name)
+				}
+
 			}
+
 			return nil
 
 		default:
@@ -429,4 +434,22 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 	default:
 		return errors.New("invalid duration")
 	}
+}
+
+func buildSuspendAnnotation(suspend bool) map[string]interface{} {
+	var annotationValue interface{} = nil
+
+	if suspend {
+		annotationValue = "true"
+	}
+
+	p := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				"release.deckhouse.io/suspended": annotationValue,
+			},
+		},
+	}
+
+	return p
 }

--- a/modules/020-deckhouse/hooks/check_deckhouse_release.go
+++ b/modules/020-deckhouse/hooks/check_deckhouse_release.go
@@ -450,5 +450,12 @@ func buildSuspendAnnotation(suspend bool) map[string]interface{} {
 		},
 	}
 
+	if !suspend {
+		p["status"] = map[string]interface{}{
+			"phase":   "Pending",
+			"message": "",
+		}
+	}
+
 	return p
 }

--- a/modules/020-deckhouse/hooks/check_deckhouse_release_test.go
+++ b/modules/020-deckhouse/hooks/check_deckhouse_release_test.go
@@ -224,6 +224,8 @@ status:
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Field("metadata.annotations.release\\.deckhouse\\.io/suspended").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Field("metadata.annotations.release\\.deckhouse\\.io/suspended").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Field("status.phase").String()).To(Equal("Pending"))
 		})
 	})
 

--- a/modules/020-deckhouse/hooks/check_deckhouse_release_test.go
+++ b/modules/020-deckhouse/hooks/check_deckhouse_release_test.go
@@ -195,6 +195,38 @@ status:
 		})
 	})
 
+	Context("Resume suspended release", func() {
+		BeforeEach(func() {
+			dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
+				LayersStub: func() ([]v1.Layer, error) {
+					return []v1.Layer{&fakeLayer{}, &fakeLayer{Body: `{"version": "v1.25.0"}`}}, nil
+				},
+				DigestStub: func() (v1.Hash, error) {
+					return v1.NewHash("sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+				},
+			}, nil)
+			f.KubeStateSet(`
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1-25-0
+  annotations:
+    release.deckhouse.io/suspended: "true"
+spec:
+  version: "v1.25.0"
+status:
+  phase: Suspended
+`)
+			f.BindingContexts.Set(f.GenerateScheduleContext("* * * * *"))
+			f.RunHook()
+		})
+		It("Release should be marked with annotation", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("DeckhouseRelease", "v1-25-0").Field("metadata.annotations.release\\.deckhouse\\.io/suspended").Exists()).To(BeFalse())
+		})
+	})
+
 	Context("Image hash not changed", func() {
 		BeforeEach(func() {
 			dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Add [possibility](https://www.google.com/search?rlz=1C5CHFA_enRU916RU916&q=possibility&spell=1&sa=X&ved=2ahUKEwjmtr7byOT4AhUlmYsKHbPKD-AQkeECKAB6BAgBEDI) to resume suspended release

## Why do we need it, and what problem does it solve?
We can suspend a release because of some circumstances but it does not mean that the release is broken. We want to have a possibility to resume the deploy process of that release

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse
type:feature
summary: Possibility to resume a suspended release
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
