### PR TITLE
[candi][dhctl] Render `detect_bundle.sh` as template before execute

### DIFF
--- a/candi/bashible/detect_bundle.sh
+++ b/candi/bashible/detect_bundle.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+{{- /*
 # Copyright 2021 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+*/}}
 if [ ! -e /etc/os-release ]; then
   >&2 echo "ERROR: Can't determine OS! /etc/os-release is not found."
   exit 1

--- a/candi/bashible/detect_bundle.sh
+++ b/candi/bashible/detect_bundle.sh
@@ -47,8 +47,9 @@ case "$ID" in
     exit 1
   ;;
 esac
-
+{{- /*
 # try to determine os by ID_LIKE
+*/}}
 for ID in $ID_LIKE; do
   case "$ID" in
     centos|rhel)
@@ -61,8 +62,9 @@ for ID in $ID_LIKE; do
     ;;
   esac
 done
-
+{{- /*
 # try to determine os by packet manager
+*/}}
 bundle="debian"
 if yum -q --version >/dev/null 2>/dev/null; then
   bundle="centos"

--- a/dhctl/pkg/operations/bootstrap.go
+++ b/dhctl/pkg/operations/bootstrap.go
@@ -185,9 +185,14 @@ func RunBashiblePipeline(sshClient *ssh.Client, cfg *config.MetaConfig, nodeIP, 
 func DetermineBundleName(sshClient *ssh.Client) (string, error) {
 	var bundleName string
 	err := log.Process("bootstrap", "Detect Bashible Bundle", func() error {
+		file, err := template.RenderAndSaveDetectBundle(make(map[string]interface{}))
+		if err != nil {
+			return err
+		}
+
 		return retry.NewSilentLoop("Get bundle", 3, 1*time.Second).Run(func() error {
 			// run detect bundle type
-			detectCmd := sshClient.UploadScript("/deckhouse/candi/bashible/detect_bundle.sh")
+			detectCmd := sshClient.UploadScript(file)
 			stdout, err := detectCmd.Execute()
 			if err != nil {
 				if ee, ok := err.(*exec.ExitError); ok {

--- a/dhctl/pkg/template/bundle.go
+++ b/dhctl/pkg/template/bundle.go
@@ -34,7 +34,7 @@ const (
 	bashibleDir      = "/var/lib/bashible"
 	candiBashibleDir = candiDir + "/bashible"
 	stepsDir         = bashibleDir + "/bundle_steps"
-	detectBundlePath = "/deckhouse/candi/bashible/detect_bundle.sh"
+	detectBundlePath = candiBashibleDir + "/detect_bundle.sh"
 )
 
 type saveFromTo struct {

--- a/dhctl/pkg/template/bundle.go
+++ b/dhctl/pkg/template/bundle.go
@@ -237,7 +237,7 @@ func RenderAndSaveDetectBundle(data map[string]interface{}) (string, error) {
 		return "", err
 	}
 
-	if err = outFile.Chmod(0777); err != nil {
+	if err = outFile.Chmod(0775); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
## Description

Render detect_bundle.sh as template before execute

## Why do we need it, and what problem does it solve?
`detect_bundle.sh` pass to new cloud node via `user-data`. In AWS `user-data` has content size limit to 16kb.
For decrease size we remove comments via helm-template.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
E2e should pass

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: fix 
summary: Render detect_bundle.sh as template before execute.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
