### PR TITLE
[istio] refactor revisions monitoring

### DIFF
--- a/ee/modules/110-istio/hooks/revisions_monitoring.go
+++ b/ee/modules/110-istio/hooks/revisions_monitoring.go
@@ -6,18 +6,17 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 package hooks
 
 import (
-	"context"
 	"encoding/json"
-	"strings"
+	"fmt"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
 	"github.com/flant/addon-operator/sdk"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/ee/modules/110-istio/hooks/internal"
-	"github.com/deckhouse/deckhouse/go_lib/dependency"
 )
 
 var (
@@ -28,11 +27,13 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: internal.Queue("revisions-discovery-monitoring"),
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
-			Name:          "namespaces_global_revision",
-			ApiVersion:    "v1",
-			Kind:          "Namespace",
-			FilterFunc:    applyNamespaceFilter, // from revisions_discovery.go
-			LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"istio-injection": "enabled"}},
+			Name:       "namespaces_global_revision",
+			ApiVersion: "v1",
+			Kind:       "Namespace",
+			FilterFunc: applyNamespaceFilter, // from revisions_discovery.go
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"istio-injection": "enabled"},
+			},
 		},
 		{
 			Name:       "namespaces_definite_revision",
@@ -48,19 +49,41 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 				},
 			},
 		},
+		{
+			Name:       "istio_pod",
+			ApiVersion: "v1",
+			Kind:       "Pod",
+			FilterFunc: applyIstioPodFilter,
+			LabelSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "service.istio.io/canonical-name",
+						Operator: "Exists",
+					},
+					{
+						Key:      "sidecar.istio.io/inject",
+						Operator: "NotIn",
+						Values:   []string{"false"},
+					},
+				},
+			},
+		},
 	},
-	Schedule: []go_hook.ScheduleConfig{ // Due to we are afraid of subscribing to all Pods in the cluster,
-		{Name: "cron", Crontab: "*/5 * * * *"}, // we run the hook every 5 minutes to discover data-plane status.
-	},
-}, dependency.WithExternalDependencies(revisionsMonitoring))
+}, revisionsMonitoring)
 
-type IstioDrivenPod v1.Pod
 type IstioPodStatus struct {
 	Revision string `json:"revision"`
-	// ... we aren't interested in the other columns
+	// ... we aren't interested in the other fields
 }
 
