### PR TITLE
[ingress-nginx] pbmetrics improvement

### DIFF
--- a/modules/402-ingress-nginx/images/controller-0-33/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-0-33/Dockerfile
@@ -25,7 +25,7 @@ FROM quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1@sha25
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends patch gcc build-essential \
-  && luarocks install lua-protobuf 0.3.2-0 \
+  && luarocks install lua-protobuf 0.3.4-1 \
   && luarocks install lua-iconv 7-3
 
 # IngressNginxController docker image

--- a/modules/402-ingress-nginx/images/controller-0-33/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-33/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -378,10 +378,6 @@ end
 
 -- send() sends buffer data to protobuf exporter via tcp socket
 local function send(premature)
-  if premature then
-    return
-  end
-
   if nkeys(buffer) == 0 then
     return
   end

--- a/modules/402-ingress-nginx/images/controller-0-33/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-33/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -419,6 +419,7 @@ local function send(premature)
   if premature then
     -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown
     sock:close()
+    return
   end
 
   if debug_enabled then

--- a/modules/402-ingress-nginx/images/controller-0-33/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-33/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -409,7 +409,10 @@ local function send(premature)
   if not ok then
     log(ERROR, format("error while sending data via tcp socket: %s", tostring(err)))
   end
-  sock:close()
+
+  if premature then
+    sock:close()
+  end
 
   if debug_enabled then
     update_time()

--- a/modules/402-ingress-nginx/images/controller-0-33/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-33/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -397,18 +397,24 @@ local function send(premature)
   end
   clear_tab(buffer)
 
+
   local sock = socket()
+  sock:settimeout(10000)
   local ok, err = sock:connect("127.0.0.1", "9090")
   if not ok then
     log(ERROR, format("failed to connect to the tcp socket, metrcis buffer will be lost: %s", tostring(err)))
     return
   end
-  sock:settimeout(60000) -- 1 min timeout
+  local ok, err = sock:setoption("keepalive", true)
+  if not ok then
+    log(ERROR, format("setoption keepalive failed: %s", tostring(err)))
+  end
 
   ok, err = sock:send(pbbuff:result())
   if not ok then
     log(ERROR, format("error while sending data via tcp socket: %s", tostring(err)))
   end
+  sock:setkeepalive(0)
 
   if premature then
     -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown

--- a/modules/402-ingress-nginx/images/controller-0-33/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-33/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -32,7 +32,6 @@ local get_env = os.getenv
 
 local new_tab = require "table.new"
 local clear_tab = require "table.clear"
-local clone_tab = require "table.clone"
 local nkeys = require "table.nkeys"
 local remove = table.remove
 local insert_tab = table.insert
@@ -389,11 +388,8 @@ local function send(premature)
 
   local start_time = now()
 
-  local current_buffer = clone_tab(buffer)
-  clear_tab(buffer)
-
   local pbbuff = pbuff.new()
-  for k, v in pairs(current_buffer) do
+  for k, v in pairs(buffer) do
     local metric_type = k:sub(1, 1)
     if metric_type == "g" then
       protogauge(pbbuff, v)
@@ -403,6 +399,7 @@ local function send(premature)
       protohist(pbbuff, v)
     end
   end
+  clear_tab(buffer)
 
   local sock = socket()
   local ok, err = sock:connect("127.0.0.1", "9090")

--- a/modules/402-ingress-nginx/images/controller-0-33/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-33/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -48,7 +48,7 @@ local GeoHash = require "geohash"
 GeoHash.precision(2)
 local geohash_encode = GeoHash.encode
 
-local buffer = new_tab(200000, 0)
+local buffer = new_tab(0, 100000)
 local debug_enabled = get_env("LUA_DEBUG")
 local use_geoip2 = get_env("LUA_USE_GEOIP2")
 
@@ -411,6 +411,7 @@ local function send(premature)
   end
 
   if premature then
+    -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown
     sock:close()
   end
 

--- a/modules/402-ingress-nginx/images/controller-0-46/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-0-46/Dockerfile
@@ -23,7 +23,7 @@ FROM quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1@sha25
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends patch gcc build-essential \
-  && luarocks install lua-protobuf 0.3.2-0 \
+  && luarocks install lua-protobuf 0.3.4-1 \
   && luarocks install lua-iconv 7-3
 
 # IngressNginxController docker image

