### PR TITLE
[prometheus] fix deckhouse group alerts label selectors

### DIFF
--- a/ee/fe/modules/340-monitoring-applications/monitoring/prometheus-rules/applications/prometheus/prometheus.yaml
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/prometheus-rules/applications/prometheus/prometheus.yaml
@@ -21,13 +21,14 @@
     for: 10m
     labels:
       severity_level: "6"
+      tier: "cluster"
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       plk_labels_as_annotations: "instance"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
-      plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
+      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: Reloading Prometheus' configuration has failed for {{ $labels.namespace }}/{{ $labels.pod }}.
       summary: Reloading Prometheus' configuration failed.
 
@@ -35,14 +36,15 @@
     expr: prometheus_notifications_queue_length / prometheus_notifications_queue_capacity > 0.2
     labels:
       severity_level: "{{ if lt $value 0.5 }}9{{ else if lt $value 0.7 }}8{{ else }}7{{ end }}"
+      tier: "cluster"
     annotations:
       plk_enable_event_severity_change: "true"
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       plk_labels_as_annotations: "instance"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
-      plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
+      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: |
         Prometheus' alert notification queue is running full for Prometheus {{ $labels.namespace }}/{{ $labels.pod}}.
 
@@ -54,13 +56,14 @@
     for: 10m
     labels:
       severity_level: "5"
+      tier: "cluster"
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       plk_labels_as_annotations: "instance"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
-      plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
+      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: |
         There's no properly functioning allertmanager in the cluster and the alerts are dropped.
       summary: There's no properly functioning allertmanager in the cluster and the alert notifications are dropping.
@@ -70,13 +73,14 @@
     for: 10m
     labels:
       severity_level: "7"
+      tier: "cluster"
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       plk_labels_as_annotations: "instance"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
-      plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
+      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: |-
         Prometheus {{ $labels.namespace }}/{{ $labels.pod}} had {{$value | humanize}}
         reload failures over the last two hours.
@@ -93,13 +97,14 @@
     for: 10m
     labels:
       severity_level: "6"
+      tier: "cluster"
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       plk_labels_as_annotations: "instance"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
-      plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
+      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: |-
         Prometheus {{ $labels.namespace }}/{{ $labels.pod}} had {{$value | humanize}}
         compaction failures over the last two hours.
@@ -121,13 +126,14 @@
 
     labels:
       severity_level: "6"
+      tier: "cluster"
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       plk_labels_as_annotations: "instance"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
-      plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
+      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: |
         Pod {{$labels.pod}} in namespace {{$labels.namespace}} has failing rule evaluations.
 
@@ -139,11 +145,12 @@
     for: 10m
     labels:
       severity_level: "5"
+      tier: "cluster"
     annotations:
       plk_protocol_version: "1"
       plk_labels_as_annotations: "instance"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
-      plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,prometheus=deckhouse,namespace={{ $labels.namespace }},service={{ $labels.service }}"
+      plk_create_group_if_not_exists__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__prometheus_malfunctioning: "PrometheusMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: Prometheus {{ $labels.namespace }}/{{ $labels.pod }} is not connected to Alertmanager.
       summary: Prometheus is not connected to Alertmanager.

--- a/ee/fe/modules/340-monitoring-applications/monitoring/prometheus-rules/warnings/warnings.yaml
+++ b/ee/fe/modules/340-monitoring-applications/monitoring/prometheus-rules/warnings/warnings.yaml
@@ -5,11 +5,12 @@
       max(d8_monitoring_applications_old_prometheus_target_total{job="deckhouse"} > 0)
     labels:
       severity_level: "9"
+      tier: "cluster"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,prometheus=deckhouse"
-      plk_grouped_by__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,prometheus=deckhouse"
+      plk_create_group_if_not_exists__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,tier=cluster,prometheus=deckhouse"
       description: |-
         Services with the `prometheus-target` label are used to collect metrics in the cluster.
 

--- a/ee/modules/110-istio/monitoring/prometheus-rules/operator.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/operator.yaml
@@ -11,6 +11,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
+      plk_create_group_if_not_exists__main: "D8IstioOperatorMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__main: "D8IstioOperatorMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "revision"
       summary: istio-operator is unable to reconcile istio control-plane setup.

--- a/ee/modules/350-node-local-dns/monitoring/prometheus-rules/node-local-dns.yaml
+++ b/ee/modules/350-node-local-dns/monitoring/prometheus-rules/node-local-dns.yaml
@@ -10,11 +10,12 @@
       severity_level: "7"
       d8_module: node-local-dns
       d8_component: node-local-dns
+      tier: "cluster"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_node_local_dns_not_scheduled_on_node: "D8NodeLocalDnsNotScheduledOnNode,prometheus=deckhouse"
-      plk_group_for__d8_node_local_dns_not_scheduled_on_node: "D8NodeLocalDnsNotScheduledOnNode,prometheus=deckhouse"
+      plk_create_group_if_not_exists__d8_node_local_dns_not_scheduled_on_node: "D8NodeLocalDnsNotScheduledOnNode,tier=cluster,prometheus=deckhouse"
+      plk_group_for__d8_node_local_dns_not_scheduled_on_node: "D8NodeLocalDnsNotScheduledOnNode,tier=cluster,prometheus=deckhouse"
       summary: node-local-dns Pod cannot schedule on Node {{ $labels.node }}
       description: |
         node-local-dns Pod cannot schedule on Node {{ $labels.node }}.

--- a/ee/modules/600-flant-integration/monitoring/prometheus-rules/sending-alerts.yaml
+++ b/ee/modules/600-flant-integration/monitoring/prometheus-rules/sending-alerts.yaml
@@ -34,7 +34,7 @@
         plk_labels_as_annotations: "pod"
         plk_create_group_if_not_exists__d8_prometheus_madison_integration_malfunctioning: "D8PrometheusMadisonIntegrationMalfunctioning,tier=cluster,prometheus=deckhouse"
         plk_grouped_by__d8_prometheus_madison_integration_malfunctioning: "D8PrometheusMadisonIntegrationMalfunctioning,tier=cluster,prometheus=deckhouse"
-        plk_caused_by__kubernetes_deployment_replicas_unavailable: "KubernetesDeploymentReplicasUnavailable,tier=cluster,prometheus=deckhouse,namespace=d8-monitoring,deployment={{ $labels.deployment }}"
+        plk_caused_by__kubernetes_deployment_replicas_unavailable: "KubernetesDeploymentReplicasUnavailable,tier=cluster,prometheus=deckhouse"
         description: |
           Pometheus is unable to deliver {{ $value | humanizePercentage }} alerts to the {{ $labels.madison_backend }} Madison backend using the {{ $labels.pod }} `madison-proxy`.
 

--- a/modules/013-helm/monitoring/prometheus-rules/deprecated-versions.yaml
+++ b/modules/013-helm/monitoring/prometheus-rules/deprecated-versions.yaml
@@ -10,8 +10,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__helm_release_resource_versions_deprecated: "HelmReleaseHasResourcesWithDeprecatedVersions,prometheus=deckhouse"
-      plk_group_for__helm_release_resource_versions_deprecated: "HelmReleaseHasResourcesWithDeprecatedVersions,prometheus=deckhouse"
+      plk_create_group_if_not_exists__helm_release_resource_versions_deprecated: "HelmReleaseHasResourcesWithDeprecatedVersions,tier=cluster,prometheus=deckhouse"
+      plk_group_for__helm_release_resource_versions_deprecated: "HelmReleaseHasResourcesWithDeprecatedVersions,tier=cluster,prometheus=deckhouse"
       summary: At least one HELM release contains resources with deprecated apiVersion, which will be removed in Kubernetes v{{ $labels.k8s_version }}.
       description: |
         To observe all resources use the expr `max by (helm_release_namespace, helm_release_name, helm_version, resource_namespace, resource_name, api_version, kind, k8s_version) (resource_versions_compatibility) == 1` in Prometheus.
@@ -28,8 +28,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__helm_release_resource_versions_deprecated: "HelmReleaseHasResourcesWithUnsupportedVersions,prometheus=deckhouse"
-      plk_group_for__helm_release_resource_versions_deprecated: "HelmReleaseHasResourcesWithUnsupportedVersions,prometheus=deckhouse"
+      plk_create_group_if_not_exists__helm_release_resource_versions_deprecated: "HelmReleaseHasResourcesWithUnsupportedVersions,tier=cluster,prometheus=deckhouse"
+      plk_group_for__helm_release_resource_versions_deprecated: "HelmReleaseHasResourcesWithUnsupportedVersions,tier=cluster,prometheus=deckhouse"
       summary:
         At least one HELM release contains resources with unsupported apiVersion for Kubernetes v{{ $labels.k8s_version }}.
       description: |

