### PR TITLE
[prometheus] fix deckhouse group alerts label selectors

### DIFF
--- a/ee/fe/modules/340-monitoring-applications/monitoring/prometheus-rules/applications/prometheus/prometheus.yaml
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/prometheus-rules/applications/prometheus/prometheus.yaml
@@ -26,7 +26,7 @@
       plk_protocol_version: "1"
       plk_labels_as_annotations: "instance"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse,d8_module=monitoring-applications,d8_component=applications"
+      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
       plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
       description: Reloading Prometheus' configuration has failed for {{ $labels.namespace }}/{{ $labels.pod }}.
       summary: Reloading Prometheus' configuration failed.
@@ -41,7 +41,7 @@
       plk_protocol_version: "1"
       plk_labels_as_annotations: "instance"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse,d8_module=monitoring-applications,d8_component=applications"
+      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
       plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
       description: |
         Prometheus' alert notification queue is running full for Prometheus {{ $labels.namespace }}/{{ $labels.pod}}.
@@ -59,7 +59,7 @@
       plk_protocol_version: "1"
       plk_labels_as_annotations: "instance"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse,d8_module=monitoring-applications,d8_component=applications"
+      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
       plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
       description: |
         There's no properly functioning allertmanager in the cluster and the alerts are dropped.
@@ -75,7 +75,7 @@
       plk_protocol_version: "1"
       plk_labels_as_annotations: "instance"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse,d8_module=monitoring-applications,d8_component=applications"
+      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
       plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
       description: |-
         Prometheus {{ $labels.namespace }}/{{ $labels.pod}} had {{$value | humanize}}
@@ -98,7 +98,7 @@
       plk_protocol_version: "1"
       plk_labels_as_annotations: "instance"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse,d8_module=monitoring-applications,d8_component=applications"
+      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
       plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
       description: |-
         Prometheus {{ $labels.namespace }}/{{ $labels.pod}} had {{$value | humanize}}
@@ -126,7 +126,7 @@
       plk_protocol_version: "1"
       plk_labels_as_annotations: "instance"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse,d8_module=monitoring-applications,d8_component=applications"
+      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
       plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
       description: |
         Pod {{$labels.pod}} in namespace {{$labels.namespace}} has failing rule evaluations.
@@ -143,7 +143,7 @@
       plk_protocol_version: "1"
       plk_labels_as_annotations: "instance"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse,d8_module=monitoring-applications,d8_component=applications"
+      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
       plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
       description: Prometheus {{ $labels.namespace }}/{{ $labels.pod }} is not connected to Alertmanager.
       summary: Prometheus is not connected to Alertmanager.

--- a/ee/fe/modules/340-monitoring-applications/monitoring/prometheus-rules/warnings/warnings.yaml
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/prometheus-rules/warnings/warnings.yaml
@@ -8,7 +8,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,tier=cluster,prometheus=deckhouse,d8_module=monitoring-applications,d8_component=warnings"
+      plk_create_group_if_not_exists__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,prometheus=deckhouse"
       plk_grouped_by__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,prometheus=deckhouse"
       description: |-
         Services with the `prometheus-target` label are used to collect metrics in the cluster.

--- a/ee/modules/110-istio/monitoring/prometheus-rules/federation.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/federation.yaml
@@ -9,8 +9,8 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_istio_federation_metadata_endpoint_failed: D8IstioFederationMetadataEndpointFailed,tier=~tier
-        plk_grouped_by__d8_istio_federation_metadata_endpoint_failed: D8IstioFederationMetadataEndpointFailed,tier=~tier
+        plk_create_group_if_not_exists__d8_istio_federation_metadata_endpoint_failed: D8IstioFederationMetadataEndpointFailed,tier=~tier,prometheus=deckhouse
+        plk_grouped_by__d8_istio_federation_metadata_endpoint_failed: D8IstioFederationMetadataEndpointFailed,tier=~tier,prometheus=deckhouse
         description: |
           Metadata endpoint `{{$labels.endpoint}}` for IstioFederation `{{$labels.federation_name}}` has failed to fetch by d8 hook.
           Reproducing request to public endpoint:

--- a/ee/modules/110-istio/monitoring/prometheus-rules/multicluster.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/multicluster.yaml
@@ -9,8 +9,8 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_istio_multicluster_remote_api_host_failed: D8IstioMulticlusterRemoteAPIHostFailed,tier=~tier
-        plk_grouped_by__d8_istio_multicluster_remote_api_host_failed: D8IstioMulticlusterRemoteAPIHostFailed,tier=~tier
+        plk_create_group_if_not_exists__d8_istio_multicluster_remote_api_host_failed: D8IstioMulticlusterRemoteAPIHostFailed,tier=~tier,prometheus=deckhouse
+        plk_grouped_by__d8_istio_multicluster_remote_api_host_failed: D8IstioMulticlusterRemoteAPIHostFailed,tier=~tier,prometheus=deckhouse
         description: |
           Remote api host `{{$labels.api_host}}` for IstioMulticluster `{{$labels.multicluster_name}}` has failed healthcheck by d8 monitoring hook.
 