--- a/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -378,10 +378,6 @@ end
 
 -- send() sends buffer data to protobuf exporter via tcp socket
 local function send(premature)
-  if premature then
-    return
-  end
-
   if nkeys(buffer) == 0 then
     return
   end

--- a/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -419,6 +419,7 @@ local function send(premature)
   if premature then
     -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown
     sock:close()
+    return
   end
 
   if debug_enabled then

--- a/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -409,7 +409,10 @@ local function send(premature)
   if not ok then
     log(ERROR, format("error while sending data via tcp socket: %s", tostring(err)))
   end
-  sock:close()
+
+  if premature then
+    sock:close()
+  end
 
   if debug_enabled then
     update_time()

--- a/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -397,18 +397,24 @@ local function send(premature)
   end
   clear_tab(buffer)
 
+
   local sock = socket()
+  sock:settimeout(10000)
   local ok, err = sock:connect("127.0.0.1", "9090")
   if not ok then
     log(ERROR, format("failed to connect to the tcp socket, metrcis buffer will be lost: %s", tostring(err)))
     return
   end
-  sock:settimeout(60000) -- 1 min timeout
+  local ok, err = sock:setoption("keepalive", true)
+  if not ok then
+    log(ERROR, format("setoption keepalive failed: %s", tostring(err)))
+  end
 
   ok, err = sock:send(pbbuff:result())
   if not ok then
     log(ERROR, format("error while sending data via tcp socket: %s", tostring(err)))
   end
+  sock:setkeepalive(0)
 
   if premature then
     -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown

--- a/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -32,7 +32,6 @@ local get_env = os.getenv
 
 local new_tab = require "table.new"
 local clear_tab = require "table.clear"
-local clone_tab = require "table.clone"
 local nkeys = require "table.nkeys"
 local remove = table.remove
 local insert_tab = table.insert
@@ -389,11 +388,8 @@ local function send(premature)
 
   local start_time = now()
 
-  local current_buffer = clone_tab(buffer)
-  clear_tab(buffer)
-
   local pbbuff = pbuff.new()
-  for k, v in pairs(current_buffer) do
+  for k, v in pairs(buffer) do
     local metric_type = k:sub(1, 1)
     if metric_type == "g" then
       protogauge(pbbuff, v)
@@ -403,6 +399,7 @@ local function send(premature)
       protohist(pbbuff, v)
     end
   end
+  clear_tab(buffer)
 
   local sock = socket()
   local ok, err = sock:connect("127.0.0.1", "9090")

--- a/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-46/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -48,7 +48,7 @@ local GeoHash = require "geohash"
 GeoHash.precision(2)
 local geohash_encode = GeoHash.encode
 
-local buffer = new_tab(200000, 0)
+local buffer = new_tab(0, 100000)
 local debug_enabled = get_env("LUA_DEBUG")
 local use_geoip2 = get_env("LUA_USE_GEOIP2")
 
@@ -411,6 +411,7 @@ local function send(premature)
   end
 
   if premature then
+    -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown
     sock:close()
   end
 

--- a/modules/402-ingress-nginx/images/controller-0-48/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-0-48/Dockerfile
@@ -23,7 +23,7 @@ FROM quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1@sha25
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends patch gcc build-essential \
-  && luarocks install lua-protobuf 0.3.2-0 \
+  && luarocks install lua-protobuf 0.3.4-1 \
   && luarocks install lua-iconv 7-3
 
 # IngressNginxController docker image

--- a/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -378,10 +378,6 @@ end
 
 -- send() sends buffer data to protobuf exporter via tcp socket
 local function send(premature)
-  if premature then
-    return
-  end
-
   if nkeys(buffer) == 0 then
     return
   end

--- a/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -419,6 +419,7 @@ local function send(premature)
   if premature then
     -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown
     sock:close()
+    return
   end
 
   if debug_enabled then

--- a/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -409,7 +409,10 @@ local function send(premature)
   if not ok then
     log(ERROR, format("error while sending data via tcp socket: %s", tostring(err)))
   end
