### PR TITLE
[bashible] fix docker-containerd migration

### DIFF
--- a/candi/bashible/bundles/centos/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/centos/node-group/031_install_containerd.sh.tpl
@@ -28,22 +28,24 @@ if bb-yum-package? docker-ce; then
   if systemctl is-active -q kubelet.service; then
     systemctl stop kubelet.service
   fi
+
+  bb-log-info "Setting reboot flag due to cri being updated"
+  bb-flag-set reboot
+
   # Stop docker containers if they run
   docker stop $(docker ps -q) || true
   systemctl stop docker.service
   systemctl stop containerd.service
   # Kill running containerd-shim processes
-  kill $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}') 2>/dev/null || true
+  kill -9 $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}') 2>/dev/null || true
   # Remove mounts
   umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true
   bb-rp-remove docker-ce containerd-io
   bb-yum-remove docker.io docker-ce containerd-io
-  rm -rf /var/lib/docker/ /var/run/docker.sock /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
-  # Pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
+  rm -rf /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
+  # Old version of pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /usr/local/bin/crictl
-
-  bb-log-info "Setting reboot flag due to cri being updated"
-  bb-flag-set reboot
+  rm -rf /var/lib/docker/ /var/run/docker.sock
 fi
 
 {{- range $key, $value := index .k8s .kubernetesVersion "bashible" "centos" }}
@@ -80,9 +82,13 @@ if [[ "$should_install_containerd" == true ]]; then
   fi
 {{- end }}
 
-  crictl_tag="{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}"
+  bb-rp-install "containerd-io:${containerd_tag}"
+fi
 
-  bb-rp-install "containerd-io:${containerd_tag}" "crictl:${crictl_tag}"
+# install crictl
+crictl_tag="{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}"
+if ! bb-rp-is-installed? "crictl" "${crictl_tag}" ; then
+  bb-rp-install "crictl:${crictl_tag}"
 fi
 
 # Upgrade containerd-flant-edition if needed

--- a/candi/bashible/bundles/centos/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/centos/node-group/031_install_containerd.sh.tpl
@@ -37,6 +37,7 @@ if bb-yum-package? docker-ce; then
   systemctl stop docker.service
   systemctl stop containerd.service
   # Kill running containerd-shim processes
+  kill $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}') 2>/dev/null || true
   kill -9 $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}') 2>/dev/null || true
   # Remove mounts
   umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true

--- a/candi/bashible/bundles/debian/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/debian/node-group/031_install_containerd.sh.tpl
@@ -37,6 +37,7 @@ if bb-apt-package? docker-ce || bb-apt-package? docker.io; then
   systemctl stop docker.service
   systemctl stop containerd.service
   # Kill running containerd-shim processes
+  kill $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}') 2>/dev/null || true
   kill -9 $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}') 2>/dev/null || true
   # Remove mounts
   umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true

--- a/candi/bashible/bundles/debian/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/debian/node-group/031_install_containerd.sh.tpl
@@ -28,22 +28,24 @@ if bb-apt-package? docker-ce || bb-apt-package? docker.io; then
   if systemctl is-active -q kubelet.service; then
     systemctl stop kubelet.service
   fi
+
+  bb-log-info "Setting reboot flag due to cri being updated"
+  bb-flag-set reboot
+
   # Stop docker containers if they run
   docker stop $(docker ps -q) || true
   systemctl stop docker.service
   systemctl stop containerd.service
   # Kill running containerd-shim processes
-  kill $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}') 2>/dev/null || true
+  kill -9 $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}') 2>/dev/null || true
   # Remove mounts
   umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true
   bb-rp-remove docker-ce containerd-io
   bb-apt-remove docker.io docker-ce containerd-io
-  rm -rf /var/lib/docker/ /var/run/docker.sock /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
-  # Pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
+  rm -rf /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
+  # Old version of pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /usr/local/bin/crictl
-
-  bb-log-info "Setting reboot flag due to cri being updated"
-  bb-flag-set reboot
+  rm -rf /var/lib/docker/ /var/run/docker.sock
 fi
 
 # set default
