### PR TITLE
[candi] use cgroupfs as cgroup driver for docker 20

### DIFF
--- a/candi/bashible/common-steps/node-group/050_configure_and_start_docker.sh.tpl
+++ b/candi/bashible/common-steps/node-group/050_configure_and_start_docker.sh.tpl
@@ -22,8 +22,7 @@ _on_docker_config_changed() {
 {{- end }}
 }
 
-mkdir -p /etc/docker
-bb-sync-file /etc/docker/daemon.json - docker-config-changed << "EOF"
+daemon_json="$(cat << "EOF"
 {
 {{- $max_concurrent_downloads := 3 }}
 {{- if hasKey .nodeGroup.cri "docker" }}
@@ -40,6 +39,16 @@ bb-sync-file /etc/docker/daemon.json - docker-config-changed << "EOF"
 {{- end }}
 }
 EOF
+)"
+
+if bb-is-ubuntu-version? 22.04 || bb-is-centos-version? 8 || bb-is-debian-version? 11; then
+  daemon_json_cgroupfs="$(jq '. + {"exec-opts": ["native.cgroupdriver=cgroupfs"]}' <<< "${daemon_json}")"
+  daemon_json="${daemon_json_cgroupfs}"
+fi
+
+mkdir -p /etc/docker
+bb-sync-file /etc/docker/daemon.json - docker-config-changed <<< ${daemon_json}
+
 {{- if .registry.ca }}
 mkdir -p /etc/docker/certs.d/{{ .registry.address }}
 bb-sync-file /etc/docker/certs.d/{{ .registry.address }}/ca.crt  - << "EOF"

--- a/candi/bashible/common-steps/node-group/050_configure_and_start_docker.sh.tpl
+++ b/candi/bashible/common-steps/node-group/050_configure_and_start_docker.sh.tpl
@@ -42,7 +42,7 @@ EOF
 )"
 
 # for docker version >=20 we should set native cgroupdriver to cgroupfs in config
-docker_major_version="$(docker version -f "{{ .Client.Version }}" 2> /dev/null | cut -d "." -f1)"
+docker_major_version="$(docker version -f "{{`{{ .Client.Version }}`}}" 2> /dev/null | cut -d "." -f1)"
 if [ ${docker_major_version} -ge 20 ]; then
   daemon_json="$(jq '. + {"exec-opts": ["native.cgroupdriver=cgroupfs"]}' <<< "${daemon_json}")"
 fi

--- a/candi/bashible/common-steps/node-group/050_configure_and_start_docker.sh.tpl
+++ b/candi/bashible/common-steps/node-group/050_configure_and_start_docker.sh.tpl
@@ -42,7 +42,7 @@ EOF
 )"
 
 if bb-is-ubuntu-version? 22.04 || bb-is-centos-version? 8 || bb-is-debian-version? 11; then
-  daemon_json_cgroupfs="$(jq '. + {"exec-opts": ["native.cgroupdriver=cgroupfs"]}' <<< "${daemon_json}")"
+  daemon_json="$(jq '. + {"exec-opts": ["native.cgroupdriver=cgroupfs"]}' <<< "${daemon_json}")"
   daemon_json="${daemon_json_cgroupfs}"
 fi
 

--- a/candi/bashible/common-steps/node-group/050_configure_and_start_docker.sh.tpl
+++ b/candi/bashible/common-steps/node-group/050_configure_and_start_docker.sh.tpl
@@ -41,7 +41,9 @@ daemon_json="$(cat << "EOF"
 EOF
 )"
 
-if bb-is-ubuntu-version? 22.04 || bb-is-centos-version? 8 || bb-is-debian-version? 11; then
+# for docker version >=20 we should set native cgroupdriver to cgroupfs in config
+docker_major_version="$(docker version -f "{{ .Client.Version }}" 2> /dev/null | cut -d "." -f1)"
+if [ ${docker_major_version} -ge 20 ]; then
   daemon_json="$(jq '. + {"exec-opts": ["native.cgroupdriver=cgroupfs"]}' <<< "${daemon_json}")"
 fi
 

--- a/candi/bashible/common-steps/node-group/050_configure_and_start_docker.sh.tpl
+++ b/candi/bashible/common-steps/node-group/050_configure_and_start_docker.sh.tpl
@@ -43,7 +43,6 @@ EOF
 
 if bb-is-ubuntu-version? 22.04 || bb-is-centos-version? 8 || bb-is-debian-version? 11; then
   daemon_json="$(jq '. + {"exec-opts": ["native.cgroupdriver=cgroupfs"]}' <<< "${daemon_json}")"
-  daemon_json="${daemon_json_cgroupfs}"
 fi
 
 mkdir -p /etc/docker

--- a/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/064_configure_kubelet.sh.tpl
@@ -63,10 +63,7 @@ cri_type="Containerd"
 {{- end }}
 
 if [[ "${cri_type}" == "Docker" || "${cri_type}" == "NotManagedDocker" ]]; then
-# Debian 11 docker uses only systemd as cgroup driver
-  if ! bb-is-debian-version? 11; then
-    cgroup_driver="cgroupfs"
-  fi
+  cgroup_driver="cgroupfs"
   criDir=$(docker info --format '{{`{{.DockerRootDir}}`}}')
   if [ -d "${criDir}/overlay2" ]; then
     criDir="${criDir}/overlay2"


### PR DESCRIPTION
Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Use cgroupfs as cgroup driver for docker 20.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Recent docker versions (20+) used in Ubuntu 22.04, Debian 11, and Centos 8 use systemd v2 as cgroup driver by default. But we expect use of cgroupfs driver. This PR adds config option to daemon.json to use cgroupfs as cgroup driver.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: use cgroupfs as cgroup driver for docker 20
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
