### PR TITLE
[bashible] Forbid using Docker 18.* 

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -2,7 +2,7 @@ bashible: &bashible
   ubuntu: &ubuntu
     '16.04':
       docker:
-        desiredVersion: "docker-ce=5:19.03.13~3-0~ubuntu"
+        desiredVersion: "docker-ce=5:19.03.13~3-0~ubuntu-xenial"
         allowedPattern: ""
         containerd:
           desiredVersion: "containerd.io=1.4.6-1"
@@ -16,7 +16,7 @@ bashible: &bashible
           allowedPattern: "4.18"
     '18.04':
       docker:
-        desiredVersion: "docker-ce=5:19.03.13~3-0~ubuntu"
+        desiredVersion: "docker-ce=5:19.03.13~3-0~ubuntu-bionic"
         allowedPattern: ""
         containerd:
           desiredVersion: "containerd.io=1.4.6-1"

--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -87,7 +87,7 @@ bashible: &bashible
     '9': &debian9
       docker:
         desiredVersion: "docker-ce=5:19.03.15~3-0~debian-stretch"
-        allowedPattern: ""
+        allowedPattern: "^docker-ce=5:19.+"
         containerd:
           desiredVersion: "containerd.io=1.4.3-1"
           allowedPattern: "containerd.io=1.[234]"
@@ -100,11 +100,11 @@ bashible: &bashible
           allowedPattern: "4.9|4.15|4.19|5.4|5.10"
     '10':
       docker:
-        desiredVersion: "docker-ce=5:20.10.12~3-0~debian-buster"
-        allowedPattern: ""
+        desiredVersion: "docker-ce=5:20.10.17~3-0~debian-buster"
+        allowedPattern: "^docker-ce=5:(19|20).+"
         containerd:
-          desiredVersion: "containerd.io=1.4.6-1"
-          allowedPattern: "containerd.io=1.[234]"
+          desiredVersion: "containerd.io=1.5.11-1"
+          allowedPattern: "containerd.io=1.[2345]"
       containerd:
         desiredVersion: "containerd.io=1.5.11-1"
         allowedPattern: "containerd.io=1.[56]"
@@ -114,11 +114,11 @@ bashible: &bashible
           allowedPattern: "4.19"
     '11':
       docker:
-        desiredVersion: "docker-ce=5:20.10.12~3-0~debian-bullseye"
-        allowedPattern: ""
+        desiredVersion: "docker-ce=5:20.10.17~3-0~debian-bullseye"
+        allowedPattern: "^docker-ce=5:(19|20).+"
         containerd:
-          desiredVersion: "containerd.io=1.4.6-1"
-          allowedPattern: "containerd.io=1.[234]"
+          desiredVersion: "containerd.io=1.5.11-1"
+          allowedPattern: "containerd.io=1.[2345]"
       containerd:
         desiredVersion: "containerd.io=1.5.11-1"
         allowedPattern: "containerd.io=1.[56]"

--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -2,8 +2,8 @@ bashible: &bashible
   ubuntu: &ubuntu
     '16.04':
       docker:
-        desiredVersion: "docker-ce=5:20.10.7~3-0~ubuntu-xenial"
-        allowedPattern: "^docker-ce=5:(19|20).+"
+        desiredVersion: "docker-ce=5:19.03.13~3-0~ubuntu"
+        allowedPattern: ""
         containerd:
           desiredVersion: "containerd.io=1.4.6-1"
           allowedPattern: "containerd.io=1.[234]"
@@ -16,11 +16,11 @@ bashible: &bashible
           allowedPattern: "4.18"
     '18.04':
       docker:
-        desiredVersion: "docker-ce=5:20.10.17~3-0~ubuntu-bionic"
-        allowedPattern: "^docker-ce=5:(19|20).+"
+        desiredVersion: "docker-ce=5:19.03.13~3-0~ubuntu"
+        allowedPattern: ""
         containerd:
-          desiredVersion: "containerd.io=1.5.11-1"
-          allowedPattern: "containerd.io=1.[2345]"
+          desiredVersion: "containerd.io=1.4.6-1"
+          allowedPattern: "containerd.io=1.[234]"
       containerd:
         desiredVersion: "containerd.io=1.5.11-1"
         allowedPattern: "containerd.io=1.[56]"
@@ -39,11 +39,11 @@ bashible: &bashible
           allowedPattern: "5.3"
     '20.04':
       docker:
-        desiredVersion: "docker-ce=5:20.10.17~3-0~ubuntu-focal"
-        allowedPattern: "^docker-ce=5:(19|20).+"
+        desiredVersion: "docker-ce=5:19.03.13~3-0~ubuntu-focal"
+        allowedPattern: ""
         containerd:
-          desiredVersion: "containerd.io=1.5.11-1"
-          allowedPattern: "containerd.io=1.[2345]"
+          desiredVersion: "containerd.io=1.4.6-1"
+          allowedPattern: "containerd.io=1.[234]"
       containerd:
         desiredVersion: "containerd.io=1.5.11-1"
         allowedPattern: "containerd.io=1.[56]"
