### PR TITLE
[bashible] Start kubelet forcibly if it is not running

### DIFF
--- a/candi/bashible/common-steps/node-group/069_start_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/069_start_kubelet.sh.tpl
@@ -67,15 +67,26 @@ fi
 
 if bb-flag? kubelet-need-restart; then
 {{- if ne .runType "ImageBuilding" }}
+  bb-log-warning "'kubelet-need-restart' flag was set. Kubelet should be restarted!"
   {{ if eq .runType "ClusterBootstrap" }}
+  bb-log-info "Restart kubelet service..."
+
   systemctl restart "kubelet.service"
+
+  bb-log-info "Kubelet service was restarted."
   {{ else }}
   if ! bb-flag? reboot; then
+    bb-log-info "Restart kubelet service..."
+
     systemctl restart "kubelet.service"
+
+    bb-log-info "Kubelet service was restarted. Sleep 60 seconds to prevent oscillation in Cloud LoadBalancer targets."
     # Issue with oscillating cloud LoadBalancer targets is tracked here.
     # https://github.com/kubernetes/kubernetes/issues/102367
     # Remove the sleep once a solution is devised.
     sleep 60
+  else
+     bb-log-info "Skip restarting kubelet because node will be rebooted."
   fi
   {{- end }}
 {{- end }}

--- a/candi/bashible/common-steps/node-group/069_start_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/069_start_kubelet.sh.tpl
@@ -82,3 +82,15 @@ if bb-flag? kubelet-need-restart; then
 
   bb-flag-unset kubelet-need-restart
 fi
+
+{{- if ne .runType "ImageBuilding" }}
+if ! systemctl is-active --quiet "kubelet.service"; then
+  bb-log-warning "Kubelet service is not running. Start it..."
+  if systemctl start "kubelet.service"; then
+    bb-log-info "Kubelet has started."
+  else
+    bb-log-error "Kubelet has not started. Exit"
+    exit 1
+  fi
+fi
+{{- end }}

--- a/candi/bashible/common-steps/node-group/069_start_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/069_start_kubelet.sh.tpl
@@ -95,7 +95,7 @@ if bb-flag? kubelet-need-restart; then
 fi
 
 {{- if ne .runType "ImageBuilding" }}
-if ! systemctl is-active --quiet "kubelet.service"; then
+if ! [ systemctl is-active --quiet "kubelet.service" ] && ! [ bb-flag? reboot ]; then
   bb-log-warning "Kubelet service is not running. Start it..."
   if systemctl start "kubelet.service"; then
     bb-log-info "Kubelet has started."


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Start kubelet forcibly if it was not started. We check that kubelet is not running `069_start_kubelet.sh`

## Why do we need it, and what problem does it solve?
Seldom, kubelet can be not started. But after `069_start_kubelet.sh` kubelet should start. 

## What is the expected result?
`kubelet` should be always running.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: bashible
type: fix
summary: Start kubelet manually if it is not running
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
