### PR TITLE
[doc] Fix security-group doc typo in AWSClusterConfiguration

### DIFF
--- a/candi/cloud-providers/aws/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/doc-ru-cluster_configuration.yaml
@@ -36,7 +36,7 @@ apiVersions:
               additionalSecurityGroups:
                 type: array
                 description: |
-                  Дополнительные теги, которые будут присвоены созданным инстансам.
+                  Дополнительные secutiry groups, которые будут присвоены созданным инстансам.
                 items:
                   type: string
               diskType:
@@ -130,7 +130,7 @@ apiVersions:
                   additionalSecurityGroups:
                     type: array
                     description: |
-                      Дополнительные теги, которые будут присвоены созданному инстансу.
+                      Дополнительные security groups, которые будут присвоены созданному инстансу.
                     items:
                       type: string
                   diskType:


### PR DESCRIPTION
## Description

Fix the typo, "tags" mentioned where it is "security groups"

## Changelog entries

```changes
section: docs
type: chore
summary: Fix the typo in the docs of `additionalSecurityGroup`.
```
