### PR TITLE
[ci] fix backport commit sha

### DIFF
--- a/.github/workflow_templates/on-pull-request-backport.yml
+++ b/.github/workflow_templates/on-pull-request-backport.yml
@@ -107,11 +107,12 @@ jobs:
         uses: deckhouse/backport-action@v1.0.0
         env:
           RELEASE_BRANCH: ${{ steps.prepare.outputs.release_branch }}
-          GITHUB_SHA: ${{ steps.prepare.outputs.commit }}
+          COMMIT_SHA: ${{ steps.prepare.outputs.commit }}
         with:
           token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
           committer: "deckhouse-BOaTswain <89150800+deckhouse-boatswain@users.noreply.github.com>"
           branch: ${{ env.RELEASE_BRANCH }}
+          commit: ${{ env.COMMIT_SHA }}
           labels: auto,backported
           automerge: true
           merge_method: squash

--- a/.github/workflows/on-pull-request-backport.yml
+++ b/.github/workflows/on-pull-request-backport.yml
@@ -111,11 +111,12 @@ jobs:
         uses: deckhouse/backport-action@v1.0.0
         env:
           RELEASE_BRANCH: ${{ steps.prepare.outputs.release_branch }}
-          GITHUB_SHA: ${{ steps.prepare.outputs.commit }}
+          COMMIT_SHA: ${{ steps.prepare.outputs.commit }}
         with:
           token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
           committer: "deckhouse-BOaTswain <89150800+deckhouse-boatswain@users.noreply.github.com>"
           branch: ${{ env.RELEASE_BRANCH }}
+          commit: ${{ env.COMMIT_SHA }}
           labels: auto,backported
           automerge: true
           merge_method: squash


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Fix commit SHA passed to the action

## Why do we need it, and what problem does it solve?
GITHUB_SHA is overwritten by github

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: chore
summary: Fix SHA of the passing commit
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