--- a/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
+++ b/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
@@ -10,8 +10,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
       plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
       summary: Some controllers (internal logical loops) are failing in agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}`
       description: |
         Check what's going on: `kubectl -n `{{`{{ $labels.namespace }}`}}` logs `{{`{{ $labels.pod }}`}}``
@@ -26,8 +26,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
       plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
       summary: Some nodes are not reachable by agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}`.
       description: |
         Check what's going on: `kubectl -n `{{`{{ $labels.namespace }}`}}` logs `{{`{{ $labels.pod }}`}}``
@@ -42,8 +42,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
       plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
       summary: Some nodes' health endpoints are not reachable by agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}`.
       description: |
         Check what's going on: `kubectl -n `{{`{{ $labels.namespace }}`}}` logs `{{`{{ $labels.pod }}`}}``
@@ -58,8 +58,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
       plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
       summary: More than half of all known Endpoints are not ready in agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}`.
       description: |
         Check what's going on: `kubectl -n `{{`{{ $labels.namespace }}`}}` logs `{{`{{ $labels.pod }}`}}``
@@ -74,8 +74,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
       plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
       summary: eBPF map `{{`{{ $labels.map_name }}`}}` is more than 80% full in agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}`.
       description: We've reached resource limit of eBPF maps. Consult with vendor for possible remediation steps.
   - alert: CiliumAgentPolicyImportErrors
@@ -88,8 +88,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
       plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
