### PR TITLE
[ingress-nginx] fix defaultControllerVersion inheritance

### DIFF
--- a/modules/402-ingress-nginx/hooks/get_ingress_controllers_test.go
+++ b/modules/402-ingress-nginx/hooks/get_ingress_controllers_test.go
@@ -92,6 +92,29 @@ spec:
 		})
 	})
 
+	Context("IngressNginxContorller without explicitly controllerVersion", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1
+kind: IngressNginxController
+metadata:
+  name: testd
+spec:
+  ingressClass: nginx
+  inlet: LoadBalancer
+`))
+			f.RunHook()
+		})
+
+		It("Shouldn't fill controller version with default value", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
+
+			Expect(f.ValuesGet("ingressNginx.internal.ingressControllers.0.spec.controllerVersion").Exists()).To(BeFalse())
+		})
+	})
+
 	Context("With Ingress Nginx Controller resource", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(`
@@ -145,7 +168,6 @@ spec:
 			Expect(f.ValuesGet("ingressNginx.internal.ingressControllers.0.spec").String()).To(MatchJSON(`{
 "config": {},
 "ingressClass": "nginx",
-"controllerVersion": "0.33",
 "inlet": "LoadBalancer",
 "hstsOptions": {},
 "geoIP2": {},
@@ -165,7 +187,6 @@ spec:
 			Expect(f.ValuesGet("ingressNginx.internal.ingressControllers.1.spec").String()).To(MatchJSON(`{
 "config": {},
 "ingressClass": "test",
-"controllerVersion": "0.33",
 "inlet": "HostPortWithProxyProtocol",
 "hstsOptions": {},
 "geoIP2": {},
@@ -185,7 +206,6 @@ spec:
 			Expect(f.ValuesGet("ingressNginx.internal.ingressControllers.2.spec").String()).To(MatchJSON(`{
 "config": {},
 "ingressClass": "test",
-"controllerVersion": "0.33",
 "inlet": "LoadBalancerWithProxyProtocol",
 "hstsOptions": {},
 "geoIP2": {},

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -100,7 +100,7 @@ metadata:
     ingress-nginx-manual-update: "true"
   {{- end }}
   annotations:
-    ingress-nginx-controller.deckhouse.io/controller-version: {{ $crd.spec.controllerVersion | quote }}
+    ingress-nginx-controller.deckhouse.io/controller-version: {{ $controllerVersion | quote }}
     ingress-nginx-controller.deckhouse.io/inlet: {{ $crd.spec.inlet | quote }}
     ingress-nginx-controller.deckhouse.io/checksum: {{ $crdChecksum }}
 spec:
@@ -171,7 +171,7 @@ spec:
       imagePullSecrets:
       - name: deckhouse-registry
       containers:
-      - image: {{ include "helm_lib_module_image" (list $context (printf "controller%s" ($crd.spec.controllerVersion | replace "." ""))) }}
+      - image: {{ include "helm_lib_module_image" (list $context (printf "controller%s" ($controllerVersion | replace "." ""))) }}
         name: controller
         env:
         - name: POD_NAME


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
We don't want to inject defaultControllerVersion to IngressNginxController CR

## Why do we need it, and what problem does it solve?
All templates fallback to defaultControllerVersion only if `.spec.controllerVersion` is not set explicitly in CR. 

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ingress-nginx
type: fix
summary: Change defaultControllerVersion without deckhouse reboot
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
