### PR TITLE
[candi] fix getting 'first_internal_ip' variable

### DIFF
--- a/modules/035-cni-simple-bridge/images/simple-bridge/rootfs/bin/simple-bridge
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/rootfs/bin/simple-bridge
@@ -14,7 +14,7 @@ function ensure_pod_network_route() {
 while true; do
   node_object="$(curl --max-time 5 -s -S -f --resolve "kubernetes.default:443:$KUBERNETES_SERVICE_HOST" -s "https://kubernetes.default/api/v1/nodes/$NODE_NAME" --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)")"
 
-  first_internal_ip=$(jq -re '.status.addresses[] | select(.type == "InternalIP") | .address' <<< "$node_object")
+  first_internal_ip=$(jq -re '[.status.addresses[] | select(.type == "InternalIP")][0] | .address' <<< "$node_object")
   if [ -z "$first_internal_ip" ]; then
     >&2 echo "ERROR: Node $(hostname) doesn't have InternalIP in .status.addresses"
     exit 1


### PR DESCRIPTION
'first_internal_ip'  will contain zero or one address if the node has more than one interface

Signed-off-by: Evgenii Aladin <34023895+EvgeniiAl@users.noreply.github.com>

## Description
<!---
  Describe your changes in detail.
Change the way jq sets 'first_internal_ip'  variable
  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
If node has more than one interface with private addresses, variable contains all of them 
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix 
summary: bugfix simple-bridge script for multi-homed nodes
impact: ↓
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
