### PR TITLE
[dhctl] Fix `config render bashible-bundle` command and add `config render master-bootstrap-scripts` command

### DIFF
--- a/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
@@ -56,11 +56,6 @@ const cacheMessage = `Create cache %s:
 	If you want to continue, please delete the cache folder manually.
 `
 
-const (
-	versionMap     = "/deckhouse/candi/version_map.yml"
-	imagesTagsJSON = "/deckhouse/candi/images_tags.json"
-)
-
 func printBanner() {
 	log.InfoLn(banner)
 }
@@ -107,33 +102,6 @@ func generateClusterUUID(stateCache state.Cache) (string, error) {
 		return nil
 	})
 	return clusterUUID, err
-}
-
-func loadConfigFromFile(path string) (*config.MetaConfig, error) {
-	metaConfig, err := config.ParseConfig(path)
-	if err != nil {
-		return nil, err
-	}
-
-	if metaConfig.ClusterConfig == nil {
-		return nil, fmt.Errorf("ClusterConfiguration must be provided")
-	}
-
-	err = metaConfig.LoadVersionMap(versionMap)
-	if err != nil {
-		return nil, err
-	}
-
-	err = metaConfig.LoadImagesTags(imagesTagsJSON)
-	if err != nil {
-		return nil, err
-	}
-
-	if metaConfig.ClusterType == config.CloudClusterType && len(metaConfig.ProviderClusterConfig) == 0 {
-		return nil, fmt.Errorf("ProviderClusterConfiguration section is required for a Cloud cluster.")
-	}
-
-	return metaConfig, nil
 }
 
 func bootstrapAdditionalNodesForCloudCluster(kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, masterAddressesForSSH map[string]string) error {
@@ -193,7 +161,7 @@ func DefineBootstrapCommand(kpApp *kingpin.Application) *kingpin.CmdClause {
 		}
 
 		// first, parse and check cluster config
-		metaConfig, err := loadConfigFromFile(app.ConfigPath)
+		metaConfig, err := config.LoadConfigFromFile(app.ConfigPath)
 		if err != nil {
 			return err
 		}

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -90,6 +90,7 @@ func main() {
 		{
 			commands.DefineRenderBashibleBundle(renderCmd)
 			commands.DefineRenderKubeadmConfig(renderCmd)
+			commands.DefineRenderMasterBootstrap(renderCmd)
 		}
 
 		editCmd := configCmd.Command("edit", "Change configuration files in Kubernetes cluster conveniently and safely.")

--- a/dhctl/pkg/app/render.go
+++ b/dhctl/pkg/app/render.go
@@ -18,6 +18,7 @@ import "gopkg.in/alecthomas/kingpin.v2"
 
 var (
 	RenderBashibleBundleDir = ""
+	BundleName              = ""
 
 	ParseInputFile = ""
 	ParseOutput    = "json"
@@ -29,6 +30,13 @@ func DefineRenderConfigFlags(cmd *kingpin.CmdClause) {
 	cmd.Flag("bundle-dir", "Directory to render bashible bundle.").
 		Envar(configEnvName("BUNDLE_DIR")).
 		StringVar(&RenderBashibleBundleDir)
+}
+
+func DefineRenderBundleFlags(cmd *kingpin.CmdClause) {
+	cmd.Flag("bundle-name", "Bundle name for render bashible bundle.").
+		Envar(configEnvName("BUNDLE_NAME")).
+		Required().
+		StringVar(&BundleName)
 }
 
 func DefineEditorConfigFlags(cmd *kingpin.CmdClause) {

--- a/dhctl/pkg/config/base.go
+++ b/dhctl/pkg/config/base.go
@@ -36,6 +36,38 @@ const (
 	DefaultKubernetesVersion = "1.21"
 )
 
+const (
+	versionMap     = "/deckhouse/candi/version_map.yml"
+	imagesTagsJSON = "/deckhouse/candi/images_tags.json"
+)
+
+func LoadConfigFromFile(path string) (*MetaConfig, error) {
+	metaConfig, err := ParseConfig(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if metaConfig.ClusterConfig == nil {
+		return nil, fmt.Errorf("ClusterConfiguration must be provided")
+	}
+
+	err = metaConfig.LoadVersionMap(versionMap)
+	if err != nil {
+		return nil, err
+	}
+
+	err = metaConfig.LoadImagesTags(imagesTagsJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	if metaConfig.ClusterType == CloudClusterType && len(metaConfig.ProviderClusterConfig) == 0 {
+		return nil, fmt.Errorf("ProviderClusterConfiguration section is required for a Cloud cluster.")
+	}
+
+	return metaConfig, nil
+}
+
 func numerateManifestLines(manifest []byte) string {
 	manifestLines := strings.Split(string(manifest), "\n")
 	builder := strings.Builder{}


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Fix panic in `config render bashible-bundle`.
In some cases we need to render `bootstrap.sh` and `bootstrap-networks.sh` for debug. I added `config render master-bootstrap-scripts` command for it.
Move loading meta config from file func to config module. 

## Why do we need it, and what problem does it solve?
Panic when run command.

## What is the expected result?
N/A

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: fix
summary: Fix `config render bashible-bundle` command and add `config render master-bootstrap-scripts` command
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
