### PR TITLE
[monitoring-ping] consider source host packet loss when monitoring ping

### DIFF
--- a/modules/340-monitoring-ping/monitoring/prometheus-rules/node-ping.yaml
+++ b/modules/340-monitoring-ping/monitoring/prometheus-rules/node-ping.yaml
@@ -3,17 +3,17 @@
   - alert: NodePingPacketLoss
     expr: >-
       (
-        sum by (destination_node) (increase(kube_node_ping_packets_sent_total[5m]))
+        sum by (node, destination_node) (increase(kube_node_ping_packets_sent_total[5m]))
         -
-        sum by (destination_node) (increase(kube_node_ping_packets_received_total[5m]))
+        sum by (node, destination_node) (increase(kube_node_ping_packets_received_total[5m]))
       )
       /
-      sum by (destination_node) (increase(kube_node_ping_packets_sent_total[5m]))  > 0.05
+      sum by (node, destination_node) (increase(kube_node_ping_packets_sent_total[5m]))  > 0.05
     for: 5m
     labels:
       severity_level: "4"
     annotations:
       plk_protocol_version: "1"
-      description: ICMP packet loss to node {{$labels.destination_node}} is more than 5%
+      description: ICMP packet loss from node {{$labels.node}} to node {{$labels.destination_node}} is more than 5%
       summary: Ping loss more than 5%
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Change expression for `NodePingPacketLoss` alert to consider the packet loss of source host when monitoring ping

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The existing expression aggregates ping packet loss across the entire cluster and does not consider losses from a particular node.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

We should receive an alert when some node in cluster cannot not reach another node.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring-ping
type: fix
summary: consider source host packet loss when monitoring ping
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