@@ -29,8 +29,8 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_istio_multicluster_metadata_endpoint_failed: D8IstioMulticlusterMetadataEndpointFailed,tier=~tier
-        plk_grouped_by__d8_istio_multicluster_metadata_endpoint_failed: D8IstioMulticlusterMetadataEndpointFailed,tier=~tier
+        plk_create_group_if_not_exists__d8_istio_multicluster_metadata_endpoint_failed: D8IstioMulticlusterMetadataEndpointFailed,tier=~tier,prometheus=deckhouse
+        plk_grouped_by__d8_istio_multicluster_metadata_endpoint_failed: D8IstioMulticlusterMetadataEndpointFailed,tier=~tier,prometheus=deckhouse
         description: |
           Metadata endpoint `{{$labels.endpoint}}` for IstioMulticluster `{{$labels.multicluster_name}}` has failed to fetch by d8 hook.
           Reproducing request to public endpoint:

--- a/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
@@ -9,8 +9,8 @@
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier
-      plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier
+      plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse
+      plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse
       summary: Desired control-plane version isn't installed
       description: |
         There is desired istio control plane revision `{{$labels.desired_revision}}` configured for pods in namespace `{{$labels.namespace}}`, but the revision isn't installed. Consider installing it or change the Namespace or Pod configuration.
@@ -34,8 +34,8 @@
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier
-      plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier
+      plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse
+      plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse
       summary: There are Pods with istio sidecars, but without istio-injection configured
       description: |
         There are Pods in `{{$labels.namespace}}` Namespace with istio sidecars, but the istio-injection isn't configured.
@@ -53,8 +53,8 @@
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier
-      plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier
+      plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse
+      plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse
       summary: There are Pods with istio data-plane revision `{{$labels.actual_revision}}`, but desired revision is `{{$labels.desired_revision}}`
       description: |
         There are Pods in Namespace `{{$labels.namespace}}` with istio data-plane revision `{{$labels.actual_revision}}`, but the desired one is `{{$labels.desired_revision}}`.
@@ -78,8 +78,8 @@
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier
-      plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier
+      plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse
+      plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse
       summary: There are Pods with data-plane patch versions different from control-plane one.
       description: |
         There are Pods in `{{$labels.namespace}}` Namespace with data-plane patch versions different from control-plane one. Consider restarting the Pods to actualize it.

--- a/ee/modules/350-node-local-dns/monitoring/prometheus-rules/node-local-dns.yaml
+++ b/ee/modules/350-node-local-dns/monitoring/prometheus-rules/node-local-dns.yaml
@@ -13,7 +13,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_node_local_dns_not_scheduled_on_node: "D8NodeLocalDnsNotScheduledOnNode,prometheus=deckhouse,d8_module=node-local-dns,d8_component=node-local-dns"
+      plk_create_group_if_not_exists__d8_node_local_dns_not_scheduled_on_node: "D8NodeLocalDnsNotScheduledOnNode,prometheus=deckhouse"
       plk_group_for__d8_node_local_dns_not_scheduled_on_node: "D8NodeLocalDnsNotScheduledOnNode,prometheus=deckhouse"
       summary: node-local-dns Pod cannot schedule on Node {{ $labels.node }}
       description: |

--- a/ee/modules/600-flant-integration/monitoring/prometheus-rules/grafana-agent.yaml
+++ b/ee/modules/600-flant-integration/monitoring/prometheus-rules/grafana-agent.yaml
@@ -13,7 +13,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_flant_pricing_malfunctioning: "FlantPricingMalfunctioning,tier=cluster,prometheus=deckhouse,d8_module=flant-integration,d8_component=pricing"
+      plk_create_group_if_not_exists__d8_flant_pricing_malfunctioning: "FlantPricingMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_flant_pricing_malfunctioning: "FlantPricingMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: |
         There are no succeeded samples metric from the Grafana Agent.
@@ -36,7 +36,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_flant_pricing_malfunctioning: "FlantPricingMalfunctioning,tier=cluster,prometheus=deckhouse,d8_module=flant-integration,d8_component=pricing"
+      plk_create_group_if_not_exists__d8_flant_pricing_malfunctioning: "FlantPricingMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_flant_pricing_malfunctioning: "FlantPricingMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: |
         Succeeded samples metric of the Grafana Agent is not increasing.

--- a/ee/modules/600-flant-integration/monitoring/prometheus-rules/sending-alerts.yaml
+++ b/ee/modules/600-flant-integration/monitoring/prometheus-rules/sending-alerts.yaml
@@ -32,7 +32,7 @@
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
         plk_labels_as_annotations: "pod"