+      plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier
       summary: Agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}` fails to import policies.
       description: |
         Check what's going on: `kubectl -n `{{`{{ $labels.namespace }}`}}` logs `{{`{{ $labels.pod }}`}}``

--- a/modules/031-linstor/monitoring/prometheus-rules/piraeus-operator.yaml
+++ b/modules/031-linstor/monitoring/prometheus-rules/piraeus-operator.yaml
@@ -9,7 +9,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_piraeus_operator_health: ",D8PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
+        plk_create_group_if_not_exists__d8_piraeus_operator_health: "D8PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_piraeus_operator_health: "D8PiraeusOperatorHealth,tier=~tier,prometheus=deckhouse"
         plk_ignore_labels: "job"
         summary: Prometheus cannot scrape the piraeus-operator metrics.

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
@@ -25,7 +25,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_control_plane_manager_unavailable: "D8ControlPlaneManagerUnavailable,tier=cluster,d8_module=control-plane-manager,d8_component=control-plane-manager"
+      plk_create_group_if_not_exists__d8_control_plane_manager_unavailable: "D8ControlPlaneManagerUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_control_plane_manager_unavailable: "D8ControlPlaneManagerUnavailable,tier=cluster,prometheus=deckhouse"
       summary: Controller Pod not running on Node {{ $labels.node }}
       description: |-

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml
@@ -9,7 +9,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__kube_etcd_malfunctioning: "KubeEtcdMalfunctioning,tier=cluster"
+        plk_create_group_if_not_exists__kube_etcd_malfunctioning: "KubeEtcdMalfunctioning,tier=cluster,prometheus=deckhouse"
         plk_grouped_by__kube_etcd_malfunctioning: "KubeEtcdMalfunctioning,tier=cluster,prometheus=deckhouse"
         description: |
           The size of the etcd database on `{{ $labels.node }}` has almost exceeded.

--- a/modules/040-node-manager/monitoring/prometheus-rules/cluster-autoscaler.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/cluster-autoscaler.tpl
@@ -12,7 +12,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_cluster_autoscaler_unavailable: "D8ClusterAutoscalerUnavailable,tier=cluster,d8_module=node-manager,d8_component=cluster-autoscaler"
+      plk_create_group_if_not_exists__d8_cluster_autoscaler_unavailable: "D8ClusterAutoscalerUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_cluster_autoscaler_unavailable: "D8ClusterAutoscalerUnavailable,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "pod"
       summary: The {{`{{$labels.pod}}`}} Pod is NOT Ready.
@@ -28,7 +28,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_cluster_autoscaler_unavailable: "D8ClusterAutoscalerUnavailable,tier=cluster,d8_module=node-manager,d8_component=cluster-autoscaler"
+      plk_create_group_if_not_exists__d8_cluster_autoscaler_unavailable: "D8ClusterAutoscalerUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_cluster_autoscaler_unavailable: "D8ClusterAutoscalerUnavailable,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "phase"
       summary: The cluster-autoscaler Pod is NOT Running.
@@ -48,7 +48,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_cluster_autoscaler_unavailable: "D8ClusterAutoscalerUnavailable,tier=cluster,d8_module=node-manager,d8_component=cluster-autoscaler"
+      plk_create_group_if_not_exists__d8_cluster_autoscaler_unavailable: "D8ClusterAutoscalerUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_cluster_autoscaler_unavailable: "D8ClusterAutoscalerUnavailable,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "instance,pod"
       plk_ignore_labels: "job"
@@ -65,7 +65,7 @@
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_cluster_autoscaler_unavailable: "D8ClusterAutoscalerUnavailable,tier=cluster,d8_module=node-manager,d8_component=cluster-autoscaler"
+      plk_create_group_if_not_exists__d8_cluster_autoscaler_unavailable: "D8ClusterAutoscalerUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_cluster_autoscaler_unavailable: "D8ClusterAutoscalerUnavailable,tier=cluster,prometheus=deckhouse"
       summary: There is no cluster-autoscaler target in Prometheus.
       description: |-
@@ -90,7 +90,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_cluster_autoscaler_malfunctioning: "D8ClusterAutoscalerMalfunctioning,tier=cluster,d8_module=node-manager,d8_component=cluster-autoscaler"
+      plk_create_group_if_not_exists__d8_cluster_autoscaler_malfunctioning: "D8ClusterAutoscalerMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_cluster_autoscaler_malfunctioning: "D8ClusterAutoscalerMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "pod"
       summary: Too many cluster-autoscaler restarts have been detected.
@@ -112,7 +112,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_cluster_autoscaler_malfunctioning: "D8ClusterAutoscalerMalfunctioning,tier=cluster,d8_module=node-manager,d8_component=cluster-autoscaler"
+      plk_create_group_if_not_exists__d8_cluster_autoscaler_malfunctioning: "D8ClusterAutoscalerMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_cluster_autoscaler_malfunctioning: "D8ClusterAutoscalerMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "instance"
       summary: Cluster-autoscaler issues too many errors.

--- a/modules/040-node-manager/monitoring/prometheus-rules/machine-controller-manager.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/machine-controller-manager.tpl
@@ -12,7 +12,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_machine_controller_manager_unavailable: "D8MachineControllerManagerUnavailable,tier=cluster,d8_module=node-manager,d8_component=machine-controller-manager"
+      plk_create_group_if_not_exists__d8_machine_controller_manager_unavailable: "D8MachineControllerManagerUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_machine_controller_manager_unavailable: "D8MachineControllerManagerUnavailable,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "pod"
       summary: The {{`{{$labels.pod}}`}} Pod is NOT Ready.
@@ -28,7 +28,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_machine_controller_manager_unavailable: "D8MachineControllerManagerUnavailable,tier=cluster,d8_module=node-manager,d8_component=machine-controller-manager"
+      plk_create_group_if_not_exists__d8_machine_controller_manager_unavailable: "D8MachineControllerManagerUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_machine_controller_manager_unavailable: "D8MachineControllerManagerUnavailable,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "phase"
       summary: The machine-controller-manager Pod is NOT Running.
@@ -48,7 +48,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_machine_controller_manager_unavailable: "D8MachineControllerManagerUnavailable,tier=cluster,d8_module=node-manager,d8_component=machine-controller-manager"
+      plk_create_group_if_not_exists__d8_machine_controller_manager_unavailable: "D8MachineControllerManagerUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_machine_controller_manager_unavailable: "D8MachineControllerManagerUnavailable,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "instance,pod"
       plk_ignore_labels: "job"
@@ -65,7 +65,7 @@
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_machine_controller_manager_unavailable: "D8MachineControllerManagerUnavailable,tier=cluster,d8_module=node-manager,d8_component=machine-controller-manager"
+      plk_create_group_if_not_exists__d8_machine_controller_manager_unavailable: "D8MachineControllerManagerUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_machine_controller_manager_unavailable: "D8MachineControllerManagerUnavailable,tier=cluster,prometheus=deckhouse"
       summary: There is no machine-controller-manager target in Prometheus.
       description: |-
@@ -88,7 +88,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_machine_controller_manager_malfunctioning: "D8MachineControllerManagerMalfunctioning,tier=cluster,d8_module=node-manager,d8_component=machine-controller-manager"
+      plk_create_group_if_not_exists__d8_machine_controller_manager_malfunctioning: "D8MachineControllerManagerMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_machine_controller_manager_malfunctioning: "D8MachineControllerManagerMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "pod"
       summary: The machine-controller-manager module restarts too often.

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-group-deprecate.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-group-deprecate.yaml
@@ -10,7 +10,7 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__cluster_has_node_groups_deprecation_alerts: "NodeGroupsDeprecationAlerts,tier=cluster,d8_module=node-manager,d8_component=node-group"
+      plk_create_group_if_not_exists__cluster_has_node_groups_deprecation_alerts: "NodeGroupsDeprecationAlerts,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__cluster_has_node_groups_deprecation_alerts: "NodeGroupsDeprecationAlerts,tier=cluster,prometheus=deckhouse"
       summary: NodeGroup {{ $labels.name }} has deprecated filed spec.static.internalNetworkCIDRs
       description: |

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
@@ -34,7 +34,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_cluster_has_node_groups_with_unavailable_replicas: "ClusterHasNodeGroupsWithUnavailableReplicas,tier=cluster,d8_module=node-manager,d8_component=node-group"
+      plk_create_group_if_not_exists__d8_cluster_has_node_groups_with_unavailable_replicas: "ClusterHasNodeGroupsWithUnavailableReplicas,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_cluster_has_node_groups_with_unavailable_replicas: "ClusterHasNodeGroupsWithUnavailableReplicas,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "node_group"
       summary: There are unavailable instances in the {{`{{ $labels.node_group }}`}} node group.
@@ -53,7 +53,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_cluster_has_node_groups_with_unavailable_replicas: "ClusterHasNodeGroupsWithUnavailableReplicas,tier=cluster,d8_module=node-manager,d8_component=node-group"
+      plk_create_group_if_not_exists__d8_cluster_has_node_groups_with_unavailable_replicas: "ClusterHasNodeGroupsWithUnavailableReplicas,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_cluster_has_node_groups_with_unavailable_replicas: "ClusterHasNodeGroupsWithUnavailableReplicas,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "node_group"
       summary: There are no available instances in the {{`{{ $labels.node_group }}`}} node group.
@@ -71,7 +71,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_cluster_has_node_groups_with_unavailable_replicas: "ClusterHasNodeGroupsWithUnavailableReplicas,tier=cluster,d8_module=node-manager,d8_component=node-group"
+      plk_create_group_if_not_exists__d8_cluster_has_node_groups_with_unavailable_replicas: "ClusterHasNodeGroupsWithUnavailableReplicas,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_cluster_has_node_groups_with_unavailable_replicas: "ClusterHasNodeGroupsWithUnavailableReplicas,tier=cluster,prometheus=deckhouse"
       plk_labels_as_annotations: "node_group"
       summary: The number of simultaneously unavailable instances in the {{`{{ $labels.node_group }}`}} node group exceeds the allowed value.

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-unmanaged.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-unmanaged.tpl
@@ -9,7 +9,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_cluster_has_unmanaged_nodes: "D8ClusterHasUnmanagedNodes,tier=cluster,d8_module=node-manager,d8_component=node-group"
+        plk_create_group_if_not_exists__d8_cluster_has_unmanaged_nodes: "D8ClusterHasUnmanagedNodes,tier=cluster,prometheus=deckhouse"
         plk_grouped_by__d8_cluster_has_unmanaged_nodes: "D8ClusterHasUnmanagedNodes,tier=cluster,prometheus=deckhouse"
     {{- if .Values.global.modules.publicDomainTemplate }}
         summary: The {{`{{ $labels.node }}`}} Node is not managed by the [node-manager]({{ include "helm_lib_module_uri_scheme" . }}://{{ include "helm_lib_module_public_domain" (list . "deckhouse") }}/modules/040-node-manager/) module.

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
@@ -13,8 +13,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,d8_module=node-manager,d8_component=node_group"
-      plk_grouped_by__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse,node_group={{ $labels.node_group }}"
+      plk_create_group_if_not_exists__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse"
       summary: The {{ $labels.node }} Node does not update.
       description: |
         There is a new update for the {{ $labels.node }} Node of the {{ $labels.node_group }} group but it has not received the update nor trying to.
@@ -49,8 +49,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,d8_module=node-manager,d8_component=node_group"
-      plk_grouped_by__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse,node_group={{ $labels.node_group }}"
+      plk_create_group_if_not_exists__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse"
       summary: The {{ $labels.node }} Node cannot complete the update.
       description: |
         There is a new update for the {{ $labels.node }} Node of the {{ $labels.node_group }} group}; the Node has learned about the update, requested and received approval, but cannot complete the update.
@@ -73,8 +73,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,d8_module=node-manager,d8_component=node_group"
-      plk_grouped_by__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse,node_group={{ $labels.node_group }}"
+      plk_create_group_if_not_exists__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse"
       summary: The {{ $labels.node }} Node cannot complete the update.
       description: |
         There is a new update for the {{ $labels.node }} Node of the {{ $labels.node_group }} group; the Node has learned about the update, requested and received approval, started the update, ran into a step that causes possible downtime. The update manager (the update_approval hook of node-group module) performed the update, and the Node received downtime approval. However, there is no success message about the update.
@@ -97,8 +97,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,d8_module=node-manager,d8_component=node_group"
-      plk_grouped_by__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse,node_group={{ $labels.node_group }}"
+      plk_create_group_if_not_exists__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse"
       summary: The {{ $labels.node }} Node cannot get disruption approval.
       description: |
         There is a new update for the {{ $labels.node }} Node of the {{ $labels.node_group }} group; the Node has learned about the update, requested and received approval, started the update, and ran into a stage that causes possible downtime. For some reason, the Node cannot get that approval (it is issued fully automatically by the `update_approval` hook of the `node-manager`).
@@ -121,8 +121,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,d8_module=node-manager,d8_component=node_group"
-      plk_grouped_by__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse,node_group={{ $labels.node_group }}"
+      plk_create_group_if_not_exists__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__d8_cluster_has_problems_with_nodes_updates: "D8ClusterHasProblemsWithNodesUpdates,tier=cluster,prometheus=deckhouse"
       summary: The {{ $labels.node_group }} node group is not handling the update correctly.
       description: |
         There is a new update for Nodes of the {{ $labels.node_group }} group; Nodes have learned about the update. However, no Node can get approval to start updating.
@@ -141,7 +141,7 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__cluster_has_nodes_requiring_disruption_approval_for_update: "ClusterHasNodesRequiringDisruptionApprovalForUpdate,tier=cluster,d8_module=node-manager,d8_component=node_group"
+      plk_create_group_if_not_exists__cluster_has_nodes_requiring_disruption_approval_for_update: "ClusterHasNodesRequiringDisruptionApprovalForUpdate,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__cluster_has_nodes_requiring_disruption_approval_for_update: "ClusterHasNodesRequiringDisruptionApprovalForUpdate,tier=cluster,prometheus=deckhouse"
       summary: The {{ $labels.node }} Node requires disruption approval to proceed with the update
       description: |
@@ -179,7 +179,7 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-        plk_create_group_if_not_exists__cluster_has_nodes_stuck_in_draining_for_disruption_during_update: "ClusterHasNodesStuckInDrainingForDisruptionDuringUpdate,tier=cluster,d8_module=node-manager,d8_component=node_group"
+        plk_create_group_if_not_exists__cluster_has_nodes_stuck_in_draining_for_disruption_during_update: "ClusterHasNodesStuckInDrainingForDisruptionDuringUpdate,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__cluster_has_nodes_stuck_in_draining_for_disruption_during_update: "ClusterHasNodesStuckInDrainingForDisruptionDuringUpdate,tier=cluster,prometheus=deckhouse"
       summary: The {{ $labels.node }} Node is stuck in draining.
       description: |

--- a/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.yaml
+++ b/modules/040-terraform-manager/monitoring/prometheus-rules/terraform-manager/terraform-state-exporter.yaml
@@ -12,7 +12,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_terraform_state_exporter_unavailable: "D8TerraformStateExporterUnavailable,tier=cluster,d8_module=terraform-manager,d8_component=terraform-state-exporter"
+      plk_create_group_if_not_exists__d8_terraform_state_exporter_unavailable: "D8TerraformStateExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_terraform_state_exporter_unavailable: "D8TerraformStateExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_ignore_labels: "job"
       description: >
@@ -34,7 +34,7 @@
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__d8_terraform_state_exporter_unavailable: "D8TerraformStateExporterUnavailable,tier=cluster,d8_module=terraform-manager,d8_component=terraform-state-exporter"
+      plk_create_group_if_not_exists__d8_terraform_state_exporter_unavailable: "D8TerraformStateExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_terraform_state_exporter_unavailable: "D8TerraformStateExporterUnavailable,tier=cluster,prometheus=deckhouse"
       description: >
         To get more details:
@@ -59,7 +59,7 @@
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
       plk_labels_as_annotations: "pod"
-      plk_create_group_if_not_exists__d8_terraform_state_exporter_unavailable: "D8TerraformStateExporterUnavailable,tier=cluster,d8_module=terraform-manager,d8_component=terraform-state-exporter"
+      plk_create_group_if_not_exists__d8_terraform_state_exporter_unavailable: "D8TerraformStateExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_terraform_state_exporter_unavailable: "D8TerraformStateExporterUnavailable,tier=cluster,prometheus=deckhouse"
       summary: Pod terraform-state-exporter is not Ready
       description: |
@@ -85,7 +85,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_terraform_state_exporter_unavailable: "D8TerraformStateExporterUnavailable,tier=cluster,d8_module=terraform-manager,d8_component=terraform-state-exporter"
+      plk_create_group_if_not_exists__d8_terraform_state_exporter_unavailable: "D8TerraformStateExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_terraform_state_exporter_unavailable: "D8TerraformStateExporterUnavailable,tier=cluster,prometheus=deckhouse"
       summary: Pod terraform-state-exporter is not Running
       description: |
@@ -110,7 +110,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,d8_module=terraform-manager,d8_component=terraform-state-exporter"
+      plk_create_group_if_not_exists__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,prometheus=deckhouse"
       description: |
         Errors occurred while terraform-state-exporter working.
@@ -130,7 +130,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,d8_module=terraform-manager,d8_component=terraform-state-exporter"
+      plk_create_group_if_not_exists__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,prometheus=deckhouse"
       description: |
         Real Kubernetes cluster state is `{{ $labels.status }}` comparing to Terraform state.
@@ -151,7 +151,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,d8_module=terraform-manager,d8_component=terraform-state-exporter"
+      plk_create_group_if_not_exists__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,prometheus=deckhouse"
       description: |
         Real Node "{{ $labels.node_group }}/{{ $labels.name }}" state is `{{ $labels.status }}` comparing to Terraform state.
@@ -172,7 +172,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,d8_module=terraform-manager,d8_component=terraform-state-exporter"
+      plk_create_group_if_not_exists__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,prometheus=deckhouse"
       description: |
         Terraform-state-exporter can't check difference between Kubernetes cluster state and Terraform state.
@@ -193,7 +193,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,d8_module=terraform-manager,d8_component=terraform-state-exporter"
+      plk_create_group_if_not_exists__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,prometheus=deckhouse"
       description: |
         Terraform-state-exporter can't check difference between Node "{{ $labels.node_group }}/{{ $labels.name }}" state and Terraform state.
@@ -214,7 +214,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,d8_module=terraform-manager,d8_component=terraform-state-exporter"
+      plk_create_group_if_not_exists__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_terraform_state_exporter_checks_failed: "D8TerraformStateExporterChecksFailed,tier=cluster,prometheus=deckhouse"
       description: |
         Terraform-state-exporter found difference between node template from cluster provider configuration and from NodeGroup {{ $labels.name }}.

--- a/modules/042-kube-dns/monitoring/prometheus-rules/kubernetes/dns.yaml
+++ b/modules/042-kube-dns/monitoring/prometheus-rules/kubernetes/dns.yaml
@@ -26,8 +26,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_kube_dns_deprecated_resources: D8KubeDnsDeprecatedResources,tier=~tier,d8_module=kube-dns,d8_component=kube-dns,prometheus=deckhouse
-      plk_grouped_by__d8_kube_dns_deprecated_resources: D8KubeDnsDeprecatedResources,tier=~tier,d8_module=kube-dns,d8_component=kube-dns,prometheus=deckhouse
+      plk_create_group_if_not_exists__d8_kube_dns_deprecated_resources: D8KubeDnsDeprecatedResources,tier=~tier,prometheus=deckhouse
+      plk_grouped_by__d8_kube_dns_deprecated_resources: D8KubeDnsDeprecatedResources,tier=~tier,prometheus=deckhouse
       summary: Deprecated Service annotation found.
       description: |
         Replace deprecated Service annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints` with `spec.publishNotReadyAddresses: true`.

