### PR TITLE
[prometheus] fix grafana dashboard provisioner

### DIFF
--- a/modules/300-prometheus/images/grafana-dashboard-provisioner/Dockerfile
+++ b/modules/300-prometheus/images/grafana-dashboard-provisioner/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_SHELL_OPERATOR
 FROM $BASE_SHELL_OPERATOR
 COPY hooks/ /hooks
-RUN apk add --no-cache curl sqlite && \
+RUN apk add --no-cache curl rsync && \
   curl https://slugify.vercel.app/ > slugify && \
   chmod +x slugify && \
   mv slugify /usr/local/bin/

--- a/modules/300-prometheus/images/grafana-dashboard-provisioner/Dockerfile
+++ b/modules/300-prometheus/images/grafana-dashboard-provisioner/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_SHELL_OPERATOR
 FROM $BASE_SHELL_OPERATOR
 COPY hooks/ /hooks
-RUN apk add --no-cache curl rsync && \
+RUN apk add --no-cache curl sqlite rsync && \
   curl https://slugify.vercel.app/ > slugify && \
   chmod +x slugify && \
   mv slugify /usr/local/bin/


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Fix and optimize grafana dashboard provisioner

## Why do we need it, and what problem does it solve?
Sometimes current provisioner script generates errors like:
```
find: /etc/grafana/dashboards/Main: No such file or directory"
```
cause of glob matching. I think we can use rsync for synchronizing tmp and target directories. It copies all files and then delete absent files, which generates more atomic changes for grafana dashboards

## What is the expected result?
Grafana will not miss all dashboard on update

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: fix
summary: Fix grafana dashboard provisioner - avoid missing all dashboard on update
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
