### PR TITLE
[deckhouse] ignore shutdown pods on update

### DIFF
--- a/modules/020-deckhouse/hooks/update_deckhouse_image.go
+++ b/modules/020-deckhouse/hooks/update_deckhouse_image.go
@@ -869,11 +869,14 @@ func updateStatus(input *go_hook.HookInput, release *deckhouseRelease, msg, phas
 func getDeckhousePod(snap []go_hook.FilterResult) *deckhousePodInfo {
 	var deckhousePod deckhousePodInfo
 
-	if len(snap) == 0 {
+	switch len(snap) {
+	case 0:
 		return nil
-	} else if len(snap) == 1 {
+
+	case 1:
 		deckhousePod = snap[0].(deckhousePodInfo)
-	} else {
+
+	default:
 		for _, sn := range snap {
 			if sn == nil {
 				continue


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Ignore shutdown and evicted pods on deckhouse image upgrade

## Why do we need it, and what problem does it solve?
Shutdown and Evicted pods are presented in the snapshot and bring a mess to the controller logic. We have to ignore such kind of pods

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse
type: fix 
summary: Ignore evicted and shutdown pods on the deckhouse update process. They could block the update
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
