### PR TITLE
[linstor] add missing libelf-dev to kernel-module-injector image

### DIFF
--- a/modules/031-linstor/images/drbd-driver-loader/Dockerfile
+++ b/modules/031-linstor/images/drbd-driver-loader/Dockerfile
@@ -26,7 +26,7 @@ RUN tar xvf /drbd.tar.gz --strip-components=2 --wildcards 'drbd-*/docker/entry.s
 FROM $BASE_DEBIAN_BULLSEYE
 
 RUN apt-get update \
- && apt-get install -y kmod gnupg wget make gcc patch curl \
+ && apt-get install -y kmod gnupg wget make gcc patch curl libelf-dev \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Description

This PR fixes problem of building DRBD module on Rocky Linux

## Why do we need it, and what problem does it solve?

fixes https://github.com/deckhouse/deckhouse/issues/2268

## What is the expected result?

drbd module compiled and successfully injected

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: linstor
type: fix
summary: add missing libelf-dev to kernel-module-injector
impact_level: low
```