--- a/modules/045-snapshot-controller/monitoring/prometheus-rules/snapshot-controller.yaml
+++ b/modules/045-snapshot-controller/monitoring/prometheus-rules/snapshot-controller.yaml
@@ -9,7 +9,7 @@
       annotations:
         plk_markup_format: "markdown"
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__d8_snapshot_controller_health: "D8SnapshotControllerHealth,tier=~tier,d8_module=snapshot-controller,d8_component=snapshot-controller"
+        plk_create_group_if_not_exists__d8_snapshot_controller_health: "D8SnapshotControllerHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_snapshot_controller_health: "D8SnapshotControllerHealth,tier=~tier,prometheus=deckhouse"
         plk_ignore_labels: "job"
         summary: Prometheus cannot scrape the snapshot-controller metrics.
@@ -28,7 +28,7 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_ignore_labels: "job"
-        plk_create_group_if_not_exists__d8_snapshot_controller_health: "D8SnapshotControllerHealth,tier=~tier,d8_module=snapshot-controller,d8_component=snapshot-controller"
+        plk_create_group_if_not_exists__d8_snapshot_controller_health: "D8SnapshotControllerHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_snapshot_controller_health: "D8SnapshotControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: There is no `snapshot-controller` target in Prometheus.
         description: |
@@ -46,7 +46,7 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_labels_as_annotations: "pod"
-        plk_create_group_if_not_exists__d8_snapshot_controller_health: "D8SnapshotControllerHealth,tier=~tier,d8_module=snapshot-controller,d8_component=snapshot-controller"
+        plk_create_group_if_not_exists__d8_snapshot_controller_health: "D8SnapshotControllerHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_snapshot_controller_health: "D8SnapshotControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: The snapshot-controller Pod is NOT Ready.
         description: |
@@ -63,7 +63,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_snapshot_controller_health: "D8SnapshotControllerHealth,tier=~tier,d8_module=snapshot-controller,d8_component=snapshot-controller"
+        plk_create_group_if_not_exists__d8_snapshot_controller_health: "D8SnapshotControllerHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_snapshot_controller_health: "D8SnapshotControllerHealth,tier=~tier,prometheus=deckhouse"
         summary: The snapshot-controller Pod is NOT Running.
         description: |

--- a/modules/045-snapshot-controller/monitoring/prometheus-rules/snapshot-validation-webhook.yaml
+++ b/modules/045-snapshot-controller/monitoring/prometheus-rules/snapshot-validation-webhook.yaml
@@ -10,7 +10,7 @@
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
         plk_labels_as_annotations: "pod"
-        plk_create_group_if_not_exists__d8_snapshot_validation_webhook_health: "D8SnapshotValidationWebhookHealth,tier=~tier,d8_module=snapshot-controller,d8_component=snapshot-controller"
+        plk_create_group_if_not_exists__d8_snapshot_validation_webhook_health: "D8SnapshotValidationWebhookHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_snapshot_validation_webhook_health: "D8SnapshotValidationWebhookHealth,tier=~tier,prometheus=deckhouse"
         summary: The snapshot-validation-webhook Pod is NOT Ready.
         description: |
@@ -27,7 +27,7 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_snapshot_validation_webhook_health: "D8SnapshotValidationWebhookHealth,tier=~tier,d8_module=snapshot-controller,d8_component=snapshot-controller"
+        plk_create_group_if_not_exists__d8_snapshot_validation_webhook_health: "D8SnapshotValidationWebhookHealth,tier=~tier,prometheus=deckhouse"
         plk_grouped_by__d8_snapshot_validation_webhook_health: "D8SnapshotValidationWebhookHealth,tier=~tier,prometheus=deckhouse"
         summary: The snapshot-validation-webhook Pod is NOT Running.
         description: |

--- a/modules/101-cert-manager/monitoring/prometheus-rules/certificate.yaml
+++ b/modules/101-cert-manager/monitoring/prometheus-rules/certificate.yaml
@@ -34,8 +34,8 @@
       severity_level: "5"
     annotations:
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_cert_manager_malfunctioning: D8CertmanagerMalfunctioning,tier=~tier,d8_module=cert-manager,d8_component=cert-manager
-      plk_grouped_by__d8_cert_manager_malfunctioning: D8CertmanagerMalfunctioning,tier=~tier
+      plk_create_group_if_not_exists__d8_cert_manager_malfunctioning: D8CertmanagerMalfunctioning,tier=~tier,prometheus=deckhouse
+      plk_grouped_by__d8_cert_manager_malfunctioning: D8CertmanagerMalfunctioning,tier=~tier,prometheus=deckhouse
       summary: Certmanager cannot order a certificate.
       description: |
         Cermanager receives responses with the code `{{ $labels.status }}` on requesting {{ $labels.scheme }}://{{ $labels.host }}{{ $labels.path }}.

