### PR TITLE
[e2e] Fix docker test in Yandex.Cloud

### DIFF
--- a/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
+++ b/testing/cloud_layouts/Yandex.Cloud/WithoutNAT/configuration.tpl.yaml
@@ -33,7 +33,7 @@ masterNodeGroup:
   instanceClass:
     cores: 4
     memory: 8192
-    imageID: fd8prmc2vlvg94qcclkn # RedOS 7.3
+    imageID: fd8kdq6d0p8sij7h5qe3 # Ubuntu 20.04 # was 'fd8prmc2vlvg94qcclkn' - RedOS 7.3, restore after fixing bootstrap
     diskSizeGB: 50
     externalIPAddresses:
     - Auto

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -208,7 +208,7 @@ function prepare_environment() {
         envsubst '${DECKHOUSE_DOCKERCFG} ${PREFIX} ${DEV_BRANCH} ${KUBERNETES_VERSION} ${CRI} ${CLOUD_ID} ${FOLDER_ID} ${SERVICE_ACCOUNT_JSON}' \
         <"$cwd/configuration.tpl.yaml" >"$cwd/configuration.yaml"
 
-    ssh_user="cloud-user"
+    ssh_user="ubuntu" # was "cloud-user" for redos
     ;;
 
   "GCP")


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Restore ubuntu image in e2e test

## Why do we need it, and what problem does it solve?
RedOS testing was used in the yandex.cloud with docker. It could not be boostrapped with error
```
│ │ bb-rp [INFO] Installing package 'docker-ce'
│ │ warning: docker-ce.x86_64.rpm: Header V4 RSA/SHA512 Signature, key ID 621e9f35: NOKEY
│ │ error: Failed dependencies:
│ │ 	libcgroup is needed by docker-ce-3:19.03.15-3.el7.x86_64
│ │ Failed to execute step /var/lib/bashible/bundle_steps/031_install_docker.sh ... retry in 10 seconds.
│ └ Run step 031_install_docker.sh (40.82 seconds) FAILED
```
[here](https://github.com/deckhouse/deckhouse/runs/8266852873?check_suite_focus=true)

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: e2e
type: chore
summary: Use ubuntu image instead of redos for yandex cloud
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