-func (p *IstioDrivenPod) getIstioRevision() string {
+type IstioPodInfo struct {
+	Name            string
+	Namespace       string
+	Revision        string
+	DesiredRevision string
+}
+
+func getIstioPodRevision(p *v1.Pod) string {
 	var istioStatusJSON string
 	var istioPodStatus IstioPodStatus
 	var revision string
@@ -82,19 +105,33 @@ func (p *IstioDrivenPod) getIstioRevision() string {
 	return revision
 }
 
-func (p *IstioDrivenPod) getProxyv2ImageTag() string {
-	for _, c := range p.Spec.Containers {
-		if c.Name == "istio-proxy" {
-			// registry.deckhouse.io/deckhouse/ee:c0a01c0694d9490973e9079dc53d49e5ea11763dd0f0d0472d38d7d0-1650502544870
-			imageSlice := strings.Split(c.Image, ":")
-			return imageSlice[len(imageSlice)-1]
-		}
+func getIstioPodDesiredRevision(p *v1.Pod) string {
+	var desiredRevision string
+	var ok bool
+	if desiredRevision, ok = p.Labels["istio.io/rev"]; ok {
+		return desiredRevision
 	}
-	return ""
+	return "unknown"
 }
 
-func revisionsMonitoring(input *go_hook.HookInput, dc dependency.Container) error {
-	// isn't discovered yet
+func applyIstioPodFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	pod := &v1.Pod{}
+	err := sdk.FromUnstructured(obj, pod)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert pod object to pod: %v", err)
+	}
+
+	result := IstioPodInfo{
+		Name:            pod.Name,
+		Namespace:       pod.Namespace,
+		Revision:        getIstioPodRevision(pod),
+		DesiredRevision: getIstioPodDesiredRevision(pod),
+	}
+
+	return result, nil
+}
+
+func revisionsMonitoring(input *go_hook.HookInput) error {
 	if !input.Values.Get("istio.internal.globalRevision").Exists() {
 		return nil
 	}
@@ -105,20 +142,6 @@ func revisionsMonitoring(input *go_hook.HookInput, dc dependency.Container) erro
 	input.MetricsCollector.Expire(revisionsMonitoringMetricsGroup)
 
 	var globalRevision = input.Values.Get("istio.internal.globalRevision").String()
-	var revisionsToInstall = make([]string, 0)
-	var revisionsToInstallResult = input.Values.Get("istio.internal.revisionsToInstall").Array()
-	for _, revisionResult := range revisionsToInstallResult {
-		revisionsToInstall = append(revisionsToInstall, revisionResult.String())
-	}
-
-	var revisionSidecarImageTagMap = map[string]string{}
-	for imageName, imageTagResult := range input.Values.Get("global.modulesImages.tags.istio").Map() {
-		if strings.HasPrefix(imageName, "proxyv2") {
-			// proxyv2V1x42 -> v1x42
-			revision := strings.ToLower(strings.TrimPrefix(imageName, "proxyv2"))
-			revisionSidecarImageTagMap[revision] = imageTagResult.String()
-		}
-	}
 
 	var namespaceRevisionMap = map[string]string{}
 	for _, ns := range append(input.Snapshots["namespaces_definite_revision"], input.Snapshots["namespaces_global_revision"]...) {
@@ -130,86 +153,22 @@ func revisionsMonitoring(input *go_hook.HookInput, dc dependency.Container) erro
 		}
 	}
 
-	// check the namespaces for uninstalled desired revisions
-	for ns, revision := range namespaceRevisionMap {
-		if !internal.Contains(revisionsToInstall, revision) {
-			// ALARM! Desired revision isn't configured to install
-			labels := map[string]string{
-				"namespace":        ns,
-				"desired_revision": revision,
-			}
-			input.MetricsCollector.Set("d8_istio_desired_revision_is_not_installed", 1, labels, metrics.WithGroup(revisionsMonitoringMetricsGroup))
-		}
-	}
+	for _, pod := range input.Snapshots["istio_pod"] {
+		istioPodInfo := pod.(IstioPodInfo)
 
-	k8sClient, err := dc.GetK8sClient()
-	if err != nil {
-		return err
-	}
-
-	podList, err := k8sClient.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{LabelSelector: "service.istio.io/canonical-name,sidecar.istio.io/inject!=false"})
-	if err != nil {
-		return err
-	}
-	for _, pod := range podList.Items {
-		istioPod := IstioDrivenPod(pod)
-		var desiredRevision string
-
-		var ok bool
-		if desiredRevision, ok = istioPod.Labels["istio.io/rev"]; !ok || desiredRevision == "v1x10x1" {
-			// migration — delete '|| desiredRevision == "v1x10x1"' when it will be retired
-			if desiredRevision, ok = namespaceRevisionMap[istioPod.GetNamespace()]; !ok {
-				// ALARM! The istio-driven pod has no desired revision, pod restarting will remove the sidecar
-				labels := map[string]string{
-					"namespace":       istioPod.GetNamespace(),
-					"actual_revision": istioPod.getIstioRevision(),
-				}
-				input.MetricsCollector.Set("d8_istio_data_plane_without_desired_revision", 1, labels, metrics.WithGroup(revisionsMonitoringMetricsGroup))
-				continue
-			}
+		desiredRevision := istioPodInfo.DesiredRevision
+		// if ns revision set -> override pod revision
+		if desiredRevisionNS, ok := namespaceRevisionMap[istioPodInfo.Namespace]; ok {
+			desiredRevision = desiredRevisionNS
 		}
 
-		// TODO: get rid of everything but this only metric https://github.com/deckhouse/deckhouse/issues/2182
 		labels := map[string]string{
-			"namespace":        istioPod.GetNamespace(),
-			"dataplane_pod":    istioPod.GetName(),
+			"namespace":        istioPodInfo.Namespace,
+			"dataplane_pod":    istioPodInfo.Name,
 			"desired_revision": desiredRevision,
-			"revision":         istioPod.getIstioRevision(),
+			"revision":         istioPodInfo.Revision,
 		}
 		input.MetricsCollector.Set("d8_istio_pod_revision", 1, labels, metrics.WithGroup(revisionsMonitoringMetricsGroup))
-
-		if !internal.Contains(revisionsToInstall, desiredRevision) {
-			// ALARM! Desired revision isn't configured to install
-			labels := map[string]string{
-				"namespace":        istioPod.GetNamespace(),
-				"desired_revision": desiredRevision,
-			}
-			input.MetricsCollector.Set("d8_istio_desired_revision_is_not_installed", 1, labels, metrics.WithGroup(revisionsMonitoringMetricsGroup))
-			continue
-		}
-
-		if istioPod.getIstioRevision() != desiredRevision {
-			// ALARM! The Pod's revision isn't equal the desired one, after Pod recreating, the actual revision will be changed
-			labels := map[string]string{
-				"namespace":        istioPod.GetNamespace(),
-				"desired_revision": desiredRevision,
-				"actual_revision":  istioPod.getIstioRevision(),
-			}
-			input.MetricsCollector.Set("d8_istio_actual_data_plane_revision_ne_desired", 1, labels, metrics.WithGroup(revisionsMonitoringMetricsGroup))
-			continue
-		}
-
-		if istioPod.getProxyv2ImageTag() != revisionSidecarImageTagMap[desiredRevision] {
-			// ALARM! actual sidecar minor version ne control-plane minor version
-			labels := map[string]string{
-				"namespace":                 istioPod.GetNamespace(),
-				"revision":                  istioPod.getIstioRevision(),
-				"actual_sidecar_image_tag":  istioPod.getProxyv2ImageTag(),
-				"desired_sidecar_image_tag": revisionSidecarImageTagMap[desiredRevision],
-			}
-			input.MetricsCollector.Set("d8_istio_data_plane_patch_version_mismatch", 1, labels, metrics.WithGroup(revisionsMonitoringMetricsGroup))
-			continue
-		}
 	}
 	return nil
 }

--- a/ee/modules/110-istio/hooks/revisions_monitoring.go
+++ b/ee/modules/110-istio/hooks/revisions_monitoring.go
@@ -183,6 +183,11 @@ func revisionsMonitoring(input *go_hook.HookInput) error {
 			desiredRevision = istioPodInfo.SpecificRevision
 		}
 
+		// we don't need metrics for pod without desired revision and without istio sidecar
+		if desiredRevision == "absent" && istioPodInfo.Revision == "absent" {
+			continue
+		}
+
 		labels := map[string]string{
 			"namespace":        istioPodInfo.Namespace,
 			"dataplane_pod":    istioPodInfo.Name,

--- a/ee/modules/110-istio/hooks/revisions_monitoring_test.go
+++ b/ee/modules/110-istio/hooks/revisions_monitoring_test.go
@@ -92,13 +92,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    istio.io/rev: v1xexotic
-  name: ns-exotic
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
     istio.io/rev: v1x10x1
   name: ns-v1x10x1
 `
@@ -134,20 +127,6 @@ spec:
   - name: aaa
   - name: istio-proxy
     image: registry.deckhouse.io/deckhouse/ee:xxx-v1x15
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod-definite-revision-not-installed
-  namespace: ns-nodesired
-  labels:
-    istio.io/rev: v1xexotic
-    service.istio.io/canonical-name: qqq
-spec:
-  containers:
-  - name: aaa
-  - name: istio-proxy
-    image: registry.deckhouse.io/deckhouse/ee:xxx-v1xexotic
 ---
 apiVersion: v1
 kind: Pod
@@ -227,38 +206,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: pod-minor-version-is-actual
-  namespace: ns-global
-  labels:
-    service.istio.io/canonical-name: qqq
-  annotations:
-    sidecar.istio.io/status: '{"a":"b","revision":"v1x42"}'
-spec:
-  containers:
-  - name: aaa
-  - name: istio-proxy
-    image: registry.deckhouse.io/deckhouse/ee:xxx-v1x42
-  - name: bbb
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod-minor-version-mismatch
-  namespace: ns-global
-  labels:
-    service.istio.io/canonical-name: qqq
-  annotations:
-    sidecar.istio.io/status: '{"a":"b","revision":"v1x42"}'
-spec:
-  containers:
-  - name: aaa
-  - name: istio-proxy
-    image: registry.deckhouse.io/deckhouse/ee:xxx-v1x42-stale
-  - name: bbb
----
-apiVersion: v1
-kind: Pod
-metadata:
   name: pod-regular-v1x10x1
   namespace: ns-v1x10x1
   labels:
@@ -283,7 +230,7 @@ spec:
 			Expect(string(f.LogrusOutput.Contents())).To(HaveLen(0))
 
 			m := f.MetricsCollector.CollectedMetrics()
-			Expect(m).To(HaveLen(11))
+			Expect(m).To(HaveLen(8))
 			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
 				Group:  revisionsMonitoringMetricsGroup,
 				Action: "expire",
@@ -306,37 +253,13 @@ spec:
 				Action: "set",
 				Value:  pointer.Float64Ptr(1.0),
 				Labels: map[string]string{
-					"desired_revision": "v1x42",
-					"revision":         "v1x15",
 					"namespace":        "ns-global",
 					"dataplane_pod":    "pod-global-revision-not-actual",
+					"desired_revision": "v1x42",
+					"revision":         "v1x15",
 				},
 			}))
 			Expect(m[3]).To(BeEquivalentTo(operation.MetricOperation{
-				Name:   "d8_istio_pod_revision",
-				Group:  revisionsMonitoringMetricsGroup,
-				Action: "set",
-				Value:  pointer.Float64Ptr(1.0),
-				Labels: map[string]string{
-					"desired_revision": "v1x42",
-					"revision":         "v1x42",
-					"namespace":        "ns-global",
-					"dataplane_pod":    "pod-minor-version-is-actual",
-				},
-			}))
-			Expect(m[4]).To(BeEquivalentTo(operation.MetricOperation{
-				Name:   "d8_istio_pod_revision",
-				Group:  revisionsMonitoringMetricsGroup,
-				Action: "set",
-				Value:  pointer.Float64Ptr(1.0),
-				Labels: map[string]string{
-					"desired_revision": "v1x42",
-					"revision":         "v1x42",
-					"namespace":        "ns-global",
-					"dataplane_pod":    "pod-minor-version-mismatch",
-				},
-			}))
-			Expect(m[5]).To(BeEquivalentTo(operation.MetricOperation{
 				Name:   "d8_istio_pod_revision",
 				Group:  revisionsMonitoringMetricsGroup,
 				Action: "set",
@@ -348,19 +271,7 @@ spec:
 					"revision":         "v1x15",
 				},
 			}))
-			Expect(m[6]).To(BeEquivalentTo(operation.MetricOperation{
-				Name:   "d8_istio_pod_revision",
-				Group:  revisionsMonitoringMetricsGroup,
-				Action: "set",
-				Value:  pointer.Float64Ptr(1.0),
-				Labels: map[string]string{
-					"namespace":        "ns-nodesired",
-					"dataplane_pod":    "pod-definite-revision-not-installed",
-					"desired_revision": "v1xexotic",
-					"revision":         "unknown",
-				},
-			}))
-			Expect(m[7]).To(BeEquivalentTo(operation.MetricOperation{
+			Expect(m[4]).To(BeEquivalentTo(operation.MetricOperation{
 				Name:   "d8_istio_pod_revision",
 				Group:  revisionsMonitoringMetricsGroup,
 				Action: "set",
@@ -372,7 +283,7 @@ spec:
 					"namespace":        "ns-nodesired",
 				},
 			}))
-			Expect(m[8]).To(BeEquivalentTo(operation.MetricOperation{
+			Expect(m[5]).To(BeEquivalentTo(operation.MetricOperation{
 				Name:   "d8_istio_pod_revision",
 				Group:  revisionsMonitoringMetricsGroup,
 				Action: "set",
@@ -385,7 +296,7 @@ spec:
 				},
 			}))
 
-			Expect(m[9]).To(BeEquivalentTo(operation.MetricOperation{
+			Expect(m[6]).To(BeEquivalentTo(operation.MetricOperation{
 				Name:   "d8_istio_pod_revision",
 				Group:  revisionsMonitoringMetricsGroup,
 				Action: "set",
@@ -397,7 +308,7 @@ spec:
 					"dataplane_pod":    "pod-definite-ns-revision-not-actual",
 				},
 			}))
-			Expect(m[10]).To(BeEquivalentTo(operation.MetricOperation{
+			Expect(m[7]).To(BeEquivalentTo(operation.MetricOperation{
 				Name:   "d8_istio_pod_revision",
 				Group:  revisionsMonitoringMetricsGroup,
 				Action: "set",

--- a/ee/modules/110-istio/hooks/revisions_monitoring_test.go
+++ b/ee/modules/110-istio/hooks/revisions_monitoring_test.go
@@ -6,27 +6,92 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 package hooks
 
 import (
+	"bytes"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
 	"github.com/flant/shell-operator/pkg/metric_storage/operation"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
-
-	. "github.com/deckhouse/deckhouse/testing/hooks"
+	"strings"
+	"text/template"
 )
 
-var _ = Describe("Istio hooks :: revisions_monitoring ::", func() {
-	f := HookExecutionConfigInit(`
-{
-  "istio":{"internal":{}},
-  "global":{"modulesImages":{"tags":{"istio":{
-    "operatorV123": "deadbeef",
-    "proxyv2V1x10x1": "xxx-v1x10x1",
-    "proxyv2V1x15": "xxx-v1x15",
-    "proxyv2V1x42": "xxx-v1x42"
-  }}}}
-}
-`, "")
+const (
+	nsName  = "ns"
+	podName = "pod"
+)
 
+const nsTemplate = `
+apiVersion: v1
+kind: Namespace
+metadata:
+ name: {{ .Name }}
+ {{- if or .GlobalRevision .DefiniteRevision }}
+ labels:
+   {{- if .GlobalRevision }}
+   istio-injection: enabled
+   {{- end -}}
+   {{ if .DefiniteRevision }}
+   istio.io/rev: "{{ .DefiniteRevision }}"
+   {{- end -}}
+{{- end -}}
+`
+
+type nsParams struct {
+	GlobalRevision   bool
+	DefiniteRevision string
+	Name             string
+}
+
+const podTemplate = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
+  labels:
+    service.istio.io/canonical-name: {{ .Name }}
+    {{ if .DisableInjection -}}sidecar.istio.io/inject: false{{ end }}
+    {{ if .DefiniteRevision }}istio.io/rev: {{ .DefiniteRevision }}{{ end }}
+  annotations:
+    sidecar.istio.io/status: '{"a":"b"{{ if .CurrentRevision }}, "revision":"{{ .CurrentRevision}}"{{ end }} }'
+spec: {}
+`
+
+type podParams struct {
+	DisableInjection bool
+	DefiniteRevision string
+	CurrentRevision  string
+	Name             string
+	Namespace        string
+}
+
+type wantedMetric struct {
+	Revision        string
+	DesiredRevision string
+}
+
+func templateToYAML(tmpl string, params interface{}) string {
+	var output bytes.Buffer
+	t := template.Must(template.New("").Parse(tmpl))
+	t.Execute(&output, params)
+	return output.String()
+}
+
+func istioNsYAML(ns nsParams) string {
+	ns.Name = nsName
+	return templateToYAML(nsTemplate, ns)
+}
+
+func istioPodYAML(pod podParams) string {
+	pod.Name = podName
+	pod.Namespace = nsName
+	return templateToYAML(podTemplate, pod)
+}
+
+var _ = Describe("Istio hooks :: revisions_monitoring ::", func() {
+	f := HookExecutionConfigInit(`{"istio":{"internal":{}},}`, "")
 	Context("Empty cluster and minimal settings", func() {
 		BeforeEach(func() {
 			f.RunHook()
@@ -42,284 +107,167 @@ var _ = Describe("Istio hooks :: revisions_monitoring ::", func() {
 		})
 	})
 
-	Context("Empty cluster and revisions are discovered", func() {
-		BeforeEach(func() {
-			f.ValuesSet("istio.internal.globalRevision", "v1x42")
-			f.ValuesSet("istio.internal.revisionsToInstall", []string{})
-			f.RunHook()
-		})
+	DescribeTable("There are different desired and actual revisions", func(objectsYAMLs []string, want *wantedMetric) {
+		f.ValuesSet("istio.internal.globalRevision", "v1x42")
+		yamlState := strings.Join(objectsYAMLs, "\n---\n")
+		f.BindingContexts.Set(f.KubeStateSet(yamlState))
 
-		It("Hook must execute successfully", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			Expect(string(f.LogrusOutput.Contents())).To(HaveLen(0))
+		f.RunHook()
+		Expect(f).To(ExecuteSuccessfully())
+		Expect(string(f.LogrusOutput.Contents())).To(HaveLen(0))
+		m := f.MetricsCollector.CollectedMetrics()
 
-			m := f.MetricsCollector.CollectedMetrics()
+		// the first action should always be "expire"
+		Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
+			Group:  revisionsMonitoringMetricsGroup,
+			Action: "expire",
+		}))
+
+		// there are no istio pods or ignored pods in the cluster, hense no metrics
+		if yamlState == "" || want == nil {
 			Expect(m).To(HaveLen(1))
-			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
-				Group:  revisionsMonitoringMetricsGroup,
-				Action: "expire",
-			}))
-		})
-	})
+			return
+		}
+		Expect(m).To(HaveLen(2))
+		Expect(m[1]).To(BeEquivalentTo(operation.MetricOperation{
+			Name:   "d8_istio_pod_revision",
+			Group:  revisionsMonitoringMetricsGroup,
+			Action: "set",
+			Value:  pointer.Float64Ptr(1.0),
+			Labels: map[string]string{
+				"namespace":        nsName,
+				"dataplane_pod":    podName,
+				"desired_revision": want.DesiredRevision,
+				"revision":         want.Revision,
+			},
+		}))
+		return
 
-	Context("There are different desired and actual revisions", func() {
-		BeforeEach(func() {
-			f.ValuesSet("istio.internal.globalRevision", "v1x42")
-			f.ValuesSet("istio.internal.revisionsToInstall", []string{"v1x15", "v1x10x1", "v1x42"})
-
-			namespacesYAML := `
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    istio-injection: enabled
-  name: ns-global
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    istio.io/rev: v1x15
-  name: ns-rev1x15
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ns-nodesired
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    istio.io/rev: v1x10x1
-  name: ns-v1x10x1
-`
-			podsYAML := `---
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod-to-ignore
-  namespace: ns-global
-  labels:
-    sidecar.istio.io/inject: false
-    service.istio.io/canonical-name: qqq
-  annotations:
-    sidecar.istio.io/status: '{"a":"b","revision":"v1x13"}'
-spec:
-  containers:
-  - name: aaa
-  - name: istio-proxy
-    image: registry.deckhouse.io/deckhouse/ee:xxx-v1x13
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod-definite-revision-installed
-  namespace: ns-nodesired
-  labels:
-    istio.io/rev: v1x15
-    service.istio.io/canonical-name: qqq
-  annotations:
-    sidecar.istio.io/status: '{"a":"b","revision":"v1x15"}'
-spec:
-  containers:
-  - name: aaa
-  - name: istio-proxy
-    image: registry.deckhouse.io/deckhouse/ee:xxx-v1x15
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod-global-revision-actual
-  namespace: ns-global
-  labels:
-    service.istio.io/canonical-name: qqq
-  annotations:
-    sidecar.istio.io/status: '{"a":"b","revision":"v1x42"}'
-spec:
-  containers:
-  - name: aaa
-  - name: istio-proxy
-    image: registry.deckhouse.io/deckhouse/ee:xxx-v1x42
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod-global-revision-not-actual
-  namespace: ns-global
-  labels:
-    service.istio.io/canonical-name: qqq
-  annotations:
-    sidecar.istio.io/status: '{"a":"b","revision":"v1x15"}'
-spec:
-  containers:
-  - name: aaa
-  - name: istio-proxy
-    image: registry.deckhouse.io/deckhouse/ee:xxx-v1x15
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod-definite-ns-revision-actual
-  namespace: ns-rev1x15
-  labels:
-    service.istio.io/canonical-name: qqq
-  annotations:
-    sidecar.istio.io/status: '{"a":"b","revision":"v1x15"}'
-spec:
-  containers:
-  - name: aaa
-  - name: istio-proxy
-    image: registry.deckhouse.io/deckhouse/ee:xxx-v1x15
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod-definite-ns-revision-not-actual
-  namespace: ns-rev1x15
-  labels:
-    service.istio.io/canonical-name: qqq
-  annotations:
-    sidecar.istio.io/status: '{"a":"b","revision":"v1x42"}'
-spec:
-  containers:
-  - name: aaa
-  - name: istio-proxy
-    image: registry.deckhouse.io/deckhouse/ee:xxx-v1x42
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod-orphan
-  namespace: ns-nodesired
-  labels:
-    service.istio.io/canonical-name: qqq
-  annotations:
-    sidecar.istio.io/status: '{"a":"b","revision":"v1x15"}'
-spec:
-  containers:
-  - name: aaa
-  - name: istio-proxy
-    image: registry.deckhouse.io/deckhouse/ee:xxx-v1x13
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod-regular-v1x10x1
-  namespace: ns-v1x10x1
-  labels:
-    service.istio.io/canonical-name: qqq
-    istio.io/rev: v1x10x1
-  annotations:
-    sidecar.istio.io/status: '{"a":"b"}'
-spec:
-  containers:
-  - name: aaa
-  - name: istio-proxy
-    image: registry.deckhouse.io/deckhouse/ee:xxx-v1x10x1
-  - name: bbb
-`
-
-			f.BindingContexts.Set(f.KubeStateSet(namespacesYAML + podsYAML))
-			f.RunHook()
-		})
-
-		It("Hook must execute successfully", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			Expect(string(f.LogrusOutput.Contents())).To(HaveLen(0))
-
-			m := f.MetricsCollector.CollectedMetrics()
-			Expect(m).To(HaveLen(8))
-			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
-				Group:  revisionsMonitoringMetricsGroup,
-				Action: "expire",
-			}))
-			Expect(m[1]).To(BeEquivalentTo(operation.MetricOperation{
-				Name:   "d8_istio_pod_revision",
-				Group:  revisionsMonitoringMetricsGroup,
-				Action: "set",
-				Value:  pointer.Float64Ptr(1.0),
-				Labels: map[string]string{
-					"namespace":        "ns-global",
-					"dataplane_pod":    "pod-global-revision-actual",
-					"desired_revision": "v1x42",
-					"revision":         "v1x42",
-				},
-			}))
-			Expect(m[2]).To(BeEquivalentTo(operation.MetricOperation{
-				Name:   "d8_istio_pod_revision",
-				Group:  revisionsMonitoringMetricsGroup,
-				Action: "set",
-				Value:  pointer.Float64Ptr(1.0),
-				Labels: map[string]string{
-					"namespace":        "ns-global",
-					"dataplane_pod":    "pod-global-revision-not-actual",
-					"desired_revision": "v1x42",
-					"revision":         "v1x15",
-				},
-			}))
-			Expect(m[3]).To(BeEquivalentTo(operation.MetricOperation{
-				Name:   "d8_istio_pod_revision",
-				Group:  revisionsMonitoringMetricsGroup,
-				Action: "set",
-				Value:  pointer.Float64Ptr(1.0),
-				Labels: map[string]string{
-					"namespace":        "ns-nodesired",
-					"dataplane_pod":    "pod-definite-revision-installed",
-					"desired_revision": "v1x15",
-					"revision":         "v1x15",
-				},
-			}))
-			Expect(m[4]).To(BeEquivalentTo(operation.MetricOperation{
-				Name:   "d8_istio_pod_revision",
-				Group:  revisionsMonitoringMetricsGroup,
-				Action: "set",
-				Value:  pointer.Float64Ptr(1.0),
-				Labels: map[string]string{
-					"dataplane_pod":    "pod-orphan",
-					"desired_revision": "unknown",
-					"revision":         "v1x15",
-					"namespace":        "ns-nodesired",
-				},
-			}))
-			Expect(m[5]).To(BeEquivalentTo(operation.MetricOperation{
-				Name:   "d8_istio_pod_revision",
-				Group:  revisionsMonitoringMetricsGroup,
-				Action: "set",
-				Value:  pointer.Float64Ptr(1.0),
-				Labels: map[string]string{
-					"dataplane_pod":    "pod-definite-ns-revision-actual",
-					"desired_revision": "v1x15",
-					"revision":         "v1x15",
-					"namespace":        "ns-rev1x15",
-				},
-			}))
-
-			Expect(m[6]).To(BeEquivalentTo(operation.MetricOperation{
-				Name:   "d8_istio_pod_revision",
-				Group:  revisionsMonitoringMetricsGroup,
-				Action: "set",
-				Value:  pointer.Float64Ptr(1.0),
-				Labels: map[string]string{
-					"desired_revision": "v1x15",
-					"revision":         "v1x42",
-					"namespace":        "ns-rev1x15",
-					"dataplane_pod":    "pod-definite-ns-revision-not-actual",
-				},
-			}))
-			Expect(m[7]).To(BeEquivalentTo(operation.MetricOperation{
-				Name:   "d8_istio_pod_revision",
-				Group:  revisionsMonitoringMetricsGroup,
-				Action: "set",
-				Value:  pointer.Float64Ptr(1.0),
-				Labels: map[string]string{
-					"namespace":        "ns-v1x10x1",
-					"dataplane_pod":    "pod-regular-v1x10x1",
-					"desired_revision": "v1x10x1",
-					"revision":         "v1x10x1",
-				},
-			}))
-		})
-	})
+	},
+		Entry("Empty cluster", []string{}, nil),
+		Entry("Pod to ignore",
+			[]string{
+				istioNsYAML(nsParams{
+					GlobalRevision: true,
+				}),
+				istioPodYAML(podParams{
+					DisableInjection: true,
+				}),
+			}, nil),
+		Entry("Global revision is actual",
+			[]string{
+				istioNsYAML(nsParams{
+					GlobalRevision: true,
+				}),
+				istioPodYAML(podParams{
+					CurrentRevision: "v1x42",
+				}),
+			}, &wantedMetric{
+				Revision:        "v1x42",
+				DesiredRevision: "v1x42",
+			}),
+		Entry("Global revision is not actual",
+			[]string{
+				istioNsYAML(nsParams{
+					GlobalRevision: true,
+				}),
+				istioPodYAML(podParams{
+					CurrentRevision: "v1x77",
+				}),
+			}, &wantedMetric{
+				Revision:        "v1x77",
+				DesiredRevision: "v1x42",
+			}),
+		Entry("Namespace with definite revision is actual",
+			[]string{
+				istioNsYAML(nsParams{
+					DefiniteRevision: "v1x15",
+				}),
+				istioPodYAML(podParams{
+					CurrentRevision: "v1x15",
+				}),
+			}, &wantedMetric{
+				Revision:        "v1x15",
+				DesiredRevision: "v1x15",
+			}),
+		Entry("Namespace with definite revision is not actual",
+			[]string{
+				istioNsYAML(nsParams{
+					DefiniteRevision: "v1x15",
+				}),
+				istioPodYAML(podParams{
+					CurrentRevision: "v1x77",
+				}),
+			}, &wantedMetric{
+				Revision:        "v1x77",
+				DesiredRevision: "v1x15",
+			}),
+		Entry("Namespace with definite revision and pod with definite revision is actual",
+			[]string{
+				istioNsYAML(nsParams{
+					DefiniteRevision: "v1x15",
+				}),
+				istioPodYAML(podParams{
+					DefiniteRevision: "v1x77",
+					CurrentRevision:  "v1x77",
+				}),
+			}, &wantedMetric{
+				Revision:        "v1x77",
+				DesiredRevision: "v1x77",
+			}),
+		Entry("Namespace with definite revision and pod with definite revision is not actual",
+			[]string{
+				istioNsYAML(nsParams{
+					DefiniteRevision: "v1x15",
+				}),
+				istioPodYAML(podParams{
+					DefiniteRevision: "v1x77",
+					CurrentRevision:  "v1x71",
+				}),
+			}, &wantedMetric{
+				Revision:        "v1x71",
+				DesiredRevision: "v1x77",
+			}),
+		Entry("Namespace without labels and pod with definite revision",
+			[]string{
+				istioNsYAML(nsParams{}),
+				istioPodYAML(podParams{
+					DefiniteRevision: "v1x77",
+					CurrentRevision:  "v1x77",
+				}),
+			}, &wantedMetric{
+				Revision:        "v1x77",
+				DesiredRevision: "v1x77",
+			}),
+		Entry("Pod orphan",
+			[]string{
+				istioNsYAML(nsParams{}),
+				istioPodYAML(podParams{
+					CurrentRevision: "v1x77",
+				}),
+			}, &wantedMetric{
+				Revision:        "v1x77",
+				DesiredRevision: "unknown",
+			}),
+		Entry("Namespace with v1x10x1 revision and pod is actual",
+			[]string{
+				istioNsYAML(nsParams{
+					DefiniteRevision: "v1x10x1",
+				}),
+				istioPodYAML(podParams{}),
+			}, &wantedMetric{
+				Revision:        "v1x10x1",
+				DesiredRevision: "v1x10x1",
+			}),
+		Entry("Pod with v1x10x1 revision is actual",
+			[]string{
+				istioNsYAML(nsParams{}),
+				istioPodYAML(podParams{
+					DefiniteRevision: "v1x10x1",
+				}),
+			}, &wantedMetric{
+				Revision:        "v1x10x1",
+				DesiredRevision: "v1x10x1",
+			}),
+	)
 })