--- a/modules/101-cert-manager/monitoring/prometheus-rules/legacy.yaml
+++ b/modules/101-cert-manager/monitoring/prometheus-rules/legacy.yaml
@@ -8,8 +8,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_cert_manager_deprecated_resources: D8CertManagerDeprecatedResources,tier=~tier,d8_module=cert-manager,d8_component=cert-manager
-      plk_grouped_by__d8_cert_manager_deprecated_resources: D8CertManagerDeprecatedResources,tier=~tier
+      plk_create_group_if_not_exists__d8_cert_manager_deprecated_resources: D8CertManagerDeprecatedResources,tier=~tier,prometheus=deckhouse
+      plk_grouped_by__d8_cert_manager_deprecated_resources: D8CertManagerDeprecatedResources,tier=~tier,prometheus=deckhouse
       summary: Deprecated Certificates found.
       description: |
         Deprecated cert-manager Certificates found. `certificates.certmanager.k8s.io/v1alpha1` support is deprecated and will be removed in the nearest future.
@@ -24,8 +24,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_cert_manager_deprecated_resources: D8CertManagerDeprecatedResources,tier=~tier,d8_module=cert-manager,d8_component=cert-manager
-      plk_grouped_by__d8_cert_manager_deprecated_resources: D8CertManagerDeprecatedResources,tier=~tier
+      plk_create_group_if_not_exists__d8_cert_manager_deprecated_resources: D8CertManagerDeprecatedResources,tier=~tier,prometheus=deckhouse
+      plk_grouped_by__d8_cert_manager_deprecated_resources: D8CertManagerDeprecatedResources,tier=~tier,prometheus=deckhouse
       summary: Deprecated Issuer found.
       description: |
         Deprecated cert-manager Issuers found. `issuers.certmanager.k8s.io/v1alpha1` support is deprecated and will be removed in the nearest future.
@@ -41,8 +41,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_cert_manager_deprecated_resources: D8CertManagerDeprecatedResources,tier=~tier,d8_module=cert-manager,d8_component=cert-manager
-      plk_grouped_by__d8_cert_manager_deprecated_resources: D8CertManagerDeprecatedResources,tier=~tier
+      plk_create_group_if_not_exists__d8_cert_manager_deprecated_resources: D8CertManagerDeprecatedResources,tier=~tier,prometheus=deckhouse
+      plk_grouped_by__d8_cert_manager_deprecated_resources: D8CertManagerDeprecatedResources,tier=~tier,prometheus=deckhouse
       summary: Deprecated ClusterIssuer found.
       description: |
         Deprecated cert-manager ClusterIssuers found. `clusterissuers.certmanager.k8s.io/v1alpha1` support is deprecated and will be removed in the nearest future.
@@ -58,8 +58,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_cert_manager_deprecated_resources: D8CertManagerDeprecatedResources,tier=~tier,d8_module=cert-manager,d8_component=cert-manager
-      plk_grouped_by__d8_cert_manager_deprecated_resources: D8CertManagerDeprecatedResources,tier=~tier
+      plk_create_group_if_not_exists__d8_cert_manager_deprecated_resources: D8CertManagerDeprecatedResources,tier=~tier,prometheus=deckhouse
+      plk_grouped_by__d8_cert_manager_deprecated_resources: D8CertManagerDeprecatedResources,tier=~tier,prometheus=deckhouse
       summary: Deprecated Ingress annotations found.
       description: |
         Deprecated cert-manager Ingress annotations found. `certmanager.k8s.io/v1alpha1` annotations support is deprecated and will be removed in the nearest future.

--- a/modules/200-operator-prometheus/monitoring/prometheus-rules/operator.yaml
+++ b/modules/200-operator-prometheus/monitoring/prometheus-rules/operator.yaml
@@ -13,7 +13,7 @@
       plk_protocol_version: "1"
       plk_labels_as_annotations: "instance,pod"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__d8_prometheus_operator_unavailable: "D8PrometheusOperatorUnavailable,tier=cluster,d8_module=operator-prometheus,d8_component=prometheus-operator"
+      plk_create_group_if_not_exists__d8_prometheus_operator_unavailable: "D8PrometheusOperatorUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_prometheus_operator_unavailable: "D8PrometheusOperatorUnavailable,tier=cluster,prometheus=deckhouse"
       description: |-
         The `prometheus-operator` Pod is not available.
@@ -37,7 +37,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_prometheus_operator_unavailable: "D8PrometheusOperatorUnavailable,tier=cluster,d8_module=operator-prometheus,d8_component=prometheus-operator"
+      plk_create_group_if_not_exists__d8_prometheus_operator_unavailable: "D8PrometheusOperatorUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_prometheus_operator_unavailable: "D8PrometheusOperatorUnavailable,tier=cluster,prometheus=deckhouse"
       summary: There is no `prometheus-operator` target in Prometheus.
       description: |
@@ -58,7 +58,7 @@
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
       plk_labels_as_annotations: "pod"
-      plk_create_group_if_not_exists__d8_prometheus_operator_unavailable: "D8PrometheusOperatorUnavailable,tier=cluster,d8_module=operator-prometheus,d8_component=prometheus-operator"
+      plk_create_group_if_not_exists__d8_prometheus_operator_unavailable: "D8PrometheusOperatorUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_prometheus_operator_unavailable: "D8PrometheusOperatorUnavailable,tier=cluster,prometheus=deckhouse"
       summary: The `prometheus-operator` Pod is NOT Ready.
       description: |
@@ -80,7 +80,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_prometheus_operator_unavailable: "D8PrometheusOperatorUnavailable,tier=cluster,d8_module=operator-prometheus,d8_component=prometheus-operator"
+      plk_create_group_if_not_exists__d8_prometheus_operator_unavailable: "D8PrometheusOperatorUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_prometheus_operator_unavailable: "D8PrometheusOperatorUnavailable,tier=cluster,prometheus=deckhouse"
       summary: The `prometheus-operator` Pod is NOT Running.
       description: |

--- a/modules/300-prometheus/monitoring/prometheus-rules/emptydir.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/emptydir.yaml
@@ -10,8 +10,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__deckhouse_module_use_empty_dir: DeckhouseModuleUseEmptyDir,prometheus=deckhouse
-      plk_group_for__deckhouse_module_use_empty_dir: DeckhouseModuleUseEmptyDir,prometheus=deckhouse
+      plk_create_group_if_not_exists__deckhouse_module_use_empty_dir: DeckhouseModuleUseEmptyDir,tier=cluster,prometheus=deckhouse
+      plk_group_for__deckhouse_module_use_empty_dir: DeckhouseModuleUseEmptyDir,tier=cluster,prometheus=deckhouse
       summary: Deckhouse module {{ $labels.module_name }} use emptydir as storage.
       description: |
         Deckhouse module {{ $labels.module_name }} use emptydir as storage.

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificate.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificate.yaml
@@ -8,10 +8,11 @@
     for: 1h
     labels:
       severity_level: "8"
+      tier: "cluster"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__certificate_secret_expiration: "CertificateSecretExpiration,tier=~tier,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=cert-exporter"
+      plk_create_group_if_not_exists__certificate_secret_expiration: "CertificateSecretExpiration,tier=~tier,prometheus=deckhouse"
       plk_grouped_by__certificate_secret_expiration: "CertificateSecretExpiration,tier=~tier,prometheus=deckhouse"
       summary: Certificate will expire soon.
       description: |
@@ -30,10 +31,11 @@
     for: 1h
     labels:
       severity_level: "8"
+      tier: "cluster"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__certificate_secret_expiration: "CertificateSecretExpiration,tier=~tier,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=cert-exporter"
+      plk_create_group_if_not_exists__certificate_secret_expiration: "CertificateSecretExpiration,tier=~tier,prometheus=deckhouse"
       plk_grouped_by__certificate_secret_expiration: "CertificateSecretExpiration,tier=~tier,prometheus=deckhouse"
       summary: Certificate expired
       description: |

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/exporter-health.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/exporter-health.yaml
@@ -6,12 +6,13 @@
     for: 1m
     labels:
       severity_level: "8"
+      tier: "cluster"
       d8_module: extended-monitoring
       d8_component: cert-exporter
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_cert_exporter_unavailable: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=cert-exporter"
+      plk_create_group_if_not_exists__d8_cert_exporter_unavailable: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_cert_exporter_unavailable: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_ignore_labels: "job"
       description: |
@@ -25,13 +26,14 @@
     for: 15m
     labels:
       severity_level: "8"
+      tier: "cluster"
       d8_module: extended-monitoring
       d8_component: cert-exporter
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__d8_cert_exporter_unavailable: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=cert-exporter"
+      plk_create_group_if_not_exists__d8_cert_exporter_unavailable: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_cert_exporter_unavailable: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse"
       description: |
         Check the Pod status: `kubectl -n d8-monitoring get pod -l app=cert-exporter`
@@ -44,13 +46,14 @@
     for: 30m
     labels:
       severity_level: "8"
+      tier: "cluster"
       d8_module: extended-monitoring
       d8_component: cert-exporter
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
       plk_labels_as_annotations: "pod"