@@ -62,8 +62,8 @@ bashible: &bashible
           allowedPattern: "5.4"
     '22.04':
       docker:
-        desiredVersion: "docker-ce=5:20.10.17~3-0~ubuntu-jammy"
-        allowedPattern: "^docker-ce=5:20.+"
+        desiredVersion: "docker-ce=5:20.10.14~3-0~ubuntu-jammy"
+        allowedPattern: ""
         containerd:
           desiredVersion: "containerd.io=1.5.11-1"
           allowedPattern: "containerd.io=1.[56]"
@@ -87,7 +87,7 @@ bashible: &bashible
     '9': &debian9
       docker:
         desiredVersion: "docker-ce=5:19.03.15~3-0~debian-stretch"
-        allowedPattern: "^docker-ce=5:19.+"
+        allowedPattern: ""
         containerd:
           desiredVersion: "containerd.io=1.4.3-1"
           allowedPattern: "containerd.io=1.[234]"
@@ -100,11 +100,11 @@ bashible: &bashible
           allowedPattern: "4.9|4.15|4.19|5.4|5.10"
     '10':
       docker:
-        desiredVersion: "docker-ce=5:20.10.17~3-0~debian-buster"
-        allowedPattern: "^docker-ce=5:(19|20).+"
+        desiredVersion: "docker-ce=5:20.10.12~3-0~debian-buster"
+        allowedPattern: ""
         containerd:
-          desiredVersion: "containerd.io=1.5.11-1"
-          allowedPattern: "containerd.io=1.[2345]"
+          desiredVersion: "containerd.io=1.4.6-1"
+          allowedPattern: "containerd.io=1.[234]"
       containerd:
         desiredVersion: "containerd.io=1.5.11-1"
         allowedPattern: "containerd.io=1.[56]"
@@ -114,11 +114,11 @@ bashible: &bashible
           allowedPattern: "4.19"
     '11':
       docker:
-        desiredVersion: "docker-ce=5:20.10.17~3-0~debian-bullseye"
-        allowedPattern: "^docker-ce=5:(19|20).+"
+        desiredVersion: "docker-ce=5:20.10.12~3-0~debian-bullseye"
+        allowedPattern: ""
         containerd:
-          desiredVersion: "containerd.io=1.5.11-1"
-          allowedPattern: "containerd.io=1.[2345]"
+          desiredVersion: "containerd.io=1.4.6-1"
+          allowedPattern: "containerd.io=1.[234]"
       containerd:
         desiredVersion: "containerd.io=1.5.11-1"
         allowedPattern: "containerd.io=1.[56]"
@@ -129,11 +129,11 @@ bashible: &bashible
   centos:
     '7':
       docker:
-        desiredVersion: "docker-ce-20.10.17-3.el7.x86_64"
-        allowedPattern: "^docker-ce-(19|20).+"
+        desiredVersion: "docker-ce-19.03.15-3.el7.x86_64"
+        allowedPattern: ""
         containerd:
-          desiredVersion: "containerd.io-1.5.11-3.1.el7.x86_64"
-          allowedPattern: "containerd.io-1.[12345]"
+          desiredVersion: "containerd.io-1.4.6-3.1.el7.x86_64"
+          allowedPattern: "containerd.io-1.[1234]"
       containerd:
         desiredVersion: "containerd.io-1.5.11-3.1.el7.x86_64"
         allowedPattern: "containerd.io-1.[56]"
@@ -143,11 +143,11 @@ bashible: &bashible
           allowedPattern: "3.10|5.[014]"
     '8':
       docker:
-        desiredVersion: "docker-ce-20.10.17-3.el8.x86_64"
-        allowedPattern: "^docker-ce-(19|20).+"
+        desiredVersion: "docker-ce-19.03.15-3.el8.x86_64"
+        allowedPattern: ""
         containerd:
-          desiredVersion: "containerd.io-1.5.11-3.1.el8.x86_64"
-          allowedPattern: "containerd.io-1.[12345]"
+          desiredVersion: "containerd.io-1.4.6-3.1.el8.x86_64"
+          allowedPattern: "containerd.io-1.[1234]"
       containerd:
         desiredVersion: "containerd.io-1.5.11-3.1.el8.x86_64"
         allowedPattern: "containerd.io-1.[56]"
@@ -167,7 +167,7 @@ k8s:
         '18.04':
           docker:
             desiredVersion: "docker-ce=5:19.03.13~3-0~ubuntu-bionic"
-            allowedPattern: "docker-ce=5:18.09.7~3-0~ubuntu-bionic"
+            allowedPattern: ""
             containerd:
               desiredVersion: "containerd.io=1.4.6-1"
               allowedPattern: "containerd.io=1.[234]"

--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -2,8 +2,8 @@ bashible: &bashible
   ubuntu: &ubuntu
     '16.04':
       docker:
