### PR TITLE
[bashible] Forbid use docker.io package

### DIFF
--- a/candi/bashible/bundles/debian/node-group/031_install_docker.sh.tpl
+++ b/candi/bashible/bundles/debian/node-group/031_install_docker.sh.tpl
@@ -37,10 +37,42 @@ post-install() {
  fi
 }
 
-# TODO: remove ASAP, provide proper migration from "docker.io" to "docker-ce"
+# TODO: remove after 1.35 release
 if bb-apt-package? docker.io ; then
-  bb-log-warning 'Skipping "docker-ce" installation, since "docker.io" is already installed'
-  exit 0
+  bb-log-warning '"docker.io" an "containerd" packages should remove and install "docker-ce" and it's desired "containerd" version'
+
+  # copy-pasted from 031_install_containerd.sh.tpl with logs adding
+  bb-deckhouse-get-disruptive-update-approval
+  if systemctl is-active -q kubelet.service; then
+    bb-log-info "Stop kubelet"
+    systemctl stop kubelet.service
+  fi
+
+  # Stop docker containers if they run
+  bb-log-info "Stop docker containers if they run"
+  docker stop $(docker ps -q) || true
+  systemctl stop docker.service
+  systemctl stop containerd.service
+
+  # Kill running containerd-shim processes
+  bb-log-info "Kill running containerd-shim processes"
+  kill $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}') 2>/dev/null || true
+
+  # Remove mounts
+  bb-log-info "Remove mounts"
+  umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true
+
+  bb-log-info "Remove packages"
+  bb-rp-remove docker-ce containerd-io
+  bb-apt-remove docker.io docker-ce containerd-io
+
+  bb-log-info "Remove files and directories"
+  rm -rf /var/lib/docker/ /var/run/docker.sock /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
+  # Pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
+  rm -rf /var/run/containerd /usr/local/bin/crictl
+
+  bb-log-info "Setting reboot flag due to cri being updated"
+  bb-flag-set reboot
 fi
 
 if bb-apt-package? containerd.io && ! bb-apt-package? docker-ce ; then

--- a/candi/bashible/bundles/debian/node-group/031_install_docker.sh.tpl
+++ b/candi/bashible/bundles/debian/node-group/031_install_docker.sh.tpl
@@ -39,7 +39,7 @@ post-install() {
 
 # TODO: remove after 1.35 release
 if bb-apt-package? docker.io ; then
-  bb-log-warning '"docker.io" an "containerd" packages should remove and install "docker-ce" and it's desired "containerd" version'
+  bb-log-warning '"docker.io" an "containerd" packages should remove and install "docker-ce" and it desired "containerd" version'
 
   # copy-pasted from 031_install_containerd.sh.tpl with logs adding
   bb-deckhouse-get-disruptive-update-approval

--- a/candi/bashible/bundles/ubuntu-lts/node-group/031_install_docker.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/node-group/031_install_docker.sh.tpl
@@ -42,8 +42,39 @@ post-install() {
 
 # TODO: remove ASAP, provide proper migration from "docker.io" to "docker-ce"
 if bb-apt-package? docker.io ; then
-  bb-log-warning 'Skipping "docker-ce" installation, since "docker.io" is already installed'
-  exit 0
+  bb-log-warning '"docker.io" an "containerd" packages should remove and install "docker-ce" and it's desired "containerd" version'
+
+  # copy-pasted from 031_install_containerd.sh.tpl with logs adding
+  bb-deckhouse-get-disruptive-update-approval
+  if systemctl is-active -q kubelet.service; then
+    bb-log-info "Stop kubelet"
+    systemctl stop kubelet.service
+  fi
+
+  # Stop docker containers if they run
+  bb-log-info "Stop docker containers if they run"
+  docker stop $(docker ps -q) || true
+  systemctl stop docker.service
+  systemctl stop containerd.service
+
+  # Kill running containerd-shim processes
+  bb-log-info "Kill running containerd-shim processes"
+  kill $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}') 2>/dev/null || true
+
+  # Remove mounts
+  bb-log-info "Remove mounts"
+  umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true
+  bb-log-info "Remove packages"
+  bb-rp-remove docker-ce containerd-io
+  bb-apt-remove docker.io docker-ce containerd-io
+
+  bb-log-info "Remove files and directories"
+  rm -rf /var/lib/docker/ /var/run/docker.sock /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
+  # Pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
+  rm -rf /var/run/containerd /usr/local/bin/crictl
+
+  bb-log-info "Setting reboot flag due to cri being updated"
+  bb-flag-set reboot
 fi
 
 if bb-apt-package? containerd.io && ! bb-apt-package? docker-ce ; then

--- a/candi/bashible/bundles/ubuntu-lts/node-group/031_install_docker.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/node-group/031_install_docker.sh.tpl
@@ -42,7 +42,7 @@ post-install() {
 
 # TODO: remove ASAP, provide proper migration from "docker.io" to "docker-ce"
 if bb-apt-package? docker.io ; then
-  bb-log-warning '"docker.io" an "containerd" packages should remove and install "docker-ce" and it's desired "containerd" version'
+  bb-log-warning '"docker.io" an "containerd" packages should remove and install "docker-ce" and its desired "containerd" version'
 
   # copy-pasted from 031_install_containerd.sh.tpl with logs adding
   bb-deckhouse-get-disruptive-update-approval


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Forbid use `docker.io` package. We always should use `docker-ce` package.
See also #2134 

## Why do we need it, and what problem does it solve?
If node has `docker.io` package bashible will stuck waiting for approve disruptive update. 

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: bashible
type: feature
summary: Forbid use docker.io package
impact: After upgrading Deckhouse all nodes with installed docker.io package will request `disruptive update`. You will receive `NodeRequiresDisruptionApprovalForUpdate` if you have manual `approvalMode` in NodeGroup.
impact_level: hight
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
