### PR TITLE
[ingress-nginx] add validation for controller version

### DIFF
--- a/modules/402-ingress-nginx/webhooks/validating/ingressnginxcontroller
+++ b/modules/402-ingress-nginx/webhooks/validating/ingressnginxcontroller
@@ -91,12 +91,14 @@ function __main__() {
   # // End check controller versions
 
   # Only ingress controller >= 1.1 is allowed for kubernetes >= 1.22
-  if semver::lt "$ctrlVersion" "1.0.0"; then
-      k8sVersion=$(kubectl version --short -o json | jq -r '.serverVersion.gitVersion' | sed 's/v//')
-      if semver::ge "$k8sVersion" "1.22.0"; then
-        forbid "only IngressNginxController 1.1 is allowed for k8s >= 1.22"
-        exit 0
-      fi
+  if context::jq -e -r '.review.request.operation == "CREATE"' >/dev/null 2>&1; then
+    if semver::lt "$ctrlVersion" "1.0.0"; then
+        k8sVersion=$(kubectl version --short -o json | jq -r '.serverVersion.gitVersion' | sed 's/v//')
+        if semver::ge "$k8sVersion" "1.22.0"; then
+          forbid "only IngressNginxController 1.1 is allowed for k8s >= 1.22"
+          exit 0
+        fi
+    fi
   fi
 
   # Allowed response.

--- a/modules/402-ingress-nginx/webhooks/validating/ingressnginxcontroller
+++ b/modules/402-ingress-nginx/webhooks/validating/ingressnginxcontroller
@@ -90,6 +90,15 @@ function __main__() {
   done < <(kubectl get ingressnginxcontrollers.deckhouse.io -o json | jq --arg class $ctrlClass --arg name $ctrlName -cr '.items[] | select(.spec.ingressClass == $class and .metadata.name != $name) | .spec.controllerVersion // 0.33')
   # // End check controller versions
 
+  # Only ingress controller >= 1.1 is allowed for kubernetes >= 1.22
+  if semver::lt "$ctrlVersion" "1.0.0"; then
+      k8sVersion=$(kubectl version --short -o json | jq '.serverVersion.gitVersion')
+      if semver::ge "$k8sVersion" "1.22.0"; then
+        forbid "only IngressNginxController 1.1 is allowed for k8s >= 1.22"
+        exit 0
+      fi
+  fi
+
   # Allowed response.
   jq -nc '{"allowed": true}' > $VALIDATING_RESPONSE_PATH
 }

--- a/modules/402-ingress-nginx/webhooks/validating/ingressnginxcontroller
+++ b/modules/402-ingress-nginx/webhooks/validating/ingressnginxcontroller
@@ -92,7 +92,7 @@ function __main__() {
 
   # Only ingress controller >= 1.1 is allowed for kubernetes >= 1.22
   if semver::lt "$ctrlVersion" "1.0.0"; then
-      k8sVersion=$(kubectl version --short -o json | jq '.serverVersion.gitVersion')
+      k8sVersion=$(kubectl version --short -o json | jq -r '.serverVersion.gitVersion' | sed 's/v//')
       if semver::ge "$k8sVersion" "1.22.0"; then
         forbid "only IngressNginxController 1.1 is allowed for k8s >= 1.22"
         exit 0


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Add validation webhook

## Why do we need it, and what problem does it solve?
Ingress controllers < 1.1 are forbidden for k8s >= 1.22. We have to notify users about it and deny creation of such controllers

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ingress-nginx
type: feature
summary: Validate ingress controllers compatibility with k8s version
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
