### PR TITLE
[prometheus] Update prometheus to v2.36.2

### DIFF
--- a/modules/020-deckhouse/images/webhook-handler/werf.inc.yaml
+++ b/modules/020-deckhouse/images/webhook-handler/werf.inc.yaml
@@ -12,7 +12,7 @@ ansible:
       unarchive:
         extra_opts:
           # The promtool version should match prometheus version from the 300-prometheus module.
-         {{- $promVersion := "2.28.0" }}
+         {{- $promVersion := "2.36.2" }}
           - prometheus-{{ $promVersion }}.linux-amd64/promtool
           - --strip-components=1
         src: https://github.com/prometheus/prometheus/releases/download/v{{ $promVersion }}/prometheus-{{ $promVersion }}.linux-amd64.tar.gz

--- a/modules/200-operator-prometheus/images/prometheus-operator/Dockerfile
+++ b/modules/200-operator-prometheus/images/prometheus-operator/Dockerfile
@@ -1,17 +1,21 @@
 ARG BASE_ALPINE
 ARG BASE_GOLANG_17_BUSTER
 FROM $BASE_GOLANG_17_BUSTER as artifact
+
 RUN apt update && apt install -qfy \
   bash make git patch ca-certificates openssh-client openssl
-RUN mkdir /coreos && cd /coreos \
+RUN mkdir /prometheus-operator && cd /prometheus-operator \
   && git clone -b "v0.56.3" --single-branch https://github.com/prometheus-operator/prometheus-operator.git
-WORKDIR /coreos/prometheus-operator
+
+WORKDIR /prometheus-operator/prometheus-operator
 COPY patches/scrape-params.patch ./
-RUN patch -p1 < scrape-params.patch && \
+COPY patches/scrape-timestamp-align.patch ./
+RUN patch -p1 < scrape-timestamp-align.patch && \
+    patch -p1 < scrape-params.patch && \
     go mod tidy && \
     make operator
 
 FROM $BASE_ALPINE
-COPY --from=artifact /coreos/prometheus-operator/operator /bin/operator
+COPY --from=artifact /prometheus-operator/prometheus-operator/operator /bin/operator
 USER 65534
 ENTRYPOINT ["/bin/operator"]

--- a/modules/200-operator-prometheus/images/prometheus-operator/patches/README.md
+++ b/modules/200-operator-prometheus/images/prometheus-operator/patches/README.md
@@ -3,3 +3,13 @@
 ## Scrape params
 
 With that patch, we are avoiding `ScrapeTimeout` being greater than `ScrapeInterval`.
+
+## Scrape timestamp align
+
+There is a bug in Go runtime. Because of it, tickers from the std library are not precise.
+This patch adds a flag to ignore timestamp difference for 10 ms instead of 2 ms,
+which promises us a 30% reduction in resource consumption.
+
+https://github.com/prometheus/prometheus/pull/9283
+
+We will not open a PR to Prometheus operator, because this flag is experimental at its current state.

--- a/modules/200-operator-prometheus/images/prometheus-operator/patches/scrape-params.patch
+++ b/modules/200-operator-prometheus/images/prometheus-operator/patches/scrape-params.patch
@@ -1,8 +1,3 @@
-Index: pkg/prometheus/promcfg.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
 diff --git a/pkg/prometheus/promcfg.go b/pkg/prometheus/promcfg.go
 --- a/pkg/prometheus/promcfg.go	(revision 8eda80dcc5d2a977b493dcaa122f0f2841e48c7b)
 +++ b/pkg/prometheus/promcfg.go	(date 1651146264253)
@@ -11,7 +6,7 @@ diff --git a/pkg/prometheus/promcfg.go b/pkg/prometheus/promcfg.go
  	"sort"
  	"strings"
 +	"time"
- 
+
 -	"github.com/blang/semver/v4"
 +	"github.com/blang/semver"
  	"github.com/go-kit/log"
