### PR TITLE
[monitoring-kubernetes] Ignore containers rootfs mount point for node-exporter in GKE

### DIFF
--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
         - '--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15})$'
         - '--collector.netdev.ignored-devices=^(veth.*|[a-f0-9]{15})$'
         - '--collector.filesystem.ignored-fs-types'
-        - '^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|fuse\.lxcfs|hugetlbfs|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs|squashfs)$'
+        - '^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|tmpfs|devtmpfs|fusectl|fuse\.lxcfs|hugetlbfs|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs|squashfs)$'
         - '--collector.textfile.directory'
         - '/host/textfile'
         - '--collector.netstat.fields'

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -57,8 +57,6 @@ spec:
         - '(^/(dev|proc|sys|run|var/lib/kubelet)($|/))|(^/var/lib/docker/)|(^/var/lib/containerd/)|(^/home/kubernetes/)'
         - '--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15})$'
         - '--collector.netdev.ignored-devices=^(veth.*|[a-f0-9]{15})$'
-        - '--collector.filesystem.ignored-fs-types'
-        - '^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|tmpfs|devtmpfs|fusectl|fuse\.lxcfs|hugetlbfs|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs|squashfs)$'
         - '--collector.textfile.directory'
         - '/host/textfile'
         - '--collector.netstat.fields'

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -54,7 +54,7 @@ spec:
         - '--collector.ntp.server-is-local'
         - '--collector.processes'
         - '--collector.filesystem.ignored-mount-points'
-        - '(^/(dev|proc|sys|run|var/lib/kubelet)($|/))|(^/var/lib/docker/)|(^/var/lib/containerd/)'
+        - '(^/(dev|proc|sys|run|var/lib/kubelet)($|/))|(^/var/lib/docker/)|(^/var/lib/containerd/)|(^/home/kubernetes/)'
         - '--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15})$'
         - '--collector.netdev.ignored-devices=^(veth.*|[a-f0-9]{15})$'
         - '--collector.filesystem.ignored-fs-types'


### PR DESCRIPTION
Signed-off-by: Konstantin Aksenov <konstantin.aksenov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- Ignore rootfs mounts to `/home/kubernetes/`
- Remove node-exporter collector settings collector.filesystem.ignored-fs-types

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
GKE uses `/home/kubernetes/` for rootfs mount points, and we want to ignore it.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring-kubernetes
type: fix
summary: Ignore containers rootfs mount point for node-exporter in GKE
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
