### PR TITLE
[docs][deckhouse] Move section about collecting debug information to the FAQ

### DIFF
--- a/modules/020-deckhouse/docs/FAQ.md
+++ b/modules/020-deckhouse/docs/FAQ.md
@@ -29,3 +29,33 @@ Then you can check report:
 ```shell
 kubectl logs job.batch/kube-bench
 ```
+
+## How to collect debug info?
+
+We always appreciate helping users with debugging complex issues. Please follow these steps so that we can help you:
+
+1. Collect all the necessary information by running the following command:
+
+   ```sh
+   kubectl -n d8-system exec deploy/deckhouse \
+     -- deckhouse-controller collect-debug-info \
+     > deckhouse-debug-$(date +"%Y_%m_%d").tar.gz
+   ```
+
+2. Send the archive to the [Deckhouse team](https://github.com/deckhouse/deckhouse/issues/new/choose) for further debugging.
+
+Data that will be collected:
+* Deckhouse queue state
+* global Deckhouse values (without any sensitive data)
+* enabled modules list
+* controllers and pods manifests from namespaces owned by Deckhouse
+* `nodes` state
+* `nodegroups` state
+* `machines` state
+* all `deckhousereleases` objects
+* `events` from all namespaces
+* Deckhouse logs
+* machine controller manager logs
+* cloud controller manager logs
+* all firing alerts from Prometheus
+* terraform-state-exporter metrics

--- a/modules/020-deckhouse/docs/FAQ_RU.md
+++ b/modules/020-deckhouse/docs/FAQ_RU.md
@@ -29,3 +29,33 @@ kubectl -n d8-system exec -ti deploy/deckhouse -- bash
 ```shell
 kubectl logs job.batch/kube-bench
 ```
+
+## Как собрать информацию для отладки?
+
+Мы всегда рады помочь пользователям с расследованием сложных проблем. Пожалуйста, выполните следующие шаги, чтобы мы смогли вам помочь:
+
+1. Выполните следующую команду, чтобы собрать необходимые данные:
+
+   ```sh
+   kubectl -n d8-system exec deploy/deckhouse \
+     -- deckhouse-controller collect-debug-info \
+     > deckhouse-debug-$(date +"%Y_%m_%d").tar.gz
+   ```
+
+2. Отправьте получившийся архив [команде Deckhouse](https://github.com/deckhouse/deckhouse/issues/new/choose) для дальнейшего расследования.
+
+Данные, которые будут собраны:
+* состояние очереди Deckhouse
+* Deckhouse values (без каких-либо конфиденциальных данных)
+* список включенных модулей
+* манифесты controller'ов и pod'ов manifests из всех пространств имен Deckhouse
+* состояние `nodes`
+* состояние `nodegroups`
+* состояние `machines`
+* все объекты `deckhousereleases`
+* `events` из всех пространств имен
+* логи Deckhouse
+* логи machine controller manager
+* логи cloud controller manager
+* все горящие уведомления в Prometheus
+* метрики terraform-state-exporter

--- a/modules/020-deckhouse/docs/USAGE.md
+++ b/modules/020-deckhouse/docs/USAGE.md
@@ -96,30 +96,4 @@ kubectl annotate DeckhouseRelease v1-36-0 release.deckhouse.io/disruption-approv
 
 ## Collect debug info
 
-We always appreciate helping users with debugging complex issues. Please follow these steps so that we can help you:
-
-1. Collect all the necessary information by running the following command:
-
-   ```sh
-   kubectl -n d8-system exec deploy/deckhouse \
-     -- deckhouse-controller collect-debug-info \
-     > deckhouse-debug-$(date +"%Y_%m_%d").tar.gz
-   ```
-
-2. Send the archive to the [Deckhouse team](https://github.com/deckhouse/deckhouse/issues/new/choose) for further debugging.
-
-Data that will be collected:
-* Deckhouse queue state
-* global Deckhouse values (without any sensitive data)
-* enabled modules list
-* controllers and pods manifests from namespaces owned by Deckhouse
-* `nodes` state
-* `nodegroups` state
-* `machines` state
-* all `deckhousereleases` objects
-* `events` from all namespaces
-* Deckhouse logs
-* machine controller manager logs
-* cloud controller manager logs
-* all firing alerts from Prometheus
-* terraform-state-exporter metrics
+Read [the FAQ](faq.html#how-to-collect-debug-info) to learn more about collecting debug information.

--- a/modules/020-deckhouse/docs/USAGE_RU.md
+++ b/modules/020-deckhouse/docs/USAGE_RU.md
@@ -96,30 +96,4 @@ kubectl annotate DeckhouseRelease v1-36-0 release.deckhouse.io/disruption-approv
 
 ## Сбор информации для отладки
 
-Мы всегда рады помочь пользователям с расследованием сложных проблем. Пожалуйста, выполните следующие шаги, чтобы мы смогли вам помочь:
-
-1. Выполните следующую команду, чтобы собрать необходимые данные:
-
-   ```sh
-   kubectl -n d8-system exec deploy/deckhouse \
-     -- deckhouse-controller collect-debug-info \
-     > deckhouse-debug-$(date +"%Y_%m_%d").tar.gz
-   ```
-
-2. Отправьте получившийся архив [команде Deckhouse](https://github.com/deckhouse/deckhouse/issues/new/choose) для дальнейшего расследования.
-
-Данные, которые будут собраны:
-* состояние очереди Deckhouse
-* Deckhouse values (без каких-либо конфиденциальных данных)
-* список включенных модулей
-* манифесты controller'ов и pod'ов manifests из всех пространств имен Deckhouse
-* состояние `nodes`
-* состояние `nodegroups`
-* состояние `machines`
-* все объекты `deckhousereleases`
-* `events` из всех пространств имен
-* логи Deckhouse
-* логи machine controller manager
-* логи cloud controller manager
-* все горящие уведомления в Prometheus
-* метрики terraform-state-exporter
+О сборе отладочной информации читайте [в FAQ](faq.html#как-собрать-информацию-для-отладки).


### PR DESCRIPTION
## Description

Moves section about collecting debug information to the FAQ.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: deckhouse
type: fix
summary: Move section about collecting debug information to the FAQ
impact_level: low
```
