### PR TITLE
[tests] Use public images when building documentation locally

### DIFF
--- a/docs/documentation/werf.yaml
+++ b/docs/documentation/werf.yaml
@@ -10,7 +10,7 @@ configVersion: 1
   {{- range $k, $v := .Images }}
     {{ $baseImagePath := (printf "%s%s" $.Images.REGISTRY_PATH (trimSuffix "/" $v)) }}
     {{- if or (eq $.Env "development") (eq $.Env "local") }}
-      {{ $baseImagePath = trimSuffix "/" $v }}
+      {{ $baseImagePath = trimSuffix "/" $v | splitList "@" | first }}
     {{- end }}
     {{- if ne $k "REGISTRY_PATH" }}
       {{- $_ := set $.Images $k $baseImagePath }}

--- a/docs/site/werf.yaml
+++ b/docs/site/werf.yaml
@@ -21,7 +21,7 @@ gitWorktree:
   {{- range $k, $v := .Images }}
     {{ $baseImagePath := (printf "%s%s" $.Images.REGISTRY_PATH (trimSuffix "/" $v)) }}
     {{- if or (eq $.Env "development") (eq $.Env "local") }}
-      {{ $baseImagePath = trimSuffix "/" $v }}
+      {{ $baseImagePath = trimSuffix "/" $v | splitList "@" | first }}
     {{- end }}
     {{- if ne $k "REGISTRY_PATH" }}
       {{- $_ := set $.Images $k $baseImagePath }}


### PR DESCRIPTION
## Description
Use public images when building documentation locally. 

## Changelog entries
```changes
section:test
type: fix
summary: Use public images when building documentation locally. 
impact_level: low
```

