### PR TITLE
[testing] Move e2e tests using OpenStack to another project

### DIFF
--- a/testing/cloud_layouts/OpenStack/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/OpenStack/WithoutNAT/configuration.tpl.yaml
@@ -36,7 +36,7 @@ standard:
 provider:
   authURL: 'https://cloud.flant.com/v3/'
   domainName: 'Default'
-  tenantName: 'dev-rnd'
+  tenantName: 'd8-tests'
   username: 'e2e-tests'
   password: '${OS_PASSWORD}'
   region: 'HetznerFinland'

--- a/testing/cloud_layouts/Static/infra.tpl.tf
+++ b/testing/cloud_layouts/Static/infra.tpl.tf
@@ -10,7 +10,7 @@ terraform {
 provider "openstack" {
   auth_url = "https://cloud.flant.com/v3/"
   domain_name = "Default"
-  tenant_name = "dev-rnd"
+  tenant_name = "d8-tests"
   user_name = "e2e-tests"
   password = "${OS_PASSWORD}"
   region = "HetznerFinland"


### PR DESCRIPTION
## Description

Update tenant for e2e tests using OpenStack.

## Why do we need it, and what problem does it solve?
Move e2e test to a separate Openstack project.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: testing
type: chore
summary: Update info for e2e tests using OpenStack.
```

