### PR TITLE
[upmeter] Fix status page descriptions

### DIFF
--- a/modules/500-upmeter/images/status/.prettierrc.yml
+++ b/modules/500-upmeter/images/status/.prettierrc.yml
@@ -1,6 +1,6 @@
 tabWidth: 2
-useTabs: false
+useTabs: true
 trailingComma: all
 arrowParens: always
 printWidth: 110
-semi: false
+semi: true

--- a/modules/500-upmeter/images/status/package-lock.json
+++ b/modules/500-upmeter/images/status/package-lock.json
@@ -1093,6 +1093,18 @@
       "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
       "dev": true
     },
+    "prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true
+    },
+    "prettier-plugin-svelte": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.7.0.tgz",
+      "integrity": "sha512-fQhhZICprZot2IqEyoiUYLTRdumULGRvw0o4dzl5jt0jfzVWdGqeYW27QTWAeXhoupEZJULmNoH3ueJwUWFLIA==",
+      "dev": true
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",

--- a/modules/500-upmeter/images/status/package.json
+++ b/modules/500-upmeter/images/status/package.json
@@ -6,13 +6,16 @@
     "build": "rollup -c",
     "dev": "rollup -c -w",
     "start": "sirv public --no-clear",
-    "validate": "svelte-check"
+    "validate": "svelte-check",
+    "fmt": "prettier --write src"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
     "@rollup/plugin-typescript": "^8.0.0",
     "@tsconfig/svelte": "^1.0.0",
+    "prettier": "^2.7.1",
+    "prettier-plugin-svelte": "^2.7.0",
     "rollup": "^2.3.4",
     "rollup-plugin-css-only": "^3.1.0",
     "rollup-plugin-dev": "^1.1.3",