--- a/ee/modules/110-istio/hooks/revisions_monitoring_test.go
+++ b/ee/modules/110-istio/hooks/revisions_monitoring_test.go
@@ -35,7 +35,7 @@ metadata:
    {{ if .DefiniteRevision }}
    istio.io/rev: "{{ .DefiniteRevision }}"
    {{- end -}}
-{{- end -}}
+ {{- end -}}
 `
 
 type nsParams struct {
@@ -154,7 +154,7 @@ var _ = Describe("Istio hooks :: revisions_monitoring ::", func() {
 					DisableInjection: true,
 				}),
 			}, nil),
-		Entry("Global revision is actual",
+		Entry("NS global revision, pod revision is actual",
 			[]string{
 				istioNsYAML(nsParams{
 					GlobalRevision: true,
@@ -166,7 +166,7 @@ var _ = Describe("Istio hooks :: revisions_monitoring ::", func() {
 				Revision:        "v1x42",
 				DesiredRevision: "v1x42",
 			}),
-		Entry("Global revision is not actual",
+		Entry("NS global revision, pod revision is not actual",
 			[]string{
 				istioNsYAML(nsParams{
 					GlobalRevision: true,
@@ -178,7 +178,7 @@ var _ = Describe("Istio hooks :: revisions_monitoring ::", func() {
 				Revision:        "v1x77",
 				DesiredRevision: "v1x42",
 			}),
-		Entry("Namespace with definite revision is actual",
+		Entry("Namespace with definite revision, pod revision is actual",
 			[]string{
 				istioNsYAML(nsParams{
 					DefiniteRevision: "v1x15",
@@ -190,7 +190,7 @@ var _ = Describe("Istio hooks :: revisions_monitoring ::", func() {
 				Revision:        "v1x15",
 				DesiredRevision: "v1x15",
 			}),
-		Entry("Namespace with definite revision is not actual",
+		Entry("Namespace with definite revision, pod revision is not actual",
 			[]string{
 				istioNsYAML(nsParams{
 					DefiniteRevision: "v1x15",
@@ -259,7 +259,7 @@ var _ = Describe("Istio hooks :: revisions_monitoring ::", func() {
 				Revision:        "v1x10x1",
 				DesiredRevision: "v1x10x1",
 			}),
-		Entry("Pod with v1x10x1 revision is actual",
+		Entry("Pod with v1x10x1 specific revision is actual",
 			[]string{
 				istioNsYAML(nsParams{}),
 				istioPodYAML(podParams{

--- a/ee/modules/110-istio/hooks/revisions_monitoring_test.go
+++ b/ee/modules/110-istio/hooks/revisions_monitoring_test.go
@@ -287,5 +287,10 @@ var _ = Describe("Istio hooks :: revisions_monitoring ::", func() {
 				Revision:        "v1x77",
 				DesiredRevision: "absent",
 			}),
+		Entry("Pod without current and desired revisions",
+			[]string{
+				istioNsYAML(nsParams{}),
+				istioPodYAML(podParams{}),
+			}, nil),
 	)
 })

--- a/ee/modules/110-istio/hooks/revisions_monitoring_test.go
+++ b/ee/modules/110-istio/hooks/revisions_monitoring_test.go
@@ -7,14 +7,16 @@ package hooks
 
 import (
 	"bytes"
-	. "github.com/deckhouse/deckhouse/testing/hooks"
+	"strings"
+	"text/template"
+
 	"github.com/flant/shell-operator/pkg/metric_storage/operation"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
-	"strings"
-	"text/template"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
 const (
@@ -74,7 +76,7 @@ type wantedMetric struct {
 func templateToYAML(tmpl string, params interface{}) string {
 	var output bytes.Buffer
 	t := template.Must(template.New("").Parse(tmpl))
-	t.Execute(&output, params)
+	_ = t.Execute(&output, params)
 	return output.String()
 }
 
@@ -140,8 +142,6 @@ var _ = Describe("Istio hooks :: revisions_monitoring ::", func() {
 				"revision":         want.Revision,
 			},
 		}))
-		return
-
 	},
 		Entry("Empty cluster", []string{}, nil),
 		Entry("Pod to ignore with inject=false label",

--- a/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
@@ -1,19 +1,9 @@
 - name: d8.istio.revisions
   rules:
   - alert: D8IstioDesiredRevisionIsNotInstalled
-    expr: max by (namespace, desired_revision) (d8_istio_desired_revision_is_not_installed == 1)
-    for: 5m
-    labels:
-      severity_level: "4"
-      tier: cluster
     annotations:
-      plk_markup_format: "markdown"
-      plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      summary: Desired control-plane version isn't installed
       description: |
-        There is desired istio control plane revision `{{$labels.desired_revision}}` configured for pods in namespace `{{$labels.namespace}}`, but the revision isn't installed. Consider installing it or change the Namespace or Pod configuration.
+        There is desired istio control plane revision `{{$labels.revision}}` configured for pods in namespace `{{$labels.namespace}}`, but the revision isn't installed. Consider installing it or change the Namespace or Pod configuration.
         Impact — Pods won't be able to re-create in the `{{$labels.namespace}}` Namespace.
         Cheat sheet:
         ```
