### PR TITLE
[prometheus] Have a mercy on trickster

### DIFF
--- a/modules/300-prometheus/templates/trickster/deployment.yaml
+++ b/modules/300-prometheus/templates/trickster/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           readOnly: true
         livenessProbe:
           httpGet:
-            path: /trickster/trickster/health/main
+            path: /trickster/trickster/ping
             port: 8443
             scheme: HTTPS
         readinessProbe:


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Use normal liveness probe

## Why do we need it, and what problem does it solve?
Deckhouse installs the most (and it seems like the last) up to date version of trickster. We probably should not bump his head every time Prometheus is unavailable, because all bugs are fixed now.

## What is the expected result?
Trickster will restart and probably freeze. Need to check it.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: fix
summary: Do not restart Trickster if Prometheus is unavailable
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
