### PR TITLE
[testing][ci] Add a check if the repository contains the actual CI workflow

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -18,6 +18,25 @@ steps:
 # </template: go_generate_template>
 {!{ end }!}
 
+{!{ define "workflow_render_template" }!}
+# <template: workflow_render_template>
+runs-on: [self-hosted, regular]
+steps:
+  {!{ tmpl.Exec "started_at_output"            . | strings.Indent 2 }!}
+  {!{ tmpl.Exec "checkout_step"                . | strings.Indent 2 }!}
+  {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}
+
+  - name: Render GitHub workflow
+    run: |
+      cd .github
+      ./render-workflows.sh
+
+  - name: Check rendered files
+    run: |
+      git diff --exit-code
+# </template: workflow_render_template>
+{!{ end }!}
+
 {!{ define "build_template" }!}
 {!{- $ctx := index . 0 -}!}
 {!{- $buildType := index . 1 -}!}

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -58,12 +58,20 @@ jobs:
       - pull_request_info
 {!{ tmpl.Exec "go_generate_template" $ctx | strings.Indent 4 }!}
 
+  workflow_render:
+    name: Render workflow
+    needs:
+      - git_info
+      - pull_request_info
+{!{ tmpl.Exec "workflow_render_template" $ctx | strings.Indent 4 }!}
+
   build_deckhouse:
     name: Build Deckhouse
     needs:
       - git_info
       - pull_request_info
       - go_generate
+      - workflow_render
     env:
       WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
 {!{ tmpl.Exec "build_template" (slice $ctx "dev") | strings.Indent 4 }!}

--- a/.github/workflow_templates/build-and-test_pre-release.yml
+++ b/.github/workflow_templates/build-and-test_pre-release.yml
@@ -25,11 +25,18 @@ jobs:
       - git_info
 {!{ tmpl.Exec "go_generate_template" $ctx | strings.Indent 4 }!}
 
+  workflow_render:
+    name: Render workflow
+    needs:
+      - git_info
+{!{ tmpl.Exec "workflow_render_template" $ctx | strings.Indent 4 }!}
+
   build_deckhouse:
     name: Build Deckhouse FE
     needs:
       - git_info
       - go_generate
+      - workflow_render
     env:
       WERF_ENV: "FE"
 {!{ tmpl.Exec "build_template" (slice $ctx "pre-release") | strings.Indent 4 }!}

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -53,12 +53,21 @@ jobs:
 {!{ tmpl.Exec "go_generate_template" $ctx | strings.Indent 4 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.go_generate) | strings.Indent 6 }!}
 
+{!{ $jobNames = coll.Merge $jobNames (dict "workflow_render" "Render workflow") }!}
+  workflow_render:
+    name: {!{ $jobNames.workflow_render }!}
+    needs:
+      - git_info
+{!{ tmpl.Exec "workflow_render_template" $ctx | strings.Indent 4 }!}
+{!{ tmpl.Exec "update_comment_on_finish" (slice "job,one-line" $jobNames.workflow_render) | strings.Indent 6 }!}
+
 {!{ $jobNames = coll.Merge $jobNames (dict "build_fe" "Build FE") }!}
   build_fe:
     name: {!{ $jobNames.build_fe }!}
     needs:
       - git_info
       - go_generate
+      - workflow_render
     env:
       WERF_ENV: "FE"
 {!{ tmpl.Exec "build_template" (slice $ctx "release") | strings.Indent 4 }!}
@@ -70,6 +79,7 @@ jobs:
     needs:
       - git_info
       - go_generate
+      - workflow_render
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "EE"
@@ -82,6 +92,7 @@ jobs:
     needs:
       - git_info
       - go_generate
+      - workflow_render
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "CE"
@@ -213,6 +224,7 @@ jobs:
       - started_at
       - git_info
       - go_generate
+      - workflow_render
       - build_fe
       - build_ee
       - build_ce

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -409,12 +409,66 @@ jobs:
     # </template: go_generate_template>
 
 
+  workflow_render:
+    name: Render workflow
+    needs:
+      - git_info
+      - pull_request_info
+
+    # <template: workflow_render_template>
+    runs-on: [self-hosted, regular]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+        with:
+          ref: ${{ needs.pull_request_info.outputs.ref }}
+      # </template: checkout_step>
+
+      # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to readonly registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          logout: false
+      # </template: login_readonly_registry_step>
+
+      - name: Render GitHub workflow
+        run: |
+          cd .github
+          ./render-workflows.sh
+
+      - name: Check rendered files
+        run: |
+          git diff --exit-code
+    # </template: workflow_render_template>
+
+
   build_deckhouse:
     name: Build Deckhouse
     needs:
       - git_info
       - pull_request_info
       - go_generate
+      - workflow_render
     env:
       WERF_ENV: ${{ needs.pull_request_info.outputs.edition }}
     # <template: build_template>

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -155,11 +155,63 @@ jobs:
     # </template: go_generate_template>
 
 
+  workflow_render:
+    name: Render workflow
+    needs:
+      - git_info
+
+    # <template: workflow_render_template>
+    runs-on: [self-hosted, regular]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
+
+      # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to readonly registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          logout: false
+      # </template: login_readonly_registry_step>
+
+      - name: Render GitHub workflow
+        run: |
+          cd .github
+          ./render-workflows.sh
+
+      - name: Check rendered files
+        run: |
+          git diff --exit-code
+    # </template: workflow_render_template>
+
+
   build_deckhouse:
     name: Build Deckhouse FE
     needs:
       - git_info
       - go_generate
