### PR TITLE
remove bashible apiserver

### DIFF
--- a/modules/040-node-manager/hooks/remove_bashible_apiserver.go
+++ b/modules/040-node-manager/hooks/remove_bashible_apiserver.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 Flant JSC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+)
+
+// this hook is needed only for release 1.34.12
+// after that release bashible-apiserver is updated and works without this
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/node-manager/remove_bashible_apiserver",
+	OnBeforeHelm: &go_hook.OrderedConfig{
+		Order: 5,
+	},
+}, removeBashibleHandler)
+
+func removeBashibleHandler(input *go_hook.HookInput) error {
+	input.PatchCollector.Delete("apps/v1", "Deployment", "d8-cloud-instance-manager", "bashible-apiserver")
+
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Delete old bashible-apiserver deployment

## Why do we need it, and what problem does it solve?
Release 1.34.12 contains fixed bashible-apiserver but before it we have to remove old deployment to avoid context race

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Remove bashible-apiserver deployment to avoid race condition
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