@@ -23,41 +13,84 @@
         kubectl get ns {{$labels.namespace}} --show-labels
 
         ### pod-wide configuration
-        kubectl -n {{$labels.namespace}} get pods -l istio.io/rev={{$labels.desired_revision}}
+        kubectl -n {{$labels.namespace}} get pods -l istio.io/rev={{$labels.revision}}
         ```
-  - alert: D8IstioDataPlaneWithoutDesiredRevision
-    expr: max by (namespace, actual_revision) (d8_istio_data_plane_without_desired_revision == 1)
-    for: 5m
-    labels:
-      severity_level: "6"
-      tier: cluster
-    annotations:
-      plk_markup_format: "markdown"
-      plk_protocol_version: "1"
       plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
       plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      summary: There are Pods with istio sidecars, but without istio-injection configured
+      plk_markup_format: markdown
+      plk_protocol_version: "1"
+      summary: Desired control-plane version isn't installed
+    expr: |
+      (
+        label_replace(kube_namespace_labels{label_istio_io_rev!=""}, "revision", "$1", "label_istio_io_rev", "(.+)")
+        or
+        label_replace(kube_pod_labels{label_istio_io_rev!="", label_sidecar_istio_io_inject!="false"}, "revision", "$1", "label_istio_io_rev", "(.+)")
+      )
+      unless on (revision)
+      (
+        istio_build{component="pilot"}
+        * on (pod,namespace) group_left(revision)
+          (
+            label_replace(kube_pod_labels, "revision", "$1", "label_istio_io_rev", "(.+)")
+          )
+      )
+    for: 5m
+    labels:
+      severity_level: "4"
+      tier: cluster
+  - alert: D8IstioDataPlaneWithoutDesiredRevision
+    annotations:
       description: |
         There are Pods in `{{$labels.namespace}}` Namespace with istio sidecars, but the istio-injection isn't configured.
         Impact — Pods will lose their istio sidecars after re-creation.
         Getting affected Pods:
         ```