-      plk_create_group_if_not_exists__d8_cert_exporter_unavailable: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=cert-exporter"
+      plk_create_group_if_not_exists__d8_cert_exporter_unavailable: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_cert_exporter_unavailable: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse"
       summary: The cert-exporter Pod is NOT Ready.
       description: |
@@ -63,12 +66,13 @@
     for: 30m
     labels:
       severity_level: "8"
+      tier: "cluster"
       d8_module: extended-monitoring
       d8_component: cert-exporter
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_cert_exporter_unavailable: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=cert-exporter"
+      plk_create_group_if_not_exists__d8_cert_exporter_unavailable: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_cert_exporter_unavailable: "D8CertExporterUnavailable,tier=cluster,prometheus=deckhouse"
       summary: The cert-exporter Pod is NOT Running.
       description: |
@@ -85,12 +89,13 @@
     for: 20m
     labels:
       severity_level: "8"
+      tier: "cluster"
       d8_module: extended-monitoring
       d8_component: cert-exporter
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_cert_exporter_malfunctioning: "D8CertExporterMalfunctioning,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=cert-exporter"
+      plk_create_group_if_not_exists__d8_cert_exporter_malfunctioning: "D8CertExporterMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_cert_exporter_malfunctioning: "D8CertExporterMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: |
         The `cert-exporter` failed to perform any checks for the certificates expiration for over 20 minutes.

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
@@ -12,11 +12,12 @@
     for: 5m
     labels:
       severity_level: "6"
+      tier: "cluster"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__deployment_replicas_unavailable: "KubernetesDeploymentReplicasUnavailable,tier=cluster,d8_module=extended-monitoring,d8_component=extended-monitoring"
-      plk_group_for__deployment_replicas_unavailable: "KubernetesDeploymentReplicasUnavailable,namespace={{ $labels.namespace }},deployment={{ $labels.deployment }}"
+      plk_create_group_if_not_exists__deployment_replicas_unavailable: "KubernetesDeploymentReplicasUnavailable,tier=cluster,prometheus=deckhouse"
+      plk_group_for__deployment_replicas_unavailable: "KubernetesDeploymentReplicasUnavailable,tier=cluster,prometheus=deckhouse"
       summary: |-
         Count of unavailable replicas in Deployment {{$labels.namespace}}/{{$labels.deployment}} is violating "spec.strategy.rollingupdate.maxunavailable".
       description: |-
@@ -39,11 +40,12 @@
     for: 5m
     labels:
       severity_level: "5"
+      tier: "cluster"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__deployment_replicas_unavailable: "KubernetesDeploymentReplicasUnavailable,tier=cluster,d8_module=extended-monitoring,d8_component=extended-monitoring"
-      plk_group_for__deployment_replicas_unavailable: "KubernetesDeploymentReplicasUnavailable,namespace={{ $labels.namespace }},deployment={{ $labels.deployment }}"
+      plk_create_group_if_not_exists__deployment_replicas_unavailable: "KubernetesDeploymentReplicasUnavailable,tier=cluster,prometheus=deckhouse"
+      plk_group_for__deployment_replicas_unavailable: "KubernetesDeploymentReplicasUnavailable,tier=cluster,prometheus=deckhouse"
       summary: |-
         Count of available replicas in Deployment {{$labels.namespace}}/{{$labels.deployment}} is at zero.
       description: |-
@@ -61,11 +63,12 @@
     for: 5m
     labels:
       severity_level: "6"
+      tier: "cluster"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__daemonset_replicas_unavailable: "KubernetesDaemonSetReplicasUnavailable,tier=cluster,d8_module=extended-monitoring,d8_component=extended-monitoring"
-      plk_group_for__daemonset_replicas_unavailable: "KubernetesDaemonSetReplicasUnavailable,namespace={{ $labels.namespace }},deployment={{ $labels.deployment }}"
+      plk_create_group_if_not_exists__daemonset_replicas_unavailable: "KubernetesDaemonSetReplicasUnavailable,tier=cluster,prometheus=deckhouse"
+      plk_group_for__daemonset_replicas_unavailable: "KubernetesDaemonSetReplicasUnavailable,tier=cluster,prometheus=deckhouse"
       summary: |-
         Count of unavailable replicas in DaemonSet {{$labels.namespace}}/{{$labels.daemonset}} above threshold.
       description: |-
@@ -87,11 +90,12 @@
     for: 5m
     labels:
       severity_level: "5"
+      tier: "cluster"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__daemonset_replicas_unavailable: "KubernetesDaemonSetReplicasUnavailable,tier=cluster,d8_module=extended-monitoring,d8_component=extended-monitoring"
-      plk_group_for__daemonset_replicas_unavailable: "KubernetesDaemonSetReplicasUnavailable,namespace={{ $labels.namespace }},deployment={{ $labels.deployment }}"
+      plk_create_group_if_not_exists__daemonset_replicas_unavailable: "KubernetesDaemonSetReplicasUnavailable,tier=cluster,prometheus=deckhouse"
+      plk_group_for__daemonset_replicas_unavailable: "KubernetesDaemonSetReplicasUnavailable,tier=cluster,prometheus=deckhouse"
       summary: |-
         Count of available replicas in DaemonSet {{$labels.namespace}}/{{$labels.daemonset}} is at zero.
       description: |-
@@ -105,11 +109,12 @@
     for: 15m
     labels:
       severity_level: "9"
+      tier: "cluster"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__daemonset_not_up_to_date: "KubernetesDaemonSetNotUpToDate,tier=cluster,d8_module=extended-monitoring,d8_component=extended-monitoring"
-      plk_group_for__daemonset_not_up_to_date: "KubernetesDaemonSetNotUpToDate,namespace={{ $labels.namespace }},deployment={{ $labels.deployment }}"
+      plk_create_group_if_not_exists__daemonset_not_up_to_date: "KubernetesDaemonSetNotUpToDate,tier=cluster,prometheus=deckhouse"
+      plk_group_for__daemonset_not_up_to_date: "KubernetesDaemonSetNotUpToDate,tier=cluster,prometheus=deckhouse"
       summary: |-
         There are {{ .Value }} outdated Pods in the {{ $labels.namespace }}/{{ $labels.daemonset }} DaemonSet for the last 15 minutes.
       description: |-
@@ -135,11 +140,12 @@
     for: 5m
     labels:
       severity_level: "6"
+      tier: "cluster"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__statefulset_replicas_unavailable: "KubernetesStatefulSetReplicasUnavailable,tier=cluster,d8_module=extended-monitoring,d8_component=extended-monitoring"
-      plk_group_for__statefulset_replicas_unavailable: "KubernetesStatefulSetReplicasUnavailable,namespace={{ $labels.namespace }},deployment={{ $labels.deployment }}"
+      plk_create_group_if_not_exists__statefulset_replicas_unavailable: "KubernetesStatefulSetReplicasUnavailable,tier=cluster,prometheus=deckhouse"
+      plk_group_for__statefulset_replicas_unavailable: "KubernetesStatefulSetReplicasUnavailable,tier=cluster,prometheus=deckhouse"
       summary: |-
         Count of unavailable replicas in StatefulSet {{$labels.namespace}}/{{$labels.statefulset}} above threshold.
       description: |-
@@ -162,11 +168,12 @@
     for: 5m
     labels:
       severity_level: "5"
+      tier: "cluster"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__statefulset_replicas_unavailable: "KubernetesStatefulSetReplicasUnavailable,tier=cluster,d8_module=extended-monitoring,d8_component=extended-monitoring"
-      plk_group_for__statefulset_replicas_unavailable: "KubernetesStatefulSetReplicasUnavailable,namespace={{ $labels.namespace }},deployment={{ $labels.deployment }}"
+      plk_create_group_if_not_exists__statefulset_replicas_unavailable: "KubernetesStatefulSetReplicasUnavailable,tier=cluster,prometheus=deckhouse"
+      plk_group_for__statefulset_replicas_unavailable: "KubernetesStatefulSetReplicasUnavailable,tier=cluster,prometheus=deckhouse"
       summary: |-
         Count of ready replicas in StatefulSet {{$labels.namespace}}/{{$labels.statefulset}} at zero.
       description: |-

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/node.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/node.yaml
@@ -19,8 +19,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=extended-monitoring"
-      plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+      plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
       summary: |-
         Node disk "{{$labels.device}}" on mountpoint "{{$labels.mountpoint}}" is using more than {{ printf "extended_monitoring_node_threshold{threshold=\"disk-bytes-warning\", node=\"%s\"}" $labels.node | query | first | value }}% of storage capacity.
         Currently at: {{ .Value }}%
@@ -44,8 +44,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=extended-monitoring"
-      plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+      plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
       summary: |-
         Node disk "{{$labels.device}}" on mountpoint "{{$labels.mountpoint}}" is using more than {{ printf "extended_monitoring_node_threshold{threshold=\"disk-bytes-critical\", node=\"%s\"}" $labels.node | query | first | value }}% of storage capacity.
         Currently at: {{ .Value }}%
