### PR TITLE
[istio] Data plane versions monitoring refactoring

### DIFF
--- a/ee/modules/110-istio/hooks/revisions_monitoring.go
+++ b/ee/modules/110-istio/hooks/revisions_monitoring.go
@@ -169,6 +169,15 @@ func revisionsMonitoring(input *go_hook.HookInput, dc dependency.Container) erro
 			}
 		}
 
+		// TODO: get rid of everything but this only metric https://github.com/deckhouse/deckhouse/issues/2182
+		labels := map[string]string{
+			"namespace":        istioPod.GetNamespace(),
+			"dataplane_pod":    istioPod.GetName(),
+			"desired_revision": desiredRevision,
+			"revision":         istioPod.getIstioRevision(),
+		}
+		input.MetricsCollector.Set("d8_istio_pod_revision", 1, labels, metrics.WithGroup(revisionsMonitoringMetricsGroup))
+
 		if !internal.Contains(revisionsToInstall, desiredRevision) {
 			// ALARM! Desired revision isn't configured to install
 			labels := map[string]string{

--- a/ee/modules/110-istio/hooks/revisions_monitoring_test.go
+++ b/ee/modules/110-istio/hooks/revisions_monitoring_test.go
@@ -315,7 +315,7 @@ spec:
 			Expect(string(f.LogrusOutput.Contents())).To(HaveLen(0))
 
 			m := f.MetricsCollector.CollectedMetrics()
-			Expect(m).To(HaveLen(7))
+			Expect(m).To(HaveLen(16))
 			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
 				Group:  revisionsMonitoringMetricsGroup,
 				Action: "expire",
@@ -331,6 +331,30 @@ spec:
 				},
 			}))
 			Expect(m[2]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_istio_pod_revision",
+				Group:  revisionsMonitoringMetricsGroup,
+				Action: "set",
+				Value:  pointer.Float64Ptr(1.0),
+				Labels: map[string]string{
+					"namespace":        "ns-global",
+					"dataplane_pod":    "pod-global-revision-actual",
+					"desired_revision": "v1x42",
+					"revision":         "v1x42",
+				},
+			}))
+			Expect(m[3]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_istio_pod_revision",
+				Group:  revisionsMonitoringMetricsGroup,
+				Action: "set",
+				Value:  pointer.Float64Ptr(1.0),
+				Labels: map[string]string{
+					"desired_revision": "v1x42",
+					"revision":         "v1x15",
+					"namespace":        "ns-global",
+					"dataplane_pod":    "pod-global-revision-not-actual",
+				},
+			}))
+			Expect(m[4]).To(BeEquivalentTo(operation.MetricOperation{
 				Name:   "d8_istio_actual_data_plane_revision_ne_desired",
 				Group:  revisionsMonitoringMetricsGroup,
 				Action: "set",
@@ -341,7 +365,31 @@ spec:
 					"desired_revision": "v1x42",
 				},
 			}))
-			Expect(m[3]).To(BeEquivalentTo(operation.MetricOperation{
+			Expect(m[5]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_istio_pod_revision",
+				Group:  revisionsMonitoringMetricsGroup,
+				Action: "set",
+				Value:  pointer.Float64Ptr(1.0),
+				Labels: map[string]string{
+					"desired_revision": "v1x42",
+					"revision":         "v1x42",
+					"namespace":        "ns-global",
+					"dataplane_pod":    "pod-minor-version-is-actual",
+				},
+			}))
+			Expect(m[6]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_istio_pod_revision",
+				Group:  revisionsMonitoringMetricsGroup,
+				Action: "set",
+				Value:  pointer.Float64Ptr(1.0),
+				Labels: map[string]string{
+					"desired_revision": "v1x42",
+					"revision":         "v1x42",
+					"namespace":        "ns-global",
+					"dataplane_pod":    "pod-minor-version-mismatch",
+				},
+			}))
+			Expect(m[7]).To(BeEquivalentTo(operation.MetricOperation{
 				Name:   "d8_istio_data_plane_patch_version_mismatch",
 				Group:  revisionsMonitoringMetricsGroup,
 				Action: "set",
@@ -353,7 +401,31 @@ spec:
 					"namespace":                 "ns-global",
 				},
 			}))
-			Expect(m[4]).To(BeEquivalentTo(operation.MetricOperation{
+			Expect(m[8]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_istio_pod_revision",
+				Group:  revisionsMonitoringMetricsGroup,
+				Action: "set",
+				Value:  pointer.Float64Ptr(1.0),
+				Labels: map[string]string{
+					"namespace":        "ns-nodesired",
+					"dataplane_pod":    "pod-definite-revision-installed",
+					"desired_revision": "v1x15",
+					"revision":         "v1x15",
+				},
+			}))
+			Expect(m[9]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_istio_pod_revision",
+				Group:  revisionsMonitoringMetricsGroup,
+				Action: "set",
+				Value:  pointer.Float64Ptr(1.0),
+				Labels: map[string]string{
+					"namespace":        "ns-nodesired",
+					"dataplane_pod":    "pod-definite-revision-not-installed",
+					"desired_revision": "v1xexotic",
+					"revision":         "unknown",
+				},
+			}))
+			Expect(m[10]).To(BeEquivalentTo(operation.MetricOperation{
 				Name:   "d8_istio_desired_revision_is_not_installed",
 				Group:  revisionsMonitoringMetricsGroup,
 				Action: "set",
@@ -363,7 +435,7 @@ spec:
 					"namespace":        "ns-nodesired",
 				},
 			}))