-        kubectl -n {{$labels.namespace}} get pods -o json | jq -r --arg revision {{$labels.actual_revision}} '.items[] | select(.metadata.annotations."sidecar.istio.io/status" | fromjson | .revision == $revision) | .metadata.name'
+        kubectl -n {{$labels.namespace}} get pods -o json | jq -r --arg revision {{$labels.revision}} '.items[] | select(.metadata.annotations."sidecar.istio.io/status" | fromjson | .revision == $revision) | .metadata.name'
         ```
-  - alert: D8IstioActualDataPlaneRevisionNeDesired
-    expr: max by (namespace, actual_revision, desired_revision) (d8_istio_actual_data_plane_revision_ne_desired == 1)
+      plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_markup_format: markdown
+      plk_protocol_version: "1"
+      summary: There are Pods with istio sidecars, but without istio-injection configured
+    expr: |
+      (
+        kube_pod_labels{label_service_istio_io_canonical_name!="",label_sidecar_istio_io_inject!="false",label_istio_io_rev=""}
+        * on (pod, namespace) group_left (revision, desired_revision)
+          label_replace(d8_istio_pod_revision{}, "pod", "$1", "dataplane_pod", "(.+)")
+      )
+      * on (namespace) group_left ()
+        kube_namespace_labels{label_istio_io_rev="", label_istio_injection=~"($^|disabled)"}
     for: 5m
     labels:
       severity_level: "6"
       tier: cluster
+  - alert: D8IstioPodsWithoutIstioSidecar
     annotations:
-      plk_markup_format: "markdown"
-      plk_protocol_version: "1"
+      description: |
+        There are Pods in `{{$labels.namespace}}` Namespace without istio sidecars, but the istio-injection is configured.
+        Getting affected Pods:
+        ```
+        kubectl -n {{$labels.namespace}} get pods -o json | jq -r '.metadata.name'
+        ```
       plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
       plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      summary: There are Pods with istio data-plane revision `{{$labels.actual_revision}}`, but desired revision is `{{$labels.desired_revision}}`
+      plk_markup_format: markdown
+      plk_protocol_version: "1"
+      summary: There are Pods without istio sidecars, but with istio-injection configured
+    expr: |
+      kube_pod_labels{label_service_istio_io_canonical_name=""}
+      * on (namespace) group_left()
+      (
+        kube_namespace_labels {label_istio_io_rev!=""} or kube_namespace_labels {label_istio_injection!=""}
+      )
+    for: 5m
+    labels:
+      severity_level: "6"
+      tier: cluster
+  - alert: D8IstioActualDataPlaneRevisionNeDesired
+    annotations:
       description: |
-        There are Pods in Namespace `{{$labels.namespace}}` with istio data-plane revision `{{$labels.actual_revision}}`, but the desired one is `{{$labels.desired_revision}}`.
+        There are Pods in Namespace `{{$labels.namespace}}` with istio data-plane revision `{{$labels.revision}}`, but the desired one is `{{$labels.desired_revision}}`.
         Impact — revision is to change after Pod restarting.
         Cheat sheet:
         ```