@@ -69,8 +69,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=extended-monitoring"
-      plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+      plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
       summary: |-
         Node disk "{{$labels.device}}" on mountpoint "{{$labels.mountpoint}}" is using more than {{ printf "extended_monitoring_node_threshold{threshold=\"disk-inodes-warning\", node=\"%s\"}" $labels.node | query | first | value }}% of storage capacity.
         Currently at: {{ .Value }}%
@@ -94,8 +94,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=extended-monitoring"
-      plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+      plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
       summary: |-
         Node disk "{{$labels.device}}" on mountpoint "{{$labels.mountpoint}}" is using more than {{ printf "extended_monitoring_node_threshold{threshold=\"disk-inodes-critical\", node=\"%s\"}" $labels.node | query | first | value }}% of storage capacity.
         Currently at: {{ .Value }}%

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/image-availability/exporter-health.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/image-availability/exporter-health.yaml
@@ -11,7 +11,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=image-availability-exporter"
+      plk_create_group_if_not_exists__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_ignore_labels: "job"
       description: |
@@ -31,7 +31,7 @@
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=image-availability-exporter"
+      plk_create_group_if_not_exists__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
       description: |
         Check the Pod status: `kubectl -n d8-monitoring get pod -l app=image-availability-exporter`
@@ -50,7 +50,7 @@
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
       plk_labels_as_annotations: "pod"
-      plk_create_group_if_not_exists__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=image-availability-exporter"
+      plk_create_group_if_not_exists__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
       summary: The image-availability-exporter Pod is NOT Ready.
       description: |
@@ -70,7 +70,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=image-availability-exporter"
+      plk_create_group_if_not_exists__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_image_availability_exporter_unavailable: "D8ImageAvailabilityExporterUnavailable,tier=cluster,prometheus=deckhouse"
       summary: The image-availability-exporter Pod is NOT Running.
       description: |
@@ -94,7 +94,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_image_availability_exporter_malfunctioning: "D8ImageAvailabilityExporterMalfunctioning,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=image-availability-exporter"
+      plk_create_group_if_not_exists__d8_image_availability_exporter_malfunctioning: "D8ImageAvailabilityExporterMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__d8_image_availability_exporter_malfunctioning: "D8ImageAvailabilityExporterMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: |
         The `image-availability-exporter` failed to perform any checks for the availability of images in the registry for over 20 minutes.

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/image-availability/image-checks.tpl
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/image-availability/image-checks.tpl
@@ -16,7 +16,7 @@
   annotations:
     plk_protocol_version: "1"
     plk_markup_format: "markdown"
-    plk_create_group_if_not_exists__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=image-availability-exporter"
+    plk_create_group_if_not_exists__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse"
     plk_grouped_by__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse"
     description: >
       You should check whether the `{{`{{ $labels.image }}`}}` image is available:
@@ -40,7 +40,7 @@
   annotations:
     plk_protocol_version: "1"
     plk_markup_format: "markdown"
-    plk_create_group_if_not_exists__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=image-availability-exporter"
+    plk_create_group_if_not_exists__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse"
     plk_grouped_by__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse"
     description: >
       You should check whether the `{{`{{ $labels.image }}`}}` image name is spelled correctly:
@@ -64,7 +64,7 @@
   annotations:
     plk_protocol_version: "1"
     plk_markup_format: "markdown"
-    plk_create_group_if_not_exists__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=image-availability-exporter"
+    plk_create_group_if_not_exists__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse"
     plk_grouped_by__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse"
     description: >
       The container registry is not available for the `{{`{{ $labels.image }}`}}` image:
@@ -88,7 +88,7 @@
   annotations:
     plk_protocol_version: "1"
     plk_markup_format: "markdown"
-    plk_create_group_if_not_exists__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=image-availability-exporter"
+    plk_create_group_if_not_exists__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse"
     plk_grouped_by__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse"
     description: >
       Unable to login to the container registry using `imagePullSecrets` for the `{{`{{ $labels.image }}`}}` image
@@ -112,7 +112,7 @@
   annotations:
     plk_protocol_version: "1"
     plk_markup_format: "markdown"
-    plk_create_group_if_not_exists__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=image-availability-exporter"
+    plk_create_group_if_not_exists__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse"
     plk_grouped_by__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse"
     description: >
       Insufficient privileges to pull the `{{`{{ $labels.image }}`}}` image using the `imagePullSecrets` specified
@@ -136,7 +136,7 @@
   annotations:
     plk_protocol_version: "1"
     plk_markup_format: "markdown"
-    plk_create_group_if_not_exists__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse,d8_module=extended-monitoring,d8_component=image-availability-exporter"
+    plk_create_group_if_not_exists__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse"
     plk_grouped_by__unavailable_images_in_namespace: "UnavailableImagesInNamespace,tier=cluster,prometheus=deckhouse"
     description: |
       An unknown error occurred for the  `{{`{{ $labels.image }}`}}` image

--- a/modules/340-monitoring-custom/monitoring/prometheus-rules/warnings/warnings.yaml
+++ b/modules/340-monitoring-custom/monitoring/prometheus-rules/warnings/warnings.yaml
@@ -5,10 +5,12 @@
       max(d8_monitoring_custom_unknown_service_monitor_total{job="deckhouse"} > 0)
     labels:
       severity_level: "9"
+      tier: "cluster"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_grouped_by__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,prometheus=deckhouse"
+      plk_create_group_if_not_exists__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,tier=cluster,prometheus=deckhouse"
       description: |-
         There are ServiceMonitors in Deckhouse namespace that were not created by Deckhouse.
 
@@ -24,10 +26,12 @@
       max(d8_monitoring_custom_unknown_pod_monitor_total{job="deckhouse"} > 0)
     labels:
       severity_level: "9"
+      tier: "cluster"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_grouped_by__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,prometheus=deckhouse"
+      plk_create_group_if_not_exists__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,tier=cluster,prometheus=deckhouse"
       description: |-
         There are PodMonitors in Deckhouse namespace that were not created by Deckhouse.
 
@@ -43,10 +47,12 @@
       max(d8_monitoring_custom_unknown_prometheus_rules_total{job="deckhouse"} > 0)
     labels:
       severity_level: "9"
+      tier: "cluster"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_grouped_by__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,prometheus=deckhouse"
+      plk_create_group_if_not_exists__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,tier=cluster,prometheus=deckhouse"
       description: |-
         There are PrometheusRules in the cluster that were not created by Deckhouse.
 
@@ -62,10 +68,12 @@
       max(d8_monitoring_custom_old_prometheus_custom_targets_total{job="deckhouse"} > 0)
     labels:
       severity_level: "9"
+      tier: "cluster"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_grouped_by__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,prometheus=deckhouse"
+      plk_create_group_if_not_exists__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,tier=cluster,prometheus=deckhouse"
+      plk_grouped_by__d8_deprecated_prometheus_functionality_in_used: "D8DeprecatedPrometheusFunctionalityIsUsed,tier=cluster,prometheus=deckhouse"
       description: |-
         Services with the `prometheus-custom-target` label are used to collect metrics in the cluster.
 
