### PR TITLE
[prometheus] Rollback prometheus-module ServiceMonitor label selector to `app=prometheus`

### DIFF
--- a/modules/300-prometheus/templates/prometheus/servicemonitor.yaml
+++ b/modules/300-prometheus/templates/prometheus/servicemonitor.yaml
@@ -22,6 +22,7 @@ spec:
   selector:
     matchLabels:
       app: prometheus
+      prometheus.deckhouse.io/target: prometheus
   namespaceSelector:
     matchNames:
     - d8-monitoring

--- a/modules/300-prometheus/templates/prometheus/servicemonitor.yaml
+++ b/modules/300-prometheus/templates/prometheus/servicemonitor.yaml
@@ -21,7 +21,7 @@ spec:
       replacement: cluster
   selector:
     matchLabels:
-      app.kubernetes.io/name: prometheus
+      app: prometheus
   namespaceSelector:
     matchNames:
     - d8-monitoring


### PR DESCRIPTION
Signed-off-by: Konstantin Aksenov <konstantin.aksenov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Rollback prometheus-module ServiceMonitor label selector to `app=prometheus`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
If enterprise edition is used or monitoring-applications module is disabled, then ServiceMonitor from prometheus module is deploed. In #1446 we broke services labels, so now they are just fixed to work as before.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: fix
summary: Rollback prometheus-module ServiceMonitor label selector to `app=prometheus`.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