@@ -69,7 +102,35 @@
         ### pod-wide configuration
         kubectl -n {{$labels.namespace}} get pods -l istio.io/rev={{$labels.desired_revision}}
         ```
+      plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_markup_format: markdown
+      plk_protocol_version: "1"
+      summary:
+        There are Pods with istio data-plane revision `{{$labels.revision}}`,
+        but desired revision is `{{$labels.desired_revision}}`
+    expr: |
+      d8_istio_pod_revision{desired_revision!="unknown"}
+      unless on (revision, dataplane_pod) label_replace(d8_istio_pod_revision{}, "revision", "$1", "desired_revision", "(.+)")
+    for: 5m
+    labels:
+      severity_level: "6"
+      tier: cluster
   - alert: D8IstioDataPlaneVersionMismatch
+    annotations:
+      description: |
+        There are Pods in `{{$labels.namespace}}` namespace with istio revision `{{$labels.revision}}` and data-plane version `{{$labels.tag}}` which differ from control-plane one `{{$labels.istiod_tag}}`.
+        Consider restarting affected Pods, use PromQL query to get the list:
+        ```
+        max by (namespace, pod) (istio_build{component="proxy", tag="{{$labels.tag}}"})
+        ```
+      plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_markup_format: markdown
+      plk_protocol_version: "1"
+      summary:
+        There are Pods with data-plane version different from control-plane
+        one.
     expr: |
       ( # join d8_istio_pod_revision and istio_build metrics to get every Pod's istio version
         max by (namespace, pod, revision, tag)
@@ -77,7 +138,7 @@
           label_replace(
             d8_istio_pod_revision, "pod", "$1", "dataplane_pod", "(.+)"
           )
-          + on (pod) group_left (tag) istio_build{component="proxy"}
+          + on (pod,namespace) group_left (tag) istio_build{component="proxy"}
         )
       )
       # enrich the metric above with control-plane istio version (will come in handy for the alert description)
@@ -88,7 +149,7 @@
           label_replace(
             istio_build{component="pilot"}, "istiod_tag", "$1", "tag", "(.+)"
           )
-          + on (pod) group_left(revision)
+          + on (pod,namespace) group_left(revision)
           (
             label_replace(kube_pod_labels, "revision", "$1", "label_istio_io_rev", "(.+)")
           )
@@ -103,15 +164,3 @@
     labels:
       severity_level: "8"
       tier: cluster
-    annotations:
-      plk_markup_format: "markdown"
-      plk_protocol_version: "1"
-      plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      summary: There are Pods with data-plane version different from control-plane one.
-      description: |
-        There are Pods in `{{$labels.namespace}}` namespace with istio revision `{{$labels.revision}}` and data-plane version `{{$labels.tag}}` which differ from control-plane one `{{$labels.istiod_tag}}`.
-        Consider restarting affected Pods, use PromQL query to get the list:
-        ```
-        max by (namespace, pod) (istio_build{component="proxy", tag="{{$labels.tag}}"})
-        ```

--- a/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
@@ -22,9 +22,7 @@
       summary: Desired control-plane version isn't installed
     expr: |
       (
-        label_replace(kube_namespace_labels{label_istio_io_rev!=""}, "revision", "$1", "label_istio_io_rev", "(.+)")
-        or
-        label_replace(kube_pod_labels{label_istio_io_rev!="", label_sidecar_istio_io_inject!="false"}, "revision", "$1", "label_istio_io_rev", "(.+)")
+        label_replace(d8_istio_pod_revision{desired_revision!="absent"}, "revision", "$1", "desired_revision", "(.+)")
       )
       unless on (revision)
       (

--- a/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
@@ -38,7 +38,7 @@
     labels:
       severity_level: "4"
       tier: cluster
-  - alert: D8IstioDataPlaneWithoutDesiredRevision
+  - alert: D8IstioDataPlaneWithoutIstioInjectionConfigured
     annotations:
       description: |
         There are Pods in `{{$labels.namespace}}` Namespace with istio sidecars, but the istio-injection isn't configured.
@@ -53,13 +53,7 @@
       plk_protocol_version: "1"
       summary: There are Pods with istio sidecars, but without istio-injection configured
     expr: |
-      (
-        kube_pod_labels{label_service_istio_io_canonical_name!="",label_sidecar_istio_io_inject!="false",label_istio_io_rev=""}
-        * on (pod, namespace) group_left (revision, desired_revision)
-          label_replace(d8_istio_pod_revision{}, "pod", "$1", "dataplane_pod", "(.+)")
-      )
-      * on (namespace) group_left ()
-        kube_namespace_labels{label_istio_io_rev="", label_istio_injection=~"($^|disabled)"}
+      d8_istio_pod_revision{revision!="absent", desired_revision="absent"}
     for: 5m
     labels:
       severity_level: "6"
@@ -107,7 +101,7 @@
         but desired revision is `{{$labels.desired_revision}}`
     expr: |
       d8_istio_pod_revision{desired_revision!="absent"}
-      unless on (revision, dataplane_pod) label_replace(d8_istio_pod_revision{}, "revision", "$1", "desired_revision", "(.+)")
+      unless on (revision, dataplane_pod, namespace) label_replace(d8_istio_pod_revision{}, "revision", "$1", "desired_revision", "(.+)")
     for: 5m
     labels:
       severity_level: "6"

--- a/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
@@ -67,7 +67,7 @@
   - alert: D8IstioPodsWithoutIstioSidecar
     annotations:
       description: |
-        There are Pods in `{{$labels.namespace}}` Namespace without istio sidecars, but the istio-injection is configured.
+        There are pods `{{$labels.dataplane_pod}}` in `{{$labels.namespace}}` Namespace without istio sidecars, but the istio-injection is configured.
         Getting affected Pods:
         ```
         kubectl -n {{$labels.namespace}} get pods -o json | jq -r '.metadata.name'
