### PR TITLE
[testing] Fix doc validation file filter

### DIFF
--- a/tools/validation/doc_changes.go
+++ b/tools/validation/doc_changes.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 )
 
-var resourceFileRe = regexp.MustCompile(`openapi/config-values.y[a]?ml$|crds/.+.y[a]?ml$`)
+var resourceFileRe = regexp.MustCompile(`openapi/config-values.y[a]?ml$|crds/.+.y[a]?ml$|openapi/cluster_configuration.y[a]?ml$|openapi/instance_class.y[a]?ml$|openapi/node_group.y[a]?ml$`)
 var docFileRe = regexp.MustCompile(`\.md$`)
 
 func RunDocChangesValidation(info *DiffInfo) (exitCode int) {


### PR DESCRIPTION
## Description

Added testing of the following files:
- openapi/cluster_configuration.y[a]?ml
- openapi/instance_class.y[a]?ml
- openapi/node_group.y[a]?ml

## Why do we need it, and what problem does it solve?
The Documentation validator doesn't cover some OpenAPI specs. E.g. spec of a module configuration, instanceClass, and nodeGroup specs.

[Example](https://github.com/deckhouse/deckhouse/runs/7952034332?check_suite_focus=true).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: testing
type: fix
summary: Fix doc validation file filter
impact_level: low
```
