### PR TITLE
[linstor] Add note about adding exiting pools using general configuration method

### DIFF
--- a/modules/031-linstor/docs/FAQ.md
+++ b/modules/031-linstor/docs/FAQ.md
@@ -71,6 +71,9 @@ kubectl annotate storageclass linstor-data-r2 storageclass.kubernetes.io/is-defa
 
 ## How to add existing LVM or LVMThin pool?
 
+> The general method is described in`[LINSTOR storage configuration](configuration.html#linstor-storage-configuration) page.
+> Unlike commands listed below it will automatically configure the StorageClasses as well.
+
 Example of adding an existing LVM pool:
 
 ```shell

--- a/modules/031-linstor/docs/FAQ_RU.md
+++ b/modules/031-linstor/docs/FAQ_RU.md
@@ -71,6 +71,9 @@ kubectl annotate storageclass linstor-data-r2 storageclass.kubernetes.io/is-defa
 
 ## Как добавить существующий LVM или LVMThin-пул?
 
+> Основной метод описан на странице [конфигурация хранилища LINSTOR](configuration.html#конфигурация-хранилища-linstor).
+> В отличие от команд перечисленных ниже, он также автоматически настроит StorageClasses.
+
 Пример добавления LVM-пула:
 
 ```shell


### PR DESCRIPTION
## Description


## Why do we need it, and what problem does it solve?


## What is the expected result?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: linstor
type: chore
summary: Add note about adding exiting pools using general configuration method
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
