### PR TITLE
Revert "[docs] Disable certificateOwnerRef (#1647)"

### DIFF
--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -79,7 +79,7 @@ kind: Certificate
 metadata:
   name: {{ .Chart.Name }}-cert
 spec:
-  # certificateOwnerRef: false
+  certificateOwnerRef: false
   secretName: tls-{{ $host }}
   issuerRef:
     kind: ClusterIssuer


### PR DESCRIPTION
## Description
This PR reverts commit d21615f5eb8f9d364be7362686b3008fccc646fd (#1647).

## Changelog entries
```changes
section: chore
type: fix
summary: Set `certificateOwnerRef` to `false` in the documentation Ingress.
impact_level: low
```