-  sock:close()
+
+  if premature then
+    sock:close()
+  end
 
   if debug_enabled then
     update_time()

--- a/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -397,18 +397,24 @@ local function send(premature)
   end
   clear_tab(buffer)
 
+
   local sock = socket()
+  sock:settimeout(10000)
   local ok, err = sock:connect("127.0.0.1", "9090")
   if not ok then
     log(ERROR, format("failed to connect to the tcp socket, metrcis buffer will be lost: %s", tostring(err)))
     return
   end
-  sock:settimeout(60000) -- 1 min timeout
+  local ok, err = sock:setoption("keepalive", true)
+  if not ok then
+    log(ERROR, format("setoption keepalive failed: %s", tostring(err)))
+  end
 
   ok, err = sock:send(pbbuff:result())
   if not ok then
     log(ERROR, format("error while sending data via tcp socket: %s", tostring(err)))
   end
+  sock:setkeepalive(0)
 
   if premature then
     -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown

--- a/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -32,7 +32,6 @@ local get_env = os.getenv
 
 local new_tab = require "table.new"
 local clear_tab = require "table.clear"
-local clone_tab = require "table.clone"
 local nkeys = require "table.nkeys"
 local remove = table.remove
 local insert_tab = table.insert
@@ -389,11 +388,8 @@ local function send(premature)
 
   local start_time = now()
 
-  local current_buffer = clone_tab(buffer)
-  clear_tab(buffer)
-
   local pbbuff = pbuff.new()
-  for k, v in pairs(current_buffer) do
+  for k, v in pairs(buffer) do
     local metric_type = k:sub(1, 1)
     if metric_type == "g" then
       protogauge(pbbuff, v)
@@ -403,6 +399,7 @@ local function send(premature)
       protohist(pbbuff, v)
     end
   end
+  clear_tab(buffer)
 
   local sock = socket()
   local ok, err = sock:connect("127.0.0.1", "9090")

--- a/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-48/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -48,7 +48,7 @@ local GeoHash = require "geohash"
 GeoHash.precision(2)
 local geohash_encode = GeoHash.encode
 
-local buffer = new_tab(200000, 0)
+local buffer = new_tab(0, 100000)
 local debug_enabled = get_env("LUA_DEBUG")
 local use_geoip2 = get_env("LUA_USE_GEOIP2")
 
@@ -411,6 +411,7 @@ local function send(premature)
   end
 
   if premature then
+    -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown
     sock:close()
   end
 

--- a/modules/402-ingress-nginx/images/controller-0-49/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-0-49/Dockerfile
@@ -23,7 +23,7 @@ FROM quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1@sha25
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends patch gcc build-essential \
-  && luarocks install lua-protobuf 0.3.2-0 \
+  && luarocks install lua-protobuf 0.3.4-1 \
   && luarocks install lua-iconv 7-3
 
 # IngressNginxController docker image

--- a/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -378,10 +378,6 @@ end
 
 -- send() sends buffer data to protobuf exporter via tcp socket
 local function send(premature)
-  if premature then
-    return
-  end
-
   if nkeys(buffer) == 0 then
     return
   end

--- a/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -419,6 +419,7 @@ local function send(premature)
   if premature then
     -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown
     sock:close()
+    return
   end
 
   if debug_enabled then

--- a/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -409,7 +409,10 @@ local function send(premature)
   if not ok then
     log(ERROR, format("error while sending data via tcp socket: %s", tostring(err)))
   end
-  sock:close()
+
+  if premature then
+    sock:close()
+  end
 
   if debug_enabled then
     update_time()

--- a/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -397,18 +397,24 @@ local function send(premature)
   end
   clear_tab(buffer)
 
+
   local sock = socket()
+  sock:settimeout(10000)
   local ok, err = sock:connect("127.0.0.1", "9090")
   if not ok then
     log(ERROR, format("failed to connect to the tcp socket, metrcis buffer will be lost: %s", tostring(err)))
     return
   end
