### PR TITLE
[docs] Update OpenAPI render and increase notification maxwidth

### DIFF
--- a/docs/documentation/_includes/openapi-tippy.html
+++ b/docs/documentation/_includes/openapi-tippy.html
@@ -6,7 +6,7 @@ $(document).ready(function () {
     tippy('[data-tippy-content]', {
         interactive: true,
         interactiveDebounce: 75,
-        maxWidth: 400,
+        maxWidth: 600,
         theme: 'custom',
         allowHTML: true,
         arrow: false,

--- a/docs/documentation/_plugins/openapi.rb
+++ b/docs/documentation/_plugins/openapi.rb
@@ -5,15 +5,22 @@ module Jekyll
     # Return localised description
     # the source parameter is for object without i18n structure and for legacy support
     def get_i18n_description(primaryLanguage, fallbackLanguage, source=nil)
-        if primaryLanguage and primaryLanguage.has_key?("description") then
+        if get_hash_value(primaryLanguage, "description") then
             result = primaryLanguage["description"]
-        elsif fallbackLanguage and fallbackLanguage.has_key?("description") then
+        elsif get_hash_value(fallbackLanguage, "description") then
             result = fallbackLanguage["description"]
-        elsif source and source.has_key?("description") then
+        elsif get_hash_value(source, "description") then
             result = source["description"]
         else
-            result = nil
+            result = ''
         end
+
+        if get_hash_value(primaryLanguage, "items", "description") then
+            result += %Q(\n\n#{primaryLanguage["items"]["description"]})
+        elsif get_hash_value(fallbackLanguage, "items", "description") then
+            result += %Q(\n\n#{fallbackLanguage["items"]["description"]})
+        end
+
         result
     end
 
@@ -315,7 +322,7 @@ module Jekyll
                 end
                 result.push('</ul>')
             else
-                result.push(format_schema("", attributes['items'], attributes, get_hash_value(primaryLanguage,'items'), get_hash_value(fallbackLanguage,'items'), fullPath))
+                # result.push(format_schema("", attributes['items'], attributes, get_hash_value(primaryLanguage,'items'), get_hash_value(fallbackLanguage,'items'), fullPath))
             end
         else
             # result.push("no properties for #{name}")


### PR DESCRIPTION
## Description
Add the description field of the `items` structure to the description of the parent parameter.

Increase notification maximum width (in tippy).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests are passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: Fixed OpenAPI render
impact_level: low
```
