### PR TITLE
[ci] Fix daily e2e tests

### DIFF
--- a/.github/ci_templates/alerting.yaml
+++ b/.github/ci_templates/alerting.yaml
@@ -1,0 +1,55 @@
+{!{- define "send_alert_template" -}!}
+{!{- $ctx := index . 0 }!}
+# <template: send_alert_template>
+- name: Check alerting credentials
+  id: check_alerting
+  if: always()
+  env:
+    KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+  run: |
+    if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+- name: Send alert on fail
+{!{- if coll.Has $ctx "if" }!}
+  if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && ( {!{- $ctx.if -}!} ) }}
+{!{- else }!}
+  if: ${{ steps.check_alerting.outputs.has_credentials == 'true' }}
+{!{- end }!}
+  env:
+    CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+  run: |
+    WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+    echo $WORKFLOW_URL
+
+    alertData=$(cat <<EOF
+    {
+      "labels": {
+{!{ range $k, $v := $ctx.labels }!}
+  {!{- $k | quote | indent 8 -}!}: {!{ $v | quote }!},
+{!{ end }!}
+        "severity_level": 7
+      },
+      "annotations": {
+{!{ range $k, $v := $ctx.annotations }!}
+  {!{- $k | quote | indent 8 -}!}: {!{ $v | quote }!},
+{!{ end }!}
+        "plk_link_url/job": "${WORKFLOW_URL}",
+        "plk_protocol_version": "1",
+        "plk_link_title_en/job": "Github job run"
+      }
+    }
+    EOF
+    )
+
+    for (( iter = 1; iter < 60; iter++ )); do
+      if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
+        exit 0
+      fi
+
+      echo "Alert was not sent. Wait 5 seconds before next attempt"
+      sleep 5
+    done
+
+    echo "Alert was not sent. Timeout"
+    exit 1
+  # </template: send_alert_template>
+{!{- end -}!}

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -14,6 +14,17 @@
 {!{ $layout }!}
 {!{ end -}!}
 
+{!{ define "e2e_send_alert_template" }!}
+{!{- $ctx := index . 0 -}!}
+
+{!{- $annotations := dict "plk_create_group_if_not_exists/cloudlayouttestfailed" "CloudLayoutTestFailedGroup" -}!}
+{!{- $annotations = coll.Merge $annotations (dict "plk_grouped_by/cloudlayouttestfailed" "CloudLayoutTestFailedGroup") -}!}
+
+{!{- $templateCtx := coll.Merge $ctx (dict "annotations" $annotations ) }!}
+
+{!{ tmpl.Exec "send_alert_template" (slice $templateCtx) }!}
+{!{ end }!}
+
 {!{ define "e2e_run_template" }!}
 # <template: e2e_run_template>
 {!{- $provider := index . 0 -}!}
@@ -92,6 +103,7 @@ run: |
 
 # </template: e2e_run_template>
 {!{- end -}!}