+      - workflow_render
     env:
       WERF_ENV: "FE"
     # <template: build_template>

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -235,11 +235,94 @@ jobs:
       # </template: update_comment_on_finish>
 
 
+  workflow_render:
+    name: Render workflow
+    needs:
+      - git_info
+
+    # <template: workflow_render_template>
+    runs-on: [self-hosted, regular]
+    steps:
+
+      # <template: started_at_output>
+      - name: Job started timestamp
+        id: started_at
+        run: |
+          unixTimestamp=$(date +%s)
+          echo "::set-output name=started_at::${unixTimestamp}"
+      # </template: started_at_output>
+
+      # <template: checkout_step>
+      - name: Checkout sources
+        uses: actions/checkout@v2.4.0
+
+      # </template: checkout_step>
+
+      # <template: login_readonly_registry_step>
+      - name: Check readonly registry credentials
+        id: check_readonly_registry
+        env:
+          HOST: ${{secrets.DECKHOUSE_REGISTRY_READ_HOST}}
+        run: |
+          if [[ -n $HOST ]]; then echo "::set-output name=has_credentials::true"; fi
+      - name: Login to readonly registry
+        uses: docker/login-action@v1.10.0
+        if: ${{ steps.check_readonly_registry.outputs.has_credentials == 'true' }}
+        with:
+          registry: ${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}
+          username: ${{ secrets.DECKHOUSE_REGISTRY_READ_USER }}
+          password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
+          logout: false
+      # </template: login_readonly_registry_step>
+
+      - name: Render GitHub workflow
+        run: |
+          cd .github
+          ./render-workflows.sh
+
+      - name: Check rendered files
+        run: |
+          git diff --exit-code
+    # </template: workflow_render_template>
+
+      # <template: update_comment_on_finish>
+      - name: Update comment on finish
+        id: update_comment_on_finish
+        if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+          JOB_CONTEXT: ${{ toJSON(job) }}
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        uses: actions/github-script@v5.0.0
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const statusConfig = 'job,one-line';
+            const name = 'Render workflow';
+            const needsContext = JSON.parse(process.env.NEEDS_CONTEXT);
+            const jobContext = JSON.parse(process.env.JOB_CONTEXT);
+            const stepsContext = JSON.parse(process.env.STEPS_CONTEXT);
+            let jobNames = null
+            if (process.env.JOB_NAMES) {
+              jobNames = JSON.parse(process.env.JOB_NAMES);
+            }
+
+            core.info(`needsContext: ${JSON.stringify(needsContext)}`);
+            core.info(`jobContext: ${JSON.stringify(jobContext)}`);
+            core.info(`stepsContext: ${JSON.stringify(stepsContext)}`);
+            core.info(`jobNames: ${JSON.stringify(jobNames)}`);
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
+      # </template: update_comment_on_finish>
+
+
   build_fe:
     name: Build FE
     needs:
       - git_info
       - go_generate
+      - workflow_render
     env:
       WERF_ENV: "FE"
     # <template: build_template>
@@ -512,6 +595,7 @@ jobs:
     needs:
       - git_info
       - go_generate
+      - workflow_render
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "EE"
@@ -785,6 +869,7 @@ jobs:
     needs:
       - git_info
       - go_generate
+      - workflow_render
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     env:
       WERF_ENV: "CE"
@@ -2410,6 +2495,7 @@ jobs:
       - started_at
       - git_info
       - go_generate
+      - workflow_render
       - build_fe
       - build_ee
       - build_ce
@@ -2428,7 +2514,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JOB_NAMES: |
-        {"build_ce":"Build CE","build_ee":"Build EE","build_fe":"Build FE","deploy_latest_web":"Deploy latest doc and site","deploy_tagged_doc":"Deploy tagged documentation","dhctl_tests":"Dhctl Tests","doc_web_build":"Doc web build","go_generate":"Go Generate","golangci_lint":"GolangCI Lint","main_web_build":"Main web build","matrix_tests":"Matrix tests","openapi_test_cases":"OpenAPI Test Cases","tests":"Tests","validators":"Validators","web_links_test":"Web links test"}
+        {"build_ce":"Build CE","build_ee":"Build EE","build_fe":"Build FE","deploy_latest_web":"Deploy latest doc and site","deploy_tagged_doc":"Deploy tagged documentation","dhctl_tests":"Dhctl Tests","doc_web_build":"Doc web build","go_generate":"Go Generate","golangci_lint":"GolangCI Lint","main_web_build":"Main web build","matrix_tests":"Matrix tests","openapi_test_cases":"OpenAPI Test Cases","tests":"Tests","validators":"Validators","web_links_test":"Web links test","workflow_render":"Render workflow"}
     steps:
 
       # <template: checkout_step>


### PR DESCRIPTION
## Description
Adds a check if the repository contains the actual GitHub workflow (that no one forgot to regenerate it).

## Why do we need it, and what problem does it solve?
Sometimes, after changing CI templates, authors forget to regenerate workflows.

## What is the expected result?
- CI has to fail completely if workflow templates have been changed, but workflow has not been regenerated.
- CI should not fail if workflow templates have been changed and workflow has been regenerated.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: testing
type: chore
summary: Added a check if the repository contains the actual GitHub workflow (that no one forgot to regenerate it).
impact_level: low
```
