### PR TITLE
[testing] support focusing for matrix tests linter

### DIFF
--- a/testing/matrix/linter/rules/modules/modules.go
+++ b/testing/matrix/linter/rules/modules/modules.go
@@ -142,7 +142,7 @@ func helmignoreModuleRule(name, path string) errors.LintRuleError {
 	return errors.EmptyRuleError
 }
 
-func GetDeckhouseModulesWithValuesMatrixTests() ([]utils.Module, error) {
+func GetDeckhouseModulesWithValuesMatrixTests(focusNames map[string]struct{}) ([]utils.Module, error) {
 	var modules []utils.Module
 
 	var possibleModulesPaths []string
@@ -167,8 +167,18 @@ func GetDeckhouseModulesWithValuesMatrixTests() ([]utils.Module, error) {
 		modulesPaths = append(modulesPaths, result...)
 	}
 
+	hasFocusNames := len(focusNames) > 0
 	var lintRuleErrorsList errors.LintRuleErrorsList
 	for _, modulePath := range modulesPaths {
+		if hasFocusNames {
+			moduleName := filepath.Base(modulePath)
+			moduleName = strings.TrimLeft(moduleName, "1234567890-")
+			_, focused := focusNames[moduleName]
+			if !focused {
+				continue
+			}
+		}
+
 		module, ok := lintModuleStructure(&lintRuleErrorsList, modulePath)
 		if !ok {
 			continue

--- a/testing/matrix/matrix_test.go
+++ b/testing/matrix/matrix_test.go
@@ -28,10 +28,7 @@ import (
 )
 
 func TestMatrix(t *testing.T) {
-	discoveredModules, err := modules.GetDeckhouseModulesWithValuesMatrixTests()
-	require.NoError(t, err)
-
-	// Use environment variable to focus on specific module, e.g. D8_TEST_MATRIX_FOCUS=user-authn,user-authz
+	// Use environment variable to focus on specific module, e.g. FOCUS=user-authn,user-authz
 	focus := os.Getenv("FOCUS")
 
 	focusNames := make(map[string]struct{})
@@ -41,6 +38,9 @@ func TestMatrix(t *testing.T) {
 			focusNames[part] = struct{}{}
 		}
 	}
+
+	discoveredModules, err := modules.GetDeckhouseModulesWithValuesMatrixTests(focusNames)
+	require.NoError(t, err)
 
 	for _, module := range discoveredModules {
 		_, ok := focusNames[module.Name]


### PR DESCRIPTION
## Description

Calculate focused modules before running module linter in matrix tests.

## Why do we need it, and what problem does it solve?

Ignore errors in other modules while testing one module.

## What is the expected result?

Running 

```
FOCUS=openvpn go test ./testing/matrix/ -v
```

should not complain about errors in other modules.

<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: testing
type: fix
summary: support focusing for matrix tests linter
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
