### PR TITLE
[ci][tests] Test improvements

### DIFF
--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -291,6 +291,7 @@ pull_request_info:
       id: changes
       with:
         token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+        # dangerous - detect if changes not allowed to test for external PRs
         # docs - detect changes in files that belong to the documentation scope
         # not_markdown - detect changes not in markdown files
         filters: |

--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -113,6 +113,8 @@ pull_request_info:
     pr_description: ${{ steps.pr_props.outputs.pr_description }}
     diff_url: ${{ steps.pr_props.outputs.diff_url }}
     labels: ${{ steps.pr_props.outputs.labels }}
+    changes_docs: ${{ steps.changes.outputs.docs }}
+    changes_not_markdown: ${{ steps.changes.outputs.not_markdown }}
 
   # Skip pull_request and pull_request_target triggers for PRs authored by deckhouse-BOaTswain, e.g. changelog PRs.
   if: ${{ ! (startsWith(github.event_name, 'pull_request') && github.event.pull_request.user.login == 'deckhouse-BOaTswain') }}
@@ -283,11 +285,11 @@ pull_request_info:
       with:
         ref: ${{ steps.pr_props.outputs.ref }}
 
-    # Detect dangerous changes in external PR.
-    - name: Check for dangerous changes
+    # Detect dangerous changes in external PR
+    - name: Check for dangerous changes in PR
       uses: {!{ index (ds "actions") "dorny/paths-filter" }!}
       if: steps.pr_props.outputs.should_check == 'true'
-      id: changes
+      id: dangerous_changes
       with:
         token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
         filters: |
@@ -300,9 +302,28 @@ pull_request_info:
             - './docs/**/images/**'
             - './docs/**/assets/**'
 
+    # Get info about other changes.
+    - name: Get info about PR changes
+      uses: {!{ index (ds "actions") "dorny/paths-filter" }!}
+      id: changes
+      with:
+        token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+        # docs - detect changes in files that belong to the documentation scope
+        # not_markdown - detect changes not in markdown files
+        filters: |
+          docs:
+            - './**/*.md'
+            - './docs/**'
+            - './**/crds/*'
+            - './**/openapi/*config-values.yaml'
+            - './candi/**/openapi/*'
+            - './ee/candi/**/openapi/*'
+          not_markdown:
+            - '!./**/*.md'
+
     # Stop workflow if external PR contains dangerous changes.
     - name: Fail workflow on dangerous changes
-      if: steps.changes.outputs.dangerous == 'true'
+      if: steps.dangerous_changes.outputs.dangerous == 'true'
       uses: {!{ index (ds "actions") "actions/github-script" }!}
       with:
         script: |

--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -285,23 +285,6 @@ pull_request_info:
       with:
         ref: ${{ steps.pr_props.outputs.ref }}
 
-    # Detect dangerous changes in external PR
-    - name: Check for dangerous changes in PR
-      uses: {!{ index (ds "actions") "dorny/paths-filter" }!}
-      if: steps.pr_props.outputs.should_check == 'true'
-      id: dangerous_changes
-      with:
-        token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
-        filters: |
-          dangerous:
-            - './.github/**'
-            - './tools/**'
-            - './testing/**'
-            - './docs/**/js/**'
-            - './docs/**/css/**'
-            - './docs/**/images/**'
-            - './docs/**/assets/**'
-
     # Get info about other changes.
     - name: Get info about PR changes
       uses: {!{ index (ds "actions") "dorny/paths-filter" }!}
@@ -311,6 +294,14 @@ pull_request_info:
         # docs - detect changes in files that belong to the documentation scope
         # not_markdown - detect changes not in markdown files
         filters: |
+          dangerous:
+            - './.github/**'
+            - './tools/**'
+            - './testing/**'
+            - './docs/**/js/**'
+            - './docs/**/css/**'
+            - './docs/**/images/**'
+            - './docs/**/assets/**'
           docs:
             - './**/*.md'
             - './docs/**'
@@ -323,7 +314,7 @@ pull_request_info:
 
     # Stop workflow if external PR contains dangerous changes.
     - name: Fail workflow on dangerous changes
-      if: steps.dangerous_changes.outputs.dangerous == 'true'
+      if: ${{ steps.pr_props.outputs.should_check == 'true' && steps.changes.outputs.dangerous == 'true' }}
       uses: {!{ index (ds "actions") "actions/github-script" }!}
       with:
         script: |

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -86,6 +86,7 @@ jobs:
 {!{ tmpl.Exec "main_web_build_template" $ctx | strings.Indent 4 }!}
 
   tests:
+    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
     name: Tests
     needs:
       - git_info
@@ -94,6 +95,7 @@ jobs:
 {!{ tmpl.Exec "tests_template" (slice $ctx "unit" "build_deckhouse") | strings.Indent 4 }!}
 
   matrix_tests:
+    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
     name: Matrix tests
     needs:
       - git_info
