### PR TITLE
[linstor] fix timestamp on dashboard

### DIFF
--- a/modules/031-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
+++ b/modules/031-linstor/monitoring/grafana-dashboards/storage/linstor_drbd.json
@@ -77,7 +77,7 @@
   "gnetId": null,
   "graphTooltip": 2,
   "id": null,
-  "iteration": 1647374865827,
+  "iteration": 1659360879340,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -2202,7 +2202,7 @@
       "type": "table"
     }
   ],
-  "refresh": false,
+  "refresh": "30s",
   "schemaVersion": 32,
   "style": "dark",
   "tags": [],
@@ -2258,8 +2258,8 @@
     ]
   },
   "time": {
-    "from": "2022-03-10T17:42:58.093Z",
-    "to": "2022-03-10T18:20:49.101Z"
+    "from": "now-3h",
+    "to": "now"
   },
   "timepicker": {},
   "timezone": "",


### PR DESCRIPTION
## Description
fix timestamp on linstor dashboard

## Why do we need it, and what problem does it solve?
The current timestamp is hardcoded to specific time

## What is the expected result?
Update linstor-dashboard

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: linstor
type: fix
summary: fix timestamp on linstor dashboard
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
