### PR TITLE
[node-manager] Bashbile apiserver migration

### DIFF
--- a/canary.json
+++ b/canary.json
@@ -1,7 +1,7 @@
 {
   "alpha": {"enabled": true, "waves": 2, "interval": "5m"},
   "beta": {"enabled": false, "waves": 1, "interval": "1m"},
-  "early-access": {"enabled": true, "waves": 6, "interval": "30m"},
+  "early-access": {"enabled": true, "waves": 3, "interval": "5m"},
   "stable": {"enabled": true, "waves": 6, "interval": "30m"},
   "rock-solid": {"enabled": false, "waves": 5, "interval": "5m"}
 }

--- a/modules/040-node-manager/hooks/remove_bashible_apiserver.go
+++ b/modules/040-node-manager/hooks/remove_bashible_apiserver.go
@@ -16,6 +16,10 @@ package hooks
 import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
 )
 
 // this hook is needed only for release 1.34.12
@@ -23,13 +27,66 @@ import (
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: "/modules/node-manager/remove_bashible_apiserver",
-	OnStartup: &go_hook.OrderedConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{
 		Order: 5,
+	},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "bashible-apiserver-remove",
+			ApiVersion: "apps/v1",
+			Kind:       "Deployment",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{bashibleNamespace},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{bashibleName},
+			},
+			ExecuteHookOnEvents: pointer.BoolPtr(false),
+			FilterFunc:          bashibleDeploymentFilter,
+		},
 	},
 }, removeBashibleHandler)
 
 func removeBashibleHandler(input *go_hook.HookInput) error {
-	input.PatchCollector.Delete("apps/v1", "Deployment", "d8-cloud-instance-manager", "bashible-apiserver")
+	snap := input.Snapshots["bashible-apiserver-remove"]
+	if len(snap) == 0 {
+		return nil
+	}
+
+	dep := snap[0].(migrateBashibleDeployment)
+
+	if dep.NeedReboot {
+		input.PatchCollector.Delete("apps/v1", "Deployment", dep.Namespace, dep.Name)
+	}
 
 	return nil
+}
+
+func bashibleDeploymentFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var dep v1.Deployment
+	err := sdk.FromUnstructured(obj, &dep)
+	if err != nil {
+		return nil, err
+	}
+
+	needReboot := true
+	if v, ok := dep.Annotations["node.deckhouse.io/migrated"]; ok {
+		if v == "1.34" {
+			needReboot = false
+		}
+	}
+
+	return migrateBashibleDeployment{
+		Namespace:  dep.Namespace,
+		Name:       dep.Name,
+		NeedReboot: needReboot,
+	}, nil
+}
+
+type migrateBashibleDeployment struct {
+	Namespace  string
+	Name       string
+	NeedReboot bool
 }

--- a/modules/040-node-manager/hooks/remove_bashible_apiserver.go
+++ b/modules/040-node-manager/hooks/remove_bashible_apiserver.go
@@ -23,7 +23,7 @@ import (
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: "/modules/node-manager/remove_bashible_apiserver",
-	OnBeforeHelm: &go_hook.OrderedConfig{
+	OnStartup: &go_hook.OrderedConfig{
 		Order: 5,
 	},
 }, removeBashibleHandler)

--- a/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
@@ -32,6 +32,8 @@ kind: Deployment
 metadata:
   name: "bashible-apiserver"
   namespace: d8-cloud-instance-manager
+  annotations:
+    node.deckhouse.io/migrated: "1.34"
   {{- include "helm_lib_module_labels" (list . (dict "app" "bashible-apiserver" "workload-resource-policy.deckhouse.io" "master")) | nindent 2 }}
 spec:
   {{- include "helm_lib_deployment_on_master_strategy_and_replicas_for_ha" . | nindent 2 }}


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Delete old bashible-apiserver deployment

## Why do we need it, and what problem does it solve?
Release 1.34.13 contains fixed bashible-apiserver but before it we have to remove old deployment to avoid context race

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Remove bashible-apiserver deployment to avoid race condition
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
