### PR TITLE
[cni-cilium] Fixed bandwidth controller metrics

### DIFF
--- a/modules/021-cni-cilium/images/cilium/Dockerfile
+++ b/modules/021-cni-cilium/images/cilium/Dockerfile
@@ -80,8 +80,11 @@ WORKDIR /tmp/cilium-repo/cilium-1.11.5
 
 COPY patches/001-netfilter-compatibility-mode.patch /
 COPY patches/002-skip-host-ip-gc.patch /
+COPY patches/003-fix-bwmap-delete-errors.patch /
+
 RUN patch -p1 < /001-netfilter-compatibility-mode.patch && \
-    patch -p1 < /002-skip-host-ip-gc.patch
+    patch -p1 < /002-skip-host-ip-gc.patch && \
+    patch -p1 < /003-fix-bwmap-delete-errors.patch
 
 RUN make PKG_BUILD=1 \
     SKIP_DOCS=true DESTDIR=/tmp/install build-container install-container-binary

--- a/modules/021-cni-cilium/images/cilium/patches/003-fix-bwmap-delete-errors.patch
+++ b/modules/021-cni-cilium/images/cilium/patches/003-fix-bwmap-delete-errors.patch
@@ -1,0 +1,74 @@
+diff --git a/pkg/endpoint/events.go b/pkg/endpoint/events.go
+index b6232c6ff1c..7c6c5d2f746 100644
+--- a/pkg/endpoint/events.go
++++ b/pkg/endpoint/events.go
+@@ -288,7 +288,7 @@ func (ev *EndpointPolicyBandwidthEvent) Handle(res chan interface{}) {
+ 			err = bwmap.Update(e.ID, bps)
+ 		}
+ 	} else {
+-		err = bwmap.Delete(e.ID)
++		err = bwmap.SilentDelete(e.ID)
+ 	}
+ 	if err != nil {
+ 		res <- &EndpointRegenerationResult{
+diff --git a/pkg/endpoint/policy.go b/pkg/endpoint/policy.go
+index 1ed031108ee..4c26c1ffa9c 100644
+--- a/pkg/endpoint/policy.go
++++ b/pkg/endpoint/policy.go
+@@ -823,7 +823,12 @@ func (e *Endpoint) UpdateNoTrackRules(annoCB AnnotationsResolverCB) {
+ 		e.getLogger().WithError(err).Error("Unable to enqueue endpoint notrack event")
+ 		return
+ 	}
+-	<-ch
++
++	updateRes := <-ch
++	regenResult := updateRes.(*EndpointRegenerationResult)
++	if regenResult.err != nil {
++		e.getLogger().WithError(regenResult.err).Error("EndpointNoTrackEvent event failed")
++	}
+ }
+
+ // UpdateVisibilityPolicy updates the visibility policy of this endpoint to
+@@ -840,7 +845,12 @@ func (e *Endpoint) UpdateVisibilityPolicy(annoCB AnnotationsResolverCB) {
+ 		e.getLogger().WithError(err).Error("Unable to enqueue endpoint policy visibility event")
+ 		return
+ 	}
+-	<-ch
++
++	updateRes := <-ch
++	regenResult := updateRes.(*EndpointRegenerationResult)
++	if regenResult.err != nil {
++		e.getLogger().WithError(regenResult.err).Error("EndpointPolicyVisibilityEvent event failed")
++	}
+ }
+
+ // UpdateBandwidthPolicy updates the egress bandwidth of this endpoint to
+@@ -854,7 +864,12 @@ func (e *Endpoint) UpdateBandwidthPolicy(annoCB AnnotationsResolverCB) {
+ 		e.getLogger().WithError(err).Error("Unable to enqueue endpoint policy bandwidth event")
+ 		return
+ 	}
+-	<-ch
++
++	updateRes := <-ch
++	regenResult := updateRes.(*EndpointRegenerationResult)
++	if regenResult.err != nil {
++		e.getLogger().WithError(regenResult.err).Error("EndpointPolicyBandwidthEvent event failed")
++	}
+ }
+
+ // GetRealizedPolicyRuleLabelsForKey returns the list of policy rule labels
+diff --git a/pkg/maps/bwmap/bwmap.go b/pkg/maps/bwmap/bwmap.go
+index 275d62c953b..66face45046 100644
+--- a/pkg/maps/bwmap/bwmap.go
++++ b/pkg/maps/bwmap/bwmap.go
+@@ -66,3 +66,10 @@ func Delete(Id uint16) error {
+ 	return ThrottleMap.Delete(
+ 		&EdtId{Id: uint64(Id)})
+ }
++
++func SilentDelete(Id uint16) error {
++	_, err := ThrottleMap.SilentDelete(
++		&EdtId{Id: uint64(Id)})
++
++	return err
++}

--- a/modules/021-cni-cilium/images/cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/cilium/patches/README.md
@@ -1,11 +1,19 @@
-# 001-netfilter-compatibility-mode.patch
+# Patches
+
+## 001-netfilter-compatibility-mode.patch
 
 Helps with handling LoadBalancer/NodePort traffic to hostNetwork endpoints.
 
-Taken from https://github.com/cilium/cilium/pull/17504
+Taken from <https://github.com/cilium/cilium/pull/17504>
 
-# 002-skip-host-ip-gc.patch
+## 002-skip-host-ip-gc.patch
 
 Fixes host connection reset when host policies are enabled and created.
 
-https://github.com/cilium/cilium/pull/19998
+<https://github.com/cilium/cilium/pull/19998>
+
+## 003-fix-bwmap-delete-errors.patch
+
+Fixes errors in metrics from Bandwidth controller. Also adds proper logging for a couple of controllers.
+
+<https://github.com/cilium/cilium/pull/20611>


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Bandwidth controller metrics are not erroring out now. Also added logging to three controllers so that we can diagnose possible issues better.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Full justification is available here: https://github.com/cilium/cilium/pull/20611

We've had a strange issue with bandwidth controller metrics, which generated garbage alerts.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Useless metrics are not generated anymore, garbage alerts are not present either.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cni-cilium
type: fix
summary: Bandwidth controller metrics are not erroring out now. Also added logging to three controllers so that we can diagnose possible issues better.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
