### PR TITLE
[istio] don't export unready ingressgateway nodes via metadata-exporter

### DIFF
--- a/ee/modules/110-istio/images/metadata-discovery/hooks/ingressgateways
+++ b/ee/modules/110-istio/images/metadata-discovery/hooks/ingressgateways
@@ -70,20 +70,17 @@ EOF
         jqFilter: |
           {
             "name": .metadata.name,
-            "address": ((.status.addresses[] | select(.type == "ExternalIP") | .address) // (.status.addresses[] | select(.type == "InternalIP") | .address))
+            "address": ((.status.addresses[] | select(.type == "ExternalIP") | .address) // (.status.addresses[] | select(.type == "InternalIP") | .address)),
+            "isActive": (
+               (any((.spec.taints // [])[]; .key == "node.kubernetes.io/unschedulable") | not) and
+               ([.status.conditions[] | select(.type == "Ready")][-1].status == "True")
+            )
           }
 EOF
   fi
 }
 
 function __on_group::main-lb() {
-  context::jq '
-    {
-      "ingressGateways": [
-        .snapshots.ingressgateway_service[].filterResult | select(.address and .port) | {"address": .address, "port": .port}
-      ]
-    }' > /metadata/ingressgateways.json
-
   context::jq '
     [
       .snapshots.ingressgateway_service[].filterResult | select(.address and .port) | {"address": .address, "port": .port}
@@ -94,18 +91,9 @@ function __on_group::main-lb() {
 function __on_group::main-np() {
   context::jq '
     .snapshots.ingressgateway_service[0].filterResult.port as $port |
-    [.snapshots.pods[].filterResult.nodeName] as $nodes |
-    {
-      "ingressGateways": [
-        .snapshots.nodes[].filterResult | .name as $name | select($nodes | index($name)) | {"address": .address, "port": $port}
-      ]
-    }' > /metadata/ingressgateways.json
-
-  context::jq '
-    .snapshots.ingressgateway_service[0].filterResult.port as $port |
-    [.snapshots.pods[].filterResult.nodeName] as $nodes |
+    [.snapshots.pods[].filterResult.nodeName] as $pod_nodes |
     [
-        .snapshots.nodes[].filterResult | .name as $name | select($nodes | index($name)) | {"address": .address, "port": $port}
+        .snapshots.nodes[] | select(.isActive) | .filterResult | .name as $name | select($pod_nodes | index($name)) | {"address": .address, "port": $port}
     ]' > /metadata/ingressgateways-array.json
 }
 

--- a/ee/modules/110-istio/images/metadata-discovery/hooks/ingressgateways
+++ b/ee/modules/110-istio/images/metadata-discovery/hooks/ingressgateways
@@ -72,8 +72,9 @@ EOF
             "name": .metadata.name,
             "address": ((.status.addresses[] | select(.type == "ExternalIP") | .address) // (.status.addresses[] | select(.type == "InternalIP") | .address)),
             "isActive": (
-               (any((.spec.taints // [])[]; .key == "node.kubernetes.io/unschedulable") | not) and
-               ([.status.conditions[] | select(.type == "Ready")][-1].status == "True")
+              all((.spec.taints // [])[] ; .key != "node.kubernetes.io/unschedulable")
+              and
+              (.status.conditions[] // [] | select(.type == "Ready") | .status == "True")
             )
           }
 EOF

--- a/ee/modules/110-istio/images/metadata-discovery/hooks/ingressgateways
+++ b/ee/modules/110-istio/images/metadata-discovery/hooks/ingressgateways
@@ -74,7 +74,7 @@ EOF
             "isActive": (
               all((.spec.taints // [])[] ; .key != "node.kubernetes.io/unschedulable")
               and
-              (.status.conditions[] // [] | select(.type == "Ready") | .status == "True")
+              ((.status.conditions // [])[] | select(.type == "Ready") | .status == "True")
             )
           }
 EOF

--- a/ee/modules/110-istio/images/metadata-discovery/hooks/ingressgateways
+++ b/ee/modules/110-istio/images/metadata-discovery/hooks/ingressgateways
@@ -93,7 +93,7 @@ function __on_group::main-np() {
     .snapshots.ingressgateway_service[0].filterResult.port as $port |
     [.snapshots.pods[].filterResult.nodeName] as $pod_nodes |
     [
-        .snapshots.nodes[] | select(.isActive) | .filterResult | .name as $name | select($pod_nodes | index($name)) | {"address": .address, "port": $port}
+        .snapshots.nodes[].filterResult | select(.isActive) | .name as $name | select($pod_nodes | index($name)) | {"address": .address, "port": $port}
     ]' > /metadata/ingressgateways-array.json
 }
 

--- a/ee/modules/110-istio/images/metadata-discovery/hooks/services
+++ b/ee/modules/110-istio/images/metadata-discovery/hooks/services
@@ -30,13 +30,6 @@ EOF
 
 function __main__() {
   context::jq '
-    {
-      "publicServices": [
-        .snapshots.public_services[].filterResult
-      ]
-    }' > /metadata/services.json
-
-  context::jq '
     [
       .snapshots.public_services[].filterResult
     ]' > /metadata/services-array.json

--- a/ee/modules/110-istio/images/metadata-exporter/main.go
+++ b/ee/modules/110-istio/images/metadata-exporter/main.go
@@ -305,87 +305,6 @@ func httpHandlerHealthz(w http.ResponseWriter, r *http.Request) {
 	logger.Println(r.RemoteAddr, r.Method, r.UserAgent(), r.URL.Path)
 }
 
-// TODO: delete after refactoring in favour of httpHandlerPrivate
-func httpHandlerFederationServices(w http.ResponseWriter, r *http.Request) {
-	err := checkAuthn(r.Header, "federation-services")
-	if err != nil {
-		http.Error(w, "Authentication error: "+err.Error(), http.StatusUnauthorized)
-		return
-	}
-
-	data, err := ioutil.ReadFile("/metadata/services.json")
-	if err != nil {
-		http.Error(w, "Error reading services.json", http.StatusInternalServerError)
-		return
-	}
-	fmt.Fprint(w, string(data))
-	logger.Println(r.RemoteAddr, r.Method, r.UserAgent(), r.URL.Path)
-}
-
-// TODO: delete after refactoring in favour of httpHandlerPrivate
-func httpHandlerFederationIngressgateways(w http.ResponseWriter, r *http.Request) {
-	err := checkAuthn(r.Header, "federation-ingressgateways")
-	if err != nil {
-		http.Error(w, "Authentication error: "+err.Error(), http.StatusUnauthorized)
-	}
-
-	data, err := ioutil.ReadFile("/metadata/ingressgateways.json")
-	if err != nil {
-		http.Error(w, "Error reading ingressgateways.json", http.StatusInternalServerError)
-		return
-	}
-	fmt.Fprint(w, string(data))
-	logger.Println(r.RemoteAddr, r.Method, r.UserAgent(), r.URL.Path)
-}
-
-// TODO: delete after refactoring in favour of httpHandlerPrivate
-func httpHandlerAllianceIngressgateways(w http.ResponseWriter, r *http.Request) {
-	err := checkAuthn(r.Header, "alliance-ingressgateways")
-	if err != nil {
-		http.Error(w, "Authentication error: "+err.Error(), http.StatusUnauthorized)
-	}
-
-	data, err := ioutil.ReadFile("/metadata/ingressgateways.json")
-	if err != nil {
-		http.Error(w, "Error reading ingressgateways.json", http.StatusInternalServerError)
-		return
-	}
-	fmt.Fprint(w, string(data))
-	logger.Println(r.RemoteAddr, r.Method, r.UserAgent(), r.URL.Path)
-}
-
-// TODO: delete after refactoring in favour of httpHandlerPrivate
-func httpHandlerMulticlusterNetworkName(w http.ResponseWriter, r *http.Request) {
-	err := checkAuthn(r.Header, "multicluster-network-name")
-	if err != nil {
-		http.Error(w, "Authentication error: "+err.Error(), http.StatusUnauthorized)
-	}
-
-	networkName := os.Getenv("MULTICLUSTER_NETWORK_NAME")
-	if len(networkName) == 0 {
-		http.Error(w, "Error reading network name", http.StatusInternalServerError)
-		return
-	}
-	fmt.Fprint(w, networkName)
-	logger.Println(r.RemoteAddr, r.Method, r.UserAgent(), r.URL.Path)
-}
-
-// TODO: delete after refactoring in favour of httpHandlerPrivate
-func httpHandlerMulticlusterAPIHost(w http.ResponseWriter, r *http.Request) {
-	err := checkAuthn(r.Header, "multicluster-api-host")
-	if err != nil {
-		http.Error(w, "Authentication error: "+err.Error(), http.StatusUnauthorized)
-	}
-
-	apiHost := os.Getenv("MULTICLUSTER_API_HOST")
-	if len(apiHost) == 0 {
-		http.Error(w, "Error reading api host", http.StatusInternalServerError)
-		return
-	}
-	fmt.Fprint(w, apiHost)
-	logger.Println(r.RemoteAddr, r.Method, r.UserAgent(), r.URL.Path)
-}
-
 func renderScheduler() {
 	time.Sleep(1 * time.Minute)
 	renderSpiffeBundleJSON()
@@ -407,16 +326,11 @@ func main() {
 	router.Handle("/metadata/public/public.json", http.HandlerFunc(httpHandlerPubilcJSON))
 
 	if os.Getenv("FEDERATION_ENABLED") == "true" {
-		router.Handle("/metadata/private/federation-services", http.HandlerFunc(httpHandlerFederationServices))
-		router.Handle("/metadata/private/federation-ingressgateways", http.HandlerFunc(httpHandlerFederationIngressgateways))
 		router.Handle("/metadata/private/federation.json", http.HandlerFunc(httpHandlerFederationPrivateJSON))
 	}
 	if os.Getenv("MULTICLUSTER_ENABLED") == "true" {
-		router.Handle("/metadata/private/multicluster-api-host", http.HandlerFunc(httpHandlerMulticlusterAPIHost))
-		router.Handle("/metadata/private/multicluster-network-name", http.HandlerFunc(httpHandlerMulticlusterNetworkName))
 		router.Handle("/metadata/private/multicluster.json", http.HandlerFunc(httpHandlerMulticlusterPrivateJSON))
 	}
-	router.Handle("/metadata/private/alliance-ingressgateways", http.HandlerFunc(httpHandlerAllianceIngressgateways))
 
 	server := &http.Server{
 		Addr:         listenAddr,


### PR DESCRIPTION
## Description
Don't export unready ingressgateway nodes via metadata-exporter for multiclusters and federations.

## Why do we need it, and what problem does it solve?
metadata-exporter exposes NotReady and cordoned nodes. It leads to unwanted connection errors.

## What is the expected result?
metadata-exporter won't export unwanted nodes.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: istio
type: fix
summary: Don't export unready ingressgateway nodes via metadata-exporter for multiclusters and federations.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