@@ -102,6 +104,7 @@ jobs:
 {!{ tmpl.Exec "tests_template" (slice $ctx "matrix" "build_deckhouse") | strings.Indent 4 }!}
 
   dhctl_tests:
+    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
     name: Dhctl Tests
     needs:
       - git_info
@@ -110,6 +113,7 @@ jobs:
 {!{ tmpl.Exec "tests_template" (slice $ctx "dhctl" "build_deckhouse") | strings.Indent 4 }!}
 
   golangci_lint:
+    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
     name: GolangCI Lint
     needs:
       - git_info
@@ -118,6 +122,7 @@ jobs:
 {!{ tmpl.Exec "tests_template" (slice $ctx "golangci_lint" "build_deckhouse") | strings.Indent 4 }!}
 
   openapi_test_cases:
+    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
     name: OpenAPI Test Cases
     needs:
       - git_info
@@ -126,6 +131,7 @@ jobs:
 {!{ tmpl.Exec "tests_template" (slice $ctx "openapi_test_cases" "build_deckhouse") | strings.Indent 4 }!}
 
   web_links_test:
+    if: ${{ needs.pull_request_info.outputs.changes_docs == 'true' }}
     name: Web links test
     needs:
       - git_info
@@ -136,6 +142,7 @@ jobs:
 {!{ tmpl.Exec "web_links_test_template" $ctx | strings.Indent 4 }!}
 
   validators:
+    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
     name: Validators
     needs:
       - git_info

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -42,6 +42,8 @@ jobs:
       pr_description: ${{ steps.pr_props.outputs.pr_description }}
       diff_url: ${{ steps.pr_props.outputs.diff_url }}
       labels: ${{ steps.pr_props.outputs.labels }}
+      changes_docs: ${{ steps.changes.outputs.docs }}
+      changes_not_markdown: ${{ steps.changes.outputs.not_markdown }}
 
     # Skip pull_request and pull_request_target triggers for PRs authored by deckhouse-BOaTswain, e.g. changelog PRs.
     if: ${{ ! (startsWith(github.event_name, 'pull_request') && github.event.pull_request.user.login == 'deckhouse-BOaTswain') }}
@@ -212,11 +214,11 @@ jobs:
         with:
           ref: ${{ steps.pr_props.outputs.ref }}
 
-      # Detect dangerous changes in external PR.
-      - name: Check for dangerous changes
+      # Detect dangerous changes in external PR
+      - name: Check for dangerous changes in PR
         uses: dorny/paths-filter@v2
         if: steps.pr_props.outputs.should_check == 'true'
-        id: changes
+        id: dangerous_changes
         with:
           token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
           filters: |
@@ -229,9 +231,28 @@ jobs:
               - './docs/**/images/**'
               - './docs/**/assets/**'
 
+      # Get info about other changes.
+      - name: Get info about PR changes
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          # docs - detect changes in files that belong to the documentation scope
+          # not_markdown - detect changes not in markdown files
+          filters: |
+            docs:
+              - './**/*.md'
+              - './docs/**'
+              - './**/crds/*'
+              - './**/openapi/*config-values.yaml'
+              - './candi/**/openapi/*'
+              - './ee/candi/**/openapi/*'
+            not_markdown:
+              - '!./**/*.md'
+
       # Stop workflow if external PR contains dangerous changes.
       - name: Fail workflow on dangerous changes
-        if: steps.changes.outputs.dangerous == 'true'
+        if: steps.dangerous_changes.outputs.dangerous == 'true'
         uses: actions/github-script@v5.0.0
         with:
           script: |
@@ -766,6 +787,7 @@ jobs:
     # </template: main_web_build_template>
 
   tests:
+    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
     name: Tests
     needs:
       - git_info
@@ -854,6 +876,7 @@ jobs:
     # </template: tests_template>
 
   matrix_tests:
+    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
     name: Matrix tests
     needs:
       - git_info
@@ -942,6 +965,7 @@ jobs:
     # </template: tests_template>
 
   dhctl_tests:
+    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
     name: Dhctl Tests
     needs:
       - git_info
@@ -1030,6 +1054,7 @@ jobs:
     # </template: tests_template>
 
   golangci_lint:
+    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
     name: GolangCI Lint
     needs:
       - git_info
@@ -1118,6 +1143,7 @@ jobs:
     # </template: tests_template>
 
   openapi_test_cases:
+    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
     name: OpenAPI Test Cases
     needs:
       - git_info
@@ -1206,6 +1232,7 @@ jobs:
     # </template: tests_template>
 
   web_links_test:
+    if: ${{ needs.pull_request_info.outputs.changes_docs == 'true' }}
     name: Web links test
     needs:
       - git_info
@@ -1358,6 +1385,7 @@ jobs:
     # </template: web_links_test_template>
 
   validators:
+    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
     name: Validators
     needs:
       - git_info