@@ -50,9 +45,9 @@ diff --git a/pkg/prometheus/promcfg.go b/pkg/prometheus/promcfg.go
  	cfg := yaml.MapSlice{
  		{
 @@ -706,11 +711,25 @@
- 
+
  	cfg = append(cfg, cg.generateK8SSDConfig(m.Spec.NamespaceSelector, m.Namespace, apiserverConfig, store, kubernetesSDRolePod))
- 
+
 +	globalScrapeIntervalDuration, _ := time.ParseDuration(globalScrapeInterval)
 +
  	if ep.Interval != "" {
@@ -82,12 +77,12 @@ diff --git a/pkg/prometheus/promcfg.go b/pkg/prometheus/promcfg.go
  	shards int32,
 +	globalScrapeInterval string,
  ) yaml.MapSlice {
- 
+
  	jobName := fmt.Sprintf("probe/%s/%s", m.Namespace, m.Name)
 @@ -929,11 +949,24 @@
  	}
  	cfg = append(cfg, yaml.MapItem{Key: "metrics_path", Value: path})
- 
+
 +	globalScrapeIntervalDuration, _ := time.ParseDuration(globalScrapeInterval)
 +
  	if m.Spec.Interval != "" {
@@ -119,9 +114,9 @@ diff --git a/pkg/prometheus/promcfg.go b/pkg/prometheus/promcfg.go
  	cfg := yaml.MapSlice{
  		{
 @@ -1169,11 +1203,24 @@
- 
+
  	cfg = append(cfg, cg.generateK8SSDConfig(m.Spec.NamespaceSelector, m.Namespace, apiserverConfig, store, role))
- 
+
 +	globalScrapeIntervalDuration, _ := time.ParseDuration(globalScrapeInterval)
 +
  	if ep.Interval != "" {

--- a/modules/200-operator-prometheus/images/prometheus-operator/patches/scrape-timestamp-align.patch
+++ b/modules/200-operator-prometheus/images/prometheus-operator/patches/scrape-timestamp-align.patch
@@ -1,0 +1,17 @@
+diff --git a/pkg/prometheus/statefulset.go b/pkg/prometheus/statefulset.go
+index 40701651d..e0edb25ce 100644
+--- a/pkg/prometheus/statefulset.go
++++ b/pkg/prometheus/statefulset.go
+@@ -390,6 +390,12 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
+ 		)
+ 	}
+
++	if version.GTE(semver.MustParse("2.30.0")) {
++		// Align scrape timestamps to reduce storage and ram consumption
++		// https://github.com/prometheus/prometheus/pull/9283
++		promArgs = append(promArgs, "-scrape.timestamp-tolerance=10ms")
++	}
++
+ 	if version.Minor >= 4 {
+ 		if p.Spec.Rules.Alert.ForOutageTolerance != "" {
+ 			promArgs = append(promArgs, "-rules.alert.for-outage-tolerance="+p.Spec.Rules.Alert.ForOutageTolerance)

--- a/modules/300-prometheus/images/prometheus/Dockerfile
+++ b/modules/300-prometheus/images/prometheus/Dockerfile
@@ -1,27 +1,32 @@
-ARG BASE_GOLANG_BUSTER
+ARG BASE_GOLANG_18_BULLSEYE
+ARG BASE_NODE_16_ALPINE
 ARG BASE_ALPINE
-FROM $BASE_GOLANG_BUSTER as artifact
 
-ENV PROMETHEUS_VERSION=v2.28.0
+FROM $BASE_GOLANG_18_BULLSEYE as artifact
+ENV PROMETHEUS_VERSION=v2.36.2
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - &&  \
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - &&  \
   apt install -y nodejs && \
   npm update -g npm && \
   npm install webpack -g && \
   npm config set registry http://registry.npmjs.org/ && \
   apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
-  apt update && apt install -y yarn && \
-  apt install -y make bash git patch ca-certificates openssl openssh-client
+  apt update && apt install -y yarn
+
+RUN apt install -y make bash git ca-certificates openssl openssh-client bzip2
 
 RUN mkdir /prometheus && cd /prometheus \
   && git clone -b "${PROMETHEUS_VERSION}" --single-branch https://github.com/prometheus/prometheus
 WORKDIR /prometheus/prometheus
+
+RUN go mod download
+
 COPY sample_limit_annotation.patch ./
 COPY successfully_sent_metric.patch ./
 
-RUN patch -p1 < sample_limit_annotation.patch && \
-  patch -p1 < successfully_sent_metric.patch && \
+RUN git apply sample_limit_annotation.patch && \
+  git apply successfully_sent_metric.patch && \
   make build
 
 FROM $BASE_ALPINE

--- a/modules/300-prometheus/images/prometheus/sample_limit_annotation.patch
+++ b/modules/300-prometheus/images/prometheus/sample_limit_annotation.patch
@@ -1,13 +1,8 @@
-:100644 100644 b5c94862a 191f96cf6 M	discovery/kubernetes/pod.go
-:100644 100644 107534540 9ffdd6b56 M	discovery/kubernetes/service.go
-:100644 100644 d9ed8a02b 79cfea1a1 M	scrape/scrape.go
-:100644 100644 4a7b6eb0f 5022a8055 M	scrape/target.go
-
 diff --git a/discovery/kubernetes/pod.go b/discovery/kubernetes/pod.go
-index b5c94862a..191f96cf6 100644
+index 2e55dce78..e84fa50b0 100644
 --- a/discovery/kubernetes/pod.go
 +++ b/discovery/kubernetes/pod.go
-@@ -245,6 +245,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
+@@ -279,6 +279,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
 
  			tg.Targets = append(tg.Targets, model.LabelSet{
  				model.AddressLabel:            lv(addr),
@@ -16,10 +11,10 @@ index b5c94862a..191f96cf6 100644
  				podContainerPortNumberLabel:   lv(ports),
  				podContainerPortNameLabel:     lv(port.Name),
 diff --git a/discovery/kubernetes/service.go b/discovery/kubernetes/service.go
-index 107534540..9ffdd6b56 100644
+index 4b3c4de51..6b8ee4772 100644
 --- a/discovery/kubernetes/service.go
 +++ b/discovery/kubernetes/service.go
-@@ -187,6 +187,7 @@ func (s *Service) buildService(svc *apiv1.Service) *targetgroup.Group {
+@@ -188,6 +188,7 @@ func (s *Service) buildService(svc *apiv1.Service) *targetgroup.Group {
 
  		labelSet := model.LabelSet{
  			model.AddressLabel:       lv(addr),
@@ -28,10 +23,10 @@ index 107534540..9ffdd6b56 100644
  			servicePortProtocolLabel: lv(string(port.Protocol)),
  			serviceType:              lv(string(svc.Spec.Type)),
 diff --git a/scrape/scrape.go b/scrape/scrape.go
-index d9ed8a02b..79cfea1a1 100644
+index 9304baecd..3e59cc738 100644
 --- a/scrape/scrape.go
 +++ b/scrape/scrape.go
-@@ -294,6 +294,11 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed
+@@ -297,6 +297,11 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed
  		}
  		opts.target.SetMetadataStore(cache)
 
@@ -43,31 +38,32 @@ index d9ed8a02b..79cfea1a1 100644
  		return newScrapeLoop(
  			ctx,
  			opts.scraper,
-@@ -303,7 +308,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed
- 				return mutateSampleLabels(l, opts.target, opts.honorLabels, opts.mrc)
- 			},
- 			func(l labels.Labels) labels.Labels { return mutateReportSampleLabels(l, opts.target) },
--			func(ctx context.Context) storage.Appender { return appender(app.Appender(ctx), opts.sampleLimit) },
-+			func(ctx context.Context) storage.Appender { return appender(app.Appender(ctx), limit) },
+@@ -310,7 +315,7 @@ func newScrapePool(cfg *config.ScrapeConfig, app storage.Appendable, jitterSeed
  			cache,
  			jitterSeed,
  			opts.honorTimestamps,
+-			opts.sampleLimit,
++			limit,
+ 			opts.labelLimits,
+ 			opts.interval,
+ 			opts.timeout,
 diff --git a/scrape/target.go b/scrape/target.go
-index 4a7b6eb0f..5022a8055 100644
+index e017a4584..f3f7352ec 100644
 --- a/scrape/target.go
 +++ b/scrape/target.go
-@@ -19,6 +19,7 @@ import (
+@@ -18,6 +18,7 @@ import (
+ 	"hash/fnv"
  	"net"
  	"net/url"
- 	"strings"
 +	"strconv"
+ 	"strings"
  	"sync"
  	"time"
-
-@@ -225,6 +226,18 @@ func (t *Target) URL() *url.URL {
+@@ -492,3 +493,15 @@ func TargetsFromGroup(tg *targetgroup.Group, cfg *config.ScrapeConfig) ([]*Targe
  	}
+ 	return targets, failures
  }
-
++
 +func (t *Target) SampleLimit() int {
 +	limit := t.labels.Get("__sample_limit__")
 +	if limit == "" {
@@ -79,7 +75,3 @@ index 4a7b6eb0f..5022a8055 100644
 +	}
 +	return convertedLimit
 +}
-+
- // Report sets target data about the last scrape.
- func (t *Target) Report(start time.Time, dur time.Duration, err error) {
- 	t.mtx.Lock()

--- a/modules/300-prometheus/images/prometheus/successfully_sent_metric.patch
+++ b/modules/300-prometheus/images/prometheus/successfully_sent_metric.patch
@@ -1,10 +1,8 @@
-:100644 100644 7af21c565 3d24759ab M	notifier/notifier.go
-
 diff --git a/notifier/notifier.go b/notifier/notifier.go
-index 7af21c565..3d24759ab 100644
+index 3d2ee5949..aa000dcf9 100644
 --- a/notifier/notifier.go
 +++ b/notifier/notifier.go
-@@ -137,6 +137,7 @@ type alertMetrics struct {
+@@ -135,6 +135,7 @@ type alertMetrics struct {
  	latency                 *prometheus.SummaryVec
  	errors                  *prometheus.CounterVec
  	sent                    *prometheus.CounterVec
@@ -12,7 +10,7 @@ index 7af21c565..3d24759ab 100644
  	dropped                 prometheus.Counter
  	queueLength             prometheus.GaugeFunc
  	queueCapacity           prometheus.Gauge
-@@ -170,6 +171,14 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
+@@ -168,6 +169,12 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
  		},
  			[]string{alertmanagerLabel},
  		),
@@ -21,13 +19,11 @@ index 7af21c565..3d24759ab 100644
 +			Subsystem: subsystem,
 +			Name:      "successfully_sent_total",
 +			Help:      "Total number of successfully sent alerts.",
-+		},
-+			[]string{alertmanagerLabel},
-+		),
++		}, []string{alertmanagerLabel}),
  		dropped: prometheus.NewCounter(prometheus.CounterOpts{
  			Namespace: namespace,
  			Subsystem: subsystem,
-@@ -201,6 +210,7 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
+@@ -199,6 +206,7 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
  			m.latency,
  			m.errors,
  			m.sent,
@@ -35,7 +31,7 @@ index 7af21c565..3d24759ab 100644
  			m.dropped,
  			m.queueLength,
  			m.queueCapacity,
-@@ -528,6 +538,7 @@ func (n *Manager) sendAll(alerts ...*Alert) bool {
+@@ -535,6 +543,7 @@ func (n *Manager) sendAll(alerts ...*Alert) bool {
  					n.metrics.errors.WithLabelValues(url).Inc()
  				} else {
  					numSuccess.Inc()
@@ -43,11 +39,11 @@ index 7af21c565..3d24759ab 100644
  				}
  				n.metrics.latency.WithLabelValues(url).Observe(time.Since(begin).Seconds())
  				n.metrics.sent.WithLabelValues(url).Add(float64(len(alerts)))
-@@ -680,6 +691,7 @@ func (s *alertmanagerSet) sync(tgs []*targetgroup.Group) {
+@@ -687,6 +696,7 @@ func (s *alertmanagerSet) sync(tgs []*targetgroup.Group) {
  		// This will initialize the Counters for the AM to 0.
  		s.metrics.sent.WithLabelValues(us)
  		s.metrics.errors.WithLabelValues(us)
 +		s.metrics.successfullySent.WithLabelValues(us)
- 
+
  		seen[us] = struct{}{}
  		s.ams = append(s.ams, am)

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -33,7 +33,7 @@ spec:
   retention: {{ .Values.prometheus.longtermRetentionDays }}d
   retentionSize: {{ .Values.prometheus.internal.prometheusLongterm.retentionGigabytes }}GB
   image: "{{ .Values.global.modulesImages.registry }}:{{ .Values.global.modulesImages.tags.prometheus.prometheus }}"
-  version: v2.28.0
+  version: v2.36.2
   imagePullSecrets:
   - name: deckhouse-registry
   listenLocal: true

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -32,7 +32,10 @@ spec:
   retention: {{ .Values.prometheus.retentionDays }}d
   retentionSize: {{ .Values.prometheus.internal.prometheusMain.retentionGigabytes }}GB
   image: "{{ .Values.global.modulesImages.registry }}:{{ .Values.global.modulesImages.tags.prometheus.prometheus }}"
-  version: v2.28.0
+  version: v2.36.2
+  enableRemoteWriteReceiver: true
+  enableFeatures:
+  - memory-snapshot-on-shutdown # https://ganeshvernekar.com/blog/prometheus-tsdb-snapshot-on-shutdown/
   imagePullSecrets:
   - name: deckhouse-registry
   listenLocal: true


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
* bump Prometheus version (v2.36.0)
* enable `scrape.timestamp-tolerance=10ms` flag
* enable `snapshot-on-shutdown` feature

## Why do we need it, and what problem does it solve?

There were some TSDB optimizations during last year, and there are also optimizations in Go runtime. The RAM consumption graph is attached to highlight the difference.

![image](https://user-images.githubusercontent.com/32434187/178591553-0966ee59-3326-4224-9096-d82cf697f1a6.png)
The first gap - Prometheus update 2.28 -> 2.36
The second gap - `scrape.timestamp-tolerance=10ms` flag is enabled

CPU and Disk consumption is slightly better than it was before.

## What is the expected result?
Prometheus will be restarted. I hope that it will consume fewer resources.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: feature
summary: Update Prometheus to v2.36.2 (decrease memory consumption)
impact: Prometheus pods will be restarted.
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