+
 
 
 {!{/*
@@ -173,13 +185,22 @@ check_e2e_labels:
         CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
         CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
         REF_FULL: ${{needs.git_info.outputs.ref_full}}
+        MANUAL_RUN: {!{ coll.Has $ctx "manualRun" | conv.ToString | strings.Quote }!}
       run: |
         # Calculate unique prefix for e2e test.
         # GITHUB_RUN_ID is a unique number for each workflow run.
         # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
         # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-        # CRI value is trimmed to reduce prefix length.
-        DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+        # CRI and PROVIDER values are trimmed to reduce prefix length.
+        DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+        if [[ "${MANUAL_RUN}" == "false" ]] ; then
+          # for jobs which run multiple providers concurrency (daily e2e, for example)
+          # add provider suffix to prevent "directory already exists" error
+          DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+        fi
+        # converts to DNS-like (all letters in lower case and replace all dots to dash)
+        # because it prefix will use for k8s resources names (nodes, for example)
+        DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
         # Create tmppath for test script.
         TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -295,52 +316,11 @@ check_e2e_labels:
 {!{- end }!}
 
 {!{- if not (coll.Has $ctx "manualRun") }!}
-    - name: Check alerting credentials
-      id: check_alerting
-      if: always()
-      env:
-        KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-      run: |
-        if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
 
-    - name: Alert on fail in default branch
-      if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
-      env:
-        PROVIDER: {!{ $ctx.providerName }!}
-        CRI: {!{ $ctx.criName }!}
-        LAYOUT: {!{ $ctx.layout }!}
-        KUBERNETES_VERSION: "{!{ $ctx.kubernetesVersion }!}"
-        CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
-      run: |
-        WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-        echo $WORKFLOW_URL
-
-        alertData=$(cat <<EOF
-        {
-          "labels": {
-            "severity_level": 7,
-            "trigger": "CloudLayoutTestFailed",
-            "provider": "${PROVIDER}",
-            "layout": "${LAYOUT}",
-            "cri": "${CRI}",
-            "kubernetes_version": "${KUBERNETES_VERSION}"
-          },
-          "annotations": {
-            "summary": "Cloud Layout Test failed",
-            "description": "Check Github workflow log for more information",
-            "plk_protocol_version": "1",
-            "plk_link_url/job": "${WORKFLOW_URL}",
-            "plk_link_title_en/job": "Github job run",
-            "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
-            "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
-          }
-        }
-        EOF
-        )
-
-        curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
-          -H 'Content-Type: application/json' \
-          -d "${alertData}"
+  {!{- $labels := dict "trigger" "CloudLayoutTestFailed" "provider" $ctx.providerName "layout" $ctx.layout "cri" $ctx.criName "kube_version" $ctx.kubernetesVersion -}!}
+  {!{- $annotations := dict "summary" "Cloud Layout Test failed" "description" "Check Github workflow log for more information" -}!}
+  {!{- $if := "github.ref == 'refs/heads/main' && (cancelled() || failure())" -}!}
+  {!{- tmpl.Exec "e2e_send_alert_template" (slice (dict "labels" $labels "annotations" $annotations "if" $if )) | strings.Indent 4 }!}
 
 {!{- end }!}
 # </template: e2e_run_job_template>

--- a/.github/workflow_templates/e2e-daily.yml
+++ b/.github/workflow_templates/e2e-daily.yml
@@ -30,11 +30,15 @@ jobs:
 {!{- $gitInfoJobCtx := coll.Merge . (dict "dependJobs" (slice "skip_tests_repos")) -}!}
 {!{ tmpl.Exec "git_info_job" $gitInfoJobCtx | strings.Indent 2 }!}
 
+{!{- $dependsJobsForAlert := slice "skip_tests_repos" "git_info" -}!}
 
 {!{/* Jobs for each CRI and Kubernetes version */}!}
 {!{- $criName := "Containerd" -}!}
 {!{- $kubernetesVersion := "1.21" -}!}
 {!{- $providerNames := slice "AWS" "Azure" "GCP" "Yandex.Cloud" "OpenStack" "vSphere" "Static" -}!}
+{!{- if $enableWorkflowOnTestRepos -}!}
+{!{-   $providerNames = slice "AWS" "OpenStack" "Azure" -}!}
+{!{- end -}!}
 {!{- range $providerName := $providerNames -}!}
 {!{-   $provider := $providerName | replaceAll "." "-" | toLower -}!}
 {!{-   $kubernetesVersionSlug := $kubernetesVersion | replaceAll "." "_" | toLower -}!}
@@ -43,9 +47,22 @@ jobs:
 {!{-   $layout := (tmpl.Exec "e2e_get_layout" (dict "provider" $provider) | strings.TrimSpace ) -}!}
 {!{-   $providerForJobId := $providerName | replaceAll "." "_" | toLower -}!}
 {!{-   $jobID := printf "run_%s_%s_%s" $providerForJobId $cri $kubernetesVersionSlug -}!}
+{!{-   $dependsJobsForAlert = $dependsJobsForAlert | coll.Append $jobID -}!}
 {!{-   $jobName := printf "%s, %s, Kubernetes %s" $providerName $criName $kubernetesVersion -}!}
 {!{-   $jobCtx := (dict "provider" $provider "cri" $cri "criName" $criName "criEnv" $criEnv "layout" $layout) }!}
 {!{-   $jobCtx = coll.Merge $jobCtx (dict "kubernetesVersion" $kubernetesVersion "kubernetesVersionSlug" $kubernetesVersionSlug) }!}
 {!{-   $jobCtx = coll.Merge $jobCtx (dict "providerName" $providerName "workflowName" $workflowName "jobName" $jobName "jobID" $jobID) }!}
 {!{   tmpl.Exec "e2e_run_job_template" $jobCtx | strings.Indent 2 }!}
