### PR TITLE
[ingress-nginx] Alert: old ingress controller versions deprecation

### DIFF
--- a/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
@@ -76,6 +76,6 @@
         Versions below 1.1 are deprecated and wouldn't work in a cluster with kubernetes >= 1.22.
         Also version 1.1 consumes fewer resources and contains fixes for many bugs.
 
-        Support of these versions (0.33|0.46|0.48|0.49) will be removed in the future.
+        Support of these versions (0.33|0.46|0.48|0.49) will be removed in the 1.40 Deckhouse release.
       summary: >
         Deprecated version of `IngressNginxController` {{ $labels.controller_version }} found.

--- a/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
@@ -62,7 +62,7 @@
         `kubectl -n d8-ingress-nginx logs $(kubectl -n d8-ingress-nginx get pods -l app=controller,name={{ $labels.controller }} -o wide | grep {{ $labels.node }} | awk '{print $1}') -c protobuf-exporter`.
       summary: The Ingress Nginx sidecar container with `protobuf_exporter` has {{ $labels.type }} errors.
   - alert: D8IngressNginxControllerVersionDeprecated
-    expr: sum by (controller_name, controller_version) (d8_ingress_nginx_controller{controller_version=~"0.25|0.26"})
+    expr: sum by (controller_name, controller_version) (d8_ingress_nginx_controller{controller_version=~"0.33|0.46|0.48|0.49"})
     labels:
       tier: cluster
       severity_level: "6"
@@ -73,7 +73,9 @@
         Found deprecated Ingress Nginx controller version: {{ $labels.controller_version }}.
 
         Please upgrade {{ $labels.controller_name }} `IngressNginxController`.
+        Versions below 1.1 are deprecated and wouldn't work in a cluster with kubernetes >= 1.22.
+        Also version 1.1 consumes fewer resources and contains fixes for many bugs.
 
-        Support of this version will be removed in the release 1.33.
+        Support of these versions (0.33|0.46|0.48|0.49) will be removed in the future.
       summary: >
         Deprecated version of `IngressNginxController` {{ $labels.controller_version }} found.

--- a/modules/402-ingress-nginx/openapi/config-values.yaml
+++ b/modules/402-ingress-nginx/openapi/config-values.yaml
@@ -1,7 +1,7 @@
 type: object
 properties:
   defaultControllerVersion:
-    default: "0.33"
+    default: "1.1"
     oneOf:
       - type: string
         enum: ["0.33", "0.46", "0.48", "0.49", "1.1"]

--- a/modules/402-ingress-nginx/openapi/config-values.yaml
+++ b/modules/402-ingress-nginx/openapi/config-values.yaml
@@ -1,7 +1,7 @@
 type: object
 properties:
   defaultControllerVersion:
-    default: "1.1"
+    default: "0.33"
     oneOf:
       - type: string
         enum: ["0.33", "0.46", "0.48", "0.49", "1.1"]


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Alert about old ingress controllers deprecation

## Why do we need it, and what problem does it solve?
Controllers before 1.0 are outdated. We shouldn't support them anymore and should push everyone to migrate to 1.1

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests are passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ingress-nginx
type: chore
summary: Mark Ingress controllers below 1.1 as deprecated
impact: Fire alerts about deprecated ingress controllers
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
