### PR TITLE
[deckhouse] Filter deckhouse pod by phase in update_deckhouse_image hook for prevent panic when have evicted pods

### DIFF
--- a/modules/020-deckhouse/hooks/update_deckhouse_image.go
+++ b/modules/020-deckhouse/hooks/update_deckhouse_image.go
@@ -70,6 +70,15 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 					"app": "deckhouse",
 				},
 			},
+			FieldSelector: &types.FieldSelector{
+				MatchExpressions: []types.FieldSelectorRequirement{
+					{
+						Field:    "status.phase",
+						Operator: "Equals",
+						Value:    "Running",
+					},
+				},
+			},
 			ExecuteHookOnEvents:          pointer.BoolPtr(false),
 			ExecuteHookOnSynchronization: pointer.BoolPtr(false),
 			FilterFunc:                   filterDeckhousePod,


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Fix panic when have `Shutdown` Deckhouse pods. 

## Why do we need it, and what problem does it solve?
Cluster also can have evicted and shutdown pods. That was missed before
```
Schedule","queue":"/modules/deckhouse/update_deckhouse_image","task.flow":"start","task.id":"5c338ba4-2c0f-4bf8-9224-f0864d62894a","time":"2022-09-02T06:27:15Z"}
panic: interface conversion: go_hook.FilterResult is nil, not hooks.deckhousePodInfo

goroutine 1069 [running]:
github.com/deckhouse/deckhouse/modules/020-deckhouse/hooks.tagUpdate(0xc0023b4240, 0x2f37638, 0xc000201b60, 0x0, 0x0)
	/deckhouse/modules/020-deckhouse/hooks/update_deckhouse_image.go:350 +0xc9f
github.com/deckhouse/deckhouse/modules/020-deckhouse/hooks.updateDeckhouse(0xc0023b4240, 0x2f37638, 0xc000201b60, 0x0, 0xc00044e518)
	/deckhouse/modules/020-deckhouse/hooks/update_deckhouse_image.go:144 +0xab1
github.com/deckhouse/deckhouse/go_lib/dependency.WithExternalDependencies.func1(0xc0023b4240, 0xc002946b01, 0xc0023b4240)
	/deckhouse/go_lib/dependency/dependency.go:201 +0x47
github.com/flant/addon-operator/sdk.(*commonGoHook).Run(0xc00068fbe0, 0xc0023b4240, 0x0, 0x43b5248)
```

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse
type: fix
summary: Fix deckhouse update with shutdown pods in dev clusters
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