--- a/modules/500-upmeter/images/status/rollup.config.js
+++ b/modules/500-upmeter/images/status/rollup.config.js
@@ -81,7 +81,7 @@ export default {
 		!production && dev({
 			spa: "./public/index.html",
 			dirs: ["./public"],
-			port: 5000,
+			port: 5011,
 			proxy: {
 				"/public/api/*": "http://localhost:8091",
 			},

--- a/modules/500-upmeter/images/status/rollup.config.js
+++ b/modules/500-upmeter/images/status/rollup.config.js
@@ -81,7 +81,7 @@ export default {
 		!production && dev({
 			spa: "./public/index.html",
 			dirs: ["./public"],
-			port: 5011,
+			port: 5000,
 			proxy: {
 				"/public/api/*": "http://localhost:8091",
 			},

--- a/modules/500-upmeter/images/status/src/App.svelte
+++ b/modules/500-upmeter/images/status/src/App.svelte
@@ -6,7 +6,7 @@
 	import { getGroupData } from "./en";
 
 	async function fetchStatusJSON() {
-		const r = await fetch("/public/api/status", { headers: { "accept": "application/json" } });
+		const r = await fetch("/public/api/status", { headers: { accept: "application/json" } });
 		return await r.json();
 	}
 
@@ -15,7 +15,6 @@
 	let error = null;
 	let pendingUpdateText = "";
 	let now = new Date();
-
 
 	async function update() {
 		now = new Date();
@@ -44,7 +43,8 @@
 		</Col>
 		<Col class="text-right">
 			<p>
-				<span class="text-muted"> as of</span> {now.toLocaleTimeString()}
+				<span class="text-muted"> as of</span>
+				{now.toLocaleTimeString()}
 			</p>
 		</Col>
 	</Row>
@@ -52,36 +52,24 @@
 	<hr class="mt-0" />
 
 	{#if data == null && error == null}
-
 		<Row class="mb-5 mt-5">
 			<Col>
 				<h2 class="text-muted font-weight-light">Wait a second...</h2>
 			</Col>
 		</Row>
+	{:else if data != null}
+		<h2 class="mb-5 mt-5 font-weight-normal">
+			<StatusText
+				status={data.status}
+				text={"Cluster " + data.status + pendingUpdateText}
+				mute={error != null}
+			/>
+		</h2>
 
-	{:else}
-
-		{#if data != null }
-			<h2 class="mb-5 mt-5 font-weight-normal">
-				<StatusText
-					status="{data.status}"
-					text={"Cluster " + data.status + pendingUpdateText}
-					mute={error != null}
-				/>
-			</h2>
-
-			{#each data.rows as row}
-				<Row class="mb-3">
-					<Group
-						{ ...getGroupData(row.group) }
-						status="{row.status}"
-						mute={error != null}
-					/>
-				</Row>
-			{/each}
-
-		{/if}
+		{#each data.rows as row}
+			<Row class="mb-3">
+				<Group {...getGroupData(row.group)} status={row.status} mute={error != null} />
+			</Row>
+		{/each}
 	{/if}
-
 </Container>
-

--- a/modules/500-upmeter/images/status/src/Group.svelte
+++ b/modules/500-upmeter/images/status/src/Group.svelte
@@ -6,7 +6,6 @@
 	export let description: string = "Waiting to be filled...";
 	export let status: string = "Operational";
 	export let mute: boolean = false;
-
 </script>
 
 <Col class="col-9">
@@ -15,6 +14,6 @@
 </Col>
 <Col class="col-3 text-right">
 	<h4 class="font-weight-light">
-		<StatusText status="{status}" text="{status}" mute={mute} />
+		<StatusText {status} text={status} {mute} />
 	</h4>
 </Col>

--- a/modules/500-upmeter/images/status/src/StatusText.svelte
+++ b/modules/500-upmeter/images/status/src/StatusText.svelte
@@ -3,7 +3,6 @@
 	export let status: string = "";
 	export let mute: boolean = false;
 
-
 	function mutedOrStatusTextClassName(mute, status) {
 		if (mute) {
 			return "text-muted";
@@ -25,4 +24,4 @@
 	}
 </script>
 
-<p class="{mutedOrStatusTextClassName(mute, status)}">{text}</p>
+<p class={mutedOrStatusTextClassName(mute, status)}>{text}</p>

--- a/modules/500-upmeter/images/status/src/en.ts
+++ b/modules/500-upmeter/images/status/src/en.ts
@@ -1,49 +1,57 @@
 interface IGroupData {
-	name: string
-	description: string
+  name: string
+  description: string
 }
 
 const defaultGroupData: IGroupData = {
-	name: "TODO",
-	description: "TODO",
-};
+  name: "TODO",
+  description: "TODO",
+}
 
 const known: { [name: string]: IGroupData } = {
-	"control-plane": {
-		name: "Control plane",
-		description: "Cluster control-plane is available. Self-healing is working.",
-	},
-	"synthetic": {
-		name: "Synthetic",
-		description: "Availability of sample application running in cluster.",
-	},
-	"monitoring-and-autoscaling": {
-		name: "Monitoring and Autoscaling",
-		description: "Availability of monitoring and autoscaling applications in the cluster.",
-	},
-	"extensions": {
-		name: "Extensions",
-		description: "Availability of extensions apps.",
-	},
-	"load-balancing": {
-		name: "Load Balancing",
-		description: "Availability of traffic load balancing and its configuration controllers.",
-	},
-	"deckhouse": {
-		name: "Deckhouse",
-		description: "The availability of deckhouse and working hook.",
-	}
-};
+  "control-plane": {
+    name: "Control plane",
+    description: "The availability of Kubernetes control-plane",
+  },
+  "synthetic": {
+    name: "Synthetic",
+    description: "The availability of sample application, and network connectivity",
+  },
+  "monitoring-and-autoscaling": {
+    name: "Monitoring and Autoscaling",
+    description: "The availability of monitoring and autoscaling applications in the cluster",
+  },
+  "extensions": {
+    name: "Extensions",
+    description: "The availability of extensions apps",
+  },
+  "load-balancing": {
+    name: "Load Balancing",
+    description: "The availability of traffic load balancing and its configuration controllers",
+  },
+  "deckhouse": {
+    name: "Deckhouse",
+    description: "The availability of deckhouse and working hook",
+  },
+  "nodegroups": {
+    name: "Node Groups",
+    description: "The availability of CloudEphemeral nodes",
+  },
+  "nginx": {
+    name: "Nginx",
+    description: "The availability of Nginx Ingress Controllers",
+  },
+}
 
 export function getGroupData(name: string): IGroupData {
-	const data = known[name];
+  const data = known[name]
 
-	if (!data) {
-		return {
-			...defaultGroupData,
-			name,
-		};
-	}
+  if (!data) {
+    return {
+      ...defaultGroupData,
+      name,
+    }
+  }
 
-	return data;
+  return data
 }

--- a/modules/500-upmeter/images/status/src/en.ts
+++ b/modules/500-upmeter/images/status/src/en.ts
@@ -1,57 +1,57 @@
 interface IGroupData {
-  name: string
-  description: string
+	name: string;
+	description: string;
 }
 
 const defaultGroupData: IGroupData = {
-  name: "TODO",
-  description: "TODO",
-}
+	name: "TODO",
+	description: "TODO",
+};
 
 const known: { [name: string]: IGroupData } = {
-  "control-plane": {
-    name: "Control plane",
-    description: "The availability of Kubernetes control-plane",
-  },
-  "synthetic": {
-    name: "Synthetic",
-    description: "The availability of sample application, and network connectivity",
-  },
-  "monitoring-and-autoscaling": {
-    name: "Monitoring and Autoscaling",
-    description: "The availability of monitoring and autoscaling applications in the cluster",
-  },
-  "extensions": {
-    name: "Extensions",
-    description: "The availability of extensions apps",
-  },
-  "load-balancing": {
-    name: "Load Balancing",
-    description: "The availability of traffic load balancing and its configuration controllers",
-  },
-  "deckhouse": {
-    name: "Deckhouse",
-    description: "The availability of deckhouse and working hook",
-  },
-  "nodegroups": {
-    name: "Node Groups",
-    description: "The availability of CloudEphemeral nodes",
-  },
-  "nginx": {
-    name: "Nginx",
-    description: "The availability of Nginx Ingress Controllers",
-  },
-}
+	"control-plane": {
+		name: "Control plane",
+		description: "The availability of Kubernetes control-plane",
+	},
+	synthetic: {
+		name: "Synthetic",
+		description: "The availability of sample application, and network connectivity",
+	},
+	"monitoring-and-autoscaling": {
+		name: "Monitoring and Autoscaling",
+		description: "The availability of monitoring and autoscaling applications in the cluster",
+	},
+	extensions: {
+		name: "Extensions",
+		description: "The availability of extensions apps",
+	},
+	"load-balancing": {
+		name: "Load Balancing",
+		description: "The availability of traffic load balancing and its configuration controllers",
+	},
+	deckhouse: {
+		name: "Deckhouse",
+		description: "The availability of deckhouse and working hook",
+	},
+	nodegroups: {
+		name: "Node Groups",
+		description: "The availability of CloudEphemeral nodes",
+	},
+	nginx: {
+		name: "Nginx",
+		description: "The availability of Nginx Ingress Controllers",
+	},
+};
 
 export function getGroupData(name: string): IGroupData {
-  const data = known[name]
+	const data = known[name];
 
-  if (!data) {
-    return {
-      ...defaultGroupData,
-      name,
-    }
-  }
+	if (!data) {
+		return {
+			...defaultGroupData,
+			name,
+		};
+	}
 
-  return data
+	return data;
 }


### PR DESCRIPTION
## Description

On status page (status.<clusterPublicDomain>)

- Added descriptions for avaiability groups "nodegroups" and "nginx".
- Rephrased other descriptions for uniformity.

## Why do we need it, and what problem does it solve?

Status page should be descriptive.

## What is the expected result?

The page looks not like it was forgotten or abandoned

## Checklist
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: upmeter
type: chore
summary: Added descriptions for avaiability groups "nodegroups" and "nginx".
```