@@ -87,9 +89,13 @@ containerd_tag="{{- index $.images.registrypackages (printf "containerdDebian%sB
   fi
 {{- end }}
 
-  crictl_tag="{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}"
+  bb-rp-install "containerd-io:${containerd_tag}"
+fi
 
-  bb-rp-install "containerd-io:${containerd_tag}" "crictl:${crictl_tag}"
+# install crictl
+crictl_tag="{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}"
+if ! bb-rp-is-installed? "crictl" "${crictl_tag}" ; then
+  bb-rp-install "crictl:${crictl_tag}"
 fi
 
 # Upgrade containerd-flant-edition if needed

--- a/candi/bashible/bundles/ubuntu-lts/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/node-group/031_install_containerd.sh.tpl
@@ -37,6 +37,7 @@ if bb-apt-package? docker-ce || bb-apt-package? docker.io; then
   systemctl stop docker.service
   systemctl stop containerd.service
   # Kill running containerd-shim processes
+  kill $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}') 2>/dev/null || true
   kill -9 $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}') 2>/dev/null || true
   # Remove mounts
   umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true

--- a/candi/bashible/bundles/ubuntu-lts/node-group/031_install_containerd.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/node-group/031_install_containerd.sh.tpl
@@ -28,22 +28,24 @@ if bb-apt-package? docker-ce || bb-apt-package? docker.io; then
   if systemctl is-active -q kubelet.service; then
     systemctl stop kubelet.service
   fi
+
+  bb-log-info "Setting reboot flag due to cri being updated"
+  bb-flag-set reboot
+
   # Stop docker containers if they run
   docker stop $(docker ps -q) || true
   systemctl stop docker.service
   systemctl stop containerd.service
   # Kill running containerd-shim processes
-  kill $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}') 2>/dev/null || true
+  kill -9 $(ps ax | grep containerd-shim | grep -v grep |awk '{print $1}') 2>/dev/null || true
   # Remove mounts
   umount $(mount | grep "/run/containerd" | cut -f3 -d" ") 2>/dev/null || true
   bb-rp-remove docker-ce containerd-io
   bb-apt-remove docker.io docker-ce containerd-io
-  rm -rf /var/lib/docker/ /var/run/docker.sock /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
-  # Pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
+  rm -rf /var/lib/containerd/ /etc/docker /etc/containerd/config.toml
+  # Old version of pod kubelet-eviction-thresholds-exporter in cri=Docker mode mounts /var/run/containerd/containerd.sock, /var/run/containerd/containerd.sock will be a directory and newly installed containerd won't run. Same thing with crictl.
   rm -rf /var/run/containerd /usr/local/bin/crictl
-
-  bb-log-info "Setting reboot flag due to cri being updated"
-  bb-flag-set reboot
+  rm -rf /var/lib/docker/ /var/run/docker.sock
 fi
 
 {{- range $key, $value := index .k8s .kubernetesVersion "bashible" "ubuntu" }}
@@ -81,9 +83,13 @@ if [[ "$should_install_containerd" == true ]]; then
   fi
 {{- end }}
 
-  crictl_tag="{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}"
+  bb-rp-install "containerd-io:${containerd_tag}"
+fi
 
-  bb-rp-install "containerd-io:${containerd_tag}" "crictl:${crictl_tag}"
+# install crictl
+crictl_tag="{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}"
+if ! bb-rp-is-installed? "crictl" "${crictl_tag}" ; then
+  bb-rp-install "crictl:${crictl_tag}"
 fi
 
 # Upgrade containerd-flant-edition if needed


### PR DESCRIPTION
Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix docker-containerd migration.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
1. On Ubuntu 22.04 on migration from docker to containerd crictl never installs.
2. On other distros, sometimes, containerd-shim locks directory /var/lib/docker and migration fails.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary:  fix docker-containerd migration
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
