### PR TITLE
[upmeter] Tweak agent HTTP timeout

### DIFF
--- a/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
+++ b/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
@@ -94,13 +94,13 @@ func parseAgentArgs(cmd *kingpin.CmdClause, config *agent.Config) {
 		Default("false").
 		BoolVar(&config.ClientConfig.TLS)
 
-	cmd.Flag("send-interval", "The interval for sending episodes to the server.").
-		Envar("UPMETER_SEND_INTERVAL").
+	cmd.Flag("export-interval", "Exporting interval when sending from WAL.").
+		Envar("UPMETER_EXPORT_INTERVAL").
 		Default("1s").
 		DurationVar(&config.Interval)
 
-	cmd.Flag("send-timeout", "Sending response timeout before retry.").
-		Envar("UPMETER_SEND_TIMEOUT").
+	cmd.Flag("export-timeout", "Exporting response timeout before retry.").
+		Envar("UPMETER_EXPORT_TIMEOUT").
 		Default("5s").
 		DurationVar(&config.ClientConfig.Timeout)
 

--- a/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
+++ b/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
@@ -96,8 +96,13 @@ func parseAgentArgs(cmd *kingpin.CmdClause, config *agent.Config) {
 
 	cmd.Flag("period", "The period of episodes sending to server, and at the same the client timeout.").
 		Envar("UPMETER_SEND_INTERVAL").
-		Default("5s").
+		Default("1s").
 		DurationVar(&config.Interval)
+
+	cmd.Flag("period", "The period of episodes sending to server, and at the same the client timeout.").
+		Envar("UPMETER_SEND_TIMEOUT").
+		Default("5s").
+		DurationVar(&config.ClientConfig.Timeout)
 
 	// Database
 	cmd.Flag("db-path", "SQLite file path.").

--- a/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
+++ b/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
@@ -94,12 +94,12 @@ func parseAgentArgs(cmd *kingpin.CmdClause, config *agent.Config) {
 		Default("false").
 		BoolVar(&config.ClientConfig.TLS)
 
-	cmd.Flag("send-interval", "The period of episodes sending to server, and at the same the client timeout.").
+	cmd.Flag("send-interval", "The interval for sending episodes to the server.").
 		Envar("UPMETER_SEND_INTERVAL").
 		Default("1s").
 		DurationVar(&config.Interval)
 
-	cmd.Flag("send-timeout", "The period of episodes sending to server, and at the same the client timeout.").
+	cmd.Flag("send-timeout", "Sending response timeout before retry.").
 		Envar("UPMETER_SEND_TIMEOUT").
 		Default("5s").
 		DurationVar(&config.ClientConfig.Timeout)

--- a/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
+++ b/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
@@ -94,12 +94,12 @@ func parseAgentArgs(cmd *kingpin.CmdClause, config *agent.Config) {
 		Default("false").
 		BoolVar(&config.ClientConfig.TLS)
 
-	cmd.Flag("period", "The period of episodes sending to server, and at the same the client timeout.").
+	cmd.Flag("send-interval", "The period of episodes sending to server, and at the same the client timeout.").
 		Envar("UPMETER_SEND_INTERVAL").
 		Default("1s").
 		DurationVar(&config.Interval)
 
-	cmd.Flag("period", "The period of episodes sending to server, and at the same the client timeout.").
+	cmd.Flag("send-timeout", "The period of episodes sending to server, and at the same the client timeout.").
 		Envar("UPMETER_SEND_TIMEOUT").
 		Default("5s").
 		DurationVar(&config.ClientConfig.Timeout)

--- a/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
+++ b/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
@@ -95,9 +95,9 @@ func parseAgentArgs(cmd *kingpin.CmdClause, config *agent.Config) {
 		BoolVar(&config.ClientConfig.TLS)
 
 	cmd.Flag("period", "The period of episodes sending to server, and at the same the client timeout.").
-		Envar("UPMETER_PERIOD").
-		Default("1s").
-		DurationVar(&config.Period)
+		Envar("UPMETER_SEND_INTERVAL").
+		Default("5s").
+		DurationVar(&config.Interval)
 
 	// Database
 	cmd.Flag("db-path", "SQLite file path.").

--- a/modules/500-upmeter/images/upmeter/pkg/agent/agent.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/agent.go
@@ -109,7 +109,7 @@ func (a *Agent) Start(ctx context.Context) error {
 
 	ch := make(chan []check.Episode)
 
-	client := sender.NewClient(a.config.ClientConfig, a.config.Interval) // uses interval as client timeout
+	client := sender.NewClient(a.config.ClientConfig)
 	storage := sender.NewStorage(dbctx)
 
 	a.sender = sender.New(client, ch, storage, a.config.Interval)

--- a/modules/500-upmeter/images/upmeter/pkg/agent/agent.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/agent.go
@@ -46,7 +46,7 @@ type Agent struct {
 }
 
 type Config struct {
-	Period       time.Duration
+	Interval     time.Duration
 	ClientConfig *sender.ClientConfig
 	DatabasePath string
 	UserAgent    string
@@ -109,10 +109,10 @@ func (a *Agent) Start(ctx context.Context) error {
 
 	ch := make(chan []check.Episode)
 
-	client := sender.NewClient(a.config.ClientConfig, a.config.Period) // use period as timeout
+	client := sender.NewClient(a.config.ClientConfig, a.config.Interval) // uses interval as client timeout
 	storage := sender.NewStorage(dbctx)
 
-	a.sender = sender.New(client, ch, storage, a.config.Period)
+	a.sender = sender.New(client, ch, storage, a.config.Interval)
 	a.scheduler = scheduler.New(registry, ch)
 
 	a.sender.Start()

--- a/modules/500-upmeter/images/upmeter/pkg/agent/sender/client.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/sender/client.go
@@ -53,12 +53,13 @@ type ClientConfig struct {
 	CAPath    string
 	TLS       bool
 	UserAgent string
+	Timeout   time.Duration
 }
 
-func NewClient(config *ClientConfig, timeout time.Duration) *Client {
+func NewClient(config *ClientConfig) *Client {
 	return &Client{
 		url:       getEndpoint(config),
-		client:    NewHttpClient(config, timeout),
+		client:    NewHttpClient(config),
 		UserAgent: config.UserAgent,
 	}
 }
@@ -89,13 +90,13 @@ func (c *Client) Send(reqBody []byte) error {
 	return nil
 }
 
-func NewHttpClient(config *ClientConfig, timeout time.Duration) *http.Client {
-	client, err := createSecureHttpClient(config.TLS, config.CAPath, timeout)
+func NewHttpClient(config *ClientConfig) *http.Client {
+	client, err := createSecureHttpClient(config.TLS, config.CAPath, config.Timeout)
 	if err != nil {
 		log.Errorf("falling back to default HTTP client: %v", err)
 		return &http.Client{
-			Timeout:   timeout,
-			Transport: newTransport(timeout / 2),
+			Timeout:   config.Timeout,
+			Transport: newTransport(config.Timeout / 2),
 		}
 	}
 	return client

--- a/modules/500-upmeter/images/upmeter/pkg/agent/sender/client.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/sender/client.go
@@ -163,9 +163,9 @@ func newTransport(timeout time.Duration) *http.Transport {
 			KeepAlive: timeout / 2,
 		}),
 		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          1,           // single connection to the server
-		IdleConnTimeout:       time.Minute, // two episode sending intervals which are always 30s
-		TLSHandshakeTimeout:   10 * time.Second,
+		MaxIdleConns:          1,                // we need only one connection to the server
+		IdleConnTimeout:       time.Minute,      // double scrape interval which is 30s by design
+		TLSHandshakeTimeout:   10 * time.Second, // 10s is the default value
 		ResponseHeaderTimeout: timeout,
 	}
 }

--- a/modules/500-upmeter/images/upmeter/pkg/agent/sender/sender.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/sender/sender.go
@@ -75,7 +75,6 @@ func (s *Sender) receiveLoop() {
 
 func (s *Sender) sendLoop() {
 	ticker := time.NewTicker(s.interval)
-	defer ticker.Stop()
 
 	for {
 		select {
@@ -85,6 +84,7 @@ func (s *Sender) sendLoop() {
 				log.Errorf("sendLoop: %v", err)
 			}
 		case <-s.stop:
+			ticker.Stop()
 			s.done <- struct{}{}
 			return
 		}

--- a/modules/500-upmeter/images/upmeter/pkg/agent/sender/sender.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/sender/sender.go
@@ -75,6 +75,7 @@ func (s *Sender) receiveLoop() {
 
 func (s *Sender) sendLoop() {
 	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
 
 	for {
 		select {
@@ -84,7 +85,6 @@ func (s *Sender) sendLoop() {
 				log.Errorf("sendLoop: %v", err)
 			}
 		case <-s.stop:
-			ticker.Stop()
 			s.done <- struct{}{}
 			return
 		}
@@ -130,7 +130,7 @@ func (s *Sender) export() error {
 	slot := episodes[0].TimeSlot
 	err = s.storage.Clean(slot)
 	if err != nil {
-		return fmt.Errorf("cannot clean storage for slot=%v: %v", slot, err)
+		return fmt.Errorf("cleaning send storage, slot=%v: %v", slot, err)
 	}
 	return nil
 }

--- a/modules/500-upmeter/images/upmeter/pkg/agent/sender/sender.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/sender/sender.go
@@ -29,21 +29,21 @@ import (
 )
 
 type Sender struct {
-	client  *Client
-	recv    chan []check.Episode
-	storage *ListStorage
-	period  time.Duration
+	client   *Client
+	recv     chan []check.Episode
+	storage  *ListStorage
+	interval time.Duration
 
 	stop chan struct{}
 	done chan struct{}
 }
 
-func New(client *Client, recv chan []check.Episode, storage *ListStorage, period time.Duration) *Sender {
+func New(client *Client, recv chan []check.Episode, storage *ListStorage, interval time.Duration) *Sender {
 	s := &Sender{
-		client:  client,
-		recv:    recv,
-		storage: storage,
-		period:  period,
+		client:   client,
+		recv:     recv,
+		storage:  storage,
+		interval: interval,
 
 		stop: make(chan struct{}),
 		done: make(chan struct{}),
@@ -74,7 +74,7 @@ func (s *Sender) receiveLoop() {
 }
 
 func (s *Sender) sendLoop() {
-	ticker := time.NewTicker(s.period)
+	ticker := time.NewTicker(s.interval)
 
 	for {
 		select {
@@ -92,14 +92,14 @@ func (s *Sender) sendLoop() {
 }
 
 func (s *Sender) cleanupLoop() {
-	ticker := time.NewTicker(s.period)
+	ticker := time.NewTicker(s.interval)
 
 	dayBack := -24 * time.Hour
 
 	for {
 		select {
 		case <-ticker.C:
-			deadline := time.Now().Truncate(s.period).Add(dayBack)
+			deadline := time.Now().Truncate(s.interval).Add(dayBack)
 			err := s.storage.Clean(deadline)
 			if err != nil {
 				log.Errorf("cannot clean old episodes: %v", err)

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -118,7 +118,7 @@ spec:
             value: "info"
           - name: LOG_TYPE
             value: "json"
-          - name: UPMETER_SEND_TIMEOUT
+          - name: UPMETER_EXPORT_TIMEOUT
             value: "15s"
           resources:
             requests:

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -118,6 +118,8 @@ spec:
             value: "info"
           - name: LOG_TYPE
             value: "json"
+          - name: UPMETER_SEND_TIMEOUT
+            value: "15s"
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}


### PR DESCRIPTION
## Description

Set more sane timeouts to upmeter-agent sender.

## Why do we need it, and what problem does it solve?

Reduces dummy logs about reached timeout and request cancellations.

## What is the expected result?

Reduced or diminished logging or cancelled requests in upmeter-agent

## Checklist
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: upmeter
type: fix
summary: Tweak HTTP sending timeouts to reduce cancellation logs
impact_level: low
```
