### PR TITLE
[flant-integration] Fix expression for D8PrometheusMadisonErrorSendingAlertsToBackend

### DIFF
--- a/ee/modules/600-flant-integration/monitoring/prometheus-rules/sending-alerts.yaml
+++ b/ee/modules/600-flant-integration/monitoring/prometheus-rules/sending-alerts.yaml
@@ -7,7 +7,7 @@
           max by (pod_ip) (
               label_replace(
                 max by (pod, alertmanager) (
-                  (rate(prometheus_notifications_errors_total{pod="prometheus-main-0"}[5m]) / rate(prometheus_notifications_sent_total{pod="prometheus-main-0"}[5m])) * 100),
+                  (rate(prometheus_notifications_errors_total{pod="prometheus-main-0"}[5m]) / rate(prometheus_notifications_sent_total{pod="prometheus-main-0"}[5m])) * 100) != 0,
                 "pod_ip", "$1", "alertmanager", ".*://(.*):.*")
           )
           * on (pod_ip) group_right()

--- a/ee/modules/600-flant-integration/monitoring/prometheus-rules/sending-alerts.yaml
+++ b/ee/modules/600-flant-integration/monitoring/prometheus-rules/sending-alerts.yaml
@@ -7,7 +7,7 @@
           max by (pod_ip) (
               label_replace(
                 max by (pod, alertmanager) (
-                  (rate(prometheus_notifications_errors_total{pod="prometheus-main-0"}[5m]) / rate(prometheus_notifications_sent_total{pod="prometheus-main-0"}[5m])) * 100) != 0,
+                  (rate(prometheus_notifications_errors_total{pod="prometheus-main-0"}[5m]) / rate(prometheus_notifications_sent_total{pod="prometheus-main-0"}[5m])) * 100) > 0,
                 "pod_ip", "$1", "alertmanager", ".*://(.*):.*")
           )
           * on (pod_ip) group_right()


### PR DESCRIPTION
Signed-off-by: Konstantin Aksenov <konstantin.aksenov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Compare percent of errors with 0.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Wrong expression leads to alerts when there are no problems.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: flant-integration
type: fix
summary: Fix expression for D8PrometheusMadisonErrorSendingAlertsToBackend
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