@@ -75,12 +83,3 @@
 
         For more information, refer to the [documentation](https://deckhouse.io/en/documentation/v1/modules/300-prometheus/faq.html).
       summary: Services with the `prometheus-custom-target` label are used to collect metrics in the cluster.
-
-  - alert: D8DeprecatedPrometheusFunctionalityIsUsed
-    expr: count(ALERTS{alertname=~"D8CustomServiceMonitorFoundInCluster|D8CustomPodMonitorFoundInCluster|D8CustomPrometheusRuleFoundInCluster|D8OldPrometheusCustomTargetFormat|D8OldPrometheusTargetFormat", alertstate="firing"}) > 0
-    annotations:
-      plk_protocol_version: "1"
-      plk_alert_type: "group"
-      summary: The deprecated Deckhouse functionality is detected.
-      description: |
-        The deprecated Deckhouse functionality is detected. Refer to the relevant alerts to find out what deprecated functionality is used and how to replace it with the updated one.

--- a/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kube-etcd3.yaml
+++ b/modules/340-monitoring-kubernetes-control-plane/monitoring/prometheus-rules/kube-etcd3.yaml
@@ -10,7 +10,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__kube_etcd_unavailable: "KubeEtcdUnavailable,tier=cluster"
+      plk_create_group_if_not_exists__kube_etcd_unavailable: "KubeEtcdUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__kube_etcd_unavailable: "KubeEtcdUnavailable,tier=cluster,prometheus=deckhouse"
       plk_ignore_labels: "job"
       description: >
@@ -28,7 +28,7 @@
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
       plk_ignore_labels: "job"
-      plk_create_group_if_not_exists__kube_etcd_unavailable: "KubeEtcdUnavailable,tier=cluster"
+      plk_create_group_if_not_exists__kube_etcd_unavailable: "KubeEtcdUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__kube_etcd_unavailable: "KubeEtcdUnavailable,tier=cluster,prometheus=deckhouse"
       description: >
         Check the status of the etcd Pods: `kubectl -n kube-system get pod -l component=etcd`
@@ -44,7 +44,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__kube_etcd_unavailable: "KubeEtcdUnavailable,tier=cluster"
+      plk_create_group_if_not_exists__kube_etcd_unavailable: "KubeEtcdUnavailable,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__kube_etcd_unavailable: "KubeEtcdUnavailable,tier=cluster,prometheus=deckhouse"
       description: >
         Check the status of the etcd Pods: `kubectl -n kube-system get pod -l component=etcd | grep {{ $labels.node }}`.
@@ -62,7 +62,7 @@
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
       plk_caused_by__ping: "NodePingPacketLoss,tier=cluster,prometheus=deckhouse,destination_node={{ $labels.node }}"
-      plk_create_group_if_not_exists__kube_etcd_malfunctioning: "KubeEtcdMalfunctioning,tier=cluster"
+      plk_create_group_if_not_exists__kube_etcd_malfunctioning: "KubeEtcdMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__kube_etcd_malfunctioning: "KubeEtcdMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: |
         There were {{ $value }} leader re-elections for the etcd cluster member running on the {{ $labels.node }} Node in the last 10 minutes.
@@ -82,7 +82,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__kube_etcd_malfunctioning: "KubeEtcdMalfunctioning,tier=cluster"
+      plk_create_group_if_not_exists__kube_etcd_malfunctioning: "KubeEtcdMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__kube_etcd_malfunctioning: "KubeEtcdMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: >
         Check the status of the etcd pods: `kubectl -n kube-system get pod -l component=etcd`.
@@ -97,7 +97,7 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__kube_etcd_malfunctioning: "KubeEtcdMalfunctioning,tier=cluster"
+      plk_create_group_if_not_exists__kube_etcd_malfunctioning: "KubeEtcdMalfunctioning,tier=cluster,prometheus=deckhouse"
       plk_grouped_by__kube_etcd_malfunctioning: "KubeEtcdMalfunctioning,tier=cluster,prometheus=deckhouse"
       description: |
         In the last 15 minutes, the 99th percentile of the fsync duration for WAL files is longer than 0.5 seconds: {{ $value }}.

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/coreos/kubelet.tpl
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/coreos/kubelet.tpl
@@ -29,8 +29,8 @@
       tier: "cluster"
     annotations:
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__target_down: "TargetDown,tier=cluster"
-      plk_group_for__target_down: "TargetDown,prometheus=deckhouse,job=kubelet"
+      plk_create_group_if_not_exists__target_down: "TargetDown,tier=cluster,prometheus=deckhouse,job=kubelet"
+      plk_group_for__target_down: "TargetDown,tier=cluster,prometheus=deckhouse,job=kubelet"
       description: Prometheus failed to scrape {{ `{{ $value }}` }}% of kubelets.
       summary: A few kubelets cannot be scraped
   - alert: K8SKubeletDown
@@ -41,8 +41,8 @@
       tier: "cluster"
     annotations:
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__target_down: "TargetDown,tier=cluster"
-      plk_group_for__target_down: "TargetDown,prometheus=deckhouse,job=kubelet"
+      plk_create_group_if_not_exists__target_down: "TargetDown,tier=cluster,prometheus=deckhouse,job=kubelet"
+      plk_group_for__target_down: "TargetDown,tier=cluster,prometheus=deckhouse,job=kubelet"
       description: Prometheus failed to scrape {{ `{{ $value }}` }}% of kubelets.
       summary: Many kubelets cannot be scraped
   - alert: K8SKubeletTooManyPods

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node-disk-usage.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node-disk-usage.yaml
@@ -13,8 +13,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster"
-        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
         description: |
           Soft eviction of nodefs on the {{$labels.node}} Node at the {{$labels.mountpoint}} mountpoint is in progress.
 
@@ -36,8 +36,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster"
-        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
         description: |
           Close to hard eviction threshold of nodefs on the {{$labels.node}} Node at the {{$labels.mountpoint}} mountpoint.
 
@@ -59,8 +59,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster"
-        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
         description: |
           Hard eviction of nodefs on the {{$labels.node}} Node at the {{$labels.mountpoint}} mountpoint is in progress.
 
@@ -83,8 +83,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster"
-        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
         summary: No more free inodes on nodefs on the {{$labels.node}} Node at the {{$labels.mountpoint}} mountpoint.
 
     - alert: KubeletImageFSInodesUsage
@@ -100,8 +100,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster"
-        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
         description: |
           Soft eviction of imagefs on the {{$labels.node}} Node at the {{$labels.mountpoint}} mountpoint is in progress.
 
@@ -123,8 +123,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster"
-        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
         description: |
           Close to hard eviction threshold of imagefs on the {{$labels.node}} Node at the {{$labels.mountpoint}} mountpoint.
 
@@ -145,8 +145,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster"
-        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
         description: |
           Hard eviction of imagefs on the {{$labels.node}} Node at the {{$labels.mountpoint}} mountpoint is in progress.
 
@@ -169,8 +169,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster"
-        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
         summary: No more free inodes on imagefs on the {{$labels.node}} Node at the {{$labels.mountpoint}} mountpoint.
 
 - name: kubernetes.node.disk_bytes_usage
@@ -188,8 +188,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster"
-        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
         description: |
           Soft eviction of nodefs on the {{$labels.node}} Node at the {{$labels.mountpoint}} mountpoint is in progress.
 
@@ -211,8 +211,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster"
-        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
         description: |
           Close to hard eviction threshold of nodefs on the {{$labels.node}} Node at the {{$labels.mountpoint}} mountpoint.
 
@@ -233,8 +233,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster"
-        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
         description: |
           Hard eviction of nodefs on the {{$labels.node}} Node at the {{$labels.mountpoint}} mountpoint is in progress.
 
@@ -257,8 +257,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster"
-        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
         summary: No more free space on nodefs on the {{$labels.node}} Node at the {{$labels.mountpoint}} mountpoint.
 
     - alert: KubeletImageFSBytesUsage
@@ -274,8 +274,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster"
-        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
         description: |
           Soft eviction of imagefs (filesystem that the container runtime uses for storing images and container writable layers) on the {{$labels.node}} Node at the {{$labels.mountpoint}} mountpoint is in progress.
 
@@ -297,8 +297,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster"
-        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
         description: |
           Close to hard eviction threshold of imagefs (filesystem that the container runtime uses for storing images and container writable layers) on node {{$labels.node}} mountpoint {{$labels.mountpoint}}.
 
@@ -319,8 +319,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster"
-        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
         description: |
           Hard eviction of imagefs (filesystem that the container runtime uses for storing images and container writable layers) on the {{$labels.node}} Node at the {{$labels.mountpoint}} mountpoint is in progress.
 
@@ -343,8 +343,8 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster"
-        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse,node={{ $labels.node }},mountpoint={{ $labels.mountpoint }}"
+        plk_create_group_if_not_exists__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_partition_disk_usage: "NodePartitionDiskUsage,tier=cluster,prometheus=deckhouse"
         description: |
           No more free bytes on imagefs (filesystem that the container runtime uses for storing images and container writable layers) on node {{$labels.node}} mountpoint {{$labels.mountpoint}}.
         summary: No more free bytes on imagefs on the {{$labels.node}} Node at the {{$labels.mountpoint}} mountpoint.

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/pod-status.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/pod-status.yaml
@@ -13,8 +13,8 @@
       annotations:
         plk_markup_format: markdown
         plk_protocol_version: "1"
-        plk_create_group_if_not_exists__node_have_pods_with_incorrect_status: "NodeHavePodsWithIncorrectStatus,tier=cluster"
-        plk_grouped_by__node_have_pods_with_incorrect_status: "NodeHavePodsWithIncorrectStatus,prometheus=deckhouse,node={{ $labels.node }}"
+        plk_create_group_if_not_exists__node_have_pods_with_incorrect_status: "NodeHavePodsWithIncorrectStatus,tier=cluster,prometheus=deckhouse"
+        plk_grouped_by__node_have_pods_with_incorrect_status: "NodeHavePodsWithIncorrectStatus,tier=cluster,prometheus=deckhouse"
         description: |
           There is a {{ $labels.namespace }}/{{ $labels.pod }} Pod in the cluster that runs on the {{ $labels.node }} and listed as NotReady while all the Pod's containers are Ready.
 


### PR DESCRIPTION
Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix deckhouse group alerts label selectors
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
`plk_create_group_if_not_exists__` and `plk_grouped_by__` labels should be equal.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: fix
summary:  fix deckhouse group alerts label selectors
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
