### PR TITLE
[prometheus] Always use custom monitors

### DIFF
--- a/modules/300-prometheus/templates/grafana/service.yaml
+++ b/modules/300-prometheus/templates/grafana/service.yaml
@@ -4,11 +4,7 @@ kind: Service
 metadata:
   name: grafana
   namespace: d8-monitoring
-  {{- include "helm_lib_module_labels" (list . (dict "app" "grafana" "prometheus.deckhouse.io/target" "grafana")) | nindent 2 }}
-  annotations:
-    prometheus.deckhouse.io/port: "8443"
-    prometheus.deckhouse.io/tls: "true"
-    prometheus.deckhouse.io/sample-limit: "5000"
+  {{- include "helm_lib_module_labels" (list . (dict "app" "grafana")) | nindent 2 }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/modules/300-prometheus/templates/grafana/servicemonitor.yaml
+++ b/modules/300-prometheus/templates/grafana/servicemonitor.yaml
@@ -1,4 +1,3 @@
-{{- if not (.Values.global.enabledModules | has "monitoring-applications") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -25,4 +24,3 @@ spec:
   namespaceSelector:
     matchNames:
     - d8-monitoring
-{{- end }}

--- a/modules/300-prometheus/templates/prometheus/longterm/service.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/service.yaml
@@ -5,11 +5,7 @@ kind: Service
 metadata:
   name: prometheus-longterm
   namespace: d8-monitoring
-  {{- include "helm_lib_module_labels" (list . (dict "app" "prometheus" "prometheus" "longterm" "prometheus.deckhouse.io/target" "prometheus")) | nindent 2 }}
-  annotations:
-    prometheus.deckhouse.io/port: "9090"
-    prometheus.deckhouse.io/tls: "true"
-    prometheus.deckhouse.io/sample-limit: "5000"
+  {{- include "helm_lib_module_labels" (list . (dict "app" "prometheus" "prometheus" "longterm")) | nindent 2 }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/modules/300-prometheus/templates/prometheus/service.yaml
+++ b/modules/300-prometheus/templates/prometheus/service.yaml
@@ -4,11 +4,7 @@ kind: Service
 metadata:
   name: prometheus
   namespace: d8-monitoring
-  {{- include "helm_lib_module_labels" (list . (dict "app" "prometheus" "prometheus" "main" "prometheus.deckhouse.io/target" "prometheus")) | nindent 2 }}
-  annotations:
-    prometheus.deckhouse.io/port: "9090"
-    prometheus.deckhouse.io/tls: "true"
-    prometheus.deckhouse.io/sample-limit: "5000"
+  {{- include "helm_lib_module_labels" (list . (dict "app" "prometheus" "prometheus" "main")) | nindent 2 }}
 spec:
   type: ClusterIP
   clusterIP: None
@@ -18,8 +14,8 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    app.kubernetes.io/name: prometheus
     prometheus: main
+    app.kubernetes.io/name: prometheus
 {{- if (include "helm_lib_ha_enabled" .) }}
 ---
 apiVersion: v1
@@ -28,9 +24,6 @@ metadata:
   name: prometheus-main-0
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "prometheus")) | nindent 2 }}
-  annotations:
-    prometheus.deckhouse.io/port: "9090"
-    prometheus.deckhouse.io/tls: "true"
 spec:
   type: ClusterIP
   clusterIP: None
@@ -39,8 +32,8 @@ spec:
     port: 9090
     targetPort: https
   selector:
-    app.kubernetes.io/name: prometheus
     prometheus: main
+    app.kubernetes.io/name: prometheus
     statefulset.kubernetes.io/pod-name: prometheus-main-0
 ---
 apiVersion: v1
@@ -49,9 +42,6 @@ metadata:
   name: prometheus-main-1
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "prometheus")) | nindent 2 }}
-  annotations:
-    prometheus.deckhouse.io/port: "9090"
-    prometheus.deckhouse.io/tls: "true"
 spec:
   type: ClusterIP
   clusterIP: None
@@ -60,7 +50,7 @@ spec:
     port: 9090
     targetPort: https
   selector:
-    app.kubernetes.io/name: prometheus
     prometheus: main
+    app.kubernetes.io/name: prometheus
     statefulset.kubernetes.io/pod-name: prometheus-main-1
 {{- end }}

--- a/modules/300-prometheus/templates/prometheus/servicemonitor.yaml
+++ b/modules/300-prometheus/templates/prometheus/servicemonitor.yaml
@@ -1,4 +1,3 @@
-{{- if not (.Values.global.enabledModules | has "monitoring-applications") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -22,8 +21,6 @@ spec:
   selector:
     matchLabels:
       app: prometheus
-      prometheus.deckhouse.io/target: prometheus
   namespaceSelector:
     matchNames:
     - d8-monitoring
-{{- end }}

--- a/modules/300-prometheus/templates/trickster/service.yaml
+++ b/modules/300-prometheus/templates/trickster/service.yaml
@@ -4,10 +4,7 @@ kind: Service
 metadata:
   name: trickster
   namespace: d8-monitoring
-  {{- include "helm_lib_module_labels" (list . (dict "app" "trickster" "prometheus.deckhouse.io/target" "trickster")) | nindent 2 }}
-  annotations:
-    prometheus.deckhouse.io/port: "8443"
-    prometheus.deckhouse.io/tls: "true"
+  {{- include "helm_lib_module_labels" (list . (dict "app" "trickster")) | nindent 2 }}
 spec:
   type: ClusterIP
   sessionAffinity: ClientIP

--- a/modules/300-prometheus/templates/trickster/servicemonitor.yaml
+++ b/modules/300-prometheus/templates/trickster/servicemonitor.yaml
@@ -1,4 +1,3 @@
-{{- if not (.Values.global.enabledModules | has "monitoring-applications") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -25,4 +24,3 @@ spec:
   namespaceSelector:
     matchNames:
     - d8-monitoring
-{{- end }}


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Always use ServiceMonitors from the prometheus module

## Why do we need it, and what problem does it solve?
These monitors are used for CE instalations, but for FE monitors from the monitoring-applications module are used. 
Using the same monitors for all editions will help us to reduce the number of bugs.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: fix
summary: Always use ServiceMonitors from the prometheus module for Promethues, Grafana and Trickster.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