-  sock:settimeout(60000) -- 1 min timeout
+  local ok, err = sock:setoption("keepalive", true)
+  if not ok then
+    log(ERROR, format("setoption keepalive failed: %s", tostring(err)))
+  end
 
   ok, err = sock:send(pbbuff:result())
   if not ok then
     log(ERROR, format("error while sending data via tcp socket: %s", tostring(err)))
   end
+  sock:setkeepalive(0)
 
   if premature then
     -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown

--- a/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -32,7 +32,6 @@ local get_env = os.getenv
 
 local new_tab = require "table.new"
 local clear_tab = require "table.clear"
-local clone_tab = require "table.clone"
 local nkeys = require "table.nkeys"
 local remove = table.remove
 local insert_tab = table.insert
@@ -389,11 +388,8 @@ local function send(premature)
 
   local start_time = now()
 
-  local current_buffer = clone_tab(buffer)
-  clear_tab(buffer)
-
   local pbbuff = pbuff.new()
-  for k, v in pairs(current_buffer) do
+  for k, v in pairs(buffer) do
     local metric_type = k:sub(1, 1)
     if metric_type == "g" then
       protogauge(pbbuff, v)
@@ -403,6 +399,7 @@ local function send(premature)
       protohist(pbbuff, v)
     end
   end
+  clear_tab(buffer)
 
   local sock = socket()
   local ok, err = sock:connect("127.0.0.1", "9090")

--- a/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-0-49/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -48,7 +48,7 @@ local GeoHash = require "geohash"
 GeoHash.precision(2)
 local geohash_encode = GeoHash.encode
 
-local buffer = new_tab(200000, 0)
+local buffer = new_tab(0, 100000)
 local debug_enabled = get_env("LUA_DEBUG")
 local use_geoip2 = get_env("LUA_USE_GEOIP2")
 
@@ -411,6 +411,7 @@ local function send(premature)
   end
 
   if premature then
+    -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown
     sock:close()
   end
 

--- a/modules/402-ingress-nginx/images/controller-1-1/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-1/Dockerfile
@@ -19,7 +19,7 @@ FROM quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1@sha25
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends patch gcc build-essential \
-  && luarocks install lua-protobuf 0.3.4-0 \
+  && luarocks install lua-protobuf 0.3.4-1 \
   && luarocks install lua-iconv 7-3
 
 # IngressNginxController docker image

--- a/modules/402-ingress-nginx/images/controller-1-1/Dockerfile
+++ b/modules/402-ingress-nginx/images/controller-1-1/Dockerfile
@@ -19,7 +19,7 @@ FROM quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1@sha25
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends patch gcc build-essential \
-  && luarocks install lua-protobuf 0.3.2-0 \
+  && luarocks install lua-protobuf 0.3.4-0 \
   && luarocks install lua-iconv 7-3
 
 # IngressNginxController docker image

--- a/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -378,10 +378,6 @@ end
 
 -- send() sends buffer data to protobuf exporter via tcp socket
 local function send(premature)
-  if premature then
-    return
-  end
-
   if nkeys(buffer) == 0 then
     return
   end

--- a/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -409,7 +409,10 @@ local function send(premature)
   if not ok then
     log(ERROR, format("error while sending data via tcp socket: %s", tostring(err)))
   end
-  sock:close()
+
+  if premature then
+    sock:close()
+  end
 
   if debug_enabled then
     update_time()

--- a/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -384,16 +384,8 @@ local function send(premature)
 
   local start_time = now()
 
-  log(ERROR, format("Ipairs"))
-  for k, v in ipairs(buffer) do
-    log(ERROR, format("IPAIR '%s': '%s'", tostring(k), tostring(v)))
-  end
-
-
   local pbbuff = pbuff.new()
   for k, v in pairs(buffer) do
-    log(ERROR, format("PAIR '%s': '%s'", tostring(k), tostring(v)))
-
     local metric_type = k:sub(1, 1)
     if metric_type == "g" then
       protogauge(pbbuff, v)
@@ -419,6 +411,7 @@ local function send(premature)
   end
 
   if premature then
+    -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown
     sock:close()
   end
 

--- a/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -125,7 +125,7 @@ end
 local function _add(metrichash, annotations, mapping, value)
   local metric_data = buffer[metrichash] or { MappingIndex = mapping, Value = 0, Labels = _extract_labels(metrichash), Annotations = annotations }
   metric_data["Value"] = metric_data["Value"] + value
