### PR TITLE
[node-manager] Subscribe to Node's CreationTimestamp instead of Machine's field in yandex_preemptibly_delete_preemtible_instances.go

### DIFF
--- a/modules/040-node-manager/hooks/yandex_preemptibly_delete_preemtible_instances.go
+++ b/modules/040-node-manager/hooks/yandex_preemptibly_delete_preemtible_instances.go
@@ -168,6 +168,10 @@ func deleteMachines(input *go_hook.HookInput) error {
 		preemptibleMachineClassesSet.Add(ic.Name)
 	}
 
+	if preemptibleMachineClassesSet.Size() == 0 {
+		return nil
+	}
+
 	for _, nodeRaw := range input.Snapshots["nodes"] {
 		if nodeRaw == nil {
 			continue
@@ -179,10 +183,6 @@ func deleteMachines(input *go_hook.HookInput) error {
 		}
 
 		nodeCreationTimestampSet[node.Name] = node.CreationTimestamp
-	}
-
-	if preemptibleMachineClassesSet.Size() == 0 {
-		return nil
 	}
 
 	for _, machineRaw := range input.Snapshots["machines"] {

--- a/modules/040-node-manager/hooks/yandex_preemptibly_delete_preemtible_instances.go
+++ b/modules/040-node-manager/hooks/yandex_preemptibly_delete_preemtible_instances.go
@@ -34,12 +34,17 @@ const (
 	preemtibleVMDeletionDuration = 24 * time.Hour
 )
 
-type Machine struct {
+type Node struct {
 	Name              string
 	CreationTimestamp metav1.Time
-	Terminating       bool
-	MachineClassKind  string
-	MachineClassName  string
+}
+
+type Machine struct {
+	Name                  string
+	NodeCreationTimestamp metav1.Time
+	Terminating           bool
+	MachineClassKind      string
+	MachineClassName      string
 }
 
 type YandexMachineClass struct {
@@ -69,11 +74,17 @@ func applyMachineFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, e
 	}
 
 	return &Machine{
+		Name:             obj.GetName(),
+		Terminating:      terminating,
+		MachineClassKind: classKind,
+		MachineClassName: className,
+	}, nil
+}
+
+func applyNodeFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	return &Node{
 		Name:              obj.GetName(),
 		CreationTimestamp: obj.GetCreationTimestamp(),
-		Terminating:       terminating,
-		MachineClassKind:  classKind,
-		MachineClassName:  className,
 	}, nil
 }
 
@@ -93,7 +104,8 @@ func isPreemptibleFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, 
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	Queue: "/modules/cloud-provider-yandex/preemtibly-delete-preemtible-instances",
+	AllowFailure: true,
+	Queue:        "/modules/cloud-provider-yandex/preemtibly-delete-preemtible-instances",
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "every-15",
@@ -125,6 +137,13 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			},
 			FilterFunc: applyMachineFilter,
 		},
+		{
+			Name:                "nodes",
+			ExecuteHookOnEvents: go_hook.Bool(false),
+			ApiVersion:          "v1",
+			Kind:                "Node",
+			FilterFunc:          applyNodeFilter,
+		},
 	},
 }, deleteMachines)
 
@@ -132,6 +151,7 @@ func deleteMachines(input *go_hook.HookInput) error {
 	var (
 		timeNow                      = time.Now().UTC()
 		preemptibleMachineClassesSet = set.Set{}
+		nodeCreationTimestampSet     = make(map[string]metav1.Time)
 		machines                     []*Machine
 	)
 
@@ -146,6 +166,19 @@ func deleteMachines(input *go_hook.HookInput) error {
 		}
 
 		preemptibleMachineClassesSet.Add(ic.Name)
+	}
+
+	for _, nodeRaw := range input.Snapshots["nodes"] {
+		if nodeRaw == nil {
+			continue
+		}
+
+		node, ok := nodeRaw.(*Node)
+		if !ok {
+			return fmt.Errorf("failed to assert to *Node")
+		}
+
+		nodeCreationTimestampSet[node.Name] = node.CreationTimestamp
 	}
 
 	if preemptibleMachineClassesSet.Size() == 0 {
@@ -167,6 +200,12 @@ func deleteMachines(input *go_hook.HookInput) error {
 		}
 
 		if !preemptibleMachineClassesSet.Has(machine.MachineClassName) {
+			continue
+		}
+
+		if creationTimestamp, ok := nodeCreationTimestampSet[machine.Name]; ok {
+			machine.NodeCreationTimestamp = creationTimestamp
+		} else {
 			continue
 		}
 
@@ -197,7 +236,7 @@ func getMachinesToDelete(timeNow time.Time, machines []*Machine) (machinesToDele
 	)
 
 	sort.Slice(machines, func(i, j int) bool {
-		return machines[i].CreationTimestamp.Before(&machines[j].CreationTimestamp)
+		return machines[i].NodeCreationTimestamp.Before(&machines[j].NodeCreationTimestamp)
 	})
 
 	batch := len(machines) / durationIterations
@@ -209,9 +248,9 @@ func getMachinesToDelete(timeNow time.Time, machines []*Machine) (machinesToDele
 		cursor int
 	)
 
-	// short-circuit if there are Machines older than 23 hours
+	// short-circuit if there are Nodes older than 23 hours
 	for _, m := range machines {
-		if expires(timeNow, m.CreationTimestamp.Time, currentSlidingDuration) {
+		if expires(timeNow, m.NodeCreationTimestamp.Time, currentSlidingDuration) {
 			machinesToDelete = append(machinesToDelete, m.Name)
 			cursor++
 		}
@@ -228,7 +267,7 @@ func getMachinesToDelete(timeNow time.Time, machines []*Machine) (machinesToDele
 				break
 			}
 
-			if expires(timeNow, machines[cursor].CreationTimestamp.Time, currentSlidingDuration) {
+			if expires(timeNow, machines[cursor].NodeCreationTimestamp.Time, currentSlidingDuration) {
 				machinesToDelete = append(machinesToDelete, machines[cursor].Name)
 				cursor++
 			} else {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

1. Node's CreationTimestamp provides accurate metrics on when VM was actually created.
2. Added `allowFailure: true` to take into account that MCM deletes a Machine object for a long time (until drain finishes).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Machines were deleted in quick succession since hook failed and was restarted quickly after a backoff.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Machines are deleted in batches every 15 minutes.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Fixed a bug with spot Machine deletion in Yandex.Cloud. It now correctly deletes machines in 15 minute intervals.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
