### PR TITLE
[ci] Skip copyright validation for the `.github/CODEOWNERS` file

### DIFF
--- a/tools/validation/copyright.go
+++ b/tools/validation/copyright.go
@@ -37,7 +37,7 @@ var CELicenseRe = regexp.MustCompile(`(?s)[/#{!-]*(\s)*Copyright 202[1-9] Flant 
 [/#{!-]*(\s)*limitations under the License.[-!}\n]*`)
 
 var fileToCheckRe = regexp.MustCompile(`\.go$|/[^/.]+$|\.sh$|\.lua$|\.py$`)
-var fileToSkipRe = regexp.MustCompile(`geohash.lua$|Dockerfile$|Makefile$|/docs/documentation/|/docs/site/|bashrc$|inputrc$`)
+var fileToSkipRe = regexp.MustCompile(`geohash.lua$|\.github/CODEOWNERS|Dockerfile$|Makefile$|/docs/documentation/|/docs/site/|bashrc$|inputrc$`)
 
 func RunCopyrightValidation(info *DiffInfo) (exitCode int) {
 	fmt.Printf("Run 'copyright' validation ...\n")


### PR DESCRIPTION
## Description
Skip copyright validation for the `.github/CODEOWNERS` file.

## Changelog entries
```changes
section: ci
type: chore
summary: Skip copyright validation for the `.github/CODEOWNERS` file
impact_level: low
```
