### PR TITLE
[istio] bump istio version to 1.13.7

### DIFF
--- a/ee/modules/110-istio/images/operator-v1x13/Dockerfile
+++ b/ee/modules/110-istio/images/operator-v1x13/Dockerfile
@@ -1,6 +1,6 @@
-# Based on https://github.com/istio/istio/blob/1.13.3/operator/docker/Dockerfile.operator
+# Based on https://github.com/istio/istio/blob/1.13.7/operator/docker/Dockerfile.operator
 ARG BASE_DEBIAN
-FROM docker.io/istio/operator:1.13.3@sha256:fbf1c3ad009106632951ba2a5ba978be789f627063ff3df4cebadb8683ea4650 as artifact
+FROM docker.io/istio/operator:1.13.7@sha256:f324e9d17968482a09d34573a4d522475e5ca83661ff71d3758a76f15ee4ebe1 as artifact
 
 FROM $BASE_DEBIAN
 

--- a/ee/modules/110-istio/images/pilot-v1x13/Dockerfile
+++ b/ee/modules/110-istio/images/pilot-v1x13/Dockerfile
@@ -1,7 +1,7 @@
-# Based on https://github.com/istio/istio/blob/1.13.3/pilot/docker/Dockerfile.pilot
+# Based on https://github.com/istio/istio/blob/1.13.7/pilot/docker/Dockerfile.pilot
 ARG BASE_DEBIAN
 
-FROM docker.io/istio/pilot:1.13.3@sha256:dec8156bed76ea584b5285e8d427ca6421d9f79949472792bc3132991dc7ee57 as artifact
+FROM docker.io/istio/pilot:1.13.7@sha256:3702d411ded12867cdc3966e84ce4d74c9c091bcd98b0d7e8a2c7946182797f9 as artifact
 
 FROM $BASE_DEBIAN
 RUN apt-get update && \

--- a/ee/modules/110-istio/images/proxyv2-v1x13/Dockerfile
+++ b/ee/modules/110-istio/images/proxyv2-v1x13/Dockerfile
@@ -1,14 +1,14 @@
-# Based on https://github.com/istio/istio/blob/1.13.3/pilot/docker/Dockerfile.proxyv2
+# Based on https://github.com/istio/istio/blob/1.13.7/pilot/docker/Dockerfile.proxyv2
 ARG BASE_DEBIAN
-FROM docker.io/istio/proxyv2:1.13.3@sha256:e8986efce46a7e1fcaf837134f453ea2b5e0750a464d0f2405502f8ddf0e2cd2 as artifact
+FROM docker.io/istio/proxyv2:1.13.7@sha256:fdf6fc9eb3336dbc8f77f45ff02530c032eb9260123d7117e2f608c0a1078b2e as artifact
 
 FROM $BASE_DEBIAN
 WORKDIR /
 
-# https://hub.docker.com/layers/proxyv2/istio/proxyv2/1.13.3/images/sha256-e8986efce46a7e1fcaf837134f453ea2b5e0750a464d0f2405502f8ddf0e2cd2?context=explore
+# https://hub.docker.com/layers/proxyv2/istio/proxyv2/1.13.7/images/sha256-fdf6fc9eb3336dbc8f77f45ff02530c032eb9260123d7117e2f608c0a1078b2e?context=explore
 # line 14
-ARG proxy_version=istio-proxy:8df7c693c8d6d0679dd72e0130f34a0ee91c210b
-ARG istio_version=1.13.3
+ARG proxy_version=istio-proxy:e0c6f64173cd0db9370e7ad8b1fbcee370a9f0f3
+ARG istio_version=1.13.7
 ARG SIDECAR=envoy
 
 RUN apt-get update && \


### PR DESCRIPTION
Signed-off-by: Pavel Tishkov <pavel.tishkov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Bump istio version from 1.13.3 to 1.13.7
https://istio.io/latest/news/releases/1.13.x/

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Istio 1.13.7 release contains a fixes for [CVE-2022-31045](https://istio.io/latest/news/security/istio-security-2022-005/#cve-2022-31045), [ISTIO-SECURITY-2022-005](https://istio.io/latest/news/security/istio-security-2022-005) and bug fixes to improve robustness.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Updating the patch version of istio will cause the `D8IstioDataPlaneVersionMismatch` alert to appear. To make the alert disappear, you must recreate all workloads so that the sidecar runs with the current version.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: istio
type: chore
summary: bump istio version from 1.13.3 to 1.13.7
impact: | 
  Updating the patch version of istio will cause the `D8IstioDataPlaneVersionMismatch` alert to appear. To make the alert disappear, you must recreate all workloads so that the sidecar runs with the current version.
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
