### PR TITLE
[prometheus-metrics-adapter] Fix panic

### DIFF
--- a/modules/301-prometheus-metrics-adapter/images/prometheus-reverse-proxy/Dockerfile
+++ b/modules/301-prometheus-metrics-adapter/images/prometheus-reverse-proxy/Dockerfile
@@ -4,7 +4,7 @@ FROM $BASE_GOLANG_17_ALPINE as artifact
 WORKDIR /src/
 COPY /app/ /src/
 RUN apk add --no-cache git && \
-    go test ./... && \
+    GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test ./... && \
     GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" ./cmd/prometheus-reverse-proxy
 
 FROM $BASE_ALPINE

--- a/modules/301-prometheus-metrics-adapter/images/prometheus-reverse-proxy/Dockerfile
+++ b/modules/301-prometheus-metrics-adapter/images/prometheus-reverse-proxy/Dockerfile
@@ -4,6 +4,7 @@ FROM $BASE_GOLANG_17_ALPINE as artifact
 WORKDIR /src/
 COPY /app/ /src/
 RUN apk add --no-cache git && \
+    go test ./... && \
     GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" ./cmd/prometheus-reverse-proxy
 
 FROM $BASE_ALPINE

--- a/modules/301-prometheus-metrics-adapter/images/prometheus-reverse-proxy/app/go.mod
+++ b/modules/301-prometheus-metrics-adapter/images/prometheus-reverse-proxy/app/go.mod
@@ -2,4 +2,7 @@ module prometheus-reverse-proxy
 
 go 1.17
 
-require github.com/google/uuid v1.3.0
+require (
+	github.com/felixge/httpsnoop v1.0.3
+	github.com/google/uuid v1.3.0
+)

--- a/modules/301-prometheus-metrics-adapter/images/prometheus-reverse-proxy/app/go.sum
+++ b/modules/301-prometheus-metrics-adapter/images/prometheus-reverse-proxy/app/go.sum
@@ -1,2 +1,4 @@
+github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
+github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/modules/301-prometheus-metrics-adapter/images/prometheus-reverse-proxy/app/server/server_test.go
+++ b/modules/301-prometheus-metrics-adapter/images/prometheus-reverse-proxy/app/server/server_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+)
+
+type testServer struct {
+	address string
+}
+
+func healthzProbe(address string) bool {
+	req, err := http.NewRequest("GET", address+"/healthz", nil)
+	if err != nil {
+		return false
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		time.Sleep(time.Microsecond)
+		return false
+	}
+
+	defer res.Body.Close()
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		time.Sleep(time.Microsecond)
+		return false
+	}
+
+	return string(b) == "Ok."
+}
+
+func setupTestServer(t *testing.T) *testServer {
+	config = map[string]map[string]CustomMetricConfig{
+		"my_kind": {
+			"my_metric": CustomMetricConfig{
+				Namespaced: map[string]string{
+					"default": "sum by (<<.GroupBy>>) (metric_name{<<.LabelMatchers>>})",
+				},
+			},
+		},
+	}
+
+	prometheusServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, r.URL.String())
+	}))
+
+	if err := os.Setenv("PROMETHEUS_URL", prometheusServer.URL); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// Search free address, then immediately close the listener to bind the server to this port instead
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	address := listener.Addr()
+	if err := listener.Close(); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if err := os.Setenv("PROXY_LISTEN_ADDRESS", address.String()); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	go NewServer().Listen()
+	ts := &testServer{
+		address: "http://" + address.String(),
+	}
+
+	for i := 0; i < 100; i++ {
+		if healthzProbe(ts.address) {
+			break
+		}
+	}
+
+	return ts
+}
+
+func TestServerHandleCustomMetrics(t *testing.T) {
+	ts := setupTestServer(t)
+	requestQuery := `/api/v1/query?query=` + url.QueryEscape(`custom_metric::my_kind::my_metric::namespace="default"::test`)
+
+	req, err := http.NewRequest("GET", ts.address+requestQuery, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal("wanted a non-nil error, got " + err.Error())
+	}
+
+	defer res.Body.Close()
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(b) != `/api/v1/query?query=`+url.QueryEscape(`sum by (test) (metric_name{namespace="default"})`) {
+		t.Fatalf("expected %q to be equal to %q", string(b), requestQuery)
+	}
+}
+
+func TestServerProxyPass(t *testing.T) {
+	ts := setupTestServer(t)
+	requestQuery := "/api/v1/query"
+
+	req, err := http.NewRequest("GET", ts.address+requestQuery, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal("wanted a non-nil error, got " + err.Error())
+	}
+
+	defer res.Body.Close()
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(b) != requestQuery {
+		t.Fatalf("expected %q to be equal to %q", string(b), requestQuery)
+	}
+}


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
Bugfix for a previos refactoring.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus-metrics-adapter
type: fix
summary: Fix panic in prometheus-reverse-proxy
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