-{!{- end -}!}
+{!{- end }!}
+
+  send_alert_about_workflow_problem:
+    name: Send alert about workflow problem
+    runs-on: ubuntu-latest
+    needs: {!{ $dependsJobsForAlert | data.ToJSON }!}
+    if: ${{ failure() }}
+    steps:
+{!{- $labels := dict "trigger" "DailyE2EWorkflowFailed" -}!}
+{!{- $annotations := dict "summary" "Daily e2e tests workflow failed" -}!}
+{!{- $annotations = coll.Merge $annotations (dict "description" "Check Daily e2e workflow log for more information or see another alerts in this group.") -}!}
+
+{!{- tmpl.Exec "e2e_send_alert_template" (slice (dict "labels" $labels "annotations" $annotations )) | strings.Indent 4 -}!}

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -278,13 +278,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -601,13 +610,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -924,13 +942,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1247,13 +1274,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1570,13 +1606,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1893,13 +1938,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2216,13 +2270,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2539,13 +2602,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2862,13 +2934,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -3185,13 +3266,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -278,13 +278,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -609,13 +618,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -940,13 +958,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1271,13 +1298,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1602,13 +1638,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1933,13 +1978,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2264,13 +2318,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2595,13 +2658,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2926,13 +2998,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -3257,13 +3338,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -5,7 +5,7 @@
 name: 'Daily e2e tests'
 on:
   schedule:
-  - cron: '5 21 * * *'
+  - cron: '0 3 * * 1-5'
   workflow_dispatch:
 
 env:
@@ -34,7 +34,7 @@ jobs:
     if: ${{ false || github.repository == 'deckhouse/deckhouse' }}
     steps:
     - name: Do nothing
-      run: echo "We use job's 'if' for checking repository. We do not need any action in this job, but Github enforce use 'steps' to us."
+      run: echo "Empty action to fulfil Github requirements."
 
 
 # Note: git_info is needed for werf.yaml
@@ -113,12 +113,9 @@ jobs:
             core.setCommandEcho(false)
 
   # </template: git_info_job>
-
-
-
   # <template: e2e_run_job_template>
   run_aws_containerd_1_21:
-    name: "Daily e2e tests, AWS, Containerd, Kubernetes 1.21"
+    name: "AWS, Containerd, Kubernetes 1.21"
     needs:
       - git_info
     env:
@@ -204,13 +201,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "false"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -392,6 +398,9 @@ jobs:
           else
             echo Not a directory.
           fi
+
+
+      # <template: send_alert_template>
       - name: Check alerting credentials
         id: check_alerting
         if: always()
@@ -399,14 +408,9 @@ jobs:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
           if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
-
-      - name: Alert on fail in default branch
-        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+      - name: Send alert on fail
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && (github.ref == 'refs/heads/main' && (cancelled() || failure())) }}
         env:
-          PROVIDER: AWS
-          CRI: Containerd
-          LAYOUT: WithoutNAT
-          KUBERNETES_VERSION: "1.21"
           CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -415,34 +419,46 @@ jobs:
           alertData=$(cat <<EOF
           {
             "labels": {
-              "severity_level": 7,
+              "cri": "Containerd",
+              "kube_version": "1.21",
+              "layout": "WithoutNAT",
+              "provider": "AWS",
               "trigger": "CloudLayoutTestFailed",
-              "provider": "${PROVIDER}",
-              "layout": "${LAYOUT}",
-              "cri": "${CRI}",
-              "kubernetes_version": "${KUBERNETES_VERSION}"
+
+              "severity_level": 7
             },
             "annotations": {
-              "summary": "Cloud Layout Test failed",
               "description": "Check Github workflow log for more information",
-              "plk_protocol_version": "1",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
+              "summary": "Cloud Layout Test failed",
+
               "plk_link_url/job": "${WORKFLOW_URL}",
-              "plk_link_title_en/job": "Github job run",
-              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
-              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+              "plk_protocol_version": "1",
+              "plk_link_title_en/job": "Github job run"
             }
           }
           EOF
           )
 
