### PR TITLE
[grafana-dashboards] Change steppedLine to false for CPU panels (#2368)

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/node.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/node.json
@@ -1049,7 +1049,7 @@
       ],
       "spaceLength": 10,
       "stack": true,
-      "steppedLine": true,
+      "steppedLine": false,
       "targets": [
         {
           "expr": "sum by (instance)(rate(node_cpu_seconds_total{mode=\"system\",node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
@@ -1653,7 +1653,7 @@
           "seriesOverrides": [],
           "spaceLength": 10,
           "stack": true,
-          "steppedLine": true,
+          "steppedLine": false,
           "targets": [
             {
               "expr": "sum by (mode)(rate(node_cpu_seconds_total{mode=\"system\",node=~\"$node\",job=\"node-exporter\"}[$__interval_sx4])) * 100",
@@ -13271,7 +13271,7 @@
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/nodes.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/nodes.json
@@ -1897,7 +1897,7 @@
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 0,
+        "sort": 1,
         "tagValuesQuery": "",
         "tagsQuery": "",
         "type": "query",


### PR DESCRIPTION
## Description
* Change steppedLine property for CPU graphs
* Add sorting

## Why do we need it, and what problem does it solve?
Copy properties of the official dashboard

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring-kubernetes
type: fix
summary: Change steppedLine to false for CPU panels and add sorting.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
