### PR TITLE
[upmeter] Fix EnableKubeEventCb

### DIFF
--- a/modules/500-upmeter/images/upmeter/pkg/monitor/downtime/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/downtime/monitor.go
@@ -72,8 +72,8 @@ func (m *Monitor) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("creating informer: %v", err)
 	}
-	m.monitor.EnableKubeEventCb()
 
+	m.monitor.EnableKubeEventCb()
 	m.monitor.Start(ctx)
 	return nil
 }

--- a/modules/500-upmeter/images/upmeter/pkg/monitor/downtime/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/downtime/monitor.go
@@ -37,7 +37,6 @@ type Monitor struct {
 func NewMonitor(kubeClient kube.Client, logger *log.Entry) *Monitor {
 	monitor := kube_events_manager.NewMonitor()
 	monitor.WithKubeClient(kubeClient)
-	monitor.EnableKubeEventCb()
 
 	return &Monitor{
 		monitor: monitor,
@@ -73,6 +72,7 @@ func (m *Monitor) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("creating informer: %v", err)
 	}
+	m.monitor.EnableKubeEventCb()
 
 	m.monitor.Start(ctx)
 	return nil

--- a/modules/500-upmeter/images/upmeter/pkg/monitor/hookprobe/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/hookprobe/monitor.go
@@ -75,6 +75,7 @@ func (m *Monitor) Start(ctx context.Context) error {
 		return fmt.Errorf("creating informer: %v", err)
 	}
 
+	m.monitor.EnableKubeEventCb()
 	m.monitor.Start(ctx)
 	return nil
 }
@@ -109,7 +110,6 @@ func (m *Monitor) Subscribe(handler Handler) {
 			handler.OnDelete(obj)
 		}
 	})
