### PR TITLE
Add cilium to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
-# cilium/                   @zuzzas @yalosev
 .github/                    @diafour
 020-deckhouse/              @yalosev
+021-cni-cilium/             @zuzzas @yalosev @RomanenkoDenys @konstantin-axenov
 030-cloud-provider-openstack/ @konstantin-axenov
 030-cloud-provider-vsphere/ @RomanenkoDenys
 031-linstor/                @kvaps


### PR DESCRIPTION
Signed-off-by: Evgeny Samoylov <EvgenySamoylov@users.noreply.github.com>

## Description

Add cilium to the codeowners file.

## Why do we need it, and what problem does it solve?

Cilium is part of the platform now and needs to be managed and reviewed by its codeowners.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.