### PR TITLE
[node-local-dns] Revert configmap node-local-dns to prevent stuck node-local-dns pod in Terminating state during moving to kube-system namespace

### DIFF
--- a/ee/modules/350-node-local-dns/templates/configmap.yaml
+++ b/ee/modules/350-node-local-dns/templates/configmap.yaml
@@ -32,3 +32,43 @@ data:
       health 0.0.0.0:9225
 {{- end }}
     }
+
+---
+# Needed for migration of node-local-dns from d8-system namespace to kube-system.
+# Kubelet has issue when config map mounted to pod is deleted before pod is removed.
+# And pod hangs in `Terminating` state.
+# TODO remove after 1.35 release
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-local-dns
+  namespace: d8-system
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+data:
+  Corefile: |
+    .:53 {
+      errors {
+        consolidate 10s ".* i/o timeout$"
+        consolidate 10s ".* write: operation not permitted$"
+      }
+      cache {
+        success 39936
+        denial 9984
+        prefetch 10 1m 25%
+        serve_stale 1h immediate
+      }
+      reload 2s
+      loop
+      forward . {{ .Values.nodeLocalDns.internal.clusterDNSRedirectAddress }} {
+        max_fails 0
+      }
+{{- if not (.Values.global.enabledModules | has "cni-cilium") }}
+      bind {{ .Values.global.discovery.clusterDNSAddress }} 169.254.20.10
+      prometheus 127.0.0.1:9254
+      health 127.0.0.1:9225
+{{- else }}
+      prometheus 127.0.0.1:9254
+      health 0.0.0.0:9225
+{{- end }}
+    }
+


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Kubelet has issue when config map mounted to pod is deleted before pod is removed. And pod hangs in `Terminating` state.
We moved `node-local-dns` to `kube-system` namespace in 1.34 release. Helm removes `node-local-dns` cm before some pods were terminated, and a lot of pods can be stuck in `Terminating` state. To fix it, we should restart kubelet on every node with stuck pod.

## Why do we need it, and what problem does it solve?
Exclude manual actions during moving `node-local-dns` to `kube-system` namespace.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-local-dns
type: fix
summary: Reverted the `node-local-dns` ConfigMap, to prevent the `node-local-dns` Pods from getting stuck in the Terminating state during moving to `kube-system`.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
