### PR TITLE
[istio] Don't exclude d8-namespaces from istiod discovery

### DIFF
--- a/ee/modules/110-istio/templates/control-plane/iop.yaml
+++ b/ee/modules/110-istio/templates/control-plane/iop.yaml
@@ -61,21 +61,11 @@ spec:
     rootNamespace: d8-{{ $.Chart.Name }}
     trustDomain: {{ $.Values.global.discovery.clusterDomain | quote }}
 
-    # The rules below exclude deckhouse-related namespaces from istiod's point of view.
-    # So, their influence to istio performance will be reduced:
-    # * upmeter's events used to affect the traffic significantly between control-plane and data-plane,
-    # * deckhouse-related services were stored in sidecar-proxies, which made no sense.
-    # The same time we need to handle some namespaces including d8-istio itself, d8-ingress-nginx to serve controllers
-    # with enableIstioSidecar and d8-user-authn to interact between applications and the dex installation.
+    # The rules below exclude upmeter-related namespaces from istiod's point of view.
+    # So, upmeter's events used to affect the traffic between control-plane and data-plane will be reduced.
     discoverySelectors:
-      # Include d8-istio, d8-ingress-nginx and d8-user-authn namespaces:
     - matchExpressions:
-      - {key: "heritage", operator: In, values: [deckhouse]}
-      - {key: "module",   operator: In, values: [istio,ingress-nginx,user-authn]}
-
-      # Exclude everything else related to deckhouse and upmeter:
-    - matchExpressions:
-      - {key: "heritage", operator: NotIn, values: [deckhouse,upmeter]}
+      - {key: "heritage", operator: NotIn, values: [upmeter]}
 
     outboundTrafficPolicy:
   {{- $outboundTrafficPolicyModeDict := dict "AllowAny" "ALLOW_ANY" "RegistryOnly" "REGISTRY_ONLY" }}


### PR DESCRIPTION
## Description
Don't exclude d8-namespaces from istiod discovery.

## Why do we need it, and what problem does it solve?
There are problems with dex-authenticator which is widely used in d8 modules. It isn't accessible from istio-enabled ingress controllers.

## What is the expected result?
d8-namespaces are being discovered by istiod.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: istio
type: fix
summary: Don't exclude d8-namespaces from istiod discovery.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