-        plk_create_group_if_not_exists__d8_prometheus_madison_integration_malfunctioning: "D8PrometheusMadisonIntegrationMalfunctioning,tier=cluster,prometheus=deckhouse,d8_module=flant-integration,d8_component=madison-proxy"
+        plk_create_group_if_not_exists__d8_prometheus_madison_integration_malfunctioning: "D8PrometheusMadisonIntegrationMalfunctioning,tier=cluster,prometheus=deckhouse"
         plk_grouped_by__d8_prometheus_madison_integration_malfunctioning: "D8PrometheusMadisonIntegrationMalfunctioning,tier=cluster,prometheus=deckhouse"
         plk_caused_by__kubernetes_deployment_replicas_unavailable: "KubernetesDeploymentReplicasUnavailable,tier=cluster,prometheus=deckhouse,namespace=d8-monitoring,deployment={{ $labels.deployment }}"
         description: |
@@ -74,7 +74,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_prometheus_madison_integration_malfunctioning: "D8PrometheusMadisonIntegrationMalfunctioning,tier=cluster,prometheus=deckhouse,d8_module=flant-integration,d8_component=madison-proxy"
+        plk_create_group_if_not_exists__d8_prometheus_madison_integration_malfunctioning: "D8PrometheusMadisonIntegrationMalfunctioning,tier=cluster,prometheus=deckhouse"
         plk_grouped_by__d8_prometheus_madison_integration_malfunctioning: "D8PrometheusMadisonIntegrationMalfunctioning,tier=cluster,prometheus=deckhouse"
         description: |
           Prometheus is unable to deliver 100% alerts through one or more madison-proxies.
@@ -116,5 +116,5 @@
         summary: Prometheus is unable to deliver 100% alerts.
         plk_protocol_version: "1"
         plk_labels_as_annotations: "pod"
-        plk_create_group_if_not_exists__d8_prometheus_madison_integration_malfunctioning: "D8PrometheusMadisonIntegrationMalfunctioning,tier=cluster,prometheus=deckhouse,d8_module=flant-integration,d8_component=madison-proxy"
+        plk_create_group_if_not_exists__d8_prometheus_madison_integration_malfunctioning: "D8PrometheusMadisonIntegrationMalfunctioning,tier=cluster,prometheus=deckhouse"
         plk_grouped_by__d8_prometheus_madison_integration_malfunctioning: "D8PrometheusMadisonIntegrationMalfunctioning,tier=cluster,prometheus=deckhouse"

--- a/modules/013-helm/monitoring/prometheus-rules/deprecated-versions.yaml
+++ b/modules/013-helm/monitoring/prometheus-rules/deprecated-versions.yaml
@@ -10,8 +10,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__helm_release_resource_versions_deprecated: "HelmReleasesHasResourcesWithDeprecatedVersions,tier=cluster"
-      plk_group_for__helm_release_resource_versions_deprecated: HelmReleaseHasResourcesWithDeprecatedVersions,prometheus=deckhouse
+      plk_create_group_if_not_exists__helm_release_resource_versions_deprecated: "HelmReleaseHasResourcesWithDeprecatedVersions,prometheus=deckhouse"
+      plk_group_for__helm_release_resource_versions_deprecated: "HelmReleaseHasResourcesWithDeprecatedVersions,prometheus=deckhouse"
       summary: At least one HELM release contains resources with deprecated apiVersion, which will be removed in Kubernetes v{{ $labels.k8s_version }}.
       description: |
         To observe all resources use the expr `max by (helm_release_namespace, helm_release_name, helm_version, resource_namespace, resource_name, api_version, kind, k8s_version) (resource_versions_compatibility) == 1` in Prometheus.
@@ -28,8 +28,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__helm_release_resource_versions_deprecated: "HelmReleasesHasResourcesWithUnsupportedVersions,tier=cluster"
-      plk_group_for__helm_release_resource_versions_deprecated: HelmReleaseHasResourcesWithUnsupportedVersions,prometheus=deckhouse
+      plk_create_group_if_not_exists__helm_release_resource_versions_deprecated: "HelmReleaseHasResourcesWithUnsupportedVersions,prometheus=deckhouse"
+      plk_group_for__helm_release_resource_versions_deprecated: "HelmReleaseHasResourcesWithUnsupportedVersions,prometheus=deckhouse"
       summary:
         At least one HELM release contains resources with unsupported apiVersion for Kubernetes v{{ $labels.k8s_version }}.
       description: |

--- a/modules/020-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/020-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -12,7 +12,7 @@
       d8_ignore_on_update: "true"
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "instance,pod"
       plk_ignore_labels: "job"
@@ -30,7 +30,7 @@
       d8_ignore_on_update: "true"
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "instance,pod"
       plk_ignore_labels: "job"
