### PR TITLE
[istio] fix tlsMode param behavior

### DIFF
--- a/ee/modules/110-istio/openapi/config-values.yaml
+++ b/ee/modules/110-istio/openapi/config-values.yaml
@@ -24,7 +24,7 @@ properties:
       - `MutualPermissive` — outgoing requests are encrypted; incoming unencrypted requests are accepted. This mode is useful when migrating to mTLS.
       - `Mutual` — outgoing requests are encrypted; incoming unencrypted requests are rejected (pods accept only encrypted requests).
       You can manage the mTLS mode separately for each application and for its client connections using the [AuthorizationPolicy](istio-cr.html#authorizationpolicy) and [DestinationRule](istio-cr.html#destinationrule) resources.
-    default: "Off"
+    default: "MutualPermissive"
   outboundTrafficPolicyMode:
     type: string
     enum: [AllowAny, RegistryOnly]

--- a/ee/modules/110-istio/template_tests/module_test.go
+++ b/ee/modules/110-istio/template_tests/module_test.go
@@ -129,8 +129,13 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 			Expect(paDefault.Exists()).To(BeTrue())
 			Expect(paDefault.Field("spec.mtls.mode").String()).To(Equal(`PERMISSIVE`))
 
-			Expect(drDefault.Exists()).To(BeFalse())
-			Expect(drApiserver.Exists()).To(BeFalse())
+			Expect(drDefault.Exists()).To(BeTrue())
+			Expect(drDefault.Field("spec.host").String()).To(Equal(`*.my.domain`))
+			Expect(drDefault.Field("spec.trafficPolicy.tls.mode").String()).To(Equal(`DISABLE`))
+
+			Expect(drApiserver.Exists()).To(BeTrue())
+			Expect(drApiserver.Field("spec.host").String()).To(Equal(`kubernetes.default.svc.my.domain`))
+			Expect(drApiserver.Field("spec.trafficPolicy.tls.mode").String()).To(Equal(`DISABLE`))
 
 			Expect(f.KubernetesResource("Deployment", "d8-istio", "metadata-exporter").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("VerticalPodAutoscaler", "d8-istio", "metadata-exporter").Exists()).To(BeFalse())
@@ -170,9 +175,11 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 
 			Expect(drDefault.Exists()).To(BeTrue())
 			Expect(drDefault.Field("spec.host").String()).To(Equal(`*.my.domain`))
+			Expect(drDefault.Field("spec.trafficPolicy.tls.mode").String()).To(Equal(`ISTIO_MUTUAL`))
 
 			Expect(drApiserver.Exists()).To(BeTrue())
 			Expect(drApiserver.Field("spec.host").String()).To(Equal(`kubernetes.default.svc.my.domain`))
+			Expect(drApiserver.Field("spec.trafficPolicy.tls.mode").String()).To(Equal(`DISABLE`))
 
 			Expect(f.KubernetesResource("Deployment", "d8-istio", "metadata-exporter").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("VerticalPodAutoscaler", "d8-istio", "metadata-exporter").Exists()).To(BeFalse())
@@ -212,9 +219,11 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 
 			Expect(drDefault.Exists()).To(BeTrue())
 			Expect(drDefault.Field("spec.host").String()).To(Equal(`*.my.domain`))
+			Expect(drDefault.Field("spec.trafficPolicy.tls.mode").String()).To(Equal(`ISTIO_MUTUAL`))
 
 			Expect(drApiserver.Exists()).To(BeTrue())
 			Expect(drApiserver.Field("spec.host").String()).To(Equal(`kubernetes.default.svc.my.domain`))
+			Expect(drApiserver.Field("spec.trafficPolicy.tls.mode").String()).To(Equal(`DISABLE`))
 
 			Expect(f.KubernetesResource("Deployment", "d8-istio", "metadata-exporter").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("VerticalPodAutoscaler", "d8-istio", "metadata-exporter").Exists()).To(BeFalse())

--- a/ee/modules/110-istio/templates/global-auth-policy.yaml
+++ b/ee/modules/110-istio/templates/global-auth-policy.yaml
@@ -6,15 +6,13 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 spec:
-{{- if eq .Values.istio.tlsMode "Mutual" }}
   mtls:
+{{- if eq .Values.istio.tlsMode "Mutual" }}
     mode: STRICT
 {{- else }}
-  mtls:
     mode: PERMISSIVE
 {{- end }}
 
-{{- if has .Values.istio.tlsMode (list "Mutual" "MutualPermissive") }}
 ---
 # Corresponding destination rule to configure client side to use mutual TLS when talking to
 # any service (host) in the mesh.
@@ -28,11 +26,15 @@ spec:
   host: "*.{{ .Values.global.discovery.clusterDomain }}"
   trafficPolicy:
     tls:
+{{- if has .Values.istio.tlsMode (list "Mutual" "MutualPermissive") }}
       mode: ISTIO_MUTUAL
+{{ else }}
+      mode: DISABLE
+{{- end }}
 ---
 # Destination rule to disable (m)TLS when talking to API server, as API server doesn't have sidecar.
 # Customer should add similar destination rules for other services that don't have sidecar.
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   name: kube-apiserver
@@ -43,4 +45,4 @@ spec:
   trafficPolicy:
     tls:
       mode: DISABLE
-{{- end }}
+

--- a/ee/modules/110-istio/templates/global-auth-policy.yaml
+++ b/ee/modules/110-istio/templates/global-auth-policy.yaml
@@ -45,4 +45,3 @@ spec:
   trafficPolicy:
     tls:
       mode: DISABLE
-


### PR DESCRIPTION
Signed-off-by: Pavel Tishkov <pavel.tishkov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix tlsMode param behavior.
Closes https://github.com/deckhouse/deckhouse/issues/2138

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
tlsMode: "Off" must totally disable the mutual tls, but it doesn't.
PERMISSIVE mode is applied to all incoming traffic. No policies were explicitly applied to outgoing traffic.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Default tlsMode now is: MutualPermissive.
PERMISSIVE mode is applied to all incoming traffic. 
ISTIO_MUTUAL mode is applied to all outgoing traffic. 


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: istio
type: fix
summary: Fix tlsMode param behavior.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
