### PR TITLE
[docs] Fix meta tags in page header on the site

### DIFF
--- a/docs/site/_includes/head.html
+++ b/docs/site/_includes/head.html
@@ -41,13 +41,13 @@
     {%- assign description = site.site_description[page.lang] | strip_html | strip_newlines | strip | truncate: 160 %}
 {% endif %}
 
+{%- if include.mode=='documentation' %}
+{%- assign page_meta_url = site.canonical_url_prefix | append: (page_url_without_lang | relative_url) %}
+{%- else %}
+{%- assign page_meta_url = page_url_without_lang | relative_url %}
+{% endif %}
 <!-- multilang -->
 {%- if page.multilang %}
-    {%- if include.mode=='documentation' %}
-    {%- assign page_meta_url = site.canonical_url_prefix | append: (page_url_without_lang | relative_url) %}
-    {%- else %}
-    {%- assign page_meta_url = page_url_without_lang | relative_url %}
-    {% endif %}
     <link data-proofer-ignore rel="alternate" hreflang="ru" href="{{ site.url }}/ru{{ page_meta_url }}" />
     <link data-proofer-ignore rel="alternate" hreflang="en" href="{{ site.url }}/en{{ page_meta_url }}" />
 {%- endif %}
@@ -59,12 +59,12 @@
 
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="website">
-<meta property="og:url" content="{% if page.change_canonical %}{{ page.url | absolute_url }}{% else %}{{ site.url }}{{ page.url }}{% endif %}">
+<meta property="og:url" content="{{ site.url }}/{{ page.lang }}{{ page_meta_url }}">
 <meta property="og:title" content="{{ generated_title }} | {{ site.site_title }}">
 <meta property="og:description" content="{{ description }}">
 
 <!-- Twitter -->
 <meta property="twitter:card" content="summary_large_image">
-<meta property="twitter:url" content="{% if page.change_canonical %}{{ page.url | absolute_url }}{% else %}{{ site.url }}{{ page.url }}{% endif %}">
+<meta property="twitter:url" content="{{ site.url }}/{{ page.lang }}{{ page_meta_url }}">
 <meta property="twitter:title" content="{{ generated_title }} | {{ site.site_title }}">
 <meta property="twitter:description" content="{{ description }}">


### PR DESCRIPTION
## Description

Fix URL in meta tags on site pages.

## Why do we need it, and what problem does it solve?
There was an incorrect page preview.

## Changelog entries
```changes
section: docs
type: fix
summary: Fix URL in meta tags on site pages.
impact_level: low
```

