### PR TITLE
[candi][monitoring-kubernetes] Bugfixes

### DIFF
--- a/candi/bashible/common-steps/node-group/069_start_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/069_start_kubelet.sh.tpl
@@ -95,7 +95,7 @@ if bb-flag? kubelet-need-restart; then
 fi
 
 {{- if ne .runType "ImageBuilding" }}
-if ! [ systemctl is-active --quiet "kubelet.service" ] && ! [ bb-flag? reboot ]; then
+if ! systemctl is-active --quiet "kubelet.service" && ! bb-flag? reboot; then
   bb-log-warning "Kubelet service is not running. Start it..."
   if systemctl start "kubelet.service"; then
     bb-log-info "Kubelet has started."

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node.yaml
@@ -95,7 +95,7 @@
         Probably, this is due to the maintenance of this Node.
 
   - alert: NodeSUnreclaimBytesUsageHigh
-    expr: predict_linear(node_memory_SUnreclaim_bytes[2h], 43200) > node_memory_MemTotal_bytes * 0.3
+    expr: predict_linear(node_memory_SUnreclaim_bytes[2h], 43200) > node_memory_MemTotal_bytes * 0.25
     for: 20m
     labels:
       severity_level: "4"


### PR DESCRIPTION
Signed-off-by: Konstantin Aksenov <konstantin.aksenov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- Fix bash for start kubelet step
- Decrease threshold of NodeSUnreclaimBytesUsageHigh alert

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
- FIxes bash error 
```
test.sh: line 4: [: too many arguments
test.sh: line 4: [: bb-flag?: unary operator expected
```
- Alert should fire earlier. The previous threshold looks too high for small control-plane nodes with 8 GB RAM.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: Fix bash for start kubelet step
impact_level: default
```

```changes
section: monitoring-kubernetes
type: fix
summary: Decrease threshold of NodeSUnreclaimBytesUsageHigh alert
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
