### PR TITLE
[kube-dns] prefer_udp

### DIFF
--- a/modules/042-kube-dns/templates/configmap.yaml
+++ b/modules/042-kube-dns/templates/configmap.yaml
@@ -25,7 +25,9 @@ data:
           ttl 30
         }
         prometheus 127.0.0.1:9153
-        forward . {{ .Values.kubeDns.upstreamNameservers | join " " | default "/etc/resolv.conf" }}
+        forward . {{ .Values.kubeDns.upstreamNameservers | join " " | default "/etc/resolv.conf" }} {
+          prefer_udp
+        }
         cache 30
         loop
         reload


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Prefer that cluster coredns uses UDP when communicating with upstream DNS servers. Dampens negative effects of [enabling](https://github.com/deckhouse/deckhouse/commit/00a3784fd9426fdb7c422d8454a0aa96506bb6a6) `serve_stale` option. 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We've observed a marked increase in kernel CPU usage after Deckhouse release v1.35.
![image](https://user-images.githubusercontent.com/950313/188893263-599457b0-8a24-4aa0-b121-4fda1750694d.png)

coredns executes a massive amount of `connect(2)` syscall.
![image](https://user-images.githubusercontent.com/950313/188900661-a017f31b-1eca-443c-bf70-6635bb369268.png)


node-local-dns's coredns [uses](https://github.com/coredns/coredns/blob/66f2ac7568ccb0178cc9ce6dbd7320bcd3428d64/plugin/cache/cache.go#L127) TCP to prefetch and serve stale requests. This means that the forward plugin in kube-dns' coredns [attempts](https://github.com/coredns/coredns/blob/5b65a58d4883e91312fcb79911f71eb5a5993b47/plugin/forward/connect.go#L85) to use TCP to connect to its upstream DNS servers as well.

Some DNS servers are not handling TCP connects (such as the one found in the Yandex.Cloud). This results in non-stop attempts to connect.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

TCP requests to kube-dns' coredns do not result in TCP connections upstream.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: kube-dns
type: fix
summary: Set `prefer_udp` option in `forward` plugin.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