-        desiredVersion: "docker-ce=5:18.09.7~3-0~ubuntu-xenial"
-        allowedPattern: ""
+        desiredVersion: "docker-ce=5:20.10.7~3-0~ubuntu-xenial"
+        allowedPattern: "^docker-ce=5:(19|20).+"
         containerd:
           desiredVersion: "containerd.io=1.4.6-1"
           allowedPattern: "containerd.io=1.[234]"
@@ -16,11 +16,11 @@ bashible: &bashible
           allowedPattern: "4.18"
     '18.04':
       docker:
-        desiredVersion: "docker-ce=5:18.09.7~3-0~ubuntu-bionic"
-        allowedPattern: ""
+        desiredVersion: "docker-ce=5:20.10.17~3-0~ubuntu-bionic"
+        allowedPattern: "^docker-ce=5:(19|20).+"
         containerd:
-          desiredVersion: "containerd.io=1.4.6-1"
-          allowedPattern: "containerd.io=1.[234]"
+          desiredVersion: "containerd.io=1.5.11-1"
+          allowedPattern: "containerd.io=1.[2345]"
       containerd:
         desiredVersion: "containerd.io=1.5.11-1"
         allowedPattern: "containerd.io=1.[56]"
@@ -39,11 +39,11 @@ bashible: &bashible
           allowedPattern: "5.3"
     '20.04':
       docker:
-        desiredVersion: "docker-ce=5:19.03.13~3-0~ubuntu-focal"
-        allowedPattern: ""
+        desiredVersion: "docker-ce=5:20.10.17~3-0~ubuntu-focal"
+        allowedPattern: "^docker-ce=5:(19|20).+"
         containerd:
-          desiredVersion: "containerd.io=1.4.6-1"
-          allowedPattern: "containerd.io=1.[234]"
+          desiredVersion: "containerd.io=1.5.11-1"
+          allowedPattern: "containerd.io=1.[2345]"
       containerd:
         desiredVersion: "containerd.io=1.5.11-1"
         allowedPattern: "containerd.io=1.[56]"
@@ -62,8 +62,8 @@ bashible: &bashible
           allowedPattern: "5.4"
     '22.04':
       docker:
-        desiredVersion: "docker-ce=5:20.10.14~3-0~ubuntu-jammy"
-        allowedPattern: ""
+        desiredVersion: "docker-ce=5:20.10.17~3-0~ubuntu-jammy"
+        allowedPattern: "^docker-ce=5:20.+"
         containerd:
           desiredVersion: "containerd.io=1.5.11-1"
           allowedPattern: "containerd.io=1.[56]"

--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -129,11 +129,11 @@ bashible: &bashible
   centos:
     '7':
       docker:
-        desiredVersion: "docker-ce-18.09.9-3.el7.x86_64"
-        allowedPattern: ""
+        desiredVersion: "docker-ce-20.10.17-3.el7.x86_64"
+        allowedPattern: "^docker-ce-(19|20).+"
         containerd:
-          desiredVersion: "containerd.io-1.4.6-3.1.el7.x86_64"
-          allowedPattern: "containerd.io-1.[1234]"
+          desiredVersion: "containerd.io-1.5.11-3.1.el7.x86_64"
+          allowedPattern: "containerd.io-1.[12345]"
       containerd:
         desiredVersion: "containerd.io-1.5.11-3.1.el7.x86_64"
         allowedPattern: "containerd.io-1.[56]"
@@ -143,11 +143,11 @@ bashible: &bashible
           allowedPattern: "3.10|5.[014]"
     '8':
       docker:
-        desiredVersion: "docker-ce-19.03.15-3.el8.x86_64"
-        allowedPattern: ""
+        desiredVersion: "docker-ce-20.10.17-3.el8.x86_64"
+        allowedPattern: "^docker-ce-(19|20).+"
         containerd:
-          desiredVersion: "containerd.io-1.4.6-3.1.el8.x86_64"
-          allowedPattern: "containerd.io-1.[1234]"
+          desiredVersion: "containerd.io-1.5.11-3.1.el8.x86_64"
+          allowedPattern: "containerd.io-1.[12345]"
       containerd:
         desiredVersion: "containerd.io-1.5.11-3.1.el8.x86_64"
         allowedPattern: "containerd.io-1.[56]"


### PR DESCRIPTION
## Description
Forbid using Docker 18.* 

Allow only 19.* and 20.* versions.

## Why do we need it, and what problem does it solve?
We have troubles on 18.* Docker during release new Deckhouse version.
Docker often stuck and we should reboot node.

## What is the expected result?
On nodes with Docker 18.* bashible should request disruptive update on step `031_install_docker.sh` 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: bashible
type: feature
summary: Forbid using Docker 18.*
impact: |
  After upgrading Deckhouse all nodes with Docker 18.* will request `disruptive update`. You will receive `NodeRequiresDisruptionApprovalForUpdate` if you have manual `approvalMode` in NodeGroup.
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
