### PR TITLE
[prometheus] Update to 2.37.0 (LTS)

### DIFF
--- a/modules/020-deckhouse/images/webhook-handler/werf.inc.yaml
+++ b/modules/020-deckhouse/images/webhook-handler/werf.inc.yaml
@@ -12,7 +12,7 @@ ansible:
       unarchive:
         extra_opts:
           # The promtool version should match prometheus version from the 300-prometheus module.
-         {{- $promVersion := "2.36.2" }}
+         {{- $promVersion := "2.37.0" }}
           - prometheus-{{ $promVersion }}.linux-amd64/promtool
           - --strip-components=1
         src: https://github.com/prometheus/prometheus/releases/download/v{{ $promVersion }}/prometheus-{{ $promVersion }}.linux-amd64.tar.gz

--- a/modules/300-prometheus/images/prometheus/Dockerfile
+++ b/modules/300-prometheus/images/prometheus/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_NODE_16_ALPINE
 ARG BASE_ALPINE
 
 FROM $BASE_GOLANG_18_BULLSEYE as artifact
-ENV PROMETHEUS_VERSION=v2.36.2
+ENV PROMETHEUS_VERSION=v2.37.0
 
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - &&  \
   apt install -y nodejs && \


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>


## Why do we need it, and what problem does it solve?
https://prometheus.io/docs/introduction/release-cycle/

<img alt="img" src="https://prometheus.io/assets/lts-cycle.png">

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: chore
summary: Update Prometheus to the latest LTS version
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
