### PR TITLE
[upmeter] Tolerate errors in hook cleaning garbage

### DIFF
--- a/modules/500-upmeter/hooks/clean_probe_garbage.go
+++ b/modules/500-upmeter/hooks/clean_probe_garbage.go
@@ -36,6 +36,7 @@ import (
 // TODO (shvgn): Change this hook in Deckhouse v1.35, so it would track objects created by agents
 // that are not present anymore, e.g. when multi-master was changed to single-master.
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/upmeter/self_cleaning",
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "delete_probe_garbage",

--- a/modules/500-upmeter/hooks/clean_probe_garbage.go
+++ b/modules/500-upmeter/hooks/clean_probe_garbage.go
@@ -31,9 +31,10 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/dependency/k8s"
 )
 
-// migration: Delete redundant objects
+// This hook deletes abandoned objects produced by upmeter.
 //
-// TODO (shvgn): Delete this hook in Deckhouse v1.35
+// TODO (shvgn): Change this hook in Deckhouse v1.35, so it would track objects created by agents
+// that are not present anymore, e.g. when multi-master was changed to single-master.
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Schedule: []go_hook.ScheduleConfig{
 		{

--- a/modules/500-upmeter/hooks/clean_probe_garbage.go
+++ b/modules/500-upmeter/hooks/clean_probe_garbage.go
@@ -38,7 +38,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "delete_probe_garbage",
-			Crontab: "* * * * *",
+			Crontab: "*/15 * * * *",
 		},
 	},
 }, dependency.WithExternalDependencies(
@@ -58,9 +58,8 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 
 		for _, r := range repos {
 			if err := cleanGarbage(ctx, r); err != nil {
-				// The queue shouldn't be stopped if there is an error
+				// The queue shouldn't be stopped event if there is an API error
 				input.LogEntry.Warn(err)
-				return err
 			}
 		}
 

--- a/modules/500-upmeter/hooks/clean_probe_garbage.go
+++ b/modules/500-upmeter/hooks/clean_probe_garbage.go
@@ -38,7 +38,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "delete_probe_garbage",
-			Crontab: "*/15 * * * *",
+			Crontab: "*/2 * * * *",
 		},
 	},
 }, dependency.WithExternalDependencies(

--- a/modules/500-upmeter/hooks/clean_probe_garbage.go
+++ b/modules/500-upmeter/hooks/clean_probe_garbage.go
@@ -36,7 +36,7 @@ import (
 // TODO (shvgn): Change this hook in Deckhouse v1.35, so it would track objects created by agents
 // that are not present anymore, e.g. when multi-master was changed to single-master.
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	Queue: "/upmeter/self_cleaning",
+	Queue: "/modules/upmeter/self_cleaning",
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "delete_probe_garbage",

--- a/modules/500-upmeter/hooks/clean_probe_garbage.go
+++ b/modules/500-upmeter/hooks/clean_probe_garbage.go
@@ -38,7 +38,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "delete_probe_garbage",
-			Crontab: "*/2 * * * *",
+			Crontab: "* * * * *",
 		},
 	},
 }, dependency.WithExternalDependencies(
@@ -60,6 +60,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			if err := cleanGarbage(ctx, r); err != nil {
 				// The queue shouldn't be stopped if there is an error
 				input.LogEntry.Warn(err)
+				return err
 			}
 		}
 


### PR DESCRIPTION
## Description

The hook can stuck main queue because of missing CRDs, e.g. `certifiates.cert-manager.io`. The PR make the hook tolerate API errors and report them with warning.

## Why do we need it, and what problem does it solve?

Avoids stucking queues in clusters where cert-manager module is off.

## What is the expected result?

The main queue will not stuck

## Changelog entries

```changes
section: upmeter
type: fix
summary: Fixed bug when cleaning old upmeter probe garbage resulting in errors stucks Deckhouse main queue
```