-          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
-            -H 'Content-Type: application/json' \
-            -d "${alertData}"
+          for (( iter = 1; iter < 60; iter++ )); do
+            if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
+              exit 0
+            fi
+
+            echo "Alert was not sent. Wait 5 seconds before next attempt"
+            sleep 5
+          done
+
+          echo "Alert was not sent. Timeout"
+          exit 1
+        # </template: send_alert_template>
+
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
   run_azure_containerd_1_21:
-    name: "Daily e2e tests, Azure, Containerd, Kubernetes 1.21"
+    name: "Azure, Containerd, Kubernetes 1.21"
     needs:
       - git_info
     env:
@@ -528,13 +544,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "false"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -724,6 +749,9 @@ jobs:
           else
             echo Not a directory.
           fi
+
+
+      # <template: send_alert_template>
       - name: Check alerting credentials
         id: check_alerting
         if: always()
@@ -731,14 +759,9 @@ jobs:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
           if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
-
-      - name: Alert on fail in default branch
-        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+      - name: Send alert on fail
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && (github.ref == 'refs/heads/main' && (cancelled() || failure())) }}
         env:
-          PROVIDER: Azure
-          CRI: Containerd
-          LAYOUT: Standard
-          KUBERNETES_VERSION: "1.21"
           CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -747,34 +770,46 @@ jobs:
           alertData=$(cat <<EOF
           {
             "labels": {
-              "severity_level": 7,
+              "cri": "Containerd",
+              "kube_version": "1.21",
+              "layout": "Standard",
+              "provider": "Azure",
               "trigger": "CloudLayoutTestFailed",
-              "provider": "${PROVIDER}",
-              "layout": "${LAYOUT}",
-              "cri": "${CRI}",
-              "kubernetes_version": "${KUBERNETES_VERSION}"
+
+              "severity_level": 7
             },
             "annotations": {
-              "summary": "Cloud Layout Test failed",
               "description": "Check Github workflow log for more information",
-              "plk_protocol_version": "1",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
+              "summary": "Cloud Layout Test failed",
+
               "plk_link_url/job": "${WORKFLOW_URL}",
-              "plk_link_title_en/job": "Github job run",
-              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
-              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+              "plk_protocol_version": "1",
+              "plk_link_title_en/job": "Github job run"
             }
           }
           EOF
           )
 
-          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
-            -H 'Content-Type: application/json' \
-            -d "${alertData}"
+          for (( iter = 1; iter < 60; iter++ )); do
+            if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
+              exit 0
+            fi
+
+            echo "Alert was not sent. Wait 5 seconds before next attempt"
+            sleep 5
+          done
+
+          echo "Alert was not sent. Timeout"
+          exit 1
+        # </template: send_alert_template>
+
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
   run_gcp_containerd_1_21:
-    name: "Daily e2e tests, GCP, Containerd, Kubernetes 1.21"
+    name: "GCP, Containerd, Kubernetes 1.21"
     needs:
       - git_info
     env:
@@ -860,13 +895,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "false"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1044,6 +1088,9 @@ jobs:
           else
             echo Not a directory.
           fi
+
+
+      # <template: send_alert_template>
       - name: Check alerting credentials
         id: check_alerting
         if: always()
@@ -1051,14 +1098,9 @@ jobs:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
           if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
-
-      - name: Alert on fail in default branch
-        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+      - name: Send alert on fail
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && (github.ref == 'refs/heads/main' && (cancelled() || failure())) }}
         env:
