### PR TITLE
[dhctl] Change color, fix empty host connection attempts

### DIFF
--- a/dhctl/pkg/log/logger.go
+++ b/dhctl/pkg/log/logger.go
@@ -188,12 +188,12 @@ func (d *PrettyLogger) LogFail(l string) {
 }
 
 func (d *PrettyLogger) LogWarnLn(a ...interface{}) {
-	a = append([]interface{}{"‼️  "}, a...)
-	d.LogInfoLn(color.New(color.Bold, color.FgHiWhite).Sprint(a...))
+	a = append([]interface{}{"❗ ~ "}, a...)
+	d.LogInfoLn(color.New(color.Bold).Sprint(a...))
 }
 
 func (d *PrettyLogger) LogWarnF(format string, a ...interface{}) {
-	line := color.New(color.Bold, color.FgHiWhite).Sprintf("‼️  "+format, a...)
+	line := color.New(color.Bold).Sprintf("❗ ~ "+format, a...)
 	d.LogInfoF(line)
 }
 

--- a/dhctl/pkg/log/options.go
+++ b/dhctl/pkg/log/options.go
@@ -40,24 +40,43 @@ func CommonOptions() logboek.LogProcessOptions {
 }
 
 func boldStyle() *logboek.Style {
-	return &logboek.Style{Attributes: []color.Attribute{color.FgHiWhite, color.Bold}}
+	return &logboek.Style{
+		Attributes: []color.Attribute{color.Bold},
+	}
 }
 
 func BoldOptions() logboek.LogProcessOptions {
-	return logboek.LogProcessOptions{LevelLogProcessOptions: logboek.LevelLogProcessOptions{Style: boldStyle()}}
+	return logboek.LogProcessOptions{
+		LevelLogProcessOptions: logboek.LevelLogProcessOptions{
+			Style: boldStyle(),
+		},
+	}
 }
 
-// TODO: cook loogboek
 func BoldStartOptions() logboek.LogProcessStartOptions {
-	return logboek.LogProcessStartOptions{LevelLogProcessStartOptions: logboek.LevelLogProcessStartOptions{Style: boldStyle()}}
+	return logboek.LogProcessStartOptions{
+		LevelLogProcessStartOptions: logboek.LevelLogProcessStartOptions{
+			Style: boldStyle(),
+		},
+	}
 }
 
 func BoldEndOptions() logboek.LogProcessEndOptions {
-	return logboek.LogProcessEndOptions{LevelLogProcessEndOptions: logboek.LevelLogProcessEndOptions{Style: boldStyle()}}
+	return logboek.LogProcessEndOptions{
+		LevelLogProcessEndOptions: logboek.LevelLogProcessEndOptions{
+			Style: boldStyle(),
+		},
+	}
 }
 
 func BoldFailOptions() logboek.LogProcessFailOptions {
-	return logboek.LogProcessFailOptions{LevelLogProcessFailOptions: logboek.LevelLogProcessFailOptions{LevelLogProcessEndOptions: logboek.LevelLogProcessEndOptions{Style: boldStyle()}}}
+	return logboek.LogProcessFailOptions{
+		LevelLogProcessFailOptions: logboek.LevelLogProcessFailOptions{
+			LevelLogProcessEndOptions: logboek.LevelLogProcessEndOptions{
+				Style: boldStyle(),
+			},
+		},
+	}
 }
 
 func TerraformOptions() logboek.LogProcessOptions {

--- a/dhctl/pkg/system/ssh/frontend/waiting.go
+++ b/dhctl/pkg/system/ssh/frontend/waiting.go
@@ -40,7 +40,7 @@ func (c *Check) WithDelaySeconds(seconds int) *Check {
 
 func (c *Check) AwaitAvailability() error {
 	if c.Session.Host() == "" {
-		return fmt.Errorf("empty host for connection received")
+		return fmt.Errorf("Empty host for connection received")
 	}
 	time.Sleep(c.delay)
 	return retry.NewLoop("Waiting for SSH connection", 50, 5*time.Second).Run(func() error {

--- a/dhctl/pkg/system/ssh/frontend/waiting.go
+++ b/dhctl/pkg/system/ssh/frontend/waiting.go
@@ -39,6 +39,9 @@ func (c *Check) WithDelaySeconds(seconds int) *Check {
 }
 
 func (c *Check) AwaitAvailability() error {
+	if c.Session.Host() == "" {
+		return fmt.Errorf("empty host for connection received")
+	}
 	time.Sleep(c.delay)
 	return retry.NewLoop("Waiting for SSH connection", 50, 5*time.Second).Run(func() error {
 		log.InfoF("Try to connect to %v host\n", c.Session.Host())


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
* Changes font colour for bold blocks from white to normal
* Fail if there is empty host for ssh connection

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: fix
summary: Changes font colour for bold blocks from white to normal
impact_level: low
---
section: dhctl
type: fix
summary: Fail if there is empty host for ssh connection
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
