### PR TITLE
[istio] remove kiali CRD (#1978)

### DIFF
--- a/ee/modules/110-istio/hooks/migration_remove_kiali_crds.go
+++ b/ee/modules/110-istio/hooks/migration_remove_kiali_crds.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2022 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+// TODO: Remove me after the hook being deployed to all clusters!
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnStartup: &go_hook.OrderedConfig{Order: 10},
+}, removeKalaiCRD)
+
+func removeKalaiCRD(input *go_hook.HookInput) error {
+	input.PatchCollector.Delete("apiextensions.k8s.io/v1", "CustomResourceDefinition", "", "monitoringdashboards.monitoring.kiali.io", object_patch.InForeground())
+	return nil
+}

--- a/ee/modules/110-istio/hooks/migration_remove_kiali_crds_test.go
+++ b/ee/modules/110-istio/hooks/migration_remove_kiali_crds_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2022 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const kialiCRD = `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: monitoringdashboards.monitoring.kiali.io
+  labels:
+    app: kiali
+spec:
+  group: monitoring.kiali.io
+  names:
+    kind: MonitoringDashboard
+    listKind: MonitoringDashboardList
+    plural: monitoringdashboards
+    singular: monitoringdashboard
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+`
+
+var _ = Describe("Modules :: istio :: hooks :: migration_remove_kiali_crd ", func() {
+	f := HookExecutionConfigInit(`{}`, `{}`)
+	Context("Empty cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("must be executed successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+	Context("CRD monitoringdashboards.monitoring.kiali.io exists", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(kialiCRD))
+			f.RunHook()
+		})
+		It("must be executed successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesGlobalResource("CustomResourceDefinition", "monitoringdashboards.monitoring.kiali.io").Exists()).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
## Description
Delete an obsolete and no longer used CRD monitoringdashboards.monitoring.kiali.io
## Why do we need it, and what problem does it solve?
This CRD is no longer used

## What is the expected result?
CRD monitoringdashboards.monitoring.kiali.io will be removed
Fixes (#1978)
## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: istio
type: chore
summary: Delete an obsolete and no longer used CRD monitoringdashboards.monitoring.kiali.io (#1978)
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
