### PR TITLE
[upmeter] Use informer for Nodes

### DIFF
--- a/modules/500-upmeter/images/upmeter/go.mod
+++ b/modules/500-upmeter/images/upmeter/go.mod
@@ -27,5 +27,4 @@ require (
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0
-	sigs.k8s.io/yaml v1.1.1-0.20191128155103-745ef44e09d6
 )

--- a/modules/500-upmeter/images/upmeter/pkg/agent/agent.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/agent.go
@@ -93,6 +93,10 @@ func (a *Agent) Start(ctx context.Context) error {
 	}
 
 	nodeMon := node.NewMonitor(kubeAccess.Kubernetes(), log.NewEntry(a.logger))
+	if err := nodeMon.Start(ctx); err != nil {
+		return fmt.Errorf("starting node monitor: %v", err)
+	}
+
 	runnerLoader := probe.NewLoader(ftr, kubeAccess, nodeMon, dynamicConfig, a.logger)
 	calcLoader := calculated.NewLoader(ftr, a.logger)
 	registry := registry.New(runnerLoader, calcLoader)

--- a/modules/500-upmeter/images/upmeter/pkg/agent/agent.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/agent.go
@@ -29,6 +29,7 @@ import (
 	"d8.io/upmeter/pkg/db"
 	dbcontext "d8.io/upmeter/pkg/db/context"
 	"d8.io/upmeter/pkg/kubernetes"
+	"d8.io/upmeter/pkg/monitor/node"
 	"d8.io/upmeter/pkg/probe"
 	"d8.io/upmeter/pkg/probe/calculated"
 	"d8.io/upmeter/pkg/registry"
@@ -90,7 +91,9 @@ func (a *Agent) Start(ctx context.Context) error {
 		NodeGroups:              a.config.DynamicProbes.NodeGroups,
 		Zones:                   a.config.DynamicProbes.Zones,
 	}
-	runnerLoader := probe.NewLoader(ftr, kubeAccess, dynamicConfig, a.logger)
+
+	nodeMon := node.NewMonitor(kubeAccess.Kubernetes(), log.NewEntry(a.logger))
+	runnerLoader := probe.NewLoader(ftr, kubeAccess, nodeMon, dynamicConfig, a.logger)
 	calcLoader := calculated.NewLoader(ftr, a.logger)
 	registry := registry.New(runnerLoader, calcLoader)
 

--- a/modules/500-upmeter/images/upmeter/pkg/monitor/downtime/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/downtime/monitor.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/flant/shell-operator/pkg/kube"
 	"github.com/flant/shell-operator/pkg/kube_events_manager"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -29,29 +30,38 @@ import (
 )
 
 type Monitor struct {
-	ctx     context.Context
-	cancel  context.CancelFunc
-	Monitor kube_events_manager.Monitor
+	monitor kube_events_manager.Monitor
+	logger  *log.Entry
 }
 
-func NewMonitor(ctx context.Context) *Monitor {
+/*func NewMonitor(ctx context.Context) *Monitor {
 	m := &Monitor{}
 	m.ctx, m.cancel = context.WithCancel(ctx)
-	m.Monitor = kube_events_manager.NewMonitor()
-	m.Monitor.WithContext(m.ctx)
+	m.monitor = kube_events_manager.NewMonitor()
+	m.monitor.WithContext(m.ctx)
 	return m
+}*/
+
+func NewMonitor(kubeClient kube.KubernetesClient, logger *log.Entry) *Monitor {
+	monitor := kube_events_manager.NewMonitor()
+	monitor.WithKubeClient(kubeClient)
+
+	return &Monitor{
+		monitor: monitor,
+		logger:  logger,
+	}
 }
 
-func (m *Monitor) Start() error {
-	m.Monitor.WithConfig(&kube_events_manager.MonitorConfig{
+func (m *Monitor) Start(ctx context.Context) error {
+	config := &kube_events_manager.MonitorConfig{
 		Metadata: struct {
 			MonitorId    string
 			DebugName    string
 			LogLabels    map[string]string
 			MetricLabels map[string]string
 		}{
-			"downtime-crds",
-			"downtime-crds",
+			"downtime-monitor",
+			"downtime-monitor",
 			map[string]string{},
 			map[string]string{},
 		},
@@ -61,24 +71,27 @@ func (m *Monitor) Start() error {
 		NamespaceSelector:       nil,
 		LogEntry:                log.WithField("component", "downtime-monitor"),
 		KeepFullObjectsInMemory: true,
-	})
-	// Load initial CRD list
-	err := m.Monitor.CreateInformers()
+	}
+
+	m.monitor.WithContext(ctx)
+	m.monitor.WithConfig(config)
+
+	err := m.monitor.CreateInformers()
 	if err != nil {
 		return fmt.Errorf("creating informer: %v", err)
 	}
 
-	m.Monitor.Start(m.ctx)
-	return m.ctx.Err()
+	m.monitor.Start(ctx)
+	return nil
 }
 
 func (m *Monitor) Stop() {
-	m.Monitor.Stop()
+	m.monitor.Stop()
 }
 
 func (m *Monitor) List() ([]check.DowntimeIncident, error) {
 	res := make([]check.DowntimeIncident, 0)
-	for _, obj := range m.Monitor.GetExistedObjects() {
+	for _, obj := range m.monitor.GetExistedObjects() {
 		incs, err := convert(obj.Object)
 		if err != nil {
 			return nil, err

--- a/modules/500-upmeter/images/upmeter/pkg/monitor/downtime/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/downtime/monitor.go
@@ -65,7 +65,7 @@ func (m *Monitor) Start() error {
 	// Load initial CRD list
 	err := m.Monitor.CreateInformers()
 	if err != nil {
-		return fmt.Errorf("create informers: %v", err)
+		return fmt.Errorf("creating informer: %v", err)
 	}
 
 	m.Monitor.Start(m.ctx)
@@ -76,10 +76,10 @@ func (m *Monitor) Stop() {
 	m.Monitor.Stop()
 }
 
-func (m *Monitor) GetDowntimeIncidents() ([]check.DowntimeIncident, error) {
+func (m *Monitor) List() ([]check.DowntimeIncident, error) {
 	res := make([]check.DowntimeIncident, 0)
 	for _, obj := range m.Monitor.GetExistedObjects() {
-		incs, err := convDowntimeIncident(obj.Object)
+		incs, err := convert(obj.Object)
 		if err != nil {
 			return nil, err
 		}
@@ -88,7 +88,7 @@ func (m *Monitor) GetDowntimeIncidents() ([]check.DowntimeIncident, error) {
 	return res, nil
 }
 
-func convDowntimeIncident(obj *unstructured.Unstructured) ([]check.DowntimeIncident, error) {
+func convert(obj *unstructured.Unstructured) ([]check.DowntimeIncident, error) {
 	var incidentObj Downtime
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &incidentObj)
 	if err != nil {

--- a/modules/500-upmeter/images/upmeter/pkg/monitor/downtime/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/downtime/monitor.go
@@ -34,14 +34,6 @@ type Monitor struct {
 	logger  *log.Entry
 }
 
-/*func NewMonitor(ctx context.Context) *Monitor {
-	m := &Monitor{}
-	m.ctx, m.cancel = context.WithCancel(ctx)
-	m.monitor = kube_events_manager.NewMonitor()
-	m.monitor.WithContext(m.ctx)
-	return m
-}*/
-
 func NewMonitor(kubeClient kube.KubernetesClient, logger *log.Entry) *Monitor {
 	monitor := kube_events_manager.NewMonitor()
 	monitor.WithKubeClient(kubeClient)

--- a/modules/500-upmeter/images/upmeter/pkg/monitor/hookprobe/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/hookprobe/monitor.go
@@ -70,14 +70,13 @@ func (m *Monitor) Start(ctx context.Context) error {
 	m.monitor.WithContext(ctx)
 	m.monitor.WithConfig(config)
 
-	// Load initial CRD list
 	err := m.monitor.CreateInformers()
 	if err != nil {
 		return fmt.Errorf("creating informer: %v", err)
 	}
 
 	m.monitor.Start(ctx)
-	return ctx.Err()
+	return nil
 }
 
 func (m *Monitor) Stop() {

--- a/modules/500-upmeter/images/upmeter/pkg/monitor/node/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/node/monitor.go
@@ -71,14 +71,13 @@ func (m *Monitor) Start(ctx context.Context) error {
 	m.monitor.WithContext(ctx)
 	m.monitor.WithConfig(config)
 
-	// Load initial CRD list
 	err := m.monitor.CreateInformers()
 	if err != nil {
 		return fmt.Errorf("creating informer: %v", err)
 	}
 
 	m.monitor.Start(ctx)
-	return ctx.Err()
+	return nil
 }
 
 func (m *Monitor) Stop() {
@@ -95,7 +94,7 @@ func (m *Monitor) Subscribe(handler Handler) {
 		evType := ev.WatchEvents[0]
 		raw := ev.Objects[0].Object
 
-		obj, err := convertNode(raw)
+		obj, err := convert(raw)
 		if err != nil {
 			m.getLogger().Errorf("cannot convert Node object: %v", err)
 			return
@@ -115,7 +114,7 @@ func (m *Monitor) Subscribe(handler Handler) {
 func (m *Monitor) List() ([]*v1.Node, error) {
 	list := make([]*v1.Node, 0)
 	for _, obj := range m.monitor.GetExistedObjects() {
-		node, err := convertNode(obj.Object)
+		node, err := convert(obj.Object)
 		if err != nil {
 			return nil, err
 		}
@@ -124,7 +123,7 @@ func (m *Monitor) List() ([]*v1.Node, error) {
 	return list, nil
 }
 
-func convertNode(o *unstructured.Unstructured) (*v1.Node, error) {
+func convert(o *unstructured.Unstructured) (*v1.Node, error) {
 	var node v1.Node
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(o.UnstructuredContent(), &node)
 	if err != nil {

--- a/modules/500-upmeter/images/upmeter/pkg/monitor/node/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/node/monitor.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package remotewrite
+package node
 
 import (
 	"context"
@@ -136,4 +136,8 @@ type Handler interface {
 	OnAdd(*v1.Node)
 	OnModify(*v1.Node)
 	OnDelete(*v1.Node)
+}
+
+type Lister interface {
+	List() ([]*v1.Node, error)
 }

--- a/modules/500-upmeter/images/upmeter/pkg/monitor/remotewrite/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/remotewrite/monitor.go
@@ -70,14 +70,13 @@ func (m *Monitor) Start(ctx context.Context) error {
 	m.monitor.WithContext(ctx)
 	m.monitor.WithConfig(config)
 
-	// Load initial CRD list
 	err := m.monitor.CreateInformers()
 	if err != nil {
 		return fmt.Errorf("creating informer: %v", err)
 	}
 
 	m.monitor.Start(ctx)
-	return ctx.Err()
+	return nil
 }
 
 func (m *Monitor) Stop() {

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_daemonset.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_daemonset.go
@@ -157,8 +157,8 @@ func (c *dsPodsReadinessChecker) verifyPodStatus(pod *v1.Pod) error {
 
 	if isPodPending(pod) || isPodRunning(pod) {
 		// Not ready, but started. Checking, how fresh it is.
-		creationDeadline := metav1.NewTime(time.Now().Add(-c.creationTimeout))
-		if !pod.CreationTimestamp.Before(&creationDeadline) {
+		acceptableCreationTime := metav1.NewTime(time.Now().Add(-c.creationTimeout))
+		if !pod.CreationTimestamp.Before(&acceptableCreationTime) {
 			return nil
 		}
 		return fmt.Errorf("not ready for too long")

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_daemonset_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_daemonset_test.go
@@ -22,11 +22,12 @@ import (
 	"time"
 
 	"github.com/flant/shell-operator/pkg/kube"
-	"github.com/flant/shell-operator/pkg/kube/fake"
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"d8.io/upmeter/pkg/check"
 	k8saccess "d8.io/upmeter/pkg/kubernetes"
@@ -68,1027 +69,371 @@ func (a *FakeAccess) ClusterDomain() string {
 	return ""
 }
 
-func getTestDsPodsReadinessChecker() (*fake.FakeCluster, *dsPodsReadinessChecker) {
-	cluster := fake.NewFakeCluster()
-	access := NewFake(cluster.KubeClient)
+func Test_checker_dsPodsReadinessChecker(t *testing.T) {
+	const (
+		creationTimeout = time.Minute
+		deletionTimeout = 5 * time.Second
+	)
 
-	dsChecker := &dsPodsReadinessChecker{
-		access:          access,
-		namespace:       "d8-monitoring",
-		name:            "node-exporter",
-		requestTimeout:  5 * time.Second,
-		creationTimeout: time.Minute,
-		deletionTimeout: 5 * time.Second,
+	type state struct {
+		pods  []v1.Pod
+		nodes []*v1.Node
+
+		dsErr, podsErr, nodesErr error
 	}
-
-	return cluster, dsChecker
-}
-
-func runDaemonsetCheckerWithCluster(setupCluster func(*fake.FakeCluster, *dsPodsReadinessChecker)) check.Error {
-	cluster, checker := getTestDsPodsReadinessChecker()
-	setupCluster(cluster, checker)
-	return checker.Check()
-}
-
-func Test_checker_DsPodsReadiness(t *testing.T) {
 	tests := []struct {
 		name  string
-		setup func(*fake.FakeCluster, *dsPodsReadinessChecker)
-		err   check.Error
+		state state
+		want  check.Status
 	}{
 		{
-			name:  "empty cluster, something is wrong",
-			err:   check.ErrUnknown(""),
-			setup: func(*fake.FakeCluster, *dsPodsReadinessChecker) {},
-		},
-		{
-			name: "daemonset exists, but no nodes and no pods, nothing to complain about",
-			err:  nil,
-			setup: func(cluster *fake.FakeCluster, checker *dsPodsReadinessChecker) {
-				_, ds, _ := getTestingClusterSetupForDaemonsSetChecker()
-				_, err := cluster.KubeClient.AppsV1().DaemonSets(checker.namespace).Create(&ds)
-				if err != nil {
-					panic("atata")
-				}
+			name: "no daemonset is not fine",
+			want: check.Down,
+			state: state{
+				dsErr: apierrors.NewNotFound(schema.GroupResource{}, ""),
 			},
 		},
 		{
-			name: "everything in place, nothing to complain about",
-			err:  nil,
-			setup: func(cluster *fake.FakeCluster, checker *dsPodsReadinessChecker) {
-				nodeList, daemonSet, podList := getTestingClusterSetupForDaemonsSetChecker()
-				if err := setupTestingClusterForDaemonsSetChecker(cluster, checker.namespace, nodeList, daemonSet, podList); err != nil {
-					panic(err)
-				}
+			name: "arbitrary error getting daemonset results in Unknown",
+			want: check.Unknown,
+			state: state{
+				dsErr: fmt.Errorf("whatever"),
 			},
 		},
 		{
-			name: "node without a daemonset pod is a problem",
-			err:  check.ErrFail(""),
-			setup: func(cluster *fake.FakeCluster, checker *dsPodsReadinessChecker) {
-				nodeList, daemonSet, podList := getTestingClusterSetupForDaemonsSetChecker()
-
-				extraNode := nodeList.Items[0]
-				extraNode.ObjectMeta.SetName("abracadabra")
-				nodeList.Items = append(nodeList.Items, extraNode)
-
-				if err := setupTestingClusterForDaemonsSetChecker(cluster, checker.namespace, nodeList, daemonSet, podList); err != nil {
-					panic(err)
-				}
+			name: "arbitrary error getting nodes results in Unknown",
+			want: check.Unknown,
+			state: state{
+				nodesErr: fmt.Errorf("whatever"),
 			},
 		},
 		{
-			name: "missing node is fine",
-			err:  nil,
-			setup: func(cluster *fake.FakeCluster, checker *dsPodsReadinessChecker) {
-				nodeList, daemonSet, podList := getTestingClusterSetupForDaemonsSetChecker()
-
-				notAllNodes := make([]v1.Node, 0)
-				notAllNodes = append(notAllNodes, nodeList.Items[:1]...)
-				notAllNodes = append(notAllNodes, nodeList.Items[2:]...)
-				nodeList.Items = notAllNodes
-
-				if err := setupTestingClusterForDaemonsSetChecker(cluster, checker.namespace, nodeList, daemonSet, podList); err != nil {
-					panic(err)
-				}
+			name: "arbitrary error getting pods results in Unknown",
+			want: check.Unknown,
+			state: state{
+				podsErr: fmt.Errorf("whatever"),
 			},
 		},
 		{
-			name: "not-ready node is fine",
-			err:  nil,
-			setup: func(cluster *fake.FakeCluster, checker *dsPodsReadinessChecker) {
-				nodeList, daemonSet, podList := getTestingClusterSetupForDaemonsSetChecker()
-
-				badNode := nodeList.Items[2]
-				for _, cond := range badNode.Status.Conditions {
-					if cond.Type != v1.NodeReady {
-						continue
-					}
-					cond.Status = v1.ConditionFalse
-				}
-
-				if err := setupTestingClusterForDaemonsSetChecker(cluster, checker.namespace, nodeList, daemonSet, podList); err != nil {
-					panic(err)
-				}
-			},
+			name:  "daemonset exists, but no nodes and no pods, resulting in success",
+			want:  check.Up,
+			state: state{},
 		},
 		{
-			name: "additional node with an additional taint is fine",
-			err:  nil,
-			setup: func(cluster *fake.FakeCluster, checker *dsPodsReadinessChecker) {
-				nodeList, daemonSet, podList := getTestingClusterSetupForDaemonsSetChecker()
-
-				tainted := nodeList.Items[2]
-				tainted.SetName("tainted")
-				tainted.Spec.Taints = append(tainted.Spec.Taints, v1.Taint{
-					Key:   "kk",
-					Value: "vv",
-				})
-				nodeList.Items = append(nodeList.Items, tainted)
-
-				if err := setupTestingClusterForDaemonsSetChecker(cluster, checker.namespace, nodeList, daemonSet, podList); err != nil {
-					panic(err)
-				}
-			},
-		},
-		{
-			name: "not-ready pod is not fine",
-			err:  check.ErrFail(""),
-			setup: func(cluster *fake.FakeCluster, checker *dsPodsReadinessChecker) {
-				nodeList, daemonSet, podList := getTestingClusterSetupForDaemonsSetChecker()
-
-				unhealthy := &podList.Items[2]
-				makePodNotReady(unhealthy)
-
-				if err := setupTestingClusterForDaemonsSetChecker(cluster, checker.namespace, nodeList, daemonSet, podList); err != nil {
-					panic(err)
-				}
-			},
-		},
-		{
-			name: "not-running pod is not fine",
-			err:  check.ErrFail(""),
-			setup: func(cluster *fake.FakeCluster, checker *dsPodsReadinessChecker) {
-				nodeList, daemonSet, podList := getTestingClusterSetupForDaemonsSetChecker()
-
-				unhealthy := &podList.Items[2]
-				unhealthy.Status.Phase = v1.PodFailed
-				makePodNotReady(unhealthy)
-
-				if err := setupTestingClusterForDaemonsSetChecker(cluster, checker.namespace, nodeList, daemonSet, podList); err != nil {
-					panic(err)
-				}
+			name: "everything in place, resulting in success",
+			want: check.Up,
+			state: state{
+				pods:  []v1.Pod{scheduledPod("a"), scheduledPod("b"), scheduledPod("c")},
+				nodes: []*v1.Node{heatlhyNode("a"), heatlhyNode("b"), heatlhyNode("c")},
 			},
 		},
 		{
 			name: "missing pod is not fine",
-			err:  check.ErrFail(""),
-			setup: func(cluster *fake.FakeCluster, checker *dsPodsReadinessChecker) {
-				nodeList, daemonSet, podList := getTestingClusterSetupForDaemonsSetChecker()
-
-				notAllPods := make([]v1.Pod, 0)
-				notAllPods = append(notAllPods, podList.Items[:1]...)
-				notAllPods = append(notAllPods, podList.Items[2:]...)
-				podList.Items = notAllPods
-
-				if err := setupTestingClusterForDaemonsSetChecker(cluster, checker.namespace, nodeList, daemonSet, podList); err != nil {
-					panic(err)
-				}
+			want: check.Down,
+			state: state{
+				pods:  []v1.Pod{scheduledPod("a") /*    no pod "b"   */, scheduledPod("c")},
+				nodes: []*v1.Node{heatlhyNode("a"), heatlhyNode("b"), heatlhyNode("c")},
+			},
+		},
+		{
+			name: "missing po on a tainted node is fine",
+			want: check.Up,
+			state: state{
+				pods:  []v1.Pod{scheduledPod("a") /*     no pod "b"   */, scheduledPod("c")},
+				nodes: []*v1.Node{heatlhyNode("a"), taintedNode("b"), heatlhyNode("c")},
+			},
+		},
+		{
+			name: "missing node is fine",
+			want: check.Up,
+			state: state{
+				pods:  []v1.Pod{scheduledPod("a"), scheduledPod("b"), scheduledPod("c")},
+				nodes: []*v1.Node{heatlhyNode("a") /*    no node "b"   */, heatlhyNode("c")},
+			},
+		},
+		{
+			name: "not-ready node is fine",
+			want: check.Up,
+			state: state{
+				pods:  []v1.Pod{scheduledPod("a"), scheduledPod("b"), scheduledPod("c")},
+				nodes: []*v1.Node{heatlhyNode("a"), notReadyNode("b"), heatlhyNode("c")},
+			},
+		},
+		{
+			name: "not-ready pod is not fine",
+			want: check.Down,
+			state: state{
+				pods:  []v1.Pod{scheduledPod("a"), notReadyPod("b"), scheduledPod("c")},
+				nodes: []*v1.Node{heatlhyNode("a"), heatlhyNode("b"), heatlhyNode("c")},
+			},
+		},
+		{
+			name: "not-running pod is not fine",
+			want: check.Down,
+			state: state{
+				pods:  []v1.Pod{scheduledPod("a"), pendingPod("b"), scheduledPod("c")},
+				nodes: []*v1.Node{heatlhyNode("a"), heatlhyNode("b"), heatlhyNode("c")},
 			},
 		},
 		{
 			name: "unhealthy pod on very fresh node is fine",
-			err:  nil,
-			setup: func(cluster *fake.FakeCluster, checker *dsPodsReadinessChecker) {
-				nodeList, daemonSet, podList := getTestingClusterSetupForDaemonsSetChecker()
-
-				// Make pod unhealthy
-				unhealthy := &podList.Items[2]
-				unhealthy.Status.Phase = v1.PodFailed
-
-				// Make its node very fresh
-				for ni, node := range nodeList.Items {
-					if node.GetName() != unhealthy.Spec.NodeName {
-						continue
-					}
-					for ci, cond := range node.Status.Conditions {
-						if cond.Type != v1.NodeReady {
-							continue
-						}
-						nodeList.Items[ni].Status.Conditions[ci].LastTransitionTime = metav1.Now()
-					}
-				}
-
-				if err := setupTestingClusterForDaemonsSetChecker(cluster, checker.namespace, nodeList, daemonSet, podList); err != nil {
-					panic(err)
-				}
+			want: check.Up,
+			state: state{
+				pods:  []v1.Pod{scheduledPod("a"), notReadyPod("b"), scheduledPod("c")},
+				nodes: []*v1.Node{heatlhyNode("a"), freshNode("b", creationTimeout/2), heatlhyNode("c")},
 			},
 		},
 		{
 			name: "not-ready pending pod for not too long is fine",
-			err:  nil,
-			setup: func(cluster *fake.FakeCluster, checker *dsPodsReadinessChecker) {
-				nodeList, daemonSet, podList := getTestingClusterSetupForDaemonsSetChecker()
-
-				unhealthy := &podList.Items[2]
-				unhealthy.Status.Phase = v1.PodPending
-				makePodNotReady(unhealthy)
-				unhealthy.CreationTimestamp = metav1.NewTime(time.Now().Add(-checker.creationTimeout + 10*time.Millisecond))
-
-				if err := setupTestingClusterForDaemonsSetChecker(cluster, checker.namespace, nodeList, daemonSet, podList); err != nil {
-					panic(err)
-				}
+			want: check.Up,
+			state: state{
+				pods:  []v1.Pod{scheduledPod("a"), agedPod(creationTimeout/2, pendingPod("b")), scheduledPod("c")},
+				nodes: []*v1.Node{heatlhyNode("a"), heatlhyNode("b"), heatlhyNode("c")},
 			},
 		},
 		{
-			name: "not-ready running pod for not too long is fine",
-			err:  nil,
-			setup: func(cluster *fake.FakeCluster, checker *dsPodsReadinessChecker) {
-				nodeList, daemonSet, podList := getTestingClusterSetupForDaemonsSetChecker()
-
-				unhealthy := &podList.Items[2]
-				unhealthy.Status.Phase = v1.PodRunning
-				makePodNotReady(unhealthy)
-				unhealthy.CreationTimestamp = metav1.NewTime(time.Now().Add(-checker.creationTimeout + 10*time.Millisecond))
-
-				if err := setupTestingClusterForDaemonsSetChecker(cluster, checker.namespace, nodeList, daemonSet, podList); err != nil {
-					panic(err)
-				}
+			name: "not-ready running pod for too long is not fine",
+			want: check.Down,
+			state: state{
+				pods:  []v1.Pod{scheduledPod("a"), agedPod(creationTimeout*2, notReadyPod("b")), scheduledPod("c")},
+				nodes: []*v1.Node{heatlhyNode("a"), heatlhyNode("b"), heatlhyNode("c")},
 			},
 		},
 		{
 			name: "terminating pod for not too long is fine",
-			err:  nil,
-			setup: func(cluster *fake.FakeCluster, checker *dsPodsReadinessChecker) {
-				nodeList, daemonSet, podList := getTestingClusterSetupForDaemonsSetChecker()
-
-				unhealthy := &podList.Items[2]
-				makePodNotReady(unhealthy)
-				preDeadline := metav1.NewTime(time.Now().Add(-checker.deletionTimeout + 10*time.Millisecond))
-				unhealthy.DeletionTimestamp = &preDeadline
-
-				if err := setupTestingClusterForDaemonsSetChecker(cluster, checker.namespace, nodeList, daemonSet, podList); err != nil {
-					panic(err)
-				}
+			want: check.Up,
+			state: state{
+				pods:  []v1.Pod{scheduledPod("a"), terminatingPod("b", deletionTimeout/2), scheduledPod("c")},
+				nodes: []*v1.Node{heatlhyNode("a"), heatlhyNode("b"), heatlhyNode("c")},
+			},
+		},
+		{
+			name: "terminating pod for too long is not fine",
+			want: check.Down,
+			state: state{
+				pods:  []v1.Pod{scheduledPod("a"), terminatingPod("b", deletionTimeout*2), scheduledPod("c")},
+				nodes: []*v1.Node{heatlhyNode("a"), heatlhyNode("b"), heatlhyNode("c")},
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := runDaemonsetCheckerWithCluster(tt.setup)
+			dsRepo := &dsRepoMock{
+				ds:    daemonSet("node-exporter"),
+				dsErr: tt.state.dsErr,
 
-			// not expecting error
-			if tt.err == nil {
-				if err == nil {
-					return
-				}
-				t.Errorf("expected success, got error status=%q, err=%q", err.Status(), err.Error())
-				return
+				pods:    tt.state.pods,
+				podsErr: tt.state.podsErr,
 			}
 
-			// expecting error
-			if err == nil {
-				t.Fatalf("got success, expected error with status %q", tt.err.Status())
+			nodeLister := &nodeListerMock{
+				nodes: tt.state.nodes,
+				err:   tt.state.nodesErr,
 			}
 
-			if err.Status() != tt.err.Status() {
-				t.Errorf("expected status %q, got status=%q  err=%v", tt.err.Status(), err.Status(), err.Error())
+			checker := &dsPodsReadinessChecker{
+				dsRepo:          dsRepo,
+				nodeLister:      nodeLister,
+				creationTimeout: creationTimeout,
+				deletionTimeout: deletionTimeout,
 			}
+
+			err := checker.Check()
+			assertCheckStatus(t, tt.want, err)
 		})
 	}
 }
 
-func setupTestingClusterForDaemonsSetChecker(cluster *fake.FakeCluster, namespace string, nodeList v1.NodeList, ds appsv1.DaemonSet, podList v1.PodList) error {
-	if _, err := cluster.KubeClient.AppsV1().DaemonSets(namespace).Create(&ds); err != nil {
-		return fmt.Errorf("DaemonSet did not create: %v", err)
-	}
-
-	for _, node := range nodeList.Items {
-		if _, err := cluster.KubeClient.CoreV1().Nodes().Create(&node); err != nil {
-			return fmt.Errorf("node did not create: %v", err)
+func assertCheckStatus(t *testing.T, want check.Status, err check.Error) {
+	if want == check.Up {
+		assert.NoError(t, err, "Expected no err")
+	} else {
+		var got check.Status
+		if err == nil {
+			got = check.Up
+		} else {
+			got = err.Status()
 		}
-	}
-
-	for _, pod := range podList.Items {
-		if _, err := cluster.KubeClient.CoreV1().Pods(namespace).Create(&pod); err != nil {
-			return fmt.Errorf("pod did not create: %v", err)
-		}
-	}
-
-	return nil
-}
-
-func makePodNotReady(pod *v1.Pod) {
-	for i, cond := range pod.Status.Conditions {
-		if cond.Type != v1.PodReady {
-			continue
-		}
-		pod.Status.Conditions[i].Status = v1.ConditionFalse
+		assert.Equal(t, want.String(), got.String())
 	}
 }
 
-// This is a consistent state of four working nodes (3×M+W), node-exporter daemonset, and four working pods
-func getTestingClusterSetupForDaemonsSetChecker() (v1.NodeList, appsv1.DaemonSet, v1.PodList) {
-	daemonSetYAML := `
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  labels:
-    app: node-exporter
-  name: node-exporter
-  namespace: d8-monitoring
-spec:
-  selector:
-    matchLabels:
-      app: node-exporter
-  template:
-    metadata:
-      labels:
-        app: node-exporter
-      name: node-exporter
-    spec:
-      containers:
-        - {}
-        - {}
-        - {}
-      terminationGracePeriodSeconds: 30
-      tolerations:
-      - key: node-role.kubernetes.io/master
-      - key: dedicated.deckhouse.io
-        operator: Exists
-      - key: dedicated
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-      - key: node.kubernetes.io/out-of-disk
-      - key: node.kubernetes.io/memory-pressure
-      - key: node.kubernetes.io/disk-pressure
-  updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 1
-    type: RollingUpdate
-status:
-  currentNumberScheduled: 4
-  desiredNumberScheduled: 4
-  numberAvailable: 4
-  numberMisscheduled: 0
-  numberReady: 4
-  observedGeneration: 6
-  updatedNumberScheduled: 4
-`
-
-	nodeListYAML := `
-apiVersion: v1
-items:
-  - apiVersion: v1
-    kind: Node
-    metadata:
-      creationTimestamp: "2020-12-18T08:38:59Z"
-      name: test-master-0
-    spec:
-      taints:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-    status:
-      conditions:
-        - lastHeartbeatTime: "2021-03-31T12:12:54Z"
-          lastTransitionTime: "2021-03-31T12:12:54Z"
-          message: Flannel is running on this node
-          reason: FlannelIsUp
-          status: "False"
-          type: NetworkUnavailable
-        - lastHeartbeatTime: "2021-05-13T03:54:27Z"
-          lastTransitionTime: "2020-12-18T08:26:20Z"
-          message: kubelet has sufficient memory available
-          reason: KubeletHasSufficientMemory
-          status: "False"
-          type: MemoryPressure
-        - lastHeartbeatTime: "2021-05-13T03:54:27Z"
-          lastTransitionTime: "2020-12-18T08:26:20Z"
-          message: kubelet has no disk pressure
-          reason: KubeletHasNoDiskPressure
-          status: "False"
-          type: DiskPressure
-        - lastHeartbeatTime: "2021-05-13T03:54:27Z"
-          lastTransitionTime: "2020-12-18T08:26:20Z"
-          message: kubelet has sufficient PID available
-          reason: KubeletHasSufficientPID
-          status: "False"
-          type: PIDPressure
-        - lastHeartbeatTime: "2021-05-13T03:54:27Z"
-          lastTransitionTime: "2021-05-12T11:10:01Z"
-          message: kubelet is posting ready status. AppArmor enabled
-          reason: KubeletReady
-          status: "True"
-          type: Ready
-  - apiVersion: v1
-    kind: Node
-    metadata:
-      creationTimestamp: "2020-12-18T08:38:59Z"
-      name: test-master-1
-    spec:
-      taints:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-    status:
-      conditions:
-        - lastHeartbeatTime: "2021-03-24T14:13:57Z"
-          lastTransitionTime: "2021-03-24T14:13:57Z"
-          message: Flannel is running on this node
-          reason: FlannelIsUp
-          status: "False"
-          type: NetworkUnavailable
-        - lastHeartbeatTime: "2021-05-13T03:54:33Z"
-          lastTransitionTime: "2021-03-24T14:13:22Z"
-          message: kubelet has sufficient memory available
-          reason: KubeletHasSufficientMemory
-          status: "False"
-          type: MemoryPressure
-        - lastHeartbeatTime: "2021-05-13T03:54:33Z"
-          lastTransitionTime: "2021-03-24T14:13:22Z"
-          message: kubelet has no disk pressure
-          reason: KubeletHasNoDiskPressure
-          status: "False"
-          type: DiskPressure
-        - lastHeartbeatTime: "2021-05-13T03:54:33Z"
-          lastTransitionTime: "2021-03-24T14:13:22Z"
-          message: kubelet has sufficient PID available
-          reason: KubeletHasSufficientPID
-          status: "False"
-          type: PIDPressure
-        - lastHeartbeatTime: "2021-05-13T03:54:33Z"
-          lastTransitionTime: "2021-05-12T11:09:14Z"
-          message: kubelet is posting ready status. AppArmor enabled
-          reason: KubeletReady
-          status: "True"
-          type: Ready
-  - apiVersion: v1
-    kind: Node
-    metadata:
-      creationTimestamp: "2020-12-18T08:38:59Z"
-      name: test-master-2
-    spec:
-      taints:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-    status:
-      conditions:
-        - lastHeartbeatTime: "2021-03-24T14:22:41Z"
-          lastTransitionTime: "2021-03-24T14:22:41Z"
-          message: Flannel is running on this node
-          reason: FlannelIsUp
-          status: "False"
-          type: NetworkUnavailable
-        - lastHeartbeatTime: "2021-05-13T03:54:33Z"
-          lastTransitionTime: "2021-03-24T14:21:31Z"
-          message: kubelet has sufficient memory available
-          reason: KubeletHasSufficientMemory
-          status: "False"
-          type: MemoryPressure
-        - lastHeartbeatTime: "2021-05-13T03:54:33Z"
-          lastTransitionTime: "2021-03-24T14:21:31Z"
-          message: kubelet has no disk pressure
-          reason: KubeletHasNoDiskPressure
-          status: "False"
-          type: DiskPressure
-        - lastHeartbeatTime: "2021-05-13T03:54:33Z"
-          lastTransitionTime: "2021-03-24T14:21:31Z"
-          message: kubelet has sufficient PID available
-          reason: KubeletHasSufficientPID
-          status: "False"
-          type: PIDPressure
-        - lastHeartbeatTime: "2021-05-13T03:54:33Z"
-          lastTransitionTime: "2021-05-12T11:08:14Z"
-          message: kubelet is posting ready status. AppArmor enabled
-          reason: KubeletReady
-          status: "True"
-          type: Ready
-  - apiVersion: v1
-    kind: Node
-    metadata:
-      creationTimestamp: "2020-12-18T08:38:59Z"
-      name: test-worker-e0af82d5-8d97b-zhbxg
-    spec: {}
-    status:
-      conditions:
-        - lastHeartbeatTime: "2021-03-22T17:50:28Z"
-          lastTransitionTime: "2021-03-22T17:50:28Z"
-          message: Flannel is running on this node
-          reason: FlannelIsUp
-          status: "False"
-          type: NetworkUnavailable
-        - lastHeartbeatTime: "2021-05-13T03:54:32Z"
-          lastTransitionTime: "2020-12-18T08:39:00Z"
-          message: kubelet has sufficient memory available
-          reason: KubeletHasSufficientMemory
-          status: "False"
-          type: MemoryPressure
-        - lastHeartbeatTime: "2021-05-13T03:54:32Z"
-          lastTransitionTime: "2021-02-21T02:00:56Z"
-          message: kubelet has no disk pressure
-          reason: KubeletHasNoDiskPressure
-          status: "False"
-          type: DiskPressure
-        - lastHeartbeatTime: "2021-05-13T03:54:32Z"
-          lastTransitionTime: "2020-12-18T08:39:00Z"
-          message: kubelet has sufficient PID available
-          reason: KubeletHasSufficientPID
-          status: "False"
-          type: PIDPressure
-        - lastHeartbeatTime: "2021-05-13T03:54:32Z"
-          lastTransitionTime: "2021-03-10T14:25:06Z"
-          message: kubelet is posting ready status. AppArmor enabled
-          reason: KubeletReady
-          status: "True"
-          type: Ready
-kind: List
-metadata:
-  resourceVersion: ""
-  selfLink: ""
-`
-
-	podListYAML := `
-apiVersion: v1
-items:
-  - apiVersion: v1
-    kind: Pod
-    metadata:
-      creationTimestamp: "2021-05-08T14:19:41Z"
-      generateName: node-exporter-
-      labels:
-        app: node-exporter
-      name: node-exporter-fq5fj
-      namespace: d8-monitoring
-      ownerReferences:
-        - apiVersion: apps/v1
-          blockOwnerDeletion: true
-          controller: true
-          kind: DaemonSet
-          name: node-exporter
-    spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchFields:
-                  - key: metadata.name
-                    operator: In
-                    values:
-                      - test-worker-e0af82d5-8d97b-zhbxg
-      containers:
-        - {}
-        - {}
-        - {}
-      nodeName: test-worker-e0af82d5-8d97b-zhbxg
-      terminationGracePeriodSeconds: 30
-      tolerations:
-        - key: node-role.kubernetes.io/master
-        - key: dedicated.deckhouse.io
-          operator: Exists
-        - key: dedicated
-          operator: Exists
-        - key: node.kubernetes.io/not-ready
-        - key: node.kubernetes.io/out-of-disk
-        - key: node.kubernetes.io/memory-pressure
-        - key: node.kubernetes.io/disk-pressure
-        - effect: NoExecute
-          key: node.kubernetes.io/not-ready
-          operator: Exists
-        - effect: NoExecute
-          key: node.kubernetes.io/unreachable
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/disk-pressure
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/memory-pressure
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/pid-pressure
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/unschedulable
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/network-unavailable
-          operator: Exists
-    status:
-      conditions:
-        - lastProbeTime: null
-          lastTransitionTime: "2021-05-08T14:19:41Z"
-          status: "True"
-          type: Initialized
-        - lastProbeTime: null
-          lastTransitionTime: "2021-05-08T14:19:44Z"
-          status: "True"
-          type: Ready
-        - lastProbeTime: null
-          lastTransitionTime: "2021-05-08T14:19:44Z"
-          status: "True"
-          type: ContainersReady
-        - lastProbeTime: null
-          lastTransitionTime: "2021-05-08T14:19:41Z"
-          status: "True"
-          type: PodScheduled
-      containerStatuses:
-        - containerID: docker://608aea933d83d64e63731eefdb6c6b4ea2e5976048f3c285d15f2bc0da76ec89
-          image: registry.deckhouse.io/deckhouse/ce/common/kube-rbac-proxy:526c5255969dcd342888947e2d3bab781eed225bb969ca0dd3bdbd30
-          imageID: docker-pullable://registry.deckhouse.io/deckhouse/ce/common/kube-rbac-proxy@sha256:233267845d84dc0b09667abfc0fc63479001cb4d71159697f7f4542e2a4f64af
-          lastState: {}
-          name: kube-rbac-proxy
-          ready: true
-          restartCount: 0
-          started: true
-          state:
-            running:
-              startedAt: "2021-05-08T14:19:43Z"
-        - containerID: docker://c6a127473c06af705e4e6d8af4bfb8c49a49f7cc3cddbea063340221327ae1c6
-          image: registry.deckhouse.io/deckhouse/ce/monitoring-kubernetes/kubelet-eviction-thresholds-exporter:455222c1194ecff9aa77c8ae0daa936260e43d420ae6e512a1026dae
-          imageID: docker-pullable://registry.deckhouse.io/deckhouse/ce/monitoring-kubernetes/kubelet-eviction-thresholds-exporter@sha256:59d8f21a33bf92a5feed1667a3b56be759e91cc4d9e46563543fad6597bb5e88
-          lastState: {}
-          name: kubelet-eviction-thresholds-exporter
-          ready: true
-          restartCount: 0
-          started: true
-          state:
-            running:
-              startedAt: "2021-05-08T14:19:43Z"
-        - containerID: docker://26c9c096aee5d6a8c69ce3344bbb7f3701d997c848ba621c64611f48ddab63da
-          image: registry.deckhouse.io/deckhouse/ce/monitoring-kubernetes/node-exporter:05e2b2361ad1d69b3ae23b369308e759540b3413834f0011e318768b
-          imageID: docker-pullable://registry.deckhouse.io/deckhouse/ce/monitoring-kubernetes/node-exporter@sha256:0b6dcee73e71b22e5018cf5243888056978b1188b32b2ba084929cb1db9e946c
-          lastState: {}
-          name: node-exporter
-          ready: true
-          restartCount: 0
-          started: true
-          state:
-            running:
-              startedAt: "2021-05-08T14:19:42Z"
-      phase: Running
-      startTime: "2021-05-08T14:19:41Z"
-  - apiVersion: v1
-    kind: Pod
-    metadata:
-      creationTimestamp: "2021-05-08T14:19:24Z"
-      generateName: node-exporter-
-      labels:
-        app: node-exporter
-      name: node-exporter-g8m6x
-      namespace: d8-monitoring
-      ownerReferences:
-        - apiVersion: apps/v1
-          blockOwnerDeletion: true
-          controller: true
-          kind: DaemonSet
-          name: node-exporter
-    spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchFields:
-                  - key: metadata.name
-                    operator: In
-                    values:
-                      - test-master-2
-      containers:
-        - {}
-        - {}
-        - {}
-      nodeName: test-master-2
-      terminationGracePeriodSeconds: 30
-      tolerations:
-        - key: node-role.kubernetes.io/master
-        - key: dedicated.deckhouse.io
-          operator: Exists
-        - key: dedicated
-          operator: Exists
-        - key: node.kubernetes.io/not-ready
-        - key: node.kubernetes.io/out-of-disk
-        - key: node.kubernetes.io/memory-pressure
-        - key: node.kubernetes.io/disk-pressure
-        - effect: NoExecute
-          key: node.kubernetes.io/not-ready
-          operator: Exists
-        - effect: NoExecute
-          key: node.kubernetes.io/unreachable
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/disk-pressure
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/memory-pressure
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/pid-pressure
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/unschedulable
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/network-unavailable
-          operator: Exists
-    status:
-      conditions:
-        - lastProbeTime: null
-          lastTransitionTime: "2021-05-08T14:19:25Z"
-          status: "True"
-          type: Initialized
-        - lastProbeTime: null
-          lastTransitionTime: "2021-05-08T14:19:28Z"
-          status: "True"
-          type: Ready
-        - lastProbeTime: null
-          lastTransitionTime: "2021-05-08T14:19:28Z"
-          status: "True"
-          type: ContainersReady
-        - lastProbeTime: null
-          lastTransitionTime: "2021-05-08T14:19:24Z"
-          status: "True"
-          type: PodScheduled
-      containerStatuses:
-        - containerID: docker://8bc0ce49bace801d3d4740102d6cf10bfdb74121bccb2ca7e3ac8381ae622d32
-          image: registry.deckhouse.io/deckhouse/ce/common/kube-rbac-proxy:526c5255969dcd342888947e2d3bab781eed225bb969ca0dd3bdbd30
-          imageID: docker-pullable://registry.deckhouse.io/deckhouse/ce/common/kube-rbac-proxy@sha256:233267845d84dc0b09667abfc0fc63479001cb4d71159697f7f4542e2a4f64af
-          lastState: {}
-          name: kube-rbac-proxy
-          ready: true
-          restartCount: 0
-          started: true
-          state:
-            running:
-              startedAt: "2021-05-08T14:19:28Z"
-        - containerID: docker://c5110045c6fca03d4486fef8475252d612226c4803a16c20f3b85412a223ae6f
-          image: registry.deckhouse.io/deckhouse/ce/monitoring-kubernetes/kubelet-eviction-thresholds-exporter:455222c1194ecff9aa77c8ae0daa936260e43d420ae6e512a1026dae
-          imageID: docker-pullable://registry.deckhouse.io/deckhouse/ce/monitoring-kubernetes/kubelet-eviction-thresholds-exporter@sha256:59d8f21a33bf92a5feed1667a3b56be759e91cc4d9e46563543fad6597bb5e88
-          lastState: {}
-          name: kubelet-eviction-thresholds-exporter
-          ready: true
-          restartCount: 0
-          started: true
-          state:
-            running:
-              startedAt: "2021-05-08T14:19:28Z"
-        - containerID: docker://4dda7d6e579fba532e3ef5b6fd4877e6d21a6e2c73ad9671b147eb84154e44de
-          image: registry.deckhouse.io/deckhouse/ce/monitoring-kubernetes/node-exporter:05e2b2361ad1d69b3ae23b369308e759540b3413834f0011e318768b
-          imageID: docker-pullable://registry.deckhouse.io/deckhouse/ce/monitoring-kubernetes/node-exporter@sha256:0b6dcee73e71b22e5018cf5243888056978b1188b32b2ba084929cb1db9e946c
-          lastState: {}
-          name: node-exporter
-          ready: true
-          restartCount: 0
-          started: true
-          state:
-            running:
-              startedAt: "2021-05-08T14:19:27Z"
-      hostIP: 192.168.199.55
-      phase: Running
-      podIP: 192.168.199.55
-      podIPs:
-        - ip: 192.168.199.55
-      qosClass: Burstable
-      startTime: "2021-05-08T14:19:25Z"
-  - apiVersion: v1
-    kind: Pod
-    metadata:
-      creationTimestamp: "2021-05-08T14:18:41Z"
-      generateName: node-exporter-
-      labels:
-        app: node-exporter
-      name: node-exporter-hrtwz
-      namespace: d8-monitoring
-      ownerReferences:
-        - apiVersion: apps/v1
-          blockOwnerDeletion: true
-          controller: true
-          kind: DaemonSet
-          name: node-exporter
-    spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchFields:
-                  - key: metadata.name
-                    operator: In
-                    values:
-                      - test-master-0
-      containers:
-        - {}
-        - {}
-        - {}
-      nodeName: test-master-0
-      terminationGracePeriodSeconds: 30
-      tolerations:
-        - key: node-role.kubernetes.io/master
-        - key: dedicated.deckhouse.io
-          operator: Exists
-        - key: dedicated
-          operator: Exists
-        - key: node.kubernetes.io/not-ready
-        - key: node.kubernetes.io/out-of-disk
-        - key: node.kubernetes.io/memory-pressure
-        - key: node.kubernetes.io/disk-pressure
-        - effect: NoExecute
-          key: node.kubernetes.io/not-ready
-          operator: Exists
-        - effect: NoExecute
-          key: node.kubernetes.io/unreachable
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/disk-pressure
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/memory-pressure
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/pid-pressure
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/unschedulable
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/network-unavailable
-          operator: Exists
-    status:
-      conditions:
-        - lastProbeTime: null
-          lastTransitionTime: "2021-05-08T14:18:41Z"
-          status: "True"
-          type: Initialized
-        - lastProbeTime: null
-          lastTransitionTime: "2021-05-08T14:18:45Z"
-          status: "True"
-          type: Ready
-        - lastProbeTime: null
-          lastTransitionTime: "2021-05-08T14:18:45Z"
-          status: "True"
-          type: ContainersReady
-        - lastProbeTime: null
-          lastTransitionTime: "2021-05-08T14:18:41Z"
-          status: "True"
-          type: PodScheduled
-      containerStatuses:
-        - containerID: docker://3c69821c8fe5272235c3f41a59f9e6f6143608bccbd4f0c2942f84532d0bf479
-          image: registry.deckhouse.io/deckhouse/ce/common/kube-rbac-proxy:526c5255969dcd342888947e2d3bab781eed225bb969ca0dd3bdbd30
-          imageID: docker-pullable://registry.deckhouse.io/deckhouse/ce/common/kube-rbac-proxy@sha256:233267845d84dc0b09667abfc0fc63479001cb4d71159697f7f4542e2a4f64af
-          lastState: {}
-          name: kube-rbac-proxy
-          ready: true
-          restartCount: 0
-          started: true
-          state:
-            running:
-              startedAt: "2021-05-08T14:18:44Z"
-        - containerID: docker://e6b8a95f2fa4a732c2b98f8e2cec4b31823c7c7c0a87aacb6fcf2f70041ec8e5
-          image: registry.deckhouse.io/deckhouse/ce/monitoring-kubernetes/kubelet-eviction-thresholds-exporter:455222c1194ecff9aa77c8ae0daa936260e43d420ae6e512a1026dae
-          imageID: docker-pullable://registry.deckhouse.io/deckhouse/ce/monitoring-kubernetes/kubelet-eviction-thresholds-exporter@sha256:59d8f21a33bf92a5feed1667a3b56be759e91cc4d9e46563543fad6597bb5e88
-          lastState: {}
-          name: kubelet-eviction-thresholds-exporter
-          ready: true
-          restartCount: 0
-          started: true
-          state:
-            running:
-              startedAt: "2021-05-08T14:18:43Z"
-        - containerID: docker://4f12f5705354fc0e93d2b44d372821a28de1a768819577b9240883ae3811abc3
-          image: registry.deckhouse.io/deckhouse/ce/monitoring-kubernetes/node-exporter:05e2b2361ad1d69b3ae23b369308e759540b3413834f0011e318768b
-          imageID: docker-pullable://registry.deckhouse.io/deckhouse/ce/monitoring-kubernetes/node-exporter@sha256:0b6dcee73e71b22e5018cf5243888056978b1188b32b2ba084929cb1db9e946c
-          lastState: {}
-          name: node-exporter
-          ready: true
-          restartCount: 0
-          started: true
-          state:
-            running:
-              startedAt: "2021-05-08T14:18:43Z"
-      hostIP: 192.168.199.224
-      phase: Running
-      podIP: 192.168.199.224
-      podIPs:
-        - ip: 192.168.199.224
-      qosClass: Burstable
-      startTime: "2021-05-08T14:18:41Z"
-  - apiVersion: v1
-    kind: Pod
-    metadata:
-      creationTimestamp: "2021-05-08T14:18:22Z"
-      labels:
-        app: node-exporter
-      name: node-exporter-x6qwz
-      namespace: d8-monitoring
-      ownerReferences:
-        - apiVersion: apps/v1
-          blockOwnerDeletion: true
-          controller: true
-          kind: DaemonSet
-          name: node-exporter
-          uid: b5ab1412-597d-400c-b3dd-1a94ef68e4ea
-    spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchFields:
-                  - key: metadata.name
-                    operator: In
-                    values:
-                      - test-master-1
-      containers:
-        - {}
-        - {}
-        - {}
-      nodeName: test-master-1
-      terminationGracePeriodSeconds: 30
-      tolerations:
-        - key: node-role.kubernetes.io/master
-        - key: dedicated.deckhouse.io
-          operator: Exists
-        - key: dedicated
-          operator: Exists
-        - key: node.kubernetes.io/not-ready
-        - key: node.kubernetes.io/out-of-disk
-        - key: node.kubernetes.io/memory-pressure
-        - key: node.kubernetes.io/disk-pressure
-        - effect: NoExecute
-          key: node.kubernetes.io/not-ready
-          operator: Exists
-        - effect: NoExecute
-          key: node.kubernetes.io/unreachable
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/disk-pressure
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/memory-pressure
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/pid-pressure
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/unschedulable
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/network-unavailable
-          operator: Exists
-    status:
-      conditions:
-        - lastProbeTime: null
-          lastTransitionTime: "2021-05-08T14:18:22Z"
-          status: "True"
-          type: Initialized
-        - lastProbeTime: null
-          lastTransitionTime: "2021-05-08T14:18:25Z"
-          status: "True"
-          type: Ready
-        - lastProbeTime: null
-          lastTransitionTime: "2021-05-08T14:18:25Z"
-          status: "True"
-          type: ContainersReady
-        - lastProbeTime: null
-          lastTransitionTime: "2021-05-08T14:18:22Z"
-          status: "True"
-          type: PodScheduled
-      containerStatuses:
-        - containerID: docker://04a332e41fd3eea06f046d9d4d47c23c0e7defb22b17d1eb61e740b23f94baad
-          image: registry.deckhouse.io/deckhouse/ce/common/kube-rbac-proxy:526c5255969dcd342888947e2d3bab781eed225bb969ca0dd3bdbd30
-          imageID: docker-pullable://registry.deckhouse.io/deckhouse/ce/common/kube-rbac-proxy@sha256:233267845d84dc0b09667abfc0fc63479001cb4d71159697f7f4542e2a4f64af
-          lastState: {}
-          name: kube-rbac-proxy
-          ready: true
-          restartCount: 0
-          started: true
-          state:
-            running:
-              startedAt: "2021-05-08T14:18:24Z"
-        - containerID: docker://6491c1fe866c951c1f91f4c29105885e95d5652de640068f20a767ac36c5d27d
-          image: registry.deckhouse.io/deckhouse/ce/monitoring-kubernetes/kubelet-eviction-thresholds-exporter:455222c1194ecff9aa77c8ae0daa936260e43d420ae6e512a1026dae
-          imageID: docker-pullable://registry.deckhouse.io/deckhouse/ce/monitoring-kubernetes/kubelet-eviction-thresholds-exporter@sha256:59d8f21a33bf92a5feed1667a3b56be759e91cc4d9e46563543fad6597bb5e88
-          lastState: {}
-          name: kubelet-eviction-thresholds-exporter
-          ready: true
-          restartCount: 0
-          started: true
-          state:
-            running:
-              startedAt: "2021-05-08T14:18:24Z"
-        - containerID: docker://9dcf7b850f708d92620ab70887ddd8ce7b03bc0dc177b5195b4da99557ebd228
-          image: registry.deckhouse.io/deckhouse/ce/monitoring-kubernetes/node-exporter:05e2b2361ad1d69b3ae23b369308e759540b3413834f0011e318768b
-          imageID: docker-pullable://registry.deckhouse.io/deckhouse/ce/monitoring-kubernetes/node-exporter@sha256:0b6dcee73e71b22e5018cf5243888056978b1188b32b2ba084929cb1db9e946c
-          lastState: {}
-          name: node-exporter
-          ready: true
-          restartCount: 0
-          started: true
-          state:
-            running:
-              startedAt: "2021-05-08T14:18:23Z"
-      hostIP: 192.168.199.94
-      phase: Running
-      podIP: 192.168.199.94
-      podIPs:
-        - ip: 192.168.199.94
-      qosClass: Burstable
-      startTime: "2021-05-08T14:18:22Z"
-kind: List
-metadata:
-  resourceVersion: ""
-  selfLink: ""
-`
-
-	var ds appsv1.DaemonSet
-	if err := yaml.Unmarshal([]byte(daemonSetYAML), &ds); err != nil {
-		panic("ds did not parse: " + err.Error())
+func daemonSet(name string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DaemonSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec:   appsv1.DaemonSetSpec{},
+		Status: appsv1.DaemonSetStatus{},
 	}
+}
 
-	var nodeList v1.NodeList
-	if err := yaml.Unmarshal([]byte(nodeListYAML), &nodeList); err != nil {
-		panic("node list did not parse: " + err.Error())
+func agedPod(age time.Duration, pod v1.Pod) v1.Pod {
+	ts := metav1.NewTime(time.Now().Add(-age))
+	pod.CreationTimestamp = ts
+	pod.Status.Conditions[0].LastTransitionTime = ts
+	return pod
+}
+
+func terminatingPod(name string, termAge time.Duration) v1.Pod {
+	when := metav1.NewTime(time.Now().Add(-termAge))
+
+	pod := scheduledPod(name)
+	pod.DeletionTimestamp = &when
+	pod.Status.Conditions[0].Status = v1.ConditionFalse
+	return pod
+}
+
+func pendingPod(name string) v1.Pod {
+	pod := scheduledPod(name)
+	pod.Status.Phase = v1.PodPending
+	pod.Status.Conditions[0].Status = v1.ConditionFalse
+	return pod
+}
+
+func notReadyPod(name string) v1.Pod {
+	pod := scheduledPod(name)
+	pod.Status.Conditions[0].Status = v1.ConditionFalse
+	return pod
+}
+
+func scheduledPod(name string) v1.Pod {
+	hourAgo := metav1.NewTime(time.Now().Add(-time.Hour))
+
+	return v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{},
+
+			CreationTimestamp: hourAgo,
+		},
+		Spec: v1.PodSpec{
+			NodeName: name,
+			Affinity: &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{
+								MatchExpressions: []v1.NodeSelectorRequirement{
+									{
+										Key:      "kubernetes.io/hostname",
+										Operator: "In",
+										Values:   []string{name},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+			Conditions: []v1.PodCondition{
+				{
+					Type:               v1.PodReady,
+					Status:             v1.ConditionTrue,
+					LastTransitionTime: hourAgo,
+				},
+			},
+		},
 	}
+}
 
-	var podList v1.PodList
-	if err := yaml.Unmarshal([]byte(podListYAML), &podList); err != nil {
-		panic("pod list did not parse: " + err.Error())
+func taintedNode(name string) *v1.Node {
+	node := heatlhyNode(name)
+	node.Spec.Taints = []v1.Taint{{
+		Key:    "key1",
+		Value:  "value1",
+		Effect: v1.TaintEffectNoExecute,
+	}}
+	return node
+}
+
+func notReadyNode(name string) *v1.Node {
+	node := heatlhyNode(name)
+	node.Status.Conditions[0].Status = v1.ConditionFalse
+	return node
+}
+
+func freshNode(name string, age time.Duration) *v1.Node {
+	when := metav1.NewTime(time.Now().Add(-age))
+
+	node := heatlhyNode(name)
+	node.Status.Conditions[0].LastTransitionTime = when
+	node.ObjectMeta.CreationTimestamp = when
+
+	return node
+}
+
+func heatlhyNode(name string) *v1.Node {
+	hourAgo := metav1.NewTime(time.Now().Add(-time.Hour))
+
+	return &v1.Node{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Node",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			CreationTimestamp: hourAgo,
+		},
+		Spec: v1.NodeSpec{
+			Taints:       nil,
+			ConfigSource: nil,
+		},
+		Status: v1.NodeStatus{
+			Capacity:    nil,
+			Allocatable: nil,
+			Phase:       "",
+			Conditions: []v1.NodeCondition{
+				{
+					Type:               v1.NodeReady,
+					Status:             v1.ConditionTrue,
+					LastTransitionTime: hourAgo,
+				},
+			},
+		},
 	}
+}
 
-	return nodeList, ds, podList
+type dsRepoMock struct {
+	dsErr   error
+	podsErr error
+	ds      *appsv1.DaemonSet
+	pods    []v1.Pod
+}
+
+func (m *dsRepoMock) Get() (*appsv1.DaemonSet, error) {
+	if m.dsErr != nil {
+		return nil, m.dsErr
+	}
+	return m.ds, nil
+}
+
+func (m *dsRepoMock) Pods() ([]v1.Pod, error) {
+	if m.podsErr != nil {
+		return nil, m.podsErr
+	}
+	return m.pods, nil
+}
+
+type nodeListerMock struct {
+	err   error
+	nodes []*v1.Node
+}
+
+func (m *nodeListerMock) List() ([]*v1.Node, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.nodes, nil
 }

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_daemonset_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_daemonset_test.go
@@ -93,15 +93,15 @@ func Test_checker_dsPodsReadinessChecker(t *testing.T) {
 			name: "missing pod is not fine",
 			want: check.Down,
 			state: state{
-				pods:  []v1.Pod{scheduledPod("a") /*    no pod "b"   */, scheduledPod("c")},
+				pods:  []v1.Pod{scheduledPod("a") /*  no pod "b"  */, scheduledPod("c")},
 				nodes: []*v1.Node{healthyNode("a"), healthyNode("b"), healthyNode("c")},
 			},
 		},
 		{
-			name: "missing po on a tainted node is fine",
+			name: "missing pod on a tainted node is fine",
 			want: check.Up,
 			state: state{
-				pods:  []v1.Pod{scheduledPod("a") /*     no pod "b"   */, scheduledPod("c")},
+				pods:  []v1.Pod{scheduledPod("a") /*  no pod "b"  */, scheduledPod("c")},
 				nodes: []*v1.Node{healthyNode("a"), taintedNode("b"), healthyNode("c")},
 			},
 		},
@@ -110,7 +110,7 @@ func Test_checker_dsPodsReadinessChecker(t *testing.T) {
 			want: check.Up,
 			state: state{
 				pods:  []v1.Pod{scheduledPod("a"), scheduledPod("b"), scheduledPod("c")},
-				nodes: []*v1.Node{healthyNode("a") /*    no node "b"   */, healthyNode("c")},
+				nodes: []*v1.Node{healthyNode("a") /*  no node "b" */, healthyNode("c")},
 			},
 		},
 		{
@@ -122,27 +122,11 @@ func Test_checker_dsPodsReadinessChecker(t *testing.T) {
 			},
 		},
 		{
-			name: "not-ready pod is not fine",
-			want: check.Down,
-			state: state{
-				pods:  []v1.Pod{scheduledPod("a"), notReadyPod("b"), scheduledPod("c")},
-				nodes: []*v1.Node{healthyNode("a"), healthyNode("b"), healthyNode("c")},
-			},
-		},
-		{
-			name: "not-running pod is not fine",
+			name: "not-ready pending pod is not fine",
 			want: check.Down,
 			state: state{
 				pods:  []v1.Pod{scheduledPod("a"), pendingPod("b"), scheduledPod("c")},
 				nodes: []*v1.Node{healthyNode("a"), healthyNode("b"), healthyNode("c")},
-			},
-		},
-		{
-			name: "unhealthy pod on very fresh node is fine",
-			want: check.Up,
-			state: state{
-				pods:  []v1.Pod{scheduledPod("a"), notReadyPod("b"), scheduledPod("c")},
-				nodes: []*v1.Node{healthyNode("a"), freshNode("b", creationTimeout/2), healthyNode("c")},
 			},
 		},
 		{
@@ -151,6 +135,22 @@ func Test_checker_dsPodsReadinessChecker(t *testing.T) {
 			state: state{
 				pods:  []v1.Pod{scheduledPod("a"), agedPod(creationTimeout/2, pendingPod("b")), scheduledPod("c")},
 				nodes: []*v1.Node{healthyNode("a"), healthyNode("b"), healthyNode("c")},
+			},
+		},
+		{
+			name: "not-ready running pod is not fine",
+			want: check.Down,
+			state: state{
+				pods:  []v1.Pod{scheduledPod("a"), notReadyPod("b"), scheduledPod("c")},
+				nodes: []*v1.Node{healthyNode("a"), healthyNode("b"), healthyNode("c")},
+			},
+		},
+		{
+			name: "not-ready running pod on very fresh node is fine",
+			want: check.Up,
+			state: state{
+				pods:  []v1.Pod{scheduledPod("a"), notReadyPod("b"), scheduledPod("c")},
+				nodes: []*v1.Node{healthyNode("a"), freshNode("b", creationTimeout/2), healthyNode("c")},
 			},
 		},
 		{
@@ -175,6 +175,14 @@ func Test_checker_dsPodsReadinessChecker(t *testing.T) {
 			state: state{
 				pods:  []v1.Pod{scheduledPod("a"), terminatingPod("b", deletionTimeout*2), scheduledPod("c")},
 				nodes: []*v1.Node{healthyNode("a"), healthyNode("b"), healthyNode("c")},
+			},
+		},
+		{
+			name: "pod-node mismatch is not fine (=missing pod on a node)",
+			want: check.Down,
+			state: state{
+				pods:  []v1.Pod{scheduledPod("a"), scheduledPod("y"), scheduledPod("c")},
+				nodes: []*v1.Node{healthyNode("a"), healthyNode("x"), healthyNode("c")},
 			},
 		},
 	}

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/smoke_mini_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/smoke_mini_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
+
+	k8saccess "d8.io/upmeter/pkg/kubernetes"
 )
 
 func Test_smokeMiniAvailable(t *testing.T) {
@@ -183,4 +185,40 @@ func respondSlowlyWith(timeout time.Duration, status int) *httptest.Server {
 		time.Sleep(timeout)
 		rw.WriteHeader(status)
 	}))
+}
+
+func NewFake(client kube.KubernetesClient) *FakeAccess {
+	return &FakeAccess{client: client}
+}
+
+type FakeAccess struct {
+	client kube.KubernetesClient
+}
+
+func (a *FakeAccess) Kubernetes() kube.KubernetesClient {
+	return a.client
+}
+
+func (a *FakeAccess) ServiceAccountToken() string {
+	return "pewpew"
+}
+
+func (a *FakeAccess) UserAgent() string {
+	return "UpmeterTestClient/1.0"
+}
+
+func (a *FakeAccess) SchedulerProbeImage() *k8saccess.ProbeImage {
+	return createTestProbeImage("test-image:latest", nil)
+}
+
+func (a *FakeAccess) SchedulerProbeNode() string {
+	return ""
+}
+
+func (a *FakeAccess) CloudControllerManagerNamespace() string {
+	return ""
+}
+
+func (a *FakeAccess) ClusterDomain() string {
+	return ""
 }

--- a/modules/500-upmeter/images/upmeter/pkg/probe/group_monitoring_and_autoscaling.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/group_monitoring_and_autoscaling.go
@@ -20,10 +20,11 @@ import (
 	"time"
 
 	"d8.io/upmeter/pkg/kubernetes"
+	"d8.io/upmeter/pkg/monitor/node"
 	"d8.io/upmeter/pkg/probe/checker"
 )
 
-func initMonitoringAndAutoscaling(access kubernetes.Access) []runnerConfig {
+func initMonitoringAndAutoscaling(access kubernetes.Access, nodeLister node.Lister) []runnerConfig {
 	const (
 		groupMonitoringAndAutoscaling = "monitoring-and-autoscaling"
 		cpTimeout                     = 5 * time.Second
@@ -139,6 +140,7 @@ func initMonitoringAndAutoscaling(access kubernetes.Access) []runnerConfig {
 			period: 10 * time.Second,
 			config: checker.DaemonSetPodsReady{
 				Access:                    access,
+				NodeLister:                nodeLister,
 				Namespace:                 "d8-monitoring",
 				Name:                      "node-exporter",
 				RequestTimeout:            5 * time.Second,

--- a/modules/500-upmeter/images/upmeter/pkg/probe/group_nodegroups.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/group_nodegroups.go
@@ -26,7 +26,7 @@ import (
 	"d8.io/upmeter/pkg/probe/checker"
 )
 
-func initNodeGroups(access kubernetes.Access, nodeGroupNames, knownZones []string, nodeLister node.Lister) []runnerConfig {
+func initNodeGroups(access kubernetes.Access, nodeLister node.Lister, nodeGroupNames, knownZones []string) []runnerConfig {
 	const (
 		groupNodeGroups = "nodegroups"
 		cpTimeout       = 5 * time.Second

--- a/modules/500-upmeter/images/upmeter/pkg/probe/load.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/load.go
@@ -137,7 +137,7 @@ func (l *Loader) collectConfigs() []runnerConfig {
 	l.configs = append(l.configs, initLoadBalancing(l.access)...)
 	l.configs = append(l.configs, initDeckhouse(l.access, l.logger)...)
 	l.configs = append(l.configs, initNginx(l.access, l.dynamic.IngressNginxControllers)...)
-	l.configs = append(l.configs, initNodeGroups(l.access, l.dynamic.NodeGroups, l.dynamic.Zones, l.nodeLister)...)
+	l.configs = append(l.configs, initNodeGroups(l.access, l.nodeLister, l.dynamic.NodeGroups, l.dynamic.Zones)...)
 
 	return l.configs
 }

--- a/modules/500-upmeter/images/upmeter/pkg/probe/load_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/load_test.go
@@ -117,6 +117,7 @@ func TestLoader_Probes(t *testing.T) {
 	filtered := NewLoader(
 		NewProbeFilter([]string{"deckhouse", "extensions/", "load-balancing/metallb", "nodegroups/spot"}),
 		&kubernetes.Accessor{},
+		nil, // nodeLister
 		DynamicConfig{
 			IngressNginxControllers: []string{"main", "main-w-pp"},
 			NodeGroups:              []string{"system", "frontend", "worker", "spot"},

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/incidents.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/incidents.go
@@ -25,7 +25,7 @@ import (
 )
 
 func fetchIncidents(monitor *downtime.Monitor, muteDowntimeTypes []string, group string, rng ranges.StepRange) ([]check.DowntimeIncident, error) {
-	allIncidents, err := monitor.GetDowntimeIncidents()
+	allIncidents, err := monitor.List()
 	if err != nil {
 		return nil, fmt.Errorf("cannot get incidents: %v", err)
 	}

--- a/modules/500-upmeter/images/upmeter/pkg/server/remotewrite/controller.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/remotewrite/controller.go
@@ -81,7 +81,7 @@ type Controller struct {
 func (c *Controller) Start(ctx context.Context) error {
 	headers := map[string]string{"User-Agent": c.userAgent}
 
-	// monitor tracks the exporter configuration in kubernetes. It is important to subscribe (add event callback)
+	// Monitor tracks the exporter configuration in kubernetes. It is important to subscribe (add event callback)
 	// before monitor starts because informers are created during monitor.Start(ctx) call.
 	c.logger.Debugln("subscribing to k8s events")
 	c.kubeMonitor.Subscribe(&updateHandler{

--- a/modules/500-upmeter/images/upmeter/pkg/server/remotewrite/controller.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/remotewrite/controller.go
@@ -81,7 +81,7 @@ type Controller struct {
 func (c *Controller) Start(ctx context.Context) error {
 	headers := map[string]string{"User-Agent": c.userAgent}
 
-	// Monitor tracks the exporter configuration in kubernetes. It is important to subscribe (add event callback)
+	// monitor tracks the exporter configuration in kubernetes. It is important to subscribe (add event callback)
 	// before monitor starts because informers are created during monitor.Start(ctx) call.
 	c.logger.Debugln("subscribing to k8s events")
 	c.kubeMonitor.Subscribe(&updateHandler{

--- a/modules/500-upmeter/images/upmeter/pkg/server/server.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/server.go
@@ -117,7 +117,7 @@ func (s *server) Start(ctx context.Context) error {
 
 	go cleanOld30sEpisodes(ctx, dbctx)
 
-	// Probe probeLister that can only list groups and probes
+	// Probe lister that can only list groups and probes
 	probeLister := newProbeLister(s.config.DisabledProbes, s.config.DynamicProbes)
 
 	// Start http server. It blocks, that's why it is the last here.
@@ -224,7 +224,7 @@ func newProbeLister(disabled []string, dynamic *DynamicProbesConfig) *registry.R
 		IngressNginxControllers: dynamic.IngressControllers,
 		NodeGroups:              dynamic.NodeGroups,
 	}
-	runLoader := probe.NewLoader(noFilter, noAccess, dynamicConfig, noLogger)
+	runLoader := probe.NewLoader(noFilter, noAccess, nil, dynamicConfig, noLogger)
 	calcLoader := calculated.NewLoader(noFilter, noLogger)
 
 	return registry.NewProbeLister(runLoader, calcLoader)

--- a/modules/500-upmeter/images/upmeter/pkg/server/server.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/server.go
@@ -103,7 +103,7 @@ func (s *server) Start(ctx context.Context) error {
 	}
 
 	// Downtime CR monitor
-	s.downtimeMonitor, err = initDowntimeMonitor(ctx, kubeClient)
+	s.downtimeMonitor, err = initDowntimeMonitor(ctx, kubeClient, s.logger)
 	if err != nil {
 		return fmt.Errorf("cannot start downtimes.deckhouse.io monitor: %v", err)
 	}
@@ -211,10 +211,9 @@ func initRemoteWriteController(ctx context.Context, dbCtx *dbcontext.DbContext, 
 	return controller, controller.Start(ctx)
 }
 
-func initDowntimeMonitor(ctx context.Context, kubeClient kube.KubernetesClient) (*downtime.Monitor, error) {
-	m := downtime.NewMonitor(ctx)
-	m.Monitor.WithKubeClient(kubeClient)
-	return m, m.Start()
+func initDowntimeMonitor(ctx context.Context, kubeClient kube.KubernetesClient, logger *log.Logger) (*downtime.Monitor, error) {
+	m := downtime.NewMonitor(kubeClient, log.NewEntry(logger))
+	return m, m.Start(ctx)
 }
 
 func newProbeLister(disabled []string, dynamic *DynamicProbesConfig) *registry.RegistryProbeLister {


### PR DESCRIPTION
## Description

Use node informer for listing nodes instead of direct listing in API

## Why do we need it, and what problem does it solve?

It reduces the load on kube-apiserver in relatively big clusters.

## What is the expected result?

Upmeter will work as expected.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests are passed.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: upmeter
type: chore
summary: Tracking nodes switched to informer instead of direct listing requests
```