-          PROVIDER: GCP
-          CRI: Containerd
-          LAYOUT: WithoutNAT
-          KUBERNETES_VERSION: "1.21"
           CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1067,34 +1109,46 @@ jobs:
           alertData=$(cat <<EOF
           {
             "labels": {
-              "severity_level": 7,
+              "cri": "Containerd",
+              "kube_version": "1.21",
+              "layout": "WithoutNAT",
+              "provider": "GCP",
               "trigger": "CloudLayoutTestFailed",
-              "provider": "${PROVIDER}",
-              "layout": "${LAYOUT}",
-              "cri": "${CRI}",
-              "kubernetes_version": "${KUBERNETES_VERSION}"
+
+              "severity_level": 7
             },
             "annotations": {
-              "summary": "Cloud Layout Test failed",
               "description": "Check Github workflow log for more information",
-              "plk_protocol_version": "1",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
+              "summary": "Cloud Layout Test failed",
+
               "plk_link_url/job": "${WORKFLOW_URL}",
-              "plk_link_title_en/job": "Github job run",
-              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
-              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+              "plk_protocol_version": "1",
+              "plk_link_title_en/job": "Github job run"
             }
           }
           EOF
           )
 
-          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
-            -H 'Content-Type: application/json' \
-            -d "${alertData}"
+          for (( iter = 1; iter < 60; iter++ )); do
+            if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
+              exit 0
+            fi
+
+            echo "Alert was not sent. Wait 5 seconds before next attempt"
+            sleep 5
+          done
+
+          echo "Alert was not sent. Timeout"
+          exit 1
+        # </template: send_alert_template>
+
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
   run_yandex_cloud_containerd_1_21:
-    name: "Daily e2e tests, Yandex.Cloud, Containerd, Kubernetes 1.21"
+    name: "Yandex.Cloud, Containerd, Kubernetes 1.21"
     needs:
       - git_info
     env:
@@ -1180,13 +1234,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "false"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1372,6 +1435,9 @@ jobs:
           else
             echo Not a directory.
           fi
+
+
+      # <template: send_alert_template>
       - name: Check alerting credentials
         id: check_alerting
         if: always()
@@ -1379,14 +1445,9 @@ jobs:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
           if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
-
-      - name: Alert on fail in default branch
-        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+      - name: Send alert on fail
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && (github.ref == 'refs/heads/main' && (cancelled() || failure())) }}
         env:
-          PROVIDER: Yandex.Cloud
-          CRI: Containerd
-          LAYOUT: WithoutNAT
-          KUBERNETES_VERSION: "1.21"
           CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1395,34 +1456,46 @@ jobs:
           alertData=$(cat <<EOF
           {
             "labels": {
-              "severity_level": 7,
+              "cri": "Containerd",
+              "kube_version": "1.21",
+              "layout": "WithoutNAT",
+              "provider": "Yandex.Cloud",
               "trigger": "CloudLayoutTestFailed",
-              "provider": "${PROVIDER}",
-              "layout": "${LAYOUT}",
-              "cri": "${CRI}",
-              "kubernetes_version": "${KUBERNETES_VERSION}"
+
+              "severity_level": 7
             },
             "annotations": {
-              "summary": "Cloud Layout Test failed",
               "description": "Check Github workflow log for more information",
-              "plk_protocol_version": "1",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
+              "summary": "Cloud Layout Test failed",
+
               "plk_link_url/job": "${WORKFLOW_URL}",
-              "plk_link_title_en/job": "Github job run",
-              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
-              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+              "plk_protocol_version": "1",
+              "plk_link_title_en/job": "Github job run"
             }
           }
           EOF
           )
 
-          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
-            -H 'Content-Type: application/json' \
-            -d "${alertData}"
+          for (( iter = 1; iter < 60; iter++ )); do
+            if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
+              exit 0
+            fi
+
+            echo "Alert was not sent. Wait 5 seconds before next attempt"
+            sleep 5
+          done
+
+          echo "Alert was not sent. Timeout"
+          exit 1
+        # </template: send_alert_template>
+
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
   run_openstack_containerd_1_21:
-    name: "Daily e2e tests, OpenStack, Containerd, Kubernetes 1.21"
+    name: "OpenStack, Containerd, Kubernetes 1.21"
     needs:
       - git_info
     env:
@@ -1508,13 +1581,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "false"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1692,6 +1774,9 @@ jobs:
           else
             echo Not a directory.
           fi
+
+
+      # <template: send_alert_template>
       - name: Check alerting credentials
         id: check_alerting
         if: always()