-	m.monitor.EnableKubeEventCb()
 }
 
 func (m *Monitor) List() ([]*HookProbe, error) {

--- a/modules/500-upmeter/images/upmeter/pkg/monitor/hookprobe/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/hookprobe/monitor.go
@@ -36,7 +36,6 @@ type Monitor struct {
 func NewMonitor(kubeClient kube.Client, logger *log.Entry) *Monitor {
 	monitor := kube_events_manager.NewMonitor()
 	monitor.WithKubeClient(kubeClient)
-	monitor.EnableKubeEventCb()
 
 	return &Monitor{
 		monitor: monitor,
@@ -109,6 +108,7 @@ func (m *Monitor) Subscribe(handler Handler) {
 			handler.OnDelete(obj)
 		}
 	})
+	m.monitor.EnableKubeEventCb()
 }
 
 func (m *Monitor) List() ([]*HookProbe, error) {

--- a/modules/500-upmeter/images/upmeter/pkg/monitor/hookprobe/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/hookprobe/monitor.go
@@ -90,7 +90,7 @@ func (m *Monitor) getLogger() *log.Entry {
 
 func (m *Monitor) Subscribe(handler Handler) {
 	m.monitor.WithKubeEventCb(func(ev types.KubeEvent) {
-		m.logger.Infof("event received: %v", ev)
+		m.logger.Debugf("event received: %v", ev)
 		// One event and one object per change, we always have single item in these lists.
 		evType := ev.WatchEvents[0]
 		raw := ev.Objects[0].Object

--- a/modules/500-upmeter/images/upmeter/pkg/monitor/hookprobe/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/hookprobe/monitor.go
@@ -89,6 +89,7 @@ func (m *Monitor) getLogger() *log.Entry {
 
 func (m *Monitor) Subscribe(handler Handler) {
 	m.monitor.WithKubeEventCb(func(ev types.KubeEvent) {
+		m.logger.Infof("event received: %v", ev)
 		// One event and one object per change, we always have single item in these lists.
 		evType := ev.WatchEvents[0]
 		raw := ev.Objects[0].Object

--- a/modules/500-upmeter/images/upmeter/pkg/monitor/node/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/node/monitor.go
@@ -37,7 +37,6 @@ type Monitor struct {
 func NewMonitor(kubeClient kube.Client, logger *log.Entry) *Monitor {
 	monitor := kube_events_manager.NewMonitor()
 	monitor.WithKubeClient(kubeClient)
-	monitor.EnableKubeEventCb()
 
 	return &Monitor{
 		monitor: monitor,
@@ -110,6 +109,7 @@ func (m *Monitor) Subscribe(handler Handler) {
 			handler.OnDelete(obj)
 		}
 	})
+	m.monitor.EnableKubeEventCb()
 }
 
 func (m *Monitor) List() ([]*v1.Node, error) {

--- a/modules/500-upmeter/images/upmeter/pkg/monitor/node/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/node/monitor.go
@@ -76,6 +76,7 @@ func (m *Monitor) Start(ctx context.Context) error {
 		return fmt.Errorf("creating informer: %v", err)
 	}
 
+	m.monitor.EnableKubeEventCb()
 	m.monitor.Start(ctx)
 	return nil
 }
@@ -109,7 +110,6 @@ func (m *Monitor) Subscribe(handler Handler) {
 			handler.OnDelete(obj)
 		}
 	})
-	m.monitor.EnableKubeEventCb()
 }
 
 func (m *Monitor) List() ([]*v1.Node, error) {

--- a/modules/500-upmeter/images/upmeter/pkg/monitor/remotewrite/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/remotewrite/monitor.go
@@ -36,7 +36,6 @@ type Monitor struct {
 func NewMonitor(kubeClient kube.Client, logger *log.Entry) *Monitor {
 	monitor := kube_events_manager.NewMonitor()
 	monitor.WithKubeClient(kubeClient)
-	monitor.EnableKubeEventCb()
 
 	return &Monitor{
 		monitor: monitor,
@@ -109,6 +108,7 @@ func (m *Monitor) Subscribe(handler Handler) {
 			handler.OnDelete(obj)
 		}
 	})
+	m.monitor.EnableKubeEventCb()
 }
 
 func (m *Monitor) List() ([]*RemoteWrite, error) {

--- a/modules/500-upmeter/images/upmeter/pkg/monitor/remotewrite/monitor.go
+++ b/modules/500-upmeter/images/upmeter/pkg/monitor/remotewrite/monitor.go
@@ -75,6 +75,7 @@ func (m *Monitor) Start(ctx context.Context) error {
 		return fmt.Errorf("creating informer: %v", err)
 	}
 
+	m.monitor.EnableKubeEventCb()
 	m.monitor.Start(ctx)
 	return nil
 }
@@ -108,7 +109,6 @@ func (m *Monitor) Subscribe(handler Handler) {
 			handler.OnDelete(obj)
 		}
 	})
-	m.monitor.EnableKubeEventCb()
 }
 
 func (m *Monitor) List() ([]*RemoteWrite, error) {

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -51,7 +51,7 @@ spec:
       serviceAccountName: upmeter-agent
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
-      {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
+      {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
       volumes:
       - name: data
@@ -139,6 +139,10 @@ spec:
             value: "json"
           - name: UPMETER_EXPORT_TIMEOUT
             value: "15s"
+          - name: KUBE_CLIENT_QPS
+            value: "30"
+          - name: KUBE_CLIENT_BURST
+            value: "60"
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -134,7 +134,7 @@ spec:
           - name: UPMETER_CLUSTER_DOMAIN
             value: {{ .Values.global.discovery.clusterDomain | quote }}
           - name: LOG_LEVEL
-            value: "info"
+            value: "debug"
           - name: LOG_TYPE
             value: "json"
           - name: UPMETER_EXPORT_TIMEOUT

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -134,7 +134,7 @@ spec:
           - name: UPMETER_CLUSTER_DOMAIN
             value: {{ .Values.global.discovery.clusterDomain | quote }}
           - name: LOG_LEVEL
-            value: "debug"
+            value: "info"
           - name: LOG_TYPE
             value: "json"
           - name: UPMETER_EXPORT_TIMEOUT


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
EnableKubeEventCb should be enabled after setting the handler.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: upmeter
type: fix
summary: Fix deckhouse probe by placing EnableKubeEventCb call properly.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