@@ -48,7 +48,7 @@
       d8_ignore_on_update: "true"
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,prometheus=deckhouse"
       summary: There is no Deckhouse target in Prometheus.
 
@@ -68,7 +68,7 @@
       d8_ignore_on_update: "true"
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "pod"
       summary: The Deckhouse Pod is NOT Ready.
@@ -89,7 +89,7 @@
       d8_ignore_on_update: "true"
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,prometheus=deckhouse"
       summary: The Deckhouse Pod is NOT Running.
 
@@ -103,7 +103,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_unavailable: "D8DeckhouseUnavailable,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "instance,pod"
       summary: Deckhouse is down.
@@ -129,7 +129,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "pod"
       summary: Excessive Deckhouse restarts detected.
@@ -151,7 +151,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "instance,pod"
       summary: Deckhouse is unable to connect to the registry.
@@ -171,7 +171,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "instance,pod"
       summary: The {{ $labels.queue }} Deckhouse queue has hung; there are {{ $value }} task(s) in the queue.
@@ -196,7 +196,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "instance,pod"
       summary: The {{ $labels.hook }} Deckhouse global hook crashes way too often.
@@ -221,7 +221,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "instance,pod"
       summary: The {{ $labels.module }}/{{ $labels.hook }} Deckhouse hook crashes way too often.
@@ -241,7 +241,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "instance,pod"
       summary: Deckhouse is unable to discover modules.
@@ -259,7 +259,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "instance,pod"
       summary: Deckhouse is unable to start the {{ $labels.module }} module.
@@ -277,7 +277,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "instance,pod"
       summary: Deckhouse is unable to delete the {{ $labels.module }} module.
@@ -295,7 +295,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "instance,pod"
       summary: Deckhouse is unable to run the {{ $labels.hook }} global hook.
@@ -313,7 +313,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "instance,pod"
       summary: Deckhouse is unable to run the {{ $labels.module }}/{{ $labels.hook }} module hook.
@@ -331,7 +331,7 @@
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,d8_module=deckhouse,d8_component=deckhouse"
+      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: |
         Deckhouse config contains errors.

--- a/modules/031-linstor/monitoring/prometheus-rules/drbd-devices.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/drbd-devices.yaml
@@ -9,7 +9,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=cluster,d8_module=linstor,d8_component=linstor-drbd-devices"
+        plk_create_group_if_not_exists__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
         summary: LINSTOR volume is not healthy
         description: |
@@ -34,7 +34,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=cluster,d8_module=linstor,d8_component=linstor-drbd-devices"
+        plk_create_group_if_not_exists__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
         summary: DRBD device has no quorum
         description: |
@@ -64,7 +64,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=cluster,d8_module=linstor,d8_component=linstor-drbd-devices"
+        plk_create_group_if_not_exists__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
         summary: DRBD device is unintentional diskless
         description: |
@@ -96,7 +96,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=cluster,d8_module=linstor,d8_component=linstor-drbd-devices"
+        plk_create_group_if_not_exists__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
         summary: DRBD device has out-of-sync data
         description: |
@@ -128,7 +128,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=cluster,d8_module=linstor,d8_component=linstor-drbd-devices"
+        plk_create_group_if_not_exists__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_drbd_device_health: "D8DrbdDeviceHealth,tier=~tier,prometheus=deckhouse"
         summary: DRBD device is not connected
         description: |

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-controller.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-controller.yaml
@@ -9,7 +9,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_linstor_controller_health: "D8LinstorControllerHealth,tier=cluster,d8_module=linstor,d8_component=linstor-controller"
+        plk_create_group_if_not_exists__d8_linstor_controller_health: "D8LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_controller_health: "D8LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: LINSTOR controller has errors
         description: |
@@ -28,7 +28,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_linstor_controller_health: "D8LinstorControllerHealth,tier=cluster,d8_module=linstor,d8_component=linstor-controller"
+        plk_create_group_if_not_exists__d8_linstor_controller_health: "D8LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_controller_health: "D8LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
         plk_ignore_labels: "job"
         summary: Prometheus cannot scrape the linstor-controller metrics.
@@ -47,7 +47,7 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_ignore_labels: "job"
-        plk_create_group_if_not_exists__d8_linstor_controller_health: "D8LinstorControllerHealth,tier=cluster,d8_module=linstor,d8_component=linstor-controller"
+        plk_create_group_if_not_exists__d8_linstor_controller_health: "D8LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_controller_health: "D8LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: There is no `linstor-controller` target in Prometheus.
         description: |
@@ -65,7 +65,7 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_labels_as_annotations: "pod"
-        plk_create_group_if_not_exists__d8_linstor_controller_health: "D8LinstorControllerHealth,tier=cluster,d8_module=linstor,d8_component=linstor-controller"
+        plk_create_group_if_not_exists__d8_linstor_controller_health: "D8LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_controller_health: "D8LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-controller Pod is NOT Ready.
         description: |
