### PR TITLE
[docs] Add api. domain into a hosts lists in the getting started

### DIFF
--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
@@ -50,7 +50,8 @@ kubectl create -f user.yml
             href="https://en.wikipedia.org/wiki/Wildcard_DNS_record">wildcard DNS</a> (e.g., <code>%s-kube.company.my</code>), then add A or CNAME records containing the public IP, you've discovered previously, for the following Deckhouse service DNS names:
           <div class="highlight">
 <pre class="highlight">
-<code example-hosts>dashboard.example.com
+<code example-hosts>api.example.com
+dashboard.example.com
 deckhouse.example.com
 dex.example.com
 grafana.example.com
@@ -67,6 +68,7 @@ upmeter.example.com</code>
 ```bash
 export PUBLIC_IP="<PUT_PUBLIC_IP_HERE>"
 sudo -E bash -c "cat <<EOF >> /etc/hosts
+$PUBLIC_IP api.example.com
 $PUBLIC_IP dashboard.example.com
 $PUBLIC_IP deckhouse.example.com
 $PUBLIC_IP dex.example.com

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -54,7 +54,8 @@ kubectl create -f user.yml
         получили выше, для следующих DNS-имен сервисов Deckhouse в вашем кластере:
         <div class="highlight">
 <pre class="highlight">
-<code example-hosts>dashboard.example.com
+<code example-hosts>api.example.com
+dashboard.example.com
 deckhouse.example.com
 dex.example.com
 grafana.example.com
@@ -72,6 +73,7 @@ upmeter.example.com</code>
 ```bash
 export PUBLIC_IP="<PUBLIC_IP>"
 sudo -E bash -c "cat <<EOF >> /etc/hosts
+$PUBLIC_IP api.example.com
 $PUBLIC_IP dashboard.example.com
 $PUBLIC_IP deckhouse.example.com
 $PUBLIC_IP dex.example.com

--- a/docs/site/_includes/getting_started/global/STEP_CLUSTER_ACCESS.md
+++ b/docs/site/_includes/getting_started/global/STEP_CLUSTER_ACCESS.md
@@ -63,7 +63,8 @@ Point a DNS domain you specified in the "[Cluster Installation](./step3.html)" s
         previously{% endif %}, for the following Deckhouse service DNS names:
         <div class="highlight">
 <pre class="highlight">
-<code example-hosts>dashboard.example.com
+<code example-hosts>api.example.com
+dashboard.example.com
 deckhouse.example.com
 dex.example.com
 grafana.example.com
@@ -112,6 +113,7 @@ export BALANCER_IP="<MASTER_OR_FRONT_IP>"
 {% snippetcut selector="example-hosts" %}
 ```bash
 sudo -E bash -c "cat <<EOF >> /etc/hosts
+$BALANCER_IP api.example.com
 $BALANCER_IP dashboard.example.com
 $BALANCER_IP deckhouse.example.com
 $BALANCER_IP dex.example.com

--- a/docs/site/_includes/getting_started/global/STEP_CLUSTER_ACCESS_RU.md
+++ b/docs/site/_includes/getting_started/global/STEP_CLUSTER_ACCESS_RU.md
@@ -61,7 +61,8 @@ echo "$BALANCER_IP"
         то добавьте А или CNAME-записи со значением IP-адреса {% if page.platform_code == 'vsphere' %}master-узла, который вы получили выше (если настроены выделенные frontend-узлы, то используйте их IP-адреса вместо IP-адреса master-узла){% else %}балансировщика (<code>BALANCER_IP</code>), который вы получили выше{% endif %}, для следующих DNS-имен сервисов Deckhouse в вашем кластере:
         <div class="highlight">
 <pre class="highlight">
-<code example-hosts>dashboard.example.com
+<code example-hosts>api.example.com
+dashboard.example.com
 deckhouse.example.com
 dex.example.com
 grafana.example.com
@@ -110,6 +111,7 @@ export BALANCER_IP="<MASTER_OR_FRONT_IP>"
 {% snippetcut selector="example-hosts" %}
 ```bash
 sudo -E bash -c "cat <<EOF >> /etc/hosts
+$BALANCER_IP api.example.com
 $BALANCER_IP dashboard.example.com
 $BALANCER_IP deckhouse.example.com
 $BALANCER_IP dex.example.com


### PR DESCRIPTION
## Description
Add api. domain into a hosts lists in the getting started

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: Add `api.` domain into a hosts lists in the getting started.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
