### PR TITLE
[ci] render workflows

### DIFF
--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -214,13 +214,15 @@ jobs:
         with:
           ref: ${{ steps.pr_props.outputs.ref }}
 
-      # Detect dangerous changes in external PR
-      - name: Check for dangerous changes in PR
+      # Get info about other changes.
+      - name: Get info about PR changes
         uses: dorny/paths-filter@v2
-        if: steps.pr_props.outputs.should_check == 'true'
-        id: dangerous_changes
+        id: changes
         with:
           token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          # dangerous - detect if changes not allowed to test for external PRs
+          # docs - detect changes in files that belong to the documentation scope
+          # not_markdown - detect changes not in markdown files
           filters: |
             dangerous:
               - './.github/**'
@@ -230,16 +232,6 @@ jobs:
               - './docs/**/css/**'
               - './docs/**/images/**'
               - './docs/**/assets/**'
-
-      # Get info about other changes.
-      - name: Get info about PR changes
-        uses: dorny/paths-filter@v2
-        id: changes
-        with:
-          token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
-          # docs - detect changes in files that belong to the documentation scope
-          # not_markdown - detect changes not in markdown files
-          filters: |
             docs:
               - './**/*.md'
               - './docs/**'
@@ -252,7 +244,7 @@ jobs:
 
       # Stop workflow if external PR contains dangerous changes.
       - name: Fail workflow on dangerous changes
-        if: steps.dangerous_changes.outputs.dangerous == 'true'
+        if: ${{ steps.pr_props.outputs.should_check == 'true' && steps.changes.outputs.dangerous == 'true' }}
         uses: actions/github-script@v5.0.0
         with:
           script: |

--- a/.github/workflows/on-pull-request-labeled.yml
+++ b/.github/workflows/on-pull-request-labeled.yml
@@ -196,13 +196,15 @@ jobs:
         with:
           ref: ${{ steps.pr_props.outputs.ref }}
 
-      # Detect dangerous changes in external PR
-      - name: Check for dangerous changes in PR
+      # Get info about other changes.
+      - name: Get info about PR changes
         uses: dorny/paths-filter@v2
-        if: steps.pr_props.outputs.should_check == 'true'
-        id: dangerous_changes
+        id: changes
         with:
           token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          # dangerous - detect if changes not allowed to test for external PRs
+          # docs - detect changes in files that belong to the documentation scope
+          # not_markdown - detect changes not in markdown files
           filters: |
             dangerous:
               - './.github/**'
@@ -212,16 +214,6 @@ jobs:
               - './docs/**/css/**'
               - './docs/**/images/**'
               - './docs/**/assets/**'
-
-      # Get info about other changes.
-      - name: Get info about PR changes
-        uses: dorny/paths-filter@v2
-        id: changes
-        with:
-          token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
-          # docs - detect changes in files that belong to the documentation scope
-          # not_markdown - detect changes not in markdown files
-          filters: |
             docs:
               - './**/*.md'
               - './docs/**'
@@ -234,7 +226,7 @@ jobs:
 
       # Stop workflow if external PR contains dangerous changes.
       - name: Fail workflow on dangerous changes
-        if: steps.dangerous_changes.outputs.dangerous == 'true'
+        if: ${{ steps.pr_props.outputs.should_check == 'true' && steps.changes.outputs.dangerous == 'true' }}
         uses: actions/github-script@v5.0.0
         with:
           script: |

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -238,13 +238,15 @@ jobs:
         with:
           ref: ${{ steps.pr_props.outputs.ref }}
 
-      # Detect dangerous changes in external PR
-      - name: Check for dangerous changes in PR
+      # Get info about other changes.
+      - name: Get info about PR changes
         uses: dorny/paths-filter@v2
-        if: steps.pr_props.outputs.should_check == 'true'
-        id: dangerous_changes
+        id: changes
         with:
           token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+          # dangerous - detect if changes not allowed to test for external PRs
+          # docs - detect changes in files that belong to the documentation scope
+          # not_markdown - detect changes not in markdown files
           filters: |
             dangerous:
               - './.github/**'
@@ -254,16 +256,6 @@ jobs:
               - './docs/**/css/**'
               - './docs/**/images/**'
               - './docs/**/assets/**'
-
-      # Get info about other changes.
-      - name: Get info about PR changes
-        uses: dorny/paths-filter@v2
-        id: changes
-        with:
-          token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
-          # docs - detect changes in files that belong to the documentation scope
-          # not_markdown - detect changes not in markdown files
-          filters: |
             docs:
               - './**/*.md'
               - './docs/**'
@@ -276,7 +268,7 @@ jobs:
 
       # Stop workflow if external PR contains dangerous changes.
       - name: Fail workflow on dangerous changes
-        if: steps.dangerous_changes.outputs.dangerous == 'true'
+        if: ${{ steps.pr_props.outputs.should_check == 'true' && steps.changes.outputs.dangerous == 'true' }}
         uses: actions/github-script@v5.0.0
         with:
           script: |


### PR DESCRIPTION
Signed-off-by: Ivan Mikheykin <ivan.mikheykin@flant.com>

## Description

Run render-workflows after #2142 
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Files in workflows directory should be rendered from workflows_templates.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

Running render-workflows.sh in main branch should tell `Render success. No changes.`
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: chore
summary: render workflows
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