@@ -78,13 +78,7 @@
       plk_protocol_version: "1"
       summary: There are Pods without istio sidecars, but with istio-injection configured
     expr: |
-      kube_pod_labels{label_service_istio_io_canonical_name="",  label_sidecar_istio_io_inject!="true"	}
-      * on (namespace) group_left()
-      (
-        kube_namespace_labels {label_istio_io_rev!=""} or kube_namespace_labels {label_istio_injection!=""}
-      )
-      or
-      kube_pod_labels{label_service_istio_io_canonical_name="", label_sidecar_istio_io_inject="true"}
+      d8_istio_pod_revision{revision="absent", desired_revision!=""}
     for: 5m
     labels:
       severity_level: "6"

--- a/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
@@ -34,7 +34,7 @@
       )
     for: 5m
     labels:
-      severity_level: "4"
+      severity_level: "6"
       tier: cluster
   - alert: D8IstioDataPlaneWithoutIstioInjectionConfigured
     annotations:
@@ -54,7 +54,7 @@
       d8_istio_pod_revision{revision!="absent", desired_revision="absent"}
     for: 5m
     labels:
-      severity_level: "6"
+      severity_level: "4"
       tier: cluster
   - alert: D8IstioPodsWithoutIstioSidecar
     annotations:
@@ -73,7 +73,7 @@
       d8_istio_pod_revision{revision="absent", desired_revision!=""}
     for: 5m
     labels:
