### PR TITLE
[istio][prometheus] Use for instead of plk_pending_until_firing_for

### DIFF
--- a/ee/modules/110-istio/monitoring/prometheus-rules/operator.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/operator.yaml
@@ -11,7 +11,6 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_pending_until_firing_for: "10m"
       plk_grouped_by__main: "D8IstioOperatorMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "revision"
       summary: istio-operator is unable to reconcile istio control-plane setup.

--- a/modules/300-prometheus/monitoring/prometheus-rules/longterm-target-down.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/longterm-target-down.yaml
@@ -1,8 +1,8 @@
 - name: d8.prometheus.longterm_federation_target_down
   rules:
   - alert: D8PrometheusLongtermFederationTargetDown
-    for: __SCRAPE_INTERVAL_X_2__
     expr: longterm_federate_scrape_successful == 0
+    for: 10m
     labels:
       severity_level: "5"
     annotations:

--- a/modules/300-prometheus/monitoring/prometheus-rules/target-down.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/target-down.yaml
@@ -1,8 +1,8 @@
 - name: d8.prometheus.target_down
   rules:
   - alert: TargetDown
-    for: __SCRAPE_INTERVAL_X_2__
     expr: up == 0 unless on (job) ALERTS{alertname=~".+TargetDown"}
+    for: 10m
     labels:
       severity_level: "7"
     annotations:

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/image-availability/exporter-health.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/image-availability/exporter-health.yaml
@@ -11,7 +11,6 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_pending_until_firing_for: "1m"
       plk_create_group_if_not_exists__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=image-availability-exporter"
       plk_grouped_by__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_ignore_labels: "job"
@@ -32,7 +31,6 @@
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
       plk_ignore_labels: "job"
-      plk_pending_until_firing_for: "15m"
       plk_create_group_if_not_exists__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=image-availability-exporter"
       plk_grouped_by__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
       description: |
@@ -51,7 +49,6 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_pending_until_firing_for: "30m"
       plk_labels_as_annotations: "pod"
       plk_create_group_if_not_exists__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=image-availability-exporter"
       plk_grouped_by__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
@@ -97,7 +94,6 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_pending_until_firing_for: "20m
       plk_create_group_if_not_exists__d8_image_availability_exporter_malfunctioning: "D8ImageAvailabilityExporterMalfunctioning,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=image-availability-exporter"
       plk_grouped_by__d8_image_availability_exporter_malfunctioning: "D8ImageAvailabilityExporterMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: |


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Use `for` instead of `plk_pending_until_firing_for` and add `for` where it was lost.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
To complete update that started in https://github.com/deckhouse/deckhouse/pull/1446.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
No alerts PrometheusConfigReloadFailing from clusters.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: istio
type: chore
summary: Use for instead of plk_pending_until_firing_for
impact_level: low
```

```changes
section: prometheus
type: chore
summary: Use for instead of plk_pending_until_firing_for
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