-			Expect(m[5]).To(BeEquivalentTo(operation.MetricOperation{
+			Expect(m[11]).To(BeEquivalentTo(operation.MetricOperation{
 				Name:   "d8_istio_data_plane_without_desired_revision",
 				Group:  revisionsMonitoringMetricsGroup,
 				Action: "set",
@@ -373,7 +445,31 @@ spec:
 					"namespace":       "ns-nodesired",
 				},
 			}))
-			Expect(m[6]).To(BeEquivalentTo(operation.MetricOperation{
+			Expect(m[12]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_istio_pod_revision",
+				Group:  revisionsMonitoringMetricsGroup,
+				Action: "set",
+				Value:  pointer.Float64Ptr(1.0),
+				Labels: map[string]string{
+					"dataplane_pod":    "pod-definite-ns-revision-actual",
+					"desired_revision": "v1x15",
+					"revision":         "v1x15",
+					"namespace":        "ns-rev1x15",
+				},
+			}))
+			Expect(m[13]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_istio_pod_revision",
+				Group:  revisionsMonitoringMetricsGroup,
+				Action: "set",
+				Value:  pointer.Float64Ptr(1.0),
+				Labels: map[string]string{
+					"desired_revision": "v1x15",
+					"revision":         "v1x42",
+					"namespace":        "ns-rev1x15",
+					"dataplane_pod":    "pod-definite-ns-revision-not-actual",
+				},
+			}))
+			Expect(m[14]).To(BeEquivalentTo(operation.MetricOperation{
 				Name:   "d8_istio_actual_data_plane_revision_ne_desired",
 				Group:  revisionsMonitoringMetricsGroup,
 				Action: "set",
@@ -382,6 +478,18 @@ spec:
 					"actual_revision":  "v1x42",
 					"desired_revision": "v1x15",
 					"namespace":        "ns-rev1x15",
+				},
+			}))
+			Expect(m[15]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_istio_pod_revision",
+				Group:  revisionsMonitoringMetricsGroup,
+				Action: "set",
+				Value:  pointer.Float64Ptr(1.0),
+				Labels: map[string]string{
+					"namespace":        "ns-v1x10x1",
+					"dataplane_pod":    "pod-regular-v1x10x1",
+					"desired_revision": "v1x10x1",
+					"revision":         "v1x10x1",
 				},
 			}))
 		})

--- a/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
@@ -69,8 +69,36 @@
         ### pod-wide configuration
         kubectl -n {{$labels.namespace}} get pods -l istio.io/rev={{$labels.desired_revision}}
         ```
-  - alert: D8IstioDataPlanePatchVersionMismatch
-    expr: max by (namespace, revision, actual_sidecar_image_tag) (d8_istio_data_plane_patch_version_mismatch == 1)
+  - alert: D8IstioDataPlaneVersionMismatch
+    expr: |
+      ( # join d8_istio_pod_revision and istio_build metrics to get every Pod's istio version
+        max by (namespace, pod, revision, tag)
+        (
+          label_replace(
+            d8_istio_pod_revision, "pod", "$1", "dataplane_pod", "(.+)"
+          )
+          + on (pod) group_left (tag) istio_build{component="proxy"}
+        )
+      )
+      # enrich the metric above with control-plane istio version (will come in handy for the alert description)
+      + on (revision) group_left (istiod_tag)
+      (
+        max by (istiod_tag, revision)
+        ( # get istiod revision from Pod's label `istio.io/rev`
+          label_replace(
+            istio_build{component="pilot"}, "istiod_tag", "$1", "tag", "(.+)"
+          )
+          + on (pod) group_left(revision)
+          (
+            label_replace(kube_pod_labels, "revision", "$1", "label_istio_io_rev", "(.+)")
+          )
+        )
+      )
+      # exclude Pod's with an actual istio version, so only the inappropriate ones left
+      unless on (tag)
+      (
+        istio_build{component="pilot"}
+      )
     for: 5m
     labels:
       severity_level: "8"
@@ -80,10 +108,10 @@
       plk_protocol_version: "1"
       plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
       plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      summary: There are Pods with data-plane patch versions different from control-plane one.
+      summary: There are Pods with data-plane version different from control-plane one.
       description: |
-        There are Pods in `{{$labels.namespace}}` Namespace with data-plane patch versions different from control-plane one. Consider restarting the Pods to actualize it.
-        Getting affected Pods:
+        There are Pods in `{{$labels.namespace}}` namespace with istio revision `{{$labels.revision}}` and data-plane version `{{$labels.tag}}` which differ from control-plane one `{{$labels.istiod_tag}}`.
+        Consider restarting affected Pods, use PromQL query to get the list:
         ```
-        kubectl -n {{$labels.namespace}} get pods -o json | jq -r --arg tag "{{$labels.actual_sidecar_image_tag}}" '.items[] | select(.spec.containers[] | select(.image | endswith(":" + $tag))) | .metadata.name'
+        max by (namespace, pod) (istio_build{component="proxy", tag="{{$labels.tag}}"})
         ```


### PR DESCRIPTION
## Description
Data plane versions monitoring refactoring. 

## Why do we need it, and what problem does it solve?
Fixes https://github.com/deckhouse/deckhouse/issues/2049.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: istio
type: feature
summary: Data plane versions monitoring refactoring. 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