@@ -82,7 +82,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_linstor_controller_health: "D8LinstorControllerHealth,tier=cluster,d8_module=linstor,d8_component=linstor-controller"
+        plk_create_group_if_not_exists__d8_linstor_controller_health: "D8LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_controller_health: "D8LinstorControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-controller Pod is NOT Running.
         description: |

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-csi-controller.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-csi-controller.yaml
@@ -10,7 +10,7 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_labels_as_annotations: "pod"
-        plk_create_group_if_not_exists__d8_linstor_csi_controller_health: "D8LinstorCsiControllerHealth,tier=cluster,d8_module=linstor,d8_component=linstor-csi-controller"
+        plk_create_group_if_not_exists__d8_linstor_csi_controller_health: "D8LinstorCsiControllerHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_csi_controller_health: "D8LinstorCsiControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-csi-controller Pod is NOT Ready.
         description: |
@@ -27,7 +27,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_linstor_csi_controller_health: "D8LinstorCsiControllerHealth,tier=cluster,d8_module=linstor,d8_component=linstor-csi-controller"
+        plk_create_group_if_not_exists__d8_linstor_csi_controller_health: "D8LinstorCsiControllerHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_csi_controller_health: "D8LinstorCsiControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-csi-controller Pod is NOT Running.
         description: |

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-csi-node.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-csi-node.yaml
@@ -10,7 +10,7 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_labels_as_annotations: "pod"
-        plk_create_group_if_not_exists__d8_linstor_csi_node_health: "D8LinstorCsiNodeHealth,tier=cluster,d8_module=linstor,d8_component=linstor-csi-node"
+        plk_create_group_if_not_exists__d8_linstor_csi_node_health: "D8LinstorCsiNodeHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_csi_node_health: "D8LinstorCsiNodeHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-csi-node Pod is NOT Ready.
         description: |
@@ -27,7 +27,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_linstor_csi_node_health: "D8LinstorCsiNodeHealth,tier=cluster,d8_module=linstor,d8_component=linstor-csi-node"
+        plk_create_group_if_not_exists__d8_linstor_csi_node_health: "D8LinstorCsiNodeHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_csi_node_health: "D8LinstorCsiNodeHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-csi-node Pod is NOT Running.
         description: |

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-ha-controller.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-ha-controller.yaml
@@ -10,9 +10,8 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_labels_as_annotations: "pod"
-        plk_create_group_if_not_exists__d8_linstor_ha_controller_health: "D8LinstorHaControllerHealth,tier=cluster,d8_module=linstor,d8_component=linstor-ha-controller"
+        plk_create_group_if_not_exists__d8_linstor_ha_controller_health: "D8LinstorHaControllerHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_ha_controller_health: "D8LinstorHaControllerHealth,tier=~tier,prometheus=deckhouse"
-        plk_grouped_by__main: "D8LinstorHaControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-ha-controller Pod is NOT Ready.
         description: |
           The recommended course of action:
@@ -28,7 +27,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_linstor_ha_controller_health: "D8LinstorHaControllerHealth,tier=cluster,d8_module=linstor,d8_component=linstor-ha-controller"
+        plk_create_group_if_not_exists__d8_linstor_ha_controller_health: "D8LinstorHaControllerHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_ha_controller_health: "D8LinstorHaControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-ha-controller Pod is NOT Running.
         description: |

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-node.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-node.yaml
@@ -8,7 +8,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_linstor_node_health: "D8LinstorNodeHealth,tier=cluster,d8_module=linstor,d8_component=linstor-node"
+        plk_create_group_if_not_exists__d8_linstor_node_health: "D8LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_node_health: "D8LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
         summary: LINSTOR node is not ONLINE
         description: |
@@ -27,7 +27,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_linstor_node_health: "D8LinstorNodeHealth,tier=cluster,d8_module=linstor,d8_component=linstor-node"
+        plk_create_group_if_not_exists__d8_linstor_node_health: "D8LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_node_health: "D8LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
         summary: LINSTOR satellite has errors
         description: |
@@ -47,7 +47,7 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_labels_as_annotations: "pod"
-        plk_create_group_if_not_exists__d8_linstor_node_health: "D8LinstorNodeHealth,tier=cluster,d8_module=linstor,d8_component=linstor-node"
+        plk_create_group_if_not_exists__d8_linstor_node_health: "D8LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_node_health: "D8LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-node Pod is NOT Ready.
         description: |
