### PR TITLE
[node-local-dns] Revert service account for prevent pod stuck in Terminating state

### DIFF
--- a/ee/modules/350-node-local-dns/templates/rbac-for-us.yaml
+++ b/ee/modules/350-node-local-dns/templates/rbac-for-us.yaml
@@ -1,4 +1,15 @@
 ---
+# Needed for migration of node-local-dns from d8-system namespace to kube-system.
+# Kubelet has issue when config map mounted to pod is deleted before pod is removed.
+# And pod hangs in `Terminating` state.
+# TODO remove after 1.35 release
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: d8-node-local-dns
+  namespace: d8-system
+  {{- include "helm_lib_module_labels" (list . (dict "app" "node-local-dns")) | nindent 2 }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/ee/modules/350-node-local-dns/templates/rbac-for-us.yaml
+++ b/ee/modules/350-node-local-dns/templates/rbac-for-us.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: d8-node-local-dns
+  name: node-local-dns
   namespace: d8-system
   {{- include "helm_lib_module_labels" (list . (dict "app" "node-local-dns")) | nindent 2 }}
 ---

--- a/modules/040-control-plane-manager/hooks/audit_policy_basic_targets_generated.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy_basic_targets_generated.go
@@ -87,6 +87,7 @@ var auditPolicyBasicServiceAccounts = []string{
 	"network-policy-engine",
 	"node-exporter",
 	"node-group",
+	"node-local-dns",
 	"node-termination-handler",
 	"okmeter",
 	"openvpn",


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Kubelet has issue when service-account mounted to pod is deleted before pod is removed. And pod hangs in Terminating state.
We moved node-local-dns to kube-system namespace in 1.34 release. Helm removes `node-local-dns` service account before some pods were terminated, and a lot of pods can be stuck in Terminating state. To fix it, we should restart kubelet on every node with stuck pod.

## Why do we need it, and what problem does it solve?
Exclude manual actions during moving node-local-dns to kube-system namespace.

## What is the expected result?
Node local dns pods should not stuck in terminating status in `d8-system` namespace

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-local-dns
type: fix
summary: Revert service account to prevent Pod from getting stuck in a Terminating state.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
