### PR TITLE
[node-manager] increase bashible-apiserver verbosity

### DIFF
--- a/modules/040-node-manager/images/bashible-apiserver/pkg/template/steps_storage.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/template/steps_storage.go
@@ -100,7 +100,7 @@ func (s *StepsStorage) Render(target, bundle, provider string, templateContext m
 	return steps, nil
 }
 
-func (s *StepsStorage) OnNodeConfigurationsChanged() chan struct{} {
+func (s *StepsStorage) OnNodeGroupConfigurationsChanged() chan struct{} {
 	return s.configurationsChanged
 }
 
@@ -120,6 +120,7 @@ func (s *StepsStorage) subscribeOnCRD(ctx context.Context, ngConfigFactory dynam
 	})
 
 	informer := ginformer.Informer()
+	informer.SetWatchErrorHandler(cache.DefaultWatchErrorHandler)
 
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
@@ -252,6 +253,7 @@ func (s *StepsStorage) readTemplates(baseDir string, templates map[string][]byte
 
 func (s *StepsStorage) AddNodeGroupConfiguration(nc *NodeGroupConfiguration) {
 	name := fmt.Sprintf("%03d_%s", nc.Spec.Weight, nc.Name)
+	klog.Infof("Adding NodeGroupConfiguration %s to context", name)
 	ngBundlePairs := generateNgBundlePairs(nc.Spec.NodeGroups, nc.Spec.Bundles)
 
 	sc := nodeConfigurationScript{
@@ -273,6 +275,7 @@ func (s *StepsStorage) AddNodeGroupConfiguration(nc *NodeGroupConfiguration) {
 
 func (s *StepsStorage) RemoveNodeGroupConfiguration(nc *NodeGroupConfiguration) {
 	name := fmt.Sprintf("%d_%s", nc.Spec.Weight, nc.Name)
+	klog.Infof("Removing NodeGroupConfiguration %s from context", name)
 	ngBundlePairs := generateNgBundlePairs(nc.Spec.NodeGroups, nc.Spec.Bundles)
 
 	s.m.Lock()


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Add more logs to the bashible-apiserver

## Why do we need it, and what problem does it solve?
It's hard to debug some situations with bashible-apiserver with detailed logs. Add more logging to the watchers on error and also add logs to the context rebuild

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: chore
summary: Add more verbosity to the bashible-apiserver logs
impact: bashible-apiserver will restart
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
