### PR TITLE
[cloud-provider-aws] Getting rid of unused associatePublicIPToNodes arg

### DIFF
--- a/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
@@ -205,8 +205,6 @@ apiVersions:
         properties:
           associatePublicIPToMasters:
             type: boolean
-          associatePublicIPToNodes:
-            type: boolean
       withoutNAT:
         type: object
         additionalProperties: false

--- a/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
@@ -202,9 +202,7 @@ apiVersions:
         additionalProperties: false
         required: []
         description: Layout is **deprecated**.
-        properties:
-          associatePublicIPToMasters:
-            type: boolean
+        properties: {}
       withoutNAT:
         type: object
         additionalProperties: false

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.standard.ce.inc
@@ -75,12 +75,6 @@ provider:
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить
   region: eu-central-1
-# [<en>] the "standard" layout parameters
-# [<ru>] параметры архитектуры "standard"
-standard:
-  # [<en>] associate public IP to master nodes
-  # [<ru>] назначать публичные IP master-узлам
-  associatePublicIPToMasters: false
 # [<en>] parameters of the master node group
 # [<ru>] параметры группы master-узлов
 masterNodeGroup:

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.standard.ee.inc
@@ -81,12 +81,6 @@ provider:
   # [<en>] you might consider changing this
   # [<ru>] возможно, захотите изменить
   region: eu-central-1
-# [<en>] the "standard" layout parameters
-# [<ru>] параметры архитектуры "standard"
-standard:
-  # [<en>] associate public IP to master nodes
-  # [<ru>] назначать публичные IP master-узлам
-  associatePublicIPToMasters: false
 # [<en>] parameters of the master node group
 # [<ru>] параметры группы master-узлов
 masterNodeGroup:


### PR DESCRIPTION
## Description
Getting rid of unused `associatePublicIPToNodes` and `associatePublicIPToMasters` args.

## Why do we need it, and what problem does it solve?
It confuses people with Standard layout installed.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: Got rid of unused `associatePublicIPToNodes` and `associatePublicIPToMasters` args in AWS Standard layout.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