--- a/.github/workflows/on-pull-request-labeled.yml
+++ b/.github/workflows/on-pull-request-labeled.yml
@@ -24,6 +24,8 @@ jobs:
       pr_description: ${{ steps.pr_props.outputs.pr_description }}
       diff_url: ${{ steps.pr_props.outputs.diff_url }}
       labels: ${{ steps.pr_props.outputs.labels }}
+      changes_docs: ${{ steps.changes.outputs.docs }}
+      changes_not_markdown: ${{ steps.changes.outputs.not_markdown }}
 
     # Skip pull_request and pull_request_target triggers for PRs authored by deckhouse-BOaTswain, e.g. changelog PRs.
     if: ${{ ! (startsWith(github.event_name, 'pull_request') && github.event.pull_request.user.login == 'deckhouse-BOaTswain') }}
@@ -194,11 +196,11 @@ jobs:
         with:
           ref: ${{ steps.pr_props.outputs.ref }}
 
-      # Detect dangerous changes in external PR.
-      - name: Check for dangerous changes
+      # Detect dangerous changes in external PR
+      - name: Check for dangerous changes in PR
         uses: dorny/paths-filter@v2
         if: steps.pr_props.outputs.should_check == 'true'
-        id: changes
+        id: dangerous_changes
         with:
           token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
           filters: |
@@ -211,9 +213,28 @@ jobs:
               - './docs/**/images/**'
               - './docs/**/assets/**'
 
+      # Get info about other changes.
+      - name: Get info about PR changes
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          # docs - detect changes in files that belong to the documentation scope
+          # not_markdown - detect changes not in markdown files
+          filters: |
+            docs:
+              - './**/*.md'
+              - './docs/**'
+              - './**/crds/*'
+              - './**/openapi/*config-values.yaml'
+              - './candi/**/openapi/*'
+              - './ee/candi/**/openapi/*'
+            not_markdown:
+              - '!./**/*.md'
+
       # Stop workflow if external PR contains dangerous changes.
       - name: Fail workflow on dangerous changes
-        if: steps.changes.outputs.dangerous == 'true'
+        if: steps.dangerous_changes.outputs.dangerous == 'true'
         uses: actions/github-script@v5.0.0
         with:
           script: |

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -66,6 +66,8 @@ jobs:
       pr_description: ${{ steps.pr_props.outputs.pr_description }}
       diff_url: ${{ steps.pr_props.outputs.diff_url }}
       labels: ${{ steps.pr_props.outputs.labels }}
+      changes_docs: ${{ steps.changes.outputs.docs }}
+      changes_not_markdown: ${{ steps.changes.outputs.not_markdown }}
 
     # Skip pull_request and pull_request_target triggers for PRs authored by deckhouse-BOaTswain, e.g. changelog PRs.
     if: ${{ ! (startsWith(github.event_name, 'pull_request') && github.event.pull_request.user.login == 'deckhouse-BOaTswain') }}
@@ -236,11 +238,11 @@ jobs:
         with:
           ref: ${{ steps.pr_props.outputs.ref }}
 
-      # Detect dangerous changes in external PR.
-      - name: Check for dangerous changes
+      # Detect dangerous changes in external PR
+      - name: Check for dangerous changes in PR
         uses: dorny/paths-filter@v2
         if: steps.pr_props.outputs.should_check == 'true'
-        id: changes
+        id: dangerous_changes
         with:
           token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
           filters: |
@@ -253,9 +255,28 @@ jobs:
               - './docs/**/images/**'
               - './docs/**/assets/**'
 
+      # Get info about other changes.
+      - name: Get info about PR changes
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          # docs - detect changes in files that belong to the documentation scope
+          # not_markdown - detect changes not in markdown files
+          filters: |
+            docs:
+              - './**/*.md'
+              - './docs/**'
+              - './**/crds/*'
+              - './**/openapi/*config-values.yaml'
+              - './candi/**/openapi/*'
+              - './ee/candi/**/openapi/*'
+            not_markdown:
+              - '!./**/*.md'
+
       # Stop workflow if external PR contains dangerous changes.
       - name: Fail workflow on dangerous changes
-        if: steps.changes.outputs.dangerous == 'true'
+        if: steps.dangerous_changes.outputs.dangerous == 'true'
         uses: actions/github-script@v5.0.0
         with:
           script: |


### PR DESCRIPTION
## Description

Test improvements:
- Skip code-related tests if only documentation changes.
- Run some documentation-related jobs only if documentation changes.

Ref: #1628 

## Why do we need it, and what problem does it solve?
There is no need to run code tests if only the documentation has changed. Code testing takes time; eliminating unnecessary testing steps will save a lot of time passing the pipeline.

## What is the expected result?
CI must not run code tests if only documentation changes. Documentation-related CI validation jobs must only run if documentation changes. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: tests
type: feature
summary: Not run code tests in only documentation changes. Run documentation-related validations if documentation changes.
impact_level: low
```
