### PR TITLE
[Upmeter] Fixup NotFound error on garbage cleaning

### DIFF
--- a/modules/500-upmeter/hooks/clean_probe_garbage.go
+++ b/modules/500-upmeter/hooks/clean_probe_garbage.go
@@ -38,7 +38,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "delete_probe_garbage",
-			Crontab: "* * * * *",
+			Crontab: "*/15 * * * *",
 		},
 	},
 }, dependency.WithExternalDependencies(

--- a/modules/500-upmeter/hooks/clean_probe_garbage.go
+++ b/modules/500-upmeter/hooks/clean_probe_garbage.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -79,7 +80,7 @@ func cleanGarbage(ctx context.Context, repo objectRepository) error {
 		if !isOldEnough {
 			continue
 		}
-		if err := repo.Delete(ctx, obj.GetName()); err != nil {
+		if err := repo.Delete(ctx, obj.GetName()); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("deleting %s: %v", obj.GetName(), err)
 		}
 		limit--

--- a/modules/500-upmeter/hooks/clean_probe_garbage.go
+++ b/modules/500-upmeter/hooks/clean_probe_garbage.go
@@ -38,7 +38,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "delete_probe_garbage",
-			Crontab: "*/15 * * * *",
+			Crontab: "* * * * *",
 		},
 	},
 }, dependency.WithExternalDependencies(


### PR DESCRIPTION
## Description

Ignore inexisting objects in garbage cleaning hook

## Why do we need it, and what problem does it solve?

Unstuck deckhouse main queue

## What is the expected result?

Dechouse queue does not hang

## Checklist
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: upemter
type: chore
summary: Fixed up garbage cleaning
```