@@ -1699,14 +1784,9 @@ jobs:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
           if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
-
-      - name: Alert on fail in default branch
-        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+      - name: Send alert on fail
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && (github.ref == 'refs/heads/main' && (cancelled() || failure())) }}
         env:
-          PROVIDER: OpenStack
-          CRI: Containerd
-          LAYOUT: WithoutNAT
-          KUBERNETES_VERSION: "1.21"
           CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -1715,34 +1795,46 @@ jobs:
           alertData=$(cat <<EOF
           {
             "labels": {
-              "severity_level": 7,
+              "cri": "Containerd",
+              "kube_version": "1.21",
+              "layout": "WithoutNAT",
+              "provider": "OpenStack",
               "trigger": "CloudLayoutTestFailed",
-              "provider": "${PROVIDER}",
-              "layout": "${LAYOUT}",
-              "cri": "${CRI}",
-              "kubernetes_version": "${KUBERNETES_VERSION}"
+
+              "severity_level": 7
             },
             "annotations": {
-              "summary": "Cloud Layout Test failed",
               "description": "Check Github workflow log for more information",
-              "plk_protocol_version": "1",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
+              "summary": "Cloud Layout Test failed",
+
               "plk_link_url/job": "${WORKFLOW_URL}",
-              "plk_link_title_en/job": "Github job run",
-              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
-              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+              "plk_protocol_version": "1",
+              "plk_link_title_en/job": "Github job run"
             }
           }
           EOF
           )
 
-          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
-            -H 'Content-Type: application/json' \
-            -d "${alertData}"
+          for (( iter = 1; iter < 60; iter++ )); do
+            if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
+              exit 0
+            fi
+
+            echo "Alert was not sent. Wait 5 seconds before next attempt"
+            sleep 5
+          done
+
+          echo "Alert was not sent. Timeout"
+          exit 1
+        # </template: send_alert_template>
+
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
   run_vsphere_containerd_1_21:
-    name: "Daily e2e tests, vSphere, Containerd, Kubernetes 1.21"
+    name: "vSphere, Containerd, Kubernetes 1.21"
     needs:
       - git_info
     env:
@@ -1828,13 +1920,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "false"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2016,6 +2117,9 @@ jobs:
           else
             echo Not a directory.
           fi
+
+
+      # <template: send_alert_template>
       - name: Check alerting credentials
         id: check_alerting
         if: always()
@@ -2023,14 +2127,9 @@ jobs:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
           if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
-
-      - name: Alert on fail in default branch
-        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+      - name: Send alert on fail
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && (github.ref == 'refs/heads/main' && (cancelled() || failure())) }}
         env:
-          PROVIDER: vSphere
-          CRI: Containerd
-          LAYOUT: Standard
-          KUBERNETES_VERSION: "1.21"
           CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -2039,34 +2138,46 @@ jobs:
           alertData=$(cat <<EOF
           {
             "labels": {
-              "severity_level": 7,
+              "cri": "Containerd",
+              "kube_version": "1.21",
+              "layout": "Standard",
+              "provider": "vSphere",
               "trigger": "CloudLayoutTestFailed",
-              "provider": "${PROVIDER}",
-              "layout": "${LAYOUT}",
-              "cri": "${CRI}",
-              "kubernetes_version": "${KUBERNETES_VERSION}"
+
+              "severity_level": 7
             },
             "annotations": {
-              "summary": "Cloud Layout Test failed",
               "description": "Check Github workflow log for more information",
-              "plk_protocol_version": "1",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
+              "summary": "Cloud Layout Test failed",
+
               "plk_link_url/job": "${WORKFLOW_URL}",
-              "plk_link_title_en/job": "Github job run",
-              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
-              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+              "plk_protocol_version": "1",
+              "plk_link_title_en/job": "Github job run"
             }
           }
           EOF
           )
 
-          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
-            -H 'Content-Type: application/json' \
-            -d "${alertData}"
+          for (( iter = 1; iter < 60; iter++ )); do
+            if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
+              exit 0
+            fi
+
+            echo "Alert was not sent. Wait 5 seconds before next attempt"
+            sleep 5
+          done
+
+          echo "Alert was not sent. Timeout"
+          exit 1
+        # </template: send_alert_template>
+
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
   run_static_containerd_1_21:
