### PR TITLE
[candi] Use ctr instead of crictl for pulling kubernetes api proxy image

### DIFF
--- a/candi/bashible/common-steps/node-group/051_pull_kubernetes_api_proxy.sh.tpl
+++ b/candi/bashible/common-steps/node-group/051_pull_kubernetes_api_proxy.sh.tpl
@@ -15,8 +15,8 @@
 image="{{ printf "%s%s:%s" $.registry.address $.registry.path (index $.images.controlPlaneManager "kubernetesApiProxy") }}"
 if docker version >/dev/null 2>/dev/null; then
   HOME=/ docker pull "$image"
-# We use ctr because it respect http_proxy and https_proxy environment variables and allows to install in air-gapped environments using simple http proxy
-# Fallback to crictl if ctr is not installed for some reason. This is just small safety precaution.
+# Use ctr because it respects http_proxy and https_proxy environment variables and allows installing in air-gapped environments using simple http proxy.
+# If ctr is not installed for some reason, fallback to crictl. This is just a small safety precaution.
 elif ctr --version >/dev/null 2>/dev/null; then
   ctr -n=k8s.io images pull "$image"
 elif crictl version >/dev/null 2>/dev/null; then

--- a/candi/bashible/common-steps/node-group/051_pull_kubernetes_api_proxy.sh.tpl
+++ b/candi/bashible/common-steps/node-group/051_pull_kubernetes_api_proxy.sh.tpl
@@ -19,7 +19,7 @@ if docker version >/dev/null 2>/dev/null; then
 # If ctr is not installed for some reason, fallback to crictl. This is just a small safety precaution.
 elif ctr --version >/dev/null 2>/dev/null; then
 {{- if .registry.auth }}
-  ctr -n=k8s.io images pull --user {{ .registry.auth | b64decode }} "$image"
+  ctr -n=k8s.io images pull --user {{ .registry.auth | b64dec }} "$image"
 {{- else }}
   ctr -n=k8s.io images pull "$image"
 {{- end }}

--- a/candi/bashible/common-steps/node-group/051_pull_kubernetes_api_proxy.sh.tpl
+++ b/candi/bashible/common-steps/node-group/051_pull_kubernetes_api_proxy.sh.tpl
@@ -18,7 +18,11 @@ if docker version >/dev/null 2>/dev/null; then
 # Use ctr because it respects http_proxy and https_proxy environment variables and allows installing in air-gapped environments using simple http proxy.
 # If ctr is not installed for some reason, fallback to crictl. This is just a small safety precaution.
 elif ctr --version >/dev/null 2>/dev/null; then
+{{- if .registry.auth }}
+  ctr -n=k8s.io images pull --user {{ .registry.auth | b64decode }} "$image"
+{{- else }}
   ctr -n=k8s.io images pull "$image"
+{{- end }}
 elif crictl version >/dev/null 2>/dev/null; then
   crictl pull "$image"
 fi

--- a/candi/bashible/common-steps/node-group/051_pull_kubernetes_api_proxy.sh.tpl
+++ b/candi/bashible/common-steps/node-group/051_pull_kubernetes_api_proxy.sh.tpl
@@ -12,8 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+image="{{ printf "%s%s:%s" $.registry.address $.registry.path (index $.images.controlPlaneManager "kubernetesApiProxy") }}"
 if docker version >/dev/null 2>/dev/null; then
-  HOME=/ docker pull {{ printf "%s%s:%s" $.registry.address $.registry.path (index $.images.controlPlaneManager "kubernetesApiProxy") }}
+  HOME=/ docker pull "$image"
+# We use ctr because it respect http_proxy and https_proxy environment variables and allows to install in air-gapped environments using simple http proxy
+# Fallback to crictl if ctr is not installed for some reason. This is just small safety precaution.
+elif ctr --version >/dev/null 2>/dev/null; then
+  ctr -n=k8s.io images pull "$image"
 elif crictl version >/dev/null 2>/dev/null; then
-  crictl pull {{ printf "%s%s:%s" $.registry.address $.registry.path (index $.images.controlPlaneManager "kubernetesApiProxy") }}
+  crictl pull "$image"
 fi


### PR DESCRIPTION
Signed-off-by: Konstantin Aksenov <konstantin.aksenov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Use ctr because it respects http_proxy and https_proxy environment variables.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
It allows installing in air-gapped environments using simple http proxy.

We also need to the documentation that http proxy must be properly configured
```
cat /etc/profile | grep http
export http_proxy=http://172.0.0.10:8888/
export https_proxy=http://172.0.0.10:8888/
cat /etc/systemd/system.conf | grep -i http
DefaultEnvironment=HTTP_PROXY=http://172.0.0.10:8888/
DefaultEnvironment=HTTPS_PROXY=http://172.0.0.10:8888/
```
And proxy in Deckhouse must be set according to the [documentation](https://deckhouse.io/ru/documentation/v1/deckhouse-configure-global.html#parameters-modules-proxy).

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: Use ctr instead of crictl for pulling kubernetes api proxy image
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