-      severity_level: "6"
+      severity_level: "4"
       tier: cluster
   - alert: D8IstioActualDataPlaneRevisionNeDesired
     annotations:

--- a/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
@@ -78,11 +78,13 @@
       plk_protocol_version: "1"
       summary: There are Pods without istio sidecars, but with istio-injection configured
     expr: |
-      kube_pod_labels{label_service_istio_io_canonical_name=""}
+      kube_pod_labels{label_service_istio_io_canonical_name="",  label_sidecar_istio_io_inject!="true"	}
       * on (namespace) group_left()
       (
         kube_namespace_labels {label_istio_io_rev!=""} or kube_namespace_labels {label_istio_injection!=""}
       )
+      or
+      kube_pod_labels{label_service_istio_io_canonical_name="", label_sidecar_istio_io_inject="true"}
     for: 5m
     labels:
       severity_level: "6"

--- a/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
@@ -1,5 +1,35 @@
 - name: d8.istio.revisions
   rules:
+  - alert: D8IstioActualRevisionIsNotInstalled
+    annotations:
+      description: |
+        There are pods with injected sidecar of revision `{{$labels.revision}}` in namespace `{{$labels.namespace}}`, but the control-plane revision isn't installed. Consider installing it or change the Namespace or Pod configuration.
+        Impact — Pods have lost their sync with k8s state.
+        Getting orphaned pods:
+        ```
+        kubectl -n {{ $labels.namespace }} get pods -l 'service.istio.io/canonical-name' -o json | jq --arg revision {{ $labels.revision }} '.items[] | select(.metadata.annotations."sidecar.istio.io/status" // "{}" | fromjson | .revision == $revision) | .metadata.name'
+        ```
+      plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_markup_format: markdown
+      plk_protocol_version: "1"
+      summary: Desired control-plane version isn't installed
+    expr: |
+      (
+        d8_istio_pod_revision{revision!="absent"}
+      )
+      unless on (revision)
+      (
+        istio_build{component="pilot"}
+        * on (pod,namespace) group_left(revision)
+          (
+            label_replace(kube_pod_labels, "revision", "$1", "label_istio_io_rev", "(.+)")
+          )
+      )
+    for: 5m
+    labels:
+      severity_level: "4"
+      tier: cluster
   - alert: D8IstioDesiredRevisionIsNotInstalled
     annotations:
       description: |
@@ -102,7 +132,7 @@
       unless on (revision, dataplane_pod, namespace) label_replace(d8_istio_pod_revision{}, "revision", "$1", "desired_revision", "(.+)")
     for: 5m
     labels:
-      severity_level: "6"
+      severity_level: "8"
       tier: cluster
   - alert: D8IstioDataPlaneVersionMismatch
     annotations:

--- a/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
@@ -62,7 +62,7 @@
         There are pods `{{$labels.dataplane_pod}}` in `{{$labels.namespace}}` Namespace without istio sidecars, but the istio-injection is configured.
         Getting affected Pods:
         ```
-        kubectl -n {{$labels.namespace}} get pods -o json | jq -r '.metadata.name'
+        kubectl -n {{$labels.namespace}} get pods -l '!service.istio.io/canonical-name' -o json | jq -r '.items[] | select(.metadata.annotations."sidecar.istio.io/inject" != "false") | .metadata.name'
         ```
       plk_create_group_if_not_exists__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
       plk_grouped_by__d8_istio_revisions_misconfigurations: D8IstioRevisionsMisconfigurations,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes

--- a/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
@@ -106,7 +106,7 @@
         There are Pods with istio data-plane revision `{{$labels.revision}}`,
         but desired revision is `{{$labels.desired_revision}}`
     expr: |
-      d8_istio_pod_revision{desired_revision!="unknown"}
+      d8_istio_pod_revision{desired_revision!="absent"}
       unless on (revision, dataplane_pod) label_replace(d8_istio_pod_revision{}, "revision", "$1", "desired_revision", "(.+)")
     for: 5m
     labels:

--- a/werf.yaml
+++ b/werf.yaml
@@ -341,7 +341,7 @@ ansible:
 
   - raw: rm -rf /var/cache/apk/*
 
-  setupCacheVersion: "2"
+  setupCacheVersion: "3"
   setup:
   - name: "Migrate ee/fe internal packages imports"
     shell: |

--- a/werf.yaml
+++ b/werf.yaml
@@ -341,7 +341,7 @@ ansible:
 
   - raw: rm -rf /var/cache/apk/*
 
-  setupCacheVersion: "3"
+  setupCacheVersion: "4"
   setup:
   - name: "Migrate ee/fe internal packages imports"
     shell: |


### PR DESCRIPTION
Signed-off-by: Pavel Tishkov <pavel.tishkov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Removed all metrics for tracking istio revisions except d8_istio_pod_revisions. All alert logic is implemented in promql.
Added an alert (D8IstioPodsWithoutIstioSidecar) tracking pods without istio sidecar, in namespaces where the inject should happen. 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
There is overengineered revisions_monitoring.go.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
The following metrics will no longer be generated:
- d8_istio_desired_revision_is_not_installed
- d8_istio_data_plane_without_desired_revision
- d8_istio_actual_data_plane_revision_ne_desired
- d8_istio_data_plane_patch_version_mismatch

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: istio
type: chore
summary: refactor istio revision monitoring
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
