### PR TITLE
[docs][control-plane-manager] Add information about backup and restore etcd-server keys and certificates

### DIFF
--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -280,8 +280,9 @@ done
 In the current directory etcd snapshot file `etcd-backup.snapshot` will be created from one of an etcd cluster members.
 From this file, you can restore the previous etcd cluster state in the future.
 
-Also, we recommended to make a backup of the directory `/etc/kubernetes` which contains the manifests and configuration of the [control-plane components](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components)
-and [Kubernetes cluster PKI](https://kubernetes.io/docs/setup/best-practices/certificates/).
+Also, we recommend making a backup of the `/etc/kubernetes` directory, which contains:
+- manifests and configurations of [control-plane components](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components);
+- [Kubernetes cluster PKI](https://kubernetes.io/docs/setup/best-practices/certificates/).
 This directory will help to quickly restore a cluster in case of complete loss of control-plane nodes without creating a new cluster
 and without rejoin the remaining nodes into the new cluster.
 

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -280,7 +280,7 @@ done
 In the current directory etcd snapshot file `etcd-backup.snapshot` will be created from one of an etcd cluster members.
 From this file, you can restore the previous etcd cluster state in the future.
 
-We also recommend that you make a backup of the directory `/etc/kubernetes/pki/etcd` where [access keys and certificates](https://etcd.io/docs/v3.5/op-guide/security/) of the etcd-server are located.
+Also, we recommend you backup the `/etc/kubernetes/pki/etcd` directory, where [access keys and certificates](https://etcd.io/docs/v3.5/op-guide/security/) of the etcd-server are located.
 
 We recommend encrypting etcd snapshot backups as well as keys and certificates for access to the etcd-server and saving them outside the Deckhouse cluster.
 You can use one of third-party files backup tools, for example: [Restic](https://restic.net/), [Borg](https://borgbackup.readthedocs.io/en/stable/), [Duplicity](https://duplicity.gitlab.io/), etc.

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -280,7 +280,7 @@ done
 In the current directory etcd snapshot file `etcd-backup.snapshot` will be created from one of an etcd cluster members.
 From this file, you can restore the previous etcd cluster state in the future.
 
-We also recommend that you make a backup of the directory `/etc/kubernetes/pki/etcd` where [access keys and certificates] (https://etcd.io/docs/v3.5/op-guide/security/) of the etcd-server are located.
+We also recommend that you make a backup of the directory `/etc/kubernetes/pki/etcd` where [access keys and certificates](https://etcd.io/docs/v3.5/op-guide/security/) of the etcd-server are located.
 
 We recommend encrypting etcd snapshot backups as well as keys and certificates for access to the etcd-server and saving them outside the Deckhouse cluster.
 You can use one of third-party files backup tools, for example: [Restic](https://restic.net/), [Borg](https://borgbackup.readthedocs.io/en/stable/), [Duplicity](https://duplicity.gitlab.io/), etc.

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -280,9 +280,12 @@ done
 In the current directory etcd snapshot file `etcd-backup.snapshot` will be created from one of an etcd cluster members.
 From this file, you can restore the previous etcd cluster state in the future.
 
-Also, we recommend you backup the `/etc/kubernetes/pki/etcd` directory, where [access keys and certificates](https://etcd.io/docs/v3.5/op-guide/security/) of the etcd-server are located.
+Also, we recommended to make a backup of the directory `/etc/kubernetes` which contains the manifests and configuration of the [control-plane components](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components)
+and [Kubernetes cluster PKI](https://kubernetes.io/docs/setup/best-practices/certificates/).
+This directory will help to quickly restore a cluster in case of complete loss of control-plane nodes without creating a new cluster
+and without rejoin the remaining nodes into the new cluster.
 
-We recommend encrypting etcd snapshot backups as well as keys and certificates for access to the etcd-server and saving them outside the Deckhouse cluster.
+We recommend encrypting etcd snapshot backups as well as backup of the directory `/etc/kubernetes/` and saving them outside the Deckhouse cluster.
 You can use one of third-party files backup tools, for example: [Restic](https://restic.net/), [Borg](https://borgbackup.readthedocs.io/en/stable/), [Duplicity](https://duplicity.gitlab.io/), etc.
 
 You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-control-plane-manager/docs/internal/ETCD_RECOVERY.md) for learn about etcd disaster recovery procedures from snapshots.

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -277,10 +277,12 @@ for pod in $(kubectl get pod -n kube-system -l component=etcd,tier=control-plane
 done
 ```
 
-In the current directory etcd snapshot file `etc-backup.snapshot` will be created from one of an etcd cluster members.
+In the current directory etcd snapshot file `etcd-backup.snapshot` will be created from one of an etcd cluster members.
 From this file, you can restore the previous etcd cluster state in the future.
 
-You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-control-plane-manager/docs/internal/ETCD_RECOVERY.md) for learn about etcd disaster recovery procedures from snapshots.
+We also recommend that you make a backup of the directory `/etc/kubernetes/pki/etcd` where [access keys and certificates] (https://etcd.io/docs/v3.5/op-guide/security/) of the etcd-server are located.
 
-We recommend encrypting etcd snapshot backups and saving them outside the Deckhouse cluster.
+We recommend encrypting etcd snapshot backups as well as keys and certificates for access to the etcd-server and saving them outside the Deckhouse cluster.
 You can use one of third-party files backup tools, for example: [Restic](https://restic.net/), [Borg](https://borgbackup.readthedocs.io/en/stable/), [Duplicity](https://duplicity.gitlab.io/), etc.
+
+You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-control-plane-manager/docs/internal/ETCD_RECOVERY.md) for learn about etcd disaster recovery procedures from snapshots.

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -286,7 +286,7 @@ done
 Также рекомендуем сделать бекап директории `/etc/kubernetes` в которой находятся манифесты и конфигурация компонентов [control-plane](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components)
 и [PKI кластера Kubernetes](https://kubernetes.io/docs/setup/best-practices/certificates/).
 Данная директория поможет быстро восстановить кластер при полной потери control-plane узлов без создания нового кластера
-и без пересоединения остальных нод в новый кластер.
+и без повторного присоединения нод в новый кластер.
 
 Мы рекомендуем хранить резервные копии снимков состояния кластера etcd, а также бекап директории `/etc/kubernetes/` в зашифрованном виде вне кластера Deckhouse.
 Для этого вы можете использовать сторонние инструменты резервного копирования файлов, например: [Restic](https://restic.net/), [Borg](https://borgbackup.readthedocs.io/en/stable/), [Duplicity](https://duplicity.gitlab.io/) и т.д.

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -284,9 +284,9 @@ done
 Из полученного снимка можно будет восстановить состояние кластера etcd.
 
 Также рекомендуем сделать бекап директории `/etc/kubernetes` в которой находятся манифесты и конфигурация компонентов [control-plane](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components)
-и [PKI кластера Kubernetes](https://kubernetes.io/docs/setup/best-practices/certificates/). 
-Данная директория поможет быстро восстановить кластер при полной потери control-plane узлов без создания нового кластера 
-и без пересоединения остальных нод в новый кластер. 
+и [PKI кластера Kubernetes](https://kubernetes.io/docs/setup/best-practices/certificates/).
+Данная директория поможет быстро восстановить кластер при полной потери control-plane узлов без создания нового кластера
+и без пересоединения остальных нод в новый кластер.
 
 Мы рекомендуем хранить резервные копии снимков состояния кластера etcd, а также бекап директории `/etc/kubernetes/` в зашифрованном виде вне кластера Deckhouse.
 Для этого вы можете использовать сторонние инструменты резервного копирования файлов, например: [Restic](https://restic.net/), [Borg](https://borgbackup.readthedocs.io/en/stable/), [Duplicity](https://duplicity.gitlab.io/) и т.д.

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -280,10 +280,12 @@ for pod in $(kubectl get pod -n kube-system -l component=etcd,tier=control-plane
 done
 ```
 
-В текущей директории будет создан файл `etc-backup.snapshot` со снимком базы etcd одного из членов etcd-кластера.
+В текущей директории будет создан файл `etcd-backup.snapshot` со снимком базы etcd одного из членов etcd-кластера.
 Из полученного снимка можно будет восстановить состояние кластера etcd.
 
-О возможных вариантах восстановления состояния кластера etcd из снимка вы можете узнать [здесь](https://github.com/deckhouse/deckhouse/blob/main/modules/040-control-plane-manager/docs/internal/ETCD_RECOVERY.md).
+Также рекомендуем сделать бекап директории `/etc/kubernetes/pki/etcd` в которой находятся [ключи и сертификаты доступа](https://etcd.io/docs/v3.5/op-guide/security/) к etcd-серверу.  
 
-Мы рекомендуем хранить резервные копии снимков состояния кластера etcd в зашифрованном виде вне кластера Deckhouse.
+Мы рекомендуем хранить резервные копии снимков состояния кластера etcd, а также ключи и сертификаты доступа к etcd-сервера в зашифрованном виде вне кластера Deckhouse.
 Для этого вы можете использовать сторонние инструменты, например: [Restic](https://restic.net/), [Borg](https://borgbackup.readthedocs.io/en/stable/), [Duplicity](https://duplicity.gitlab.io/) или другие инструменты резервного копирования файлов.
+
+О возможных вариантах восстановления состояния кластера etcd из снимка вы можете узнать [здесь](https://github.com/deckhouse/deckhouse/blob/main/modules/040-control-plane-manager/docs/internal/ETCD_RECOVERY.md).

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -289,3 +289,4 @@ done
 Для этого вы можете использовать сторонние инструменты, например: [Restic](https://restic.net/), [Borg](https://borgbackup.readthedocs.io/en/stable/), [Duplicity](https://duplicity.gitlab.io/) или другие инструменты резервного копирования файлов.
 
 О возможных вариантах восстановления состояния кластера etcd из снимка вы можете узнать [здесь](https://github.com/deckhouse/deckhouse/blob/main/modules/040-control-plane-manager/docs/internal/ETCD_RECOVERY.md).
+

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -283,9 +283,12 @@ done
 В текущей директории будет создан файл `etcd-backup.snapshot` со снимком базы etcd одного из членов etcd-кластера.
 Из полученного снимка можно будет восстановить состояние кластера etcd.
 
-Также рекомендуем сделать бекап директории `/etc/kubernetes/pki/etcd` в которой находятся [ключи и сертификаты доступа](https://etcd.io/docs/v3.5/op-guide/security/) к etcd-серверу.  
+Также рекомендуем сделать бекап директории `/etc/kubernetes` в которой находятся манифесты и конфигурация компонентов [control-plane](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components)
+и [PKI кластера Kubernetes](https://kubernetes.io/docs/setup/best-practices/certificates/). 
+Данная директория поможет быстро восстановить кластер при полной потери control-plane узлов без создания нового кластера 
+и без пересоединения остальных нод в новый кластер. 
 
-Мы рекомендуем хранить резервные копии снимков состояния кластера etcd, а также ключи и сертификаты доступа к etcd-серверу в зашифрованном виде вне кластера Deckhouse.
-Для этого вы можете использовать сторонние инструменты, например: [Restic](https://restic.net/), [Borg](https://borgbackup.readthedocs.io/en/stable/), [Duplicity](https://duplicity.gitlab.io/) или другие инструменты резервного копирования файлов.
+Мы рекомендуем хранить резервные копии снимков состояния кластера etcd, а также бекап директории `/etc/kubernetes/` в зашифрованном виде вне кластера Deckhouse.
+Для этого вы можете использовать сторонние инструменты резервного копирования файлов, например: [Restic](https://restic.net/), [Borg](https://borgbackup.readthedocs.io/en/stable/), [Duplicity](https://duplicity.gitlab.io/) и т.д.
 
-О возможных вариантах восстановления состояния кластера etcd из снимка вы можете узнать [здесь](https://github.com/deckhouse/deckhouse/blob/main/modules/040-control-plane-manager/docs/internal/ETCD_RECOVERY.md).
+О возможных вариантах восстановления состояния кластера из снимка etcd вы можете узнать [здесь](https://github.com/deckhouse/deckhouse/blob/main/modules/040-control-plane-manager/docs/internal/ETCD_RECOVERY.md).

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -283,8 +283,9 @@ done
 В текущей директории будет создан файл `etcd-backup.snapshot` со снимком базы etcd одного из членов etcd-кластера.
 Из полученного снимка можно будет восстановить состояние кластера etcd.
 
-Также рекомендуем сделать бекап директории `/etc/kubernetes` в которой находятся манифесты и конфигурация компонентов [control-plane](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components)
-и [PKI кластера Kubernetes](https://kubernetes.io/docs/setup/best-practices/certificates/).
+Также рекомендуем сделать бекап директории `/etc/kubernetes` в которой находятся:
+- манифесты и конфигурация компонентов [control-plane](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components);
+- [PKI кластера Kubernetes](https://kubernetes.io/docs/setup/best-practices/certificates/).
 Данная директория поможет быстро восстановить кластер при полной потери control-plane узлов без создания нового кластера
 и без повторного присоединения узлов в новый кластер.
 

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -286,7 +286,7 @@ done
 Также рекомендуем сделать бекап директории `/etc/kubernetes` в которой находятся манифесты и конфигурация компонентов [control-plane](https://kubernetes.io/docs/concepts/overview/components/#control-plane-components)
 и [PKI кластера Kubernetes](https://kubernetes.io/docs/setup/best-practices/certificates/).
 Данная директория поможет быстро восстановить кластер при полной потери control-plane узлов без создания нового кластера
-и без повторного присоединения нод в новый кластер.
+и без повторного присоединения узлов в новый кластер.
 
 Мы рекомендуем хранить резервные копии снимков состояния кластера etcd, а также бекап директории `/etc/kubernetes/` в зашифрованном виде вне кластера Deckhouse.
 Для этого вы можете использовать сторонние инструменты резервного копирования файлов, например: [Restic](https://restic.net/), [Borg](https://borgbackup.readthedocs.io/en/stable/), [Duplicity](https://duplicity.gitlab.io/) и т.д.

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -289,4 +289,3 @@ done
 Для этого вы можете использовать сторонние инструменты, например: [Restic](https://restic.net/), [Borg](https://borgbackup.readthedocs.io/en/stable/), [Duplicity](https://duplicity.gitlab.io/) или другие инструменты резервного копирования файлов.
 
 О возможных вариантах восстановления состояния кластера etcd из снимка вы можете узнать [здесь](https://github.com/deckhouse/deckhouse/blob/main/modules/040-control-plane-manager/docs/internal/ETCD_RECOVERY.md).
-

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -285,7 +285,7 @@ done
 
 Также рекомендуем сделать бекап директории `/etc/kubernetes/pki/etcd` в которой находятся [ключи и сертификаты доступа](https://etcd.io/docs/v3.5/op-guide/security/) к etcd-серверу.  
 
-Мы рекомендуем хранить резервные копии снимков состояния кластера etcd, а также ключи и сертификаты доступа к etcd-сервера в зашифрованном виде вне кластера Deckhouse.
+Мы рекомендуем хранить резервные копии снимков состояния кластера etcd, а также ключи и сертификаты доступа к etcd-серверу в зашифрованном виде вне кластера Deckhouse.
 Для этого вы можете использовать сторонние инструменты, например: [Restic](https://restic.net/), [Borg](https://borgbackup.readthedocs.io/en/stable/), [Duplicity](https://duplicity.gitlab.io/) или другие инструменты резервного копирования файлов.
 
 О возможных вариантах восстановления состояния кластера etcd из снимка вы можете узнать [здесь](https://github.com/deckhouse/deckhouse/blob/main/modules/040-control-plane-manager/docs/internal/ETCD_RECOVERY.md).

--- a/modules/040-control-plane-manager/docs/internal/ETCD_RECOVERY.md
+++ b/modules/040-control-plane-manager/docs/internal/ETCD_RECOVERY.md
@@ -8,6 +8,9 @@ Before doing this, make sure that etcd is not running. To stop etcd, remove the 
 ### Restoring from a backup
 
 Follow these steps to restore from a backup:
+
+1. If necessary restore etcd-server access keys and certificates into `/etc/kubernetes/pki/etcd` directory.
+
 1. Upload [etcdctl](https://github.com/etcd-io/etcd/releases) to the server (best if it has the same version as the etcd version on the server).
 
    ```shell
@@ -99,6 +102,8 @@ On another (two) nodes do the following:
    ```
 
 On the selected node do the following:
+1. If necessary restore etcd-server access keys and certificates into `/etc/kubernetes/pki/etcd` directory.
+
 1. Upload [etcdctl](https://github.com/etcd-io/etcd/releases) to the server (best if it has the same version as the etcd version on the server).
 
    ```shell

--- a/modules/040-control-plane-manager/docs/internal/ETCD_RECOVERY.md
+++ b/modules/040-control-plane-manager/docs/internal/ETCD_RECOVERY.md
@@ -9,7 +9,7 @@ Before doing this, make sure that etcd is not running. To stop etcd, remove the 
 
 Follow these steps to restore from a backup:
 
-1. If necessary restore etcd-server access keys and certificates into `/etc/kubernetes/pki/etcd` directory.
+1. If necessary restore etcd-server access keys and certificates into `/etc/kubernetes` directory.
 
 1. Upload [etcdctl](https://github.com/etcd-io/etcd/releases) to the server (best if it has the same version as the etcd version on the server).
 
@@ -102,7 +102,7 @@ On another (two) nodes do the following:
    ```
 
 On the selected node do the following:
-1. If necessary restore etcd-server access keys and certificates into `/etc/kubernetes/pki/etcd` directory.
+1. If necessary restore etcd-server access keys and certificates into `/etc/kubernetes` directory.
 
 1. Upload [etcdctl](https://github.com/etcd-io/etcd/releases) to the server (best if it has the same version as the etcd version on the server).
 


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Add information about backup and restore `/etc/kubernetes` directory.

## Why do we need it, and what problem does it solve?
In some cases restoring `/etc/kubernetes` directory is necessary. 

## What is the expected result?
N/A

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: docs
type: chore
summary: Add information about backup and restore etcd-server keys and certificates.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
