### PR TITLE
[istio] D8IstioDataPlanePatchVersionMismatch alert description fix

### DIFF
--- a/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
@@ -85,5 +85,5 @@
         There are Pods in `{{$labels.namespace}}` Namespace with data-plane patch versions different from control-plane one. Consider restarting the Pods to actualize it.
         Getting affected Pods:
         ```
-        kubectl -n c1 get pods -o json | jq -r --arg tag "{{$labels.actual_sidecar_image_tag}}" '.items[] | select(.spec.containers[] | select(.image | endswith(":" + $tag))) | .metadata.name'
+        kubectl -n {{$labels.namespace}} get pods -o json | jq -r --arg tag "{{$labels.actual_sidecar_image_tag}}" '.items[] | select(.spec.containers[] | select(.image | endswith(":" + $tag))) | .metadata.name'
         ```


### PR DESCRIPTION
## Description
D8IstioDataPlanePatchVersionMismatch alert description fix.

## Why do we need it, and what problem does it solve?
There was wrong command in description.

## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: istio
type: fix
summary: D8IstioDataPlanePatchVersionMismatch alert description fix
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
