### PR TITLE
[control-plane-manager] added feature gate EndpointSliceTerminatingCondition for Kubernetes 1.20

### DIFF
--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -164,6 +164,9 @@ scheduler:
     config: "/etc/kubernetes/deckhouse/extra-files/scheduler-config.yaml"
 {{- end }}
     profiling: "false"
+{{- if semverCompare "< 1.20" .clusterConfiguration.kubernetesVersion }}
+    {{- $featureGates = "DefaultPodTopologySpread=true"
+{{- end }}
     feature-gates: {{ $featureGates | quote }}
     bind-address: "127.0.0.1"
     port: "0"

--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -161,9 +161,10 @@ scheduler:
 {{- end }}
     profiling: "false"
 {{- if semverCompare "< 1.20" .clusterConfiguration.kubernetesVersion }}
-    {{- $featureGates = "DefaultPodTopologySpread=true" }}
-{{- end }}
+    feature-gates: "DefaultPodTopologySpread=true"
+{{- else }}
     feature-gates: {{ $featureGates | quote }}
+{{- end }}
     bind-address: "127.0.0.1"
     port: "0"
 {{- if hasKey . "etcd" }}

--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -165,7 +165,7 @@ scheduler:
 {{- end }}
     profiling: "false"
 {{- if semverCompare "< 1.20" .clusterConfiguration.kubernetesVersion }}
-    {{- $featureGates = "DefaultPodTopologySpread=true"
+    {{- $featureGates = "DefaultPodTopologySpread=true" }}
 {{- end }}
     feature-gates: {{ $featureGates | quote }}
     bind-address: "127.0.0.1"

--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -6,11 +6,7 @@
     {{- $featureGates = "TTLAfterFinished=true" }}
 {{- end }}
 {{- if semverCompare "= 1.20" .clusterConfiguration.kubernetesVersion }}
-  {{- if hasKey . "cni" }}
-    {{- if eq .cni "Cilium" }}
-      {{- $featureGates = printf "%s,%s" $featureGates "EndpointSliceTerminatingCondition=true" }}
-    {{- end }}
-  {{- end }}
+    {{- $featureGates = printf "%s,%s" $featureGates "EndpointSliceTerminatingCondition=true" }}
 {{- end }}
 
 {{- if semverCompare ">= 1.22" .clusterConfiguration.kubernetesVersion }}

--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -49,6 +49,9 @@ apiServer:
 {{- if semverCompare ">= 1.21" .clusterConfiguration.kubernetesVersion }}
     feature-gates: "EndpointSliceTerminatingCondition=true,DaemonSetUpdateSurge=true"
 {{- end }}
+{{- if and (semverCompare "= 1.20" .clusterConfiguration.kubernetesVersion) (eq .cni "Cilium") }}
+    feature-gates: "EndpointSliceTerminatingCondition=true"
+{{- end }}
 {{- if semverCompare "< 1.21" .clusterConfiguration.kubernetesVersion }}
     feature-gates: "TTLAfterFinished=true"
 {{- end }}

--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -2,11 +2,11 @@
 {{- if semverCompare ">= 1.21" .clusterConfiguration.kubernetesVersion }}
     {{- $featureGates = "EndpointSliceTerminatingCondition=true,DaemonSetUpdateSurge=true" }}
 {{- end }}
-{{- if semverCompare "< 1.21" .clusterConfiguration.kubernetesVersion }}
-    {{- $featureGates = "TTLAfterFinished=true" }}
-{{- end }}
 {{- if semverCompare "= 1.20" .clusterConfiguration.kubernetesVersion }}
-    {{- $featureGates = printf "%s,%s" $featureGates "EndpointSliceTerminatingCondition=true" }}
+    {{- $featureGates = "EndpointSliceTerminatingCondition=true,TTLAfterFinished=true" }}
+{{- end }}
+{{- if semverCompare "< 1.20" .clusterConfiguration.kubernetesVersion }}
+    {{- $featureGates = "TTLAfterFinished=true" }}
 {{- end }}
 
 {{- if semverCompare ">= 1.22" .clusterConfiguration.kubernetesVersion }}

--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -49,8 +49,10 @@ apiServer:
 {{- if semverCompare ">= 1.21" .clusterConfiguration.kubernetesVersion }}
     feature-gates: "EndpointSliceTerminatingCondition=true,DaemonSetUpdateSurge=true"
 {{- end }}
-{{- if and (semverCompare "= 1.20" .clusterConfiguration.kubernetesVersion) (eq .cni "Cilium") }}
+{{- if hasKey . "cni" }}
+  {{- if and (semverCompare "= 1.20" .clusterConfiguration.kubernetesVersion) (eq .cni "Cilium") }}
     feature-gates: "EndpointSliceTerminatingCondition=true"
+  {{- end }}
 {{- end }}
 {{- if semverCompare "< 1.21" .clusterConfiguration.kubernetesVersion }}
     feature-gates: "TTLAfterFinished=true"

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -24,9 +24,6 @@
 {{- $_ := set $tpl_context "apiserver" dict }}
 {{- $_ := set $tpl_context "resourcesRequestsMilliCpuControlPlane" .Values.global.internal.modules.resourcesRequests.milliCpuControlPlane }}
 {{- $_ := set $tpl_context "resourcesRequestsMemoryControlPlane" .Values.global.internal.modules.resourcesRequests.memoryControlPlane }}
-{{- if (.Values.global.enabledModules | has "cni-cilium") }}
-  {{- $_ := set $tpl_context "cni" "Cilium" }}
-{{- end }}
 
 {{- if hasKey .Values.controlPlaneManager.internal "etcdServers" }}
   {{- $_ := set $tpl_context.apiserver "etcdServers" .Values.controlPlaneManager.internal.etcdServers }}

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -24,11 +24,9 @@
 {{- $_ := set $tpl_context "apiserver" dict }}
 {{- $_ := set $tpl_context "resourcesRequestsMilliCpuControlPlane" .Values.global.internal.modules.resourcesRequests.milliCpuControlPlane }}
 {{- $_ := set $tpl_context "resourcesRequestsMemoryControlPlane" .Values.global.internal.modules.resourcesRequests.memoryControlPlane }}
-{{- $clusterCNI := "" }}
 {{- if (.Values.global.enabledModules | has "cni-cilium") }}
-  {{- $clusterCNI = set "Cilium" }}
+  {{- $_ := set $tpl_context "cni" "Cilium" }}
 {{- end }}
-{{- $_ := set $tpl_context "cni" $clusterCNI }}
 
 {{- if hasKey .Values.controlPlaneManager.internal "etcdServers" }}
   {{- $_ := set $tpl_context.apiserver "etcdServers" .Values.controlPlaneManager.internal.etcdServers }}

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -24,6 +24,11 @@
 {{- $_ := set $tpl_context "apiserver" dict }}
 {{- $_ := set $tpl_context "resourcesRequestsMilliCpuControlPlane" .Values.global.internal.modules.resourcesRequests.milliCpuControlPlane }}
 {{- $_ := set $tpl_context "resourcesRequestsMemoryControlPlane" .Values.global.internal.modules.resourcesRequests.memoryControlPlane }}
+{{- $clusterCNI := "" }}
+{{- if (.Values.global.enabledModules | has "cni-cilium") }}
+  {{- $clusterCNI = set "Cilium" }}
+{{- end }}
+{{- $_ := set $tpl_context "cni" $clusterCNI }}
 
 {{- if hasKey .Values.controlPlaneManager.internal "etcdServers" }}
   {{- $_ := set $tpl_context.apiserver "etcdServers" .Values.controlPlaneManager.internal.etcdServers }}


### PR DESCRIPTION
Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
Added feature gate `EndpointSliceTerminatingCondition` for  Kubernetes 1.20.

Started from Kubernetes 1.21 feature gate `EndpointSliceTerminatingCondition` is enabled by default.
Cilium supports the use of this feature gate starting from Kubernetes 1.20, so we enabled this feature gate  in Kubernetes 1.20 (https://docs.cilium.io/en/latest/gettingstarted/kubeproxy-free/#graceful-termination)

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: control-plane-manager
type: feature
summary: Added feature gate `EndpointSliceTerminatingCondition` for Kubernetes 1.20.
impact: all control-plane components should be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