@@ -64,7 +64,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_linstor_node_health: "D8LinstorNodeHealth,tier=cluster,d8_module=linstor,d8_component=linstor-node"
+        plk_create_group_if_not_exists__d8_linstor_node_health: "D8LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_node_health: "D8LinstorNodeHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-node Pod is NOT Running.
         description: |

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-scheduler.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-scheduler.yaml
@@ -10,7 +10,7 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_labels_as_annotations: "pod"
-        plk_create_group_if_not_exists__d8_linstor_scheduler_health: "D8LinstorSchedulerHealth,tier=cluster,d8_module=linstor,d8_component=linstor-scheduler"
+        plk_create_group_if_not_exists__d8_linstor_scheduler_health: "D8LinstorSchedulerHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_scheduler_health: "D8LinstorSchedulerHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-scheduler Pod is NOT Ready.
         description: |
@@ -27,7 +27,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_linstor_scheduler_health: "D8LinstorSchedulerHealth,tier=cluster,d8_module=linstor,d8_component=linstor-scheduler"
+        plk_create_group_if_not_exists__d8_linstor_scheduler_health: "D8LinstorSchedulerHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_scheduler_health: "D8LinstorSchedulerHealth,tier=~tier,prometheus=deckhouse"
         summary: The linstor-scheduler Pod is NOT Running.
         description: |

--- a/modules/031-linstor/monitoring/prometheus-rules/linstor-storage-pools.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/linstor-storage-pools.yaml
@@ -9,7 +9,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_linstor_storage_pool_health: "D8LinstorStoragePoolHealth,tier=cluster,d8_module=linstor,d8_component=linstor-storage-pools"
+        plk_create_group_if_not_exists__d8_linstor_storage_pool_health: "D8LinstorStoragePoolHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_storage_pool_health: "D8LinstorStoragePoolHealth,tier=~tier,prometheus=deckhouse"
         summary: LINSTOR storage pool has errors
         description: |
@@ -28,7 +28,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_linstor_storage_pool_health: "D8LinstorStoragePoolHealth,tier=cluster,d8_module=linstor,d8_component=linstor-storage-pools"
+        plk_create_group_if_not_exists__d8_linstor_storage_pool_health: "D8LinstorStoragePoolHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_linstor_storage_pool_health: "D8LinstorStoragePoolHealth,tier=~tier,prometheus=deckhouse"
         summary: Storage pool running out of free space
         description: |

--- a/modules/031-linstor/monitoring/prometheus-rules/piraeus-operator.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/piraeus-operator.yaml
@@ -9,7 +9,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_piraeus_operator_health: ",D8PiraeusOperatorHealthtier=cluster,d8_module=linstor,d8_component=linstor-piraeus-operator"
+        plk_create_group_if_not_exists__d8_piraeus_operator_health: ",D8PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_piraeus_operator_health: "D8PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
         plk_ignore_labels: "job"
         summary: Prometheus cannot scrape the piraeus-operator metrics.
@@ -28,7 +28,7 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_ignore_labels: "job"
-        plk_create_group_if_not_exists__d8_piraeus_operator_health: "D8PiraeusOperatorHealth,tier=cluster,d8_module=linstor,d8_component=linstor-piraeus-operator"
+        plk_create_group_if_not_exists__d8_piraeus_operator_health: "D8PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_piraeus_operator_health: "D8PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
         summary: There is no `piraeus-operator` target in Prometheus.
         description: |
@@ -46,7 +46,7 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_labels_as_annotations: "pod"
-        plk_create_group_if_not_exists__d8_piraeus_operator_health: "D8PiraeusOperatorHealth,tier=cluster,d8_module=linstor,d8_component=linstor-piraeus-operator"
+        plk_create_group_if_not_exists__d8_piraeus_operator_health: "D8PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_piraeus_operator_health: "D8PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
         summary: The piraeus-operator Pod is NOT Ready.
         description: |
@@ -63,7 +63,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_piraeus_operator_health: "D8PiraeusOperatorHealth,tier=cluster,d8_module=linstor,d8_component=linstor-piraeus-operator"
+        plk_create_group_if_not_exists__d8_piraeus_operator_health: "D8PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_piraeus_operator_health: "D8PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
         summary: The piraeus-operator Pod is NOT Running.
         description: |