-    name: "Daily e2e tests, Static, Containerd, Kubernetes 1.21"
+    name: "Static, Containerd, Kubernetes 1.21"
     needs:
       - git_info
     env:
@@ -2152,13 +2263,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "false"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2336,6 +2456,9 @@ jobs:
           else
             echo Not a directory.
           fi
+
+
+      # <template: send_alert_template>
       - name: Check alerting credentials
         id: check_alerting
         if: always()
@@ -2343,14 +2466,9 @@ jobs:
           KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
           if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
-
-      - name: Alert on fail in default branch
-        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (cancelled() || failure()) }}
+      - name: Send alert on fail
+        if: ${{ steps.check_alerting.outputs.has_credentials == 'true' && (github.ref == 'refs/heads/main' && (cancelled() || failure())) }}
         env:
-          PROVIDER: Static
-          CRI: Containerd
-          LAYOUT: Static
-          KUBERNETES_VERSION: "1.21"
           CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
@@ -2359,27 +2477,98 @@ jobs:
           alertData=$(cat <<EOF
           {
             "labels": {
-              "severity_level": 7,
+              "cri": "Containerd",
+              "kube_version": "1.21",
+              "layout": "Static",
+              "provider": "Static",
               "trigger": "CloudLayoutTestFailed",
-              "provider": "${PROVIDER}",
-              "layout": "${LAYOUT}",
-              "cri": "${CRI}",
-              "kubernetes_version": "${KUBERNETES_VERSION}"
+
+              "severity_level": 7
             },
             "annotations": {
-              "summary": "Cloud Layout Test failed",
               "description": "Check Github workflow log for more information",
-              "plk_protocol_version": "1",
+              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
+              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
+              "summary": "Cloud Layout Test failed",
+
               "plk_link_url/job": "${WORKFLOW_URL}",
-              "plk_link_title_en/job": "Github job run",
-              "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider",
-              "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup,provider=~provider"
+              "plk_protocol_version": "1",
+              "plk_link_title_en/job": "Github job run"
             }
           }
           EOF
           )
 
-          curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" \
-            -H 'Content-Type: application/json' \
-            -d "${alertData}"
+          for (( iter = 1; iter < 60; iter++ )); do
+            if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
+              exit 0
+            fi
+
+            echo "Alert was not sent. Wait 5 seconds before next attempt"
+            sleep 5
+          done
+
+          echo "Alert was not sent. Timeout"
+          exit 1
+        # </template: send_alert_template>
+
   # </template: e2e_run_job_template>
