### PR TITLE
[candi] Fix GCP terraform discovery of cloudNATAddresses

### DIFF
--- a/candi/cloud-providers/gcp/terraform-modules/base-infrastructure/variables.tf
+++ b/candi/cloud-providers/gcp/terraform-modules/base-infrastructure/variables.tf
@@ -42,7 +42,7 @@ locals {
   prefix              = var.clusterConfiguration.cloud.prefix
   pod_subnet_cidr     = lookup(var.clusterConfiguration, "podSubnetCIDR", "10.100.0.0/16")
   subnetwork_cidr     = lookup(var.providerClusterConfiguration, "subnetworkCIDR", "10.172.0.0/16")
-  cloud_nat_addresses = var.providerClusterConfiguration.layout == "Standard" && lookup(var.providerClusterConfiguration, "standard", false) ? lookup(var.providerClusterConfiguration.standard, "cloudNATAddresses", []) : []
+  cloud_nat_addresses = var.providerClusterConfiguration.layout == "Standard" ? lookup(lookup(var.providerClusterConfiguration, "standard", {}), "cloudNATAddresses", []) : []
   peered_vpcs_names   = lookup(var.providerClusterConfiguration, "peeredVPCs", [])
   ssh_allow_list      = lookup(var.providerClusterConfiguration, "sshAllowList", ["0.0.0.0/0"])
 }


### PR DESCRIPTION
# Description

Fixed bug preventing from bootstrap in GCP with "Standard" layout. The workaround for this is to remove "standard" section from init configuration at all.

The error from terraform, when `providerClusterConfiguration.standard` is prerent:

> Unusitable values for right operand: bool required

The problem is that right operand can become either `false`, which is ok, or an object, which is an error for && operation.

```
... && lookup(var.providerClusterConfiguration, "standard", false) ? ...
```

This place needs to be improved for type safety.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.

## Changelog entries

```changes
section: candi
type: fix
summary: Fixed cloudNATAddresses discovery when bootstrapping cluster in GCP with sandard layout
```
