### PR TITLE
[control-plane-manager] alert k8s deprecated

### DIFF
--- a/modules/040-control-plane-manager/hooks/effective_kubernetes_version.go
+++ b/modules/040-control-plane-manager/hooks/effective_kubernetes_version.go
@@ -227,6 +227,7 @@ func handleEffectiveK8sVersion(input *go_hook.HookInput, dc dependency.Container
 	resultStr := fmt.Sprintf("%d.%d", effectiveKubernetesVersion.Major(), effectiveKubernetesVersion.Minor())
 
 	input.Values.Set("controlPlaneManager.internal.effectiveKubernetesVersion", resultStr)
+	input.MetricsCollector.Set("d8_kubernetes_version", 1, map[string]string{"k8s_version": resultStr})
 
 	if !effectiveKubernetesVersion.LessThan(maxUsedControlPlaneVersion) {
 		encoded := base64.StdEncoding.EncodeToString([]byte(resultStr))

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
@@ -33,3 +33,18 @@
 
         Consider checking state of the `kube-system/d8-control-plane-manager` DaemonSet and its Pods:
         `kubectl -n kube-system get daemonset,pod --selector=app=d8-control-plane-manager`
+
+  - alert: D8KubernetesVersionIsDeprecated
+    for: 10m
+    expr: max by (k8s_version) (d8_kubernetes_version{k8s_version="1.23"}) == 1
+    labels:
+      severity_level: "7"
+      tier: cluster
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      summary: Kubernetes version {{ $labels.k8s_version }} is deprecated
+      description: |-
+        Current kubernetes version {{ $labels.k8s_version }} is deprecated and will be removed in the 1.36 release
+
+        Please migrate to the next kubernetes version (at least 1.20)

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
@@ -36,15 +36,15 @@
 
   - alert: D8KubernetesVersionIsDeprecated
     for: 10m
-    expr: max by (k8s_version) (d8_kubernetes_version{k8s_version="1.23"}) == 1
+    expr: max by (k8s_version) (d8_kubernetes_version{k8s_version="1.19"}) == 1
     labels:
       severity_level: "7"
       tier: cluster
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      summary: Kubernetes version {{ $labels.k8s_version }} is deprecated
+      summary: Kubernetes version "{{ $labels.k8s_version }}" is deprecated
       description: |-
-        Current kubernetes version {{ $labels.k8s_version }} is deprecated and will be removed in the 1.36 release
+        Current kubernetes version "{{ $labels.k8s_version }}" is deprecated and it's support will be removed in the 1.36 release
 
         Please migrate to the next kubernetes version (at least 1.20)

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
@@ -45,6 +45,6 @@
       plk_markup_format: "markdown"
       summary: Kubernetes version "{{ $labels.k8s_version }}" is deprecated
       description: |-
-        Current kubernetes version "{{ $labels.k8s_version }}" is deprecated and it's support will be removed in the 1.36 release
+        Current kubernetes version "{{ $labels.k8s_version }}" is deprecated, and its support will be removed in the 1.36 release
 
         Please migrate to the next kubernetes version (at least 1.20)


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Add an alert about deprecated kubernetes version

## Why do we need it, and what problem does it solve?
In the release 1.36 we will remove support of the 1.19 k8s version. We want to warn users about it

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: control-plane-manager
type: feature
summary: Add an alert about deprecated kubernetes version
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