+
+
+  send_alert_about_workflow_problem:
+    name: Send alert about workflow problem
+    runs-on: ubuntu-latest
+    needs: ["skip_tests_repos","git_info","run_aws_containerd_1_21","run_azure_containerd_1_21","run_gcp_containerd_1_21","run_yandex_cloud_containerd_1_21","run_openstack_containerd_1_21","run_vsphere_containerd_1_21","run_static_containerd_1_21"]
+    if: ${{ failure() }}
+    steps:
+
+
+    # <template: send_alert_template>
+    - name: Check alerting credentials
+      id: check_alerting
+      if: always()
+      env:
+        KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+      run: |
+        if [[ -n $KEY ]]; then echo "::set-output name=has_credentials::true"; fi
+    - name: Send alert on fail
+      if: ${{ steps.check_alerting.outputs.has_credentials == 'true' }}
+      env:
+        CLOUD_LAYOUT_TESTS_MADISON_KEY: ${{secrets.CLOUD_LAYOUT_TESTS_MADISON_KEY}}
+      run: |
+        WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+        echo $WORKFLOW_URL
+
+        alertData=$(cat <<EOF
+        {
+          "labels": {
+            "trigger": "DailyE2EWorkflowFailed",
+
+            "severity_level": 7
+          },
+          "annotations": {
+            "description": "Check Daily e2e workflow log for more information or see another alerts in this group.",
+            "plk_create_group_if_not_exists/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
+            "plk_grouped_by/cloudlayouttestfailed": "CloudLayoutTestFailedGroup",
+            "summary": "Daily e2e tests workflow failed",
+
+            "plk_link_url/job": "${WORKFLOW_URL}",
+            "plk_protocol_version": "1",
+            "plk_link_title_en/job": "Github job run"
+          }
+        }
+        EOF
+        )
+
+        for (( iter = 1; iter < 60; iter++ )); do
+          if curl -sS -X "POST" "https://madison.flant.com/api/events/custom/${CLOUD_LAYOUT_TESTS_MADISON_KEY}" -H 'Content-Type: application/json' -d "${alertData}"; then
+            exit 0
+          fi
+
+          echo "Alert was not sent. Wait 5 seconds before next attempt"
+          sleep 5
+        done
+
+        echo "Alert was not sent. Timeout"
+        exit 1
+      # </template: send_alert_template>

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -278,13 +278,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -597,13 +606,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -916,13 +934,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1235,13 +1262,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1554,13 +1590,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1873,13 +1918,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2192,13 +2246,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2511,13 +2574,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2830,13 +2902,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -3149,13 +3230,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -278,13 +278,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -597,13 +606,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -916,13 +934,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1235,13 +1262,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1554,13 +1590,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1873,13 +1918,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2192,13 +2246,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2511,13 +2574,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2830,13 +2902,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -3149,13 +3230,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -278,13 +278,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -597,13 +606,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -916,13 +934,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1235,13 +1262,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1554,13 +1590,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1873,13 +1918,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2192,13 +2246,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2511,13 +2574,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2830,13 +2902,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -3149,13 +3230,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -278,13 +278,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -601,13 +610,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -924,13 +942,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1247,13 +1274,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1570,13 +1606,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1893,13 +1938,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2216,13 +2270,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2539,13 +2602,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2862,13 +2934,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -3185,13 +3266,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -278,13 +278,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -605,13 +614,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -932,13 +950,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1259,13 +1286,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1586,13 +1622,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -1913,13 +1958,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2240,13 +2294,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2567,13 +2630,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -2894,13 +2966,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}
@@ -3221,13 +3302,22 @@ jobs:
           CI_COMMIT_BRANCH: ${{needs.git_info.outputs.ci_commit_branch}}
           CI_COMMIT_REF_SLUG: ${{needs.git_info.outputs.ci_commit_ref_slug}}
           REF_FULL: ${{needs.git_info.outputs.ref_full}}
+          MANUAL_RUN: "true"
         run: |
           # Calculate unique prefix for e2e test.
           # GITHUB_RUN_ID is a unique number for each workflow run.
           # GITHUB_RUN_ATTEMPT is a unique number for each attempt of a particular workflow run in a repository.
           # Add CRI and KUBERNETES_VERSION to create unique directory for each job.
-          # CRI value is trimmed to reduce prefix length.
-          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
+          # CRI and PROVIDER values are trimmed to reduce prefix length.
+          DHCTL_PREFIX=$(echo "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(echo ${CRI} | head -c 3)-${KUBERNETES_VERSION}")
+          if [[ "${MANUAL_RUN}" == "false" ]] ; then
+            # for jobs which run multiple providers concurrency (daily e2e, for example)
+            # add provider suffix to prevent "directory already exists" error
+            DHCTL_PREFIX="${DHCTL_PREFIX}-$(echo ${PROVIDER} | head -c 2)"
+          fi
+          # converts to DNS-like (all letters in lower case and replace all dots to dash)
+          # because it prefix will use for k8s resources names (nodes, for example)
+          DHCTL_PREFIX=$(echo "$DHCTL_PREFIX" | tr '.' '-' | tr '[:upper:]' '[:lower:]')
 
           # Create tmppath for test script.
           TMP_DIR_PATH=/mnt/cloud-layouts/layouts/${DHCTL_PREFIX}


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Rerender workflow fix for daily e2e tests.
Move alerts sending steps to separate template.
Fix alert trigger.
Fix DHCTL_PATH for creation multiple directories on runner.

## Why do we need it, and what problem does it solve?
Daily e2e runs with incorrect schedule.

## What is the expected result?
E2E test do not run for all providers (only one 2).
Alerts about workflow problems do not send.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: fix
summary: Fix daily e2e tests
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