-  log(ngx.INFO, "write to buffer")
+  print("write to buffer")
   buffer[metrichash] = metric_data
 end
 
@@ -150,7 +150,7 @@ local function _observe(buckets, metrichash, annotations, mapping, value)
       break
     end
   end
-  log(ngx.INFO, "write to buffer")
+  print("write to buffer")
   buffer[metrichash] = metric_data
 end
 
@@ -391,7 +391,7 @@ local function send(premature)
   local start_time = now()
 
   local count = nkeys(buffer)
-  log(ngx.INFO, format("copy to pb: %s", tostring(count)))
+  log(ERROR, format("copy to pb: %s", tostring(count)))
   local pbbuff = pbuff.new()
   for k, v in pairs(buffer) do
     local metric_type = k:sub(1, 1)
@@ -403,9 +403,9 @@ local function send(premature)
       protohist(pbbuff, v)
     end
   end
-  log(ngx.INFO, "clear buffer")
+  log(ERROR, "clear buffer")
   clear_tab(buffer)
-  log(ngx.INFO, "buffer cleared")
+  log(ERROR, "buffer cleared")
 
   local sock = socket()
   local ok, err = sock:connect("127.0.0.1", "9090")

--- a/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -376,23 +376,6 @@ local function fill_buffer()
   end
 end
 
-local sock
-
-local function connect()
-  sock = socket()
-  sock:settimeout(0)
-  local ok, err = sock:connect("127.0.0.1", "9090")
-  if not ok then
-    log(ERROR, format("failed to connect to the tcp socket, metrcis buffer will be lost: %s", tostring(err)))
-    return
-  end
-  local ok, err = sock:setoption("keepalive", true)
-  if not ok then
-    log(ERROR, format("setoption keepalive failed: %s", tostring(err)))
-    return
-  end
-end
-
 -- send() sends buffer data to protobuf exporter via tcp socket
 local function send(premature)
   if nkeys(buffer) == 0 then
@@ -414,10 +397,25 @@ local function send(premature)
   end
   clear_tab(buffer)
 
+
+  local sock = socket()
+  sock:settimeout(10000)
+  local ok, err = sock:connect("127.0.0.1", "9090")
+  if not ok then
+    log(ERROR, format("failed to connect to the tcp socket, metrcis buffer will be lost: %s", tostring(err)))
+    return
+  end
+  local ok, err = sock:setoption("keepalive", true)
+  if not ok then
+    log(ERROR, format("setoption keepalive failed: %s", tostring(err)))
+    return
+  end
+
   ok, err = sock:send(pbbuff:result())
   if not ok then
     log(ERROR, format("error while sending data via tcp socket: %s", tostring(err)))
   end
+  sock:setkeepalive(0)
 
   if premature then
     -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown
@@ -434,7 +432,6 @@ local _M = {}
 
 -- init_worker() used at init_worker_by_lua_block stage to send buffer data to protobuf-exporter
 function _M.init_worker()
-  connect()
   local _, err = timer_every(1, send)
   if err then
     log(ERROR, format("error while sending data: %s", tostring(err)))

--- a/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -416,11 +416,6 @@ local function send(premature)
   end
   sock:setkeepalive(0)
 
-  if premature then
-    -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown
-    sock:close()
-  end
-
   if debug_enabled then
     update_time()
     log(WARNING, format("lua send seconds: %s", tostring(now() - start_time)))

--- a/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -408,7 +408,6 @@ local function send(premature)
   local ok, err = sock:setoption("keepalive", true)
   if not ok then
     log(ERROR, format("setoption keepalive failed: %s", tostring(err)))
-    return
   end
 
   ok, err = sock:send(pbbuff:result())

--- a/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -386,6 +386,8 @@ local function send(premature)
 
   local pbbuff = pbuff.new()
   for k, v in pairs(buffer) do
+    log(ERROR, format("PAIR '%s': '%s'", tostring(k), tostring(v)))
+
     local metric_type = k:sub(1, 1)
     if metric_type == "g" then
       protogauge(pbbuff, v)