--- a/modules/042-kube-dns/monitoring/prometheus-rules/kubernetes/dns.yaml
+++ b/modules/042-kube-dns/monitoring/prometheus-rules/kubernetes/dns.yaml
@@ -26,8 +26,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_kube_dns_deprecated_resources: D8KubeDnsDeprecatedResources,tier=~tier,d8_module=kube-dns,d8_component=kube-dns
-      plk_grouped_by__d8_kube_dns_deprecated_resources: D8KubeDnsDeprecatedResources,tier=~tier,d8_module=kube-dns,d8_component=kube-dns
+      plk_create_group_if_not_exists__d8_kube_dns_deprecated_resources: D8KubeDnsDeprecatedResources,tier=~tier,d8_module=kube-dns,d8_component=kube-dns,prometheus=deckhouse
+      plk_grouped_by__d8_kube_dns_deprecated_resources: D8KubeDnsDeprecatedResources,tier=~tier,d8_module=kube-dns,d8_component=kube-dns,prometheus=deckhouse
       summary: Deprecated Service annotation found.
       description: |
         Replace deprecated Service annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints` with `spec.publishNotReadyAddresses: true`.

--- a/modules/300-prometheus/monitoring/prometheus-rules/base.tpl
+++ b/modules/300-prometheus/monitoring/prometheus-rules/base.tpl
@@ -12,7 +12,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_longterm_prometheus_malfunctioning: "D8LongtermPrometheusMalfunctioning,tier=cluster,d8_module=prometheus,d8_component=prometheus-longterm"
+        plk_create_group_if_not_exists__d8_longterm_prometheus_malfunctioning: "D8LongtermPrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
         plk_grouped_by__d8_longterm_prometheus_malfunctioning: "D8LongtermPrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
         description: |-
           This Prometheus component is only used to display historical data and is not crucial. However, if its unavailability will last long enough, you will not be able to view the statistics.
@@ -38,7 +38,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_prometheus_malfunctioning: "D8PrometheusMalfunctioning,tier=cluster,d8_module=prometheus,d8_component=trickster"
+        plk_create_group_if_not_exists__d8_prometheus_malfunctioning: "D8PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
         plk_grouped_by__d8_prometheus_malfunctioning: "D8PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
         description: |-
           The following modules use this component:
@@ -64,7 +64,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_prometheus_malfunctioning: "D8PrometheusMalfunctioning,tier=cluster,d8_module=prometheus,d8_component=trickster"
+        plk_create_group_if_not_exists__d8_prometheus_malfunctioning: "D8PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
         plk_grouped_by__d8_prometheus_malfunctioning: "D8PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
         description: |-
           The following modules use this component:

--- a/modules/300-prometheus/monitoring/prometheus-rules/emptydir.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/emptydir.yaml
@@ -10,7 +10,7 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__deckhouse_module_use_empty_dir: DeckhouseModuleUseEmptyDir,prometheus=deckhouse,tier=cluster,d8_module=prometheus,d8_component=prometheus
+      plk_create_group_if_not_exists__deckhouse_module_use_empty_dir: DeckhouseModuleUseEmptyDir,prometheus=deckhouse
       plk_group_for__deckhouse_module_use_empty_dir: DeckhouseModuleUseEmptyDir,prometheus=deckhouse
       summary: Deckhouse module {{ $labels.module_name }} use emptydir as storage.
       description: |

--- a/modules/300-prometheus/monitoring/prometheus-rules/grafana.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/grafana.yaml
@@ -15,7 +15,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_grafana_unavailable: "D8GrafanaUnavailable,tier=cluster,prometheus=deckhouse,d8_module=prometheus,db_component=grafana"
+      plk_create_group_if_not_exists__d8_grafana_unavailable: "D8GrafanaUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_grafana_unavailable: "D8GrafanaUnavailable,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "pod"
       summary: The Grafana Pod is NOT Ready.
@@ -41,7 +41,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_grafana_unavailable: "D8GrafanaUnavailable,tier=cluster,prometheus=deckhouse,d8_module=prometheus,db_component=grafana"
+      plk_create_group_if_not_exists__d8_grafana_unavailable: "D8GrafanaUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_grafana_unavailable: "D8GrafanaUnavailable,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "phase"
       summary: One or more Grafana Pods are NOT Running.
@@ -65,7 +65,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_grafana_unavailable: "D8GrafanaUnavailable,tier=cluster,prometheus=deckhouse,d8_module=prometheus,db_component=grafana"
+      plk_create_group_if_not_exists__d8_grafana_unavailable: "D8GrafanaUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_grafana_unavailable: "D8GrafanaUnavailable,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "instance,pod"
       plk_ignore_labels: "job"
@@ -82,7 +82,7 @@
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_grafana_unavailable: "D8GrafanaUnavailable,tier=cluster,prometheus=deckhouse,d8_module=prometheus,db_component=grafana"
+      plk_create_group_if_not_exists__d8_grafana_unavailable: "D8GrafanaUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_grafana_unavailable: "D8GrafanaUnavailable,tier=cluster,prometheus=deckhouse"
       summary: There is no Grafana target in Prometheus.
       description: |-
@@ -114,7 +114,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_grafana_malfunctioning: "D8GrafanaMalfunctioning,tier=cluster,prometheus=deckhouse,d8_module=prometheus,db_component=grafana"
+      plk_create_group_if_not_exists__d8_grafana_malfunctioning: "D8GrafanaMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_grafana_malfunctioning: "D8GrafanaMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "pod"
       summary: Excessive Grafana restarts are detected.

--- a/modules/300-prometheus/monitoring/prometheus-rules/longterm-target-down.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/longterm-target-down.yaml
@@ -7,7 +7,7 @@
       severity_level: "5"
     annotations:
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_longterm_prometheus_malfunctioning: "D8LongtermPrometheusMalfunctioning,tier=cluster,d8_module=prometheus,d8_component=prometheus-longterm"
+      plk_create_group_if_not_exists__d8_longterm_prometheus_malfunctioning: "D8LongtermPrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_longterm_prometheus_malfunctioning: "D8LongtermPrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
       summary: prometheus-longterm cannot scrape prometheus.
       description: prometheus-longterm cannot scrape "/federate" endpoint from Prometheus. Check error cause in prometheus-longterm WebUI or logs.

--- a/modules/500-okmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-okmeter/monitoring/prometheus-rules/alerting.yaml
@@ -15,7 +15,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_okmeter_unavailable: "D8OkmeterUnavailable,tier=cluster,prometheus=deckhouse,d8_module=okmeter,d8_component=agent"
+        plk_create_group_if_not_exists__d8_okmeter_unavailable: "D8OkmeterUnavailable,tier=cluster,prometheus=deckhouse"
         plk_grouped_by__d8_okmeter_unavailable: "D8OkmeterUnavailable,tier=cluster,prometheus=deckhouse"
         plk_labels_as_annotations: "pod"
         summary: Okmeter agent is not Ready

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -15,7 +15,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_upmeter_unavailable: "D8UpmeterUnavailable,prometheus=deckhouse,tier=cluster,d8_module=upmeter,d8_component=server"
+        plk_create_group_if_not_exists__d8_upmeter_unavailable: "D8UpmeterUnavailable,tier=cluster,prometheus=deckhouse"
         plk_grouped_by__d8_upmeter_unavailable: "D8UpmeterUnavailable,tier=cluster,prometheus=deckhouse"
         plk_labels_as_annotations: "pod"
         summary: Upmeter server is not Ready
@@ -35,7 +35,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_upmeter_unavailable: "D8UpmeterUnavailable,prometheus=deckhouse,tier=cluster,d8_module=upmeter,d8_component=agent"
+        plk_create_group_if_not_exists__d8_upmeter_unavailable: "D8UpmeterUnavailable,tier=cluster,prometheus=deckhouse"
         plk_grouped_by__d8_upmeter_unavailable: "D8UpmeterUnavailable,tier=cluster,prometheus=deckhouse"
         plk_labels_as_annotations: "pod"
         summary: Upmeter agent is not Ready
@@ -61,7 +61,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_upmeter_unavailable: "D8UpmeterUnavailable,prometheus=deckhouse,tier=cluster,d8_module=upmeter,d8_component=server"
+        plk_create_group_if_not_exists__d8_upmeter_unavailable: "D8UpmeterUnavailable,tier=cluster,prometheus=deckhouse"
         plk_grouped_by__d8_upmeter_unavailable: "D8UpmeterUnavailable,tier=cluster,prometheus=deckhouse"
         plk_labels_as_annotations: "phase"
         summary: One or more Upmeter server pods is NOT Running
@@ -93,7 +93,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_upmeter_unavailable: "D8UpmeterUnavailable,prometheus=deckhouse,tier=cluster,d8_module=upmeter,d8_component=agent"
+        plk_create_group_if_not_exists__d8_upmeter_unavailable: "D8UpmeterUnavailable,tier=cluster,prometheus=deckhouse"
         plk_grouped_by__d8_upmeter_unavailable: "D8UpmeterUnavailable,tier=cluster,prometheus=deckhouse"
         plk_labels_as_annotations: "phase"
         summary: One or more Upmeter agent pods is NOT Running
@@ -124,7 +124,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_upmeter_malfunctioning: "D8UpmeterMalfunctioning,prometheus=deckhouse,tier=cluster,d8_module=upmeter,d8_component=server"
+        plk_create_group_if_not_exists__d8_upmeter_malfunctioning: "D8UpmeterMalfunctioning,tier=cluster,prometheus=deckhouse"
         plk_grouped_by__d8_upmeter_malfunctioning: "D8UpmeterMalfunctioning,tier=cluster,prometheus=deckhouse"
         plk_labels_as_annotations: "pod"
         summary: Upmeter server is restarting too often.
@@ -155,7 +155,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_smoke_mini_unavailable: "D8SmokeMiniUnavailable,prometheus=deckhouse,tier=cluster,d8_module=upmeter,d8_component=smoke-mini"
+        plk_create_group_if_not_exists__d8_smoke_mini_unavailable: "D8SmokeMiniUnavailable,tier=cluster,prometheus=deckhouse"
         plk_grouped_by__d8_smoke_mini_unavailable: "D8SmokeMiniUnavailable,tier=cluster,prometheus=deckhouse"
         summary: Smoke-mini has unbound or lost persistent volume claims.
         description: |


### PR DESCRIPTION
Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix deckhouse group alerts label selectors
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
`plk_create_group_if_not_exists__` and `plk_grouped_by__` labels should be equal.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: fix
summary:  fix deckhouse group alerts label selectors
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
