### PR TITLE
[cloud-provider-yandex] Fix defaults for diskType and platformID

### DIFF
--- a/candi/cloud-providers/yandex/openapi/instance_class.yaml
+++ b/candi/cloud-providers/yandex/openapi/instance_class.yaml
@@ -176,7 +176,7 @@ spec:
                 platformID:
                   description: |
                     Paltform ID. [List of available platforms...](https://cloud.yandex.com/en-ru/docs/compute/concepts/vm-platforms)
-                  x-doc-default: standard-v2
+                  x-doc-default: standard-v3
                   type: string
                 preemptible:
                   description: |

--- a/candi/cloud-providers/yandex/openapi/instance_class.yaml
+++ b/candi/cloud-providers/yandex/openapi/instance_class.yaml
@@ -71,7 +71,7 @@ spec:
                   description: |
                     Instance [disk type](https://cloud.yandex.com/en-ru/docs/compute/concepts/disk#disks_types).
                   example: "network-hdd"
-                  x-doc-default: "network-ssd"
+                  x-doc-default: "network-hdd"
                   type: string
                   enum:
                   - "network-ssd"

--- a/modules/030-cloud-provider-yandex/cloud-instance-manager/machine-class.yaml
+++ b/modules/030-cloud-provider-yandex/cloud-instance-manager/machine-class.yaml
@@ -15,7 +15,7 @@ spec:
     gpus: {{ .nodeGroup.instanceClass.gpus | default 0 }}
   bootDiskSpec:
     autoDelete: true
-    typeID: {{ .nodeGroup.instanceClass.diskType }}
+    typeID: {{ .nodeGroup.instanceClass.diskType | default "network-hdd" }}
     size: {{ mul (.nodeGroup.instanceClass.diskSizeGB | default 50) 1024 1024 1024 }}
     imageID: {{ .nodeGroup.instanceClass.imageID | default .Values.nodeManager.internal.cloudProvider.yandex.instanceClassDefaults.imageID }}
   networkInterfaceSpecs:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- Fix docs for platformID, real default is `standard-v3`
- Explicitly set default in YandexMachineClass and fix docs

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Real defaults differ from described in docs.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Machine-controller-manager don't roll out machines in Yandex cloud after release.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-yandex
type: fix
summary: Fix defaults for diskType and platformID
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
