### PR TITLE
[Upmeter] Fix UpmeterHookProbe garbage

### DIFF
--- a/modules/500-upmeter/hooks/clean_probe_garbage.go
+++ b/modules/500-upmeter/hooks/clean_probe_garbage.go
@@ -248,7 +248,7 @@ func (r *deployRepo) Delete(ctx context.Context, name string) error {
 var upmeterHookProbeGVR = schema.GroupVersionResource{
 	Group:    "deckhouse.io",
 	Version:  "v1",
-	Resource: "uphookprobes",
+	Resource: "upmeterhookprobes",
 }
 
 type upmeterHookProbeRepo struct {

--- a/modules/500-upmeter/hooks/clean_probe_garbage.go
+++ b/modules/500-upmeter/hooks/clean_probe_garbage.go
@@ -37,7 +37,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "delete_probe_garbage",
-			Crontab: "*/15 * * * *",
+			Crontab: "*/2 * * * *",
 		},
 	},
 }, dependency.WithExternalDependencies(

--- a/modules/500-upmeter/hooks/clean_probe_garbage.go
+++ b/modules/500-upmeter/hooks/clean_probe_garbage.go
@@ -52,7 +52,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			&deployRepo{k},
 			&podRepo{k},
 			&namespaceRepo{k},
-			&upmeterHokProbeRepo{k},
+			&upmeterHookProbeRepo{k},
 		}
 
 		for _, r := range repos {
@@ -251,18 +251,18 @@ var upmeterHookProbeGVR = schema.GroupVersionResource{
 	Resource: "uphookprobes",
 }
 
-type upmeterHookProbe struct {
+type upmeterHookProbeRepo struct {
 	k k8s.Client
 }
 
-func (r *upmeterHookProbe) List(ctx context.Context) ([]metav1.Object, error) {
+func (r *upmeterHookProbeRepo) List(ctx context.Context) ([]metav1.Object, error) {
 	obj := &unstructured.Unstructured{}
 	obj.SetName("35d78cbb") // empty NODE_NAME results in this hash, fixing the bug
 	obj.SetCreationTimestamp(metav1.NewTime(time.Now().Add(-1 * time.Hour)))
 	return []metav1.Object{obj}, nil
 }
 
-func (r *upmeterHookProbe) Delete(ctx context.Context, name string) error {
+func (r *upmeterHookProbeRepo) Delete(ctx context.Context, name string) error {
 	return r.k.Dynamic().
 		Resource(upmeterHookProbeGVR).
 		Delete(ctx, name, metav1.DeleteOptions{})

--- a/modules/500-upmeter/hooks/clean_probe_garbage.go
+++ b/modules/500-upmeter/hooks/clean_probe_garbage.go
@@ -37,7 +37,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "delete_probe_garbage",
-			Crontab: "*/2 * * * *",
+			Crontab: "*/15 * * * *",
 		},
 	},
 }, dependency.WithExternalDependencies(

--- a/modules/500-upmeter/images/upmeter/pkg/probe/run/id.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/run/id.go
@@ -44,15 +44,15 @@ var id string
 
 func ID() string {
 	if id == "" {
-		h32 := murmur3.New32WithSeed(seed)
-		_, _ = h32.Write([]byte(NodeName()))
-		id = strconv.FormatInt(int64(h32.Sum32()), 16)
+		id = nodeNameHash(os.Getenv("NODE_NAME"))
 	}
 	return id
 }
 
-func NodeName() string {
-	return os.Getenv("NODE_NAME")
+func nodeNameHash(nodeName string) string {
+	h32 := murmur3.New32WithSeed(seed)
+	_, _ = h32.Write([]byte(nodeName))
+	return strconv.FormatInt(int64(h32.Sum32()), 16)
 }
 
 func randomAlphaNum(count int) string {

--- a/modules/500-upmeter/images/upmeter/pkg/probe/run/id_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/run/id_test.go
@@ -34,3 +34,26 @@ func Test_RandomIdentifier(t *testing.T) {
 		t.Errorf("expected %q != %q", a, b)
 	}
 }
+
+func Test_nodeNameHash(t *testing.T) {
+	tests := []struct {
+		nodeName string
+		want     string
+	}{
+		{nodeName: "", want: "35d78cbb"},
+		{nodeName: "kube-master", want: "36174012"},
+		{nodeName: "kube-master-0", want: "c349c19b"},
+		{nodeName: "kube-master-1", want: "57fb8ddf"},
+		{nodeName: "kube-master-2", want: "2a547f6c"},
+		{nodeName: "dev2-master-0", want: "7131bf4e"},
+		{nodeName: "dev2-master-1", want: "ccbabc3"},
+		{nodeName: "dev2-master-2", want: "35dc4115"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.nodeName, func(t *testing.T) {
+			if got := nodeNameHash(tt.nodeName); got != tt.want {
+				t.Errorf("nodeNameHash(%q) = %v, want %v", tt.nodeName, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Cleans garbage caused by a bug.

## Why do we need it, and what problem does it solve?

Automatically resolves an alert about upmeter garbage objects.

## What is the expected result?

The UpmeterHookProbe object named "35d78cbb" will be deleted, and corresponding alert will stop firing.

## Checklist
- [x] The code is covered by unit tests.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: upmeter
type: fix
summary: Added the auto-clean of garbage UpmeterHookProbe object produced by a bug
```
