### PR TITLE
[testing] Enable automatic integration tests for linstor module

### DIFF
--- a/testing/cloud_layouts/Static/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Static/configuration.tpl.yaml
@@ -17,6 +17,7 @@ deckhouse:
   configOverrides:
     cniFlannelEnabled: true
     flantIntegrationEnabled: false
+    linstorEnabled: true
     global:
       modules:
         publicDomainTemplate: "%s.k8s.smoke.flant.com"

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -324,7 +324,7 @@ function run-test() {
   fi
 
   if [[ "$PROVIDER" == "Static" ]]; then
-    run_linstor_tests "$ssh_private_key_path" "$ssh_user" "${master_ip}"
+    run_linstor_tests || return $?
   fi
 }
 
@@ -637,7 +637,7 @@ function run_linstor_tests() {
 
   testScript=$(cat <<"END_SCRIPT"
 set -Eeuo pipefail
->&2 echo "Running linstor suit tests ..."
+>&2 echo "Running linstor test suite ..."
 set -x
 >&2 kubectl -n d8-system exec deploy/deckhouse -- helm test -n d8-system linstor
 END_SCRIPT
@@ -645,7 +645,7 @@ END_SCRIPT
 
   testRunAttempts=5
   for ((i=1; i<=$testRunAttempts; i++)); do
-    if ssh -o GlobalKnownHostsFile=/dev/null -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "$ssh_private_key_path" "$ssh_user@$master_ip" sudo -i /bin/bash <<<"${testScript}"; then
+    if $ssh_command -i "$ssh_private_key_path" "$ssh_user@$master_ip" sudo su -c /bin/bash <<<"${testScript}"; then
       test_failed=""
       break
     else

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -322,10 +322,6 @@ function run-test() {
     change_deckhouse_image "${SWITCH_TO_IMAGE_TAG}" || return $?
     wait_cluster_ready || return $?
   fi
-
-  if [[ "$PROVIDER" == "Static" ]]; then
-    run_linstor_tests || return $?
-  fi
 }
 
 function bootstrap_static() {
@@ -509,6 +505,11 @@ END_SCRIPT
 #  - ssh_user
 #  - master_ip
 function wait_cluster_ready() {
+  if [[ "$PROVIDER" == "Static" ]]; then
+    run_linstor_tests || return $?
+  fi
+  echo "Linstor test suite: success"
+
   test_failed=
 
   testScript=$(cat <<"END_SCRIPT"

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -323,7 +323,9 @@ function run-test() {
     wait_cluster_ready || return $?
   fi
 
-  run_helm_tests "$ssh_private_key_path" "$ssh_user" "${master_ip}"
+  if [[ "$PROVIDER" == "Static" ]]; then
+    run_linstor_tests "$ssh_private_key_path" "$ssh_user" "${master_ip}"
+  fi
 }
 
 function bootstrap_static() {
@@ -622,19 +624,22 @@ ENDSSH
   fi
 }
 
-# run_helm_tests executes helm tests for all deckhouse modules
+# run_linstor_tests executes helm test for linstor module
 #
 # Arguments:
 #  - ssh_private_key_path
 #  - ssh_user
 #  - master_ip
-function run_helm_tests() {
+#
+# TODO: replace with testing framework: https://github.com/deckhouse/deckhouse/issues/2380
+function run_linstor_tests() {
   test_failed=
 
   testScript=$(cat <<"END_SCRIPT"
 set -Eeuo pipefail
->&2 echo "Running Deckhouse helm suit tests ..."
-kubectl -n d8-system exec deploy/deckhouse -- sh -c "helm ls -n d8-system | awk 'NR>2 {print \"helm test -n d8-system \" \$1}' | sh -ex"
+>&2 echo "Running linstor suit tests ..."
+set -x
+>&2 kubectl -n d8-system exec deploy/deckhouse -- helm test -n d8-system linstor
 END_SCRIPT
 )
 


### PR DESCRIPTION
## Description

This PR enables helm test for linstor module.

This is temporary solution before implementing https://github.com/deckhouse/deckhouse/issues/2380

## Why do we need it, and what problem does it solve?

Execute e2e tests for linstor

## What is the expected result?
<!---

When run e2e tests for `Static` enviroment, the linstor module will be tested as well

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: testing
type: chore
summary: Enable automatic integration tests for linstor module
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