--- a/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -416,6 +416,12 @@ local function send(premature)
   end
   sock:setkeepalive(0)
 
+  if premature then
+    -- sock:connect is checking connection pool for active sockets, so we are closing socket only on a worker shutdown
+    sock:close()
+    return
+  end
+
   if debug_enabled then
     update_time()
     log(WARNING, format("lua send seconds: %s", tostring(now() - start_time)))

--- a/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -380,7 +380,7 @@ local sock = socket()
 
 local function connect()
   sock:settimeout(0)
-  local ok, err = sock:connect("127.0.0.1", "9090", {pool_size = 3, backlog = 5})
+  local ok, err = sock:connect("127.0.0.1", "9090")
   if not ok then
     log(ERROR, format("failed to connect to the tcp socket, metrcis buffer will be lost: %s", tostring(err)))
     return

--- a/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -48,7 +48,7 @@ local GeoHash = require "geohash"
 GeoHash.precision(2)
 local geohash_encode = GeoHash.encode
 
-local buffer = new_tab(200000, 0)
+local buffer = new_tab(0, 100000)
 local debug_enabled = get_env("LUA_DEBUG")
 local use_geoip2 = get_env("LUA_USE_GEOIP2")
 
@@ -383,6 +383,12 @@ local function send(premature)
   end
 
   local start_time = now()
+
+  log(ERROR, format("Ipairs"))
+  for k, v in ipairs(buffer) do
+    log(ERROR, format("IPAIR '%s': '%s'", tostring(k), tostring(v)))
+  end
+
 
   local pbbuff = pbuff.new()
   for k, v in pairs(buffer) do

--- a/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -125,7 +125,6 @@ end
 local function _add(metrichash, annotations, mapping, value)
   local metric_data = buffer[metrichash] or { MappingIndex = mapping, Value = 0, Labels = _extract_labels(metrichash), Annotations = annotations }
   metric_data["Value"] = metric_data["Value"] + value
-  print("write to buffer")
   buffer[metrichash] = metric_data
 end
 
@@ -150,7 +149,6 @@ local function _observe(buckets, metrichash, annotations, mapping, value)
       break
     end
   end
-  print("write to buffer")
   buffer[metrichash] = metric_data
 end
 
@@ -390,8 +388,6 @@ local function send(premature)
 
   local start_time = now()
 
-  local count = nkeys(buffer)
-  log(ERROR, format("copy to pb: %s", tostring(count)))
   local pbbuff = pbuff.new()
   for k, v in pairs(buffer) do
     local metric_type = k:sub(1, 1)
@@ -403,9 +399,7 @@ local function send(premature)
       protohist(pbbuff, v)
     end
   end
-  log(ERROR, "clear buffer")
   clear_tab(buffer)
-  log(ERROR, "buffer cleared")
 
   local sock = socket()
   local ok, err = sock:connect("127.0.0.1", "9090")

--- a/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
+++ b/modules/402-ingress-nginx/images/controller-1-1/rootfs/etc/nginx/lua/pbmetrics.lua
@@ -376,9 +376,10 @@ local function fill_buffer()
   end
 end
 
-local sock = socket()
+local sock
 
 local function connect()
+  sock = socket()
   sock:settimeout(0)
   local ok, err = sock:connect("127.0.0.1", "9090")
   if not ok then


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
- Premature removal
`Premature timer expiration happens when the Nginx worker process is trying to shut down, as in an Nginx configuration reload triggered by the HUP signal or in an Nginx server shutdown.`
It seems like a good idea to send collected metrics on a worker shutdown. We are not using recursive timers, so can skip premature handler. Also we can close the tcp socket on premature

- Remove table copy
`Lua is single-threaded by design, one and only one thread can access the data at same moment.`
We can avoid an extra copy of a metrics table. Like an node event-loop nginx stops main thread execution when calls a timer's callback function, so we can avoid extra time and memory consumption

- We can backport it to 1.35, cause it already has an ingress controller reboot
- Bump protobuf to avoid memory leak

## Why do we need it, and what problem does it solve?
Speed up metrics collection. Low memory consumption

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ingress-nginx
type: fix
summary: Improve metrics collection script
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
