### PR TITLE
[docs] Fix typo in the NodeGroup example

### DIFF
--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -388,7 +388,7 @@ spec:
                     Chaos monkey settings.
                   x-doc-example: |
                     ```yaml
-                    mode: DrainAndReboot
+                    mode: DrainAndDelete
                     period: 24h
                     ```
                   type: object


### PR DESCRIPTION
## Description

Fix typo in the NodeGroup example.

Close: #2180 

## Changelog entries
```changes
section: docs
type: fix
summary: Fix typo in the NodeGroup example
impact_level: low
```
