### PR TITLE
[dhctl] Increase attempts to wait ssh master node connect

### DIFF
--- a/dhctl/pkg/system/ssh/frontend/waiting.go
+++ b/dhctl/pkg/system/ssh/frontend/waiting.go
@@ -40,7 +40,7 @@ func (c *Check) WithDelaySeconds(seconds int) *Check {
 
 func (c *Check) AwaitAvailability() error {
 	time.Sleep(c.delay)
-	return retry.NewLoop("Waiting for SSH connection", 35, 5*time.Second).Run(func() error {
+	return retry.NewLoop("Waiting for SSH connection", 50, 5*time.Second).Run(func() error {
 		log.InfoF("Try to connect to %v host\n", c.Session.Host())
 		output, err := c.ExpectAvailable()
 		if err == nil {


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Increase attempts to wait ssh master node connect

## Why do we need it, and what problem does it solve?
Some clouds provide machines slowly. Our openstack provider is slow and e2e tests were failed often.

## What is the expected result?
Openstack e2e always pass.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: chore
summary: Increase attempts to wait ssh master node connect
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
