### PR TITLE
[ci] Make executing a single e2e test mandatory to accept the PR

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -21,17 +21,19 @@
 # <template: set_e2e_requirement_status>
 - name: Set commit status after e2e run
   id: set_e2e_requirement_status
+  needs:
+  - git_info
   if: ${{ always() }}
   uses: {!{ index (ds "actions") "actions/github-script" }!}
-  env:
-    JOB_STATUS: ${{ job.status }}
   with:
     github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+    status_target_commit: ${{needs.git_info.outputs.github_sha}}
+    job_status: ${{ job.status }}
     script: |
       const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
       let done = false;
-      const jobStat = process.env.JOB_STATUS;
+      const jobStat = process.env.INPUT_JOB_STATUS;
       if (jobStat === 'failure' || jobStat === 'cancelled') {
         done = await e2eStatus.setFail({github, context, core});
       } else if (jobStat === 'success') {

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -14,6 +14,36 @@
 {!{ $layout }!}
 {!{ end -}!}
 
+# job for set e2e requirement status
+# $1 - name of function to set status. see ../scripts/e2e-commit-status.js
+{!{ define "set_e2e_requirement_status" }!}
+
+# <template: set_e2e_requirement_status>
+- name: Set commit status after e2e run
+  id: set_e2e_requirement_status
+  if: ${{ always() }}
+  uses: {!{ index (ds "actions") "actions/github-script" }!}
+  env:
+    JOB_STATUS: ${{ job.status }}
+  with:
+    github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+    script: |
+      const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+      let done = false;
+      const jobStat = process.env.JOB_STATUS;
+      if (jobStat === 'failure' || jobStat === 'cancelled') {
+        done = await e2eStatus.setFail({github, context, core});
+      } else if (jobStat === 'success') {
+        done = await e2eStatus.setSuccess({github, context, core});
+      }
+
+      if (!done) {
+        core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+      }
+# </template: set_e2e_requirement_status>
+{!{- end -}!}
+
 {!{ define "e2e_send_alert_template" }!}
 {!{- $ctx := index . 0 -}!}
 
@@ -313,6 +343,7 @@ check_e2e_labels:
 
 {!{- if coll.Has $ctx "manualRun" }!}
 {!{    tmpl.Exec "update_comment_on_finish" (slice "job,separate" $ctx.jobName) | strings.Indent 4 }!}
+{!{    tmpl.Exec "set_e2e_requirement_status" slice | strings.Indent 4 }!}
 {!{- end }!}
 
 {!{- if not (coll.Has $ctx "manualRun") }!}

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -31,17 +31,7 @@
     script: |
       const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-      let done = false;
-      const jobStat = process.env.JOB_STATUS;
-      if (jobStat === 'failure' || jobStat === 'cancelled') {
-        done = await e2eStatus.setFail({github, context, core});
-      } else if (jobStat === 'success') {
-        done = await e2eStatus.setSuccess({github, context, core});
-      }
-
-      if (!done) {
-        core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-      }
+      await e2eStatus.setStatusAfterE2eRun({github, context, core});
 # </template: set_e2e_requirement_status>
 {!{- end -}!}
 

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -25,15 +25,16 @@
   - git_info
   if: ${{ always() }}
   uses: {!{ index (ds "actions") "actions/github-script" }!}
+  env:
+    JOB_STATUS: ${{ job.status }}
+    STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
   with:
     github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-    status_target_commit: ${{needs.git_info.outputs.github_sha}}
-    job_status: ${{ job.status }}
     script: |
       const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
       let done = false;
-      const jobStat = process.env.INPUT_JOB_STATUS;
+      const jobStat = process.env.JOB_STATUS;
       if (jobStat === 'failure' || jobStat === 'cancelled') {
         done = await e2eStatus.setFail({github, context, core});
       } else if (jobStat === 'success') {

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -21,8 +21,6 @@
 # <template: set_e2e_requirement_status>
 - name: Set commit status after e2e run
   id: set_e2e_requirement_status
-  needs:
-  - git_info
   if: ${{ always() }}
   uses: {!{ index (ds "actions") "actions/github-script" }!}
   env:

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -334,7 +334,6 @@ check_e2e_labels:
 
 {!{- if coll.Has $ctx "manualRun" }!}
 {!{    tmpl.Exec "update_comment_on_finish" (slice "job,separate" $ctx.jobName) | strings.Indent 4 }!}
-{!{    tmpl.Exec "set_e2e_requirement_status" slice | strings.Indent 4 }!}
 {!{- end }!}
 
 {!{- if not (coll.Has $ctx "manualRun") }!}

--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -913,7 +913,7 @@ module.exports.runWorkflowForPullRequest = async ({ github, context, core, ref }
       context,
       core,
       labeled: command.setE2eShouldSkipped,
-      commitSha: context.sha,
+      commitSha: context.payload.pull_request.head.sha,
     });
   }
 

--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -1,5 +1,8 @@
 //@ts-check
 
+const skipE2eLabel = 'skip/e2e';
+module.exports.skipE2eLabel = skipE2eLabel;
+
 // Labels available for pull requests.
 const labels = {
   // Skip validations.
@@ -8,7 +11,7 @@ const labels = {
   'skip/copyright-validation': { type: 'skip-validation', validation_name: 'copyright' },
   'skip/markdown-validation': { type: 'skip-validation', validation_name: 'markdown' },
   'skip/actionlint': { type: 'skip-validation', validation_name: 'actionlint' },
-  'skip/e2e': { type: 'skip-validation', validation_name: 'e2e_skip' },
+  [skipE2eLabel]: { type: 'skip-validation', validation_name: 'e2e_skip' },
 
   // E2E
   'e2e/run/aws': { type: 'e2e-run', provider: 'aws' },

--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -8,6 +8,7 @@ const labels = {
   'skip/copyright-validation': { type: 'skip-validation', validation_name: 'copyright' },
   'skip/markdown-validation': { type: 'skip-validation', validation_name: 'markdown' },
   'skip/actionlint': { type: 'skip-validation', validation_name: 'actionlint' },
+  'skip/e2e': { type: 'skip-validation', validation_name: 'e2e_skip' },
 
   // E2E
   'e2e/run/aws': { type: 'e2e-run', provider: 'aws' },

--- a/.github/scripts/js/constants.js
+++ b/.github/scripts/js/constants.js
@@ -11,7 +11,6 @@ const labels = {
   'skip/copyright-validation': { type: 'skip-validation', validation_name: 'copyright' },
   'skip/markdown-validation': { type: 'skip-validation', validation_name: 'markdown' },
   'skip/actionlint': { type: 'skip-validation', validation_name: 'actionlint' },
-  [skipE2eLabel]: { type: 'skip-validation', validation_name: 'e2e_skip' },
 
   // E2E
   'e2e/run/aws': { type: 'e2e-run', provider: 'aws' },

--- a/.github/scripts/js/e2e-commit-status.js
+++ b/.github/scripts/js/e2e-commit-status.js
@@ -6,7 +6,8 @@ function workflowUrl({core, context}) {
   core.debug(`workflowUrl context: ${JSON.stringify(context)}`);
   const {serverUrl, repo, runId} = context;
   const repository = repo.repo;
-  const url = `${serverUrl}/${repository}/actions/runs/${runId}}`;
+  const owner = repo.owner;
+  const url = `${serverUrl}/${owner}/${repository}/actions/runs/${runId}`;
   core.debug(`workflowUrl url: ${url}`);
   return url
 }

--- a/.github/scripts/js/e2e-commit-status.js
+++ b/.github/scripts/js/e2e-commit-status.js
@@ -51,7 +51,7 @@ module.exports.setFail = async ({github, context, core}) => {
     core,
     state: 'failure',
     description: 'E2e test was failed.',
-    url: workflowUrl(github),
+    url: workflowUrl(context),
   })
 };
 
@@ -62,6 +62,6 @@ module.exports.setSuccess = async ({github, context, core}) => {
     core,
     state: 'success',
     description: 'E2e test was passed.',
-    url: workflowUrl(github),
+    url: workflowUrl(context),
   })
 };

--- a/.github/scripts/js/e2e-commit-status.js
+++ b/.github/scripts/js/e2e-commit-status.js
@@ -19,7 +19,7 @@ async function sendCreateCommitStatus({github, context, core, state, description
     });
 
     core.debug(`rest.repos.createCommitStatus response: ${JSON.stringify(response)}`);
-    if (response.status === 200) {
+    if (response.status === 201) {
       return true;
     }
 

--- a/.github/scripts/js/e2e-commit-status.js
+++ b/.github/scripts/js/e2e-commit-status.js
@@ -1,0 +1,63 @@
+const {
+  sleep
+} = require('./time');
+
+function workflowUrl({server_url, repository, run_id}) {
+  return `${server_url}/${repository}/actions/runs/${run_id}}`
+}
+
+async function sendCreateCommitStatus({github, context, core, state, description, url}) {
+  for(let i = 0; i < 3; i++) {
+    const response = await github.rest.repos.createCommitStatus({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      sha: context.sha,
+      state: state,
+      description: description,
+      target_url: url,
+      context: 'deckhouse/e2e-requirement'
+    });
+
+    core.debug(`rest.repos.createCommitStatus response: ${JSON.stringify(response)}`);
+    if (response.status === 200) {
+      return true;
+    }
+
+    // wait 3s for retry request
+    await sleep(3000);
+  }
+
+  return false
+}
+
+module.exports.setWait = async ({github, context, core}) => {
+  return sendCreateCommitStatus({
+    github,
+    context,
+    core,
+    state: 'pending',
+    description: 'Waiting for run e2e test.'
+  })
+};
+
+module.exports.setFail = async ({github, context, core}) => {
+  return sendCreateCommitStatus({
+    github,
+    context,
+    core,
+    state: 'failure',
+    description: 'E2e test was failed.',
+    url: workflowUrl(github),
+  })
+};
+
+module.exports.setSuccess = async ({github, context, corel}) => {
+  return sendCreateCommitStatus({
+    github,
+    context,
+    core,
+    state: 'success',
+    description: 'E2e test was passed.',
+    url: workflowUrl(github),
+  })
+};

--- a/.github/scripts/js/e2e-commit-status.js
+++ b/.github/scripts/js/e2e-commit-status.js
@@ -2,9 +2,13 @@ const {
   sleep
 } = require('./time');
 
-function workflowUrl({serverUrl, repo, runId}) {
-  const { repository } = repo;
-  return `${serverUrl}/${repository}/actions/runs/${runId}}`
+function workflowUrl({core, context}) {
+  core.debug(`workflowUrl context: ${JSON.stringify(context)}`);
+  const {serverUrl, repo, runId} = context;
+  const repository = repo.repo;
+  const url = `${serverUrl}/${repository}/actions/runs/${runId}}`;
+  core.debug(`workflowUrl url: ${url}`);
+  return url
 }
 
 async function sendCreateCommitStatus({github, context, core, state, description, url}) {
@@ -52,7 +56,7 @@ module.exports.setFail = async ({github, context, core}) => {
     core,
     state: 'failure',
     description: 'E2e test was failed.',
-    url: workflowUrl(context),
+    url: workflowUrl({core, context}),
   })
 };
 
@@ -63,6 +67,6 @@ module.exports.setSuccess = async ({github, context, core}) => {
     core,
     state: 'success',
     description: 'E2e test was passed.',
-    url: workflowUrl(context),
+    url: workflowUrl({core, context}),
   })
 };

--- a/.github/scripts/js/e2e-commit-status.js
+++ b/.github/scripts/js/e2e-commit-status.js
@@ -7,11 +7,14 @@ function workflowUrl({server_url, repository, run_id}) {
 }
 
 async function sendCreateCommitStatus({github, context, core, state, description, url}) {
+  const commit_sha = process.env.INPUT_STATUS_TARGET_COMMIT;
+  core.debug(`sendCreateCommitStatus target commit: ${commit_sha}`);
+
   for(let i = 0; i < 3; i++) {
     const response = await github.rest.repos.createCommitStatus({
       owner: context.repo.owner,
       repo: context.repo.repo,
-      sha: context.sha,
+      sha: commit_sha,
       state: state,
       description: description,
       target_url: url,
@@ -19,7 +22,6 @@ async function sendCreateCommitStatus({github, context, core, state, description
     });
 
     core.debug(`rest.repos.createCommitStatus response: ${JSON.stringify(response)}`);
-    core.debug(`rest.repos.createCommitStatus response.status: ${response.status}`);
     if (response.status === 201) {
       core.debug(`rest.repos.createCommitStatus response status is 201. Returns true`);
       return true;
@@ -53,7 +55,7 @@ module.exports.setFail = async ({github, context, core}) => {
   })
 };
 
-module.exports.setSuccess = async ({github, context, corel}) => {
+module.exports.setSuccess = async ({github, context, core}) => {
   return sendCreateCommitStatus({
     github,
     context,

--- a/.github/scripts/js/e2e-commit-status.js
+++ b/.github/scripts/js/e2e-commit-status.js
@@ -2,8 +2,9 @@ const {
   sleep
 } = require('./time');
 
-function workflowUrl({server_url, repository, run_id}) {
-  return `${server_url}/${repository}/actions/runs/${run_id}}`
+function workflowUrl({serverUrl, repo, runId}) {
+  const { repository } = repo;
+  return `${serverUrl}/${repository}/actions/runs/${runId}}`
 }
 
 async function sendCreateCommitStatus({github, context, core, state, description, url}) {

--- a/.github/scripts/js/e2e-commit-status.js
+++ b/.github/scripts/js/e2e-commit-status.js
@@ -2,6 +2,13 @@ const {
   sleep
 } = require('./time');
 
+/**
+ * Build workflow run url for add it to commit status target url
+ * @param {object} inputs
+ * @param {object} inputs.core - A reference to the '@actions/core' package.
+ * @param {object} inputs.context - A reference to context https://github.com/actions/toolkit/blob/main/packages/github/src/context.ts#L6
+ * @returns string
+ */
 function workflowUrl({core, context}) {
   core.debug(`workflowUrl context: ${JSON.stringify(context)}`);
   const {serverUrl, repo, runId} = context;
@@ -12,6 +19,18 @@ function workflowUrl({core, context}) {
   return url
 }
 
+/**
+ * Wrap github.rest.repos.createCommitStatus. Returns true if status was set
+ * Use STATUS_TARGET_COMMIT env var as target commit sha
+ * @param {object} inputs
+ * @param {object} inputs.core - A reference to the '@actions/core' package.
+ * @param {object} inputs.github - A pre-authenticated octokit/rest.js client with pagination plugins.
+ * @param {object} inputs.context - A reference to context https://github.com/actions/toolkit/blob/main/packages/github/src/context.ts#L6
+ * @param {string} inputs.state - A state type as 'success' (it is mark in github ui)
+ * @param {string} inputs.description - A description for commit status
+ * @param {string|undefined} inputs.url - A target url for commit status (Details link in github ui)
+ * @returns Promise<bool>
+ */
 async function sendCreateCommitStatus({github, context, core, state, description, url}) {
   const commit_sha = process.env.STATUS_TARGET_COMMIT;
   core.debug(`sendCreateCommitStatus target commit: ${commit_sha}`);
@@ -40,7 +59,16 @@ async function sendCreateCommitStatus({github, context, core, state, description
   return false
 }
 
-module.exports.setWait = async ({github, context, core}) => {
+/**
+ * Set `waiting for start e2e` status (pending) Uses with push commit
+ * Use STATUS_TARGET_COMMIT env var as target commit sha
+ * @param {object} inputs
+ * @param {object} inputs.core - A reference to the '@actions/core' package.
+ * @param {object} inputs.github - A pre-authenticated octokit/rest.js client with pagination plugins.
+ * @param {object} inputs.context - A reference to context https://github.com/actions/toolkit/blob/main/packages/github/src/context.ts#L6
+ * @returns Promise<bool>
+ */
+async function setWait ({github, context, core}) {
   return sendCreateCommitStatus({
     github,
     context,
@@ -48,9 +76,18 @@ module.exports.setWait = async ({github, context, core}) => {
     state: 'pending',
     description: 'Waiting for run e2e test.'
   })
-};
+}
 
-module.exports.setFail = async ({github, context, core}) => {
+/**
+ * Set `e2e was failed` status (failed) when e2e was failed
+ * Use STATUS_TARGET_COMMIT env var as target commit sha
+ * @param {object} inputs
+ * @param {object} inputs.core - A reference to the '@actions/core' package.
+ * @param {object} inputs.github - A pre-authenticated octokit/rest.js client with pagination plugins.
+ * @param {object} inputs.context - A reference to context https://github.com/actions/toolkit/blob/main/packages/github/src/context.ts#L6
+ * @returns Promise<bool>
+ */
+async function setFail({github, context, core}){
   return sendCreateCommitStatus({
     github,
     context,
@@ -59,9 +96,18 @@ module.exports.setFail = async ({github, context, core}) => {
     description: 'E2e test was failed.',
     url: workflowUrl({core, context}),
   })
-};
+}
 
-module.exports.setSuccess = async ({github, context, core}) => {
+/**
+ * Set `e2e was passed` status (failed) when e2e was failed
+ * Use STATUS_TARGET_COMMIT env var as target commit sha
+ * @param {object} inputs
+ * @param {object} inputs.core - A reference to the '@actions/core' package.
+ * @param {object} inputs.github - A pre-authenticated octokit/rest.js client with pagination plugins.
+ * @param {object} inputs.context - A reference to context https://github.com/actions/toolkit/blob/main/packages/github/src/context.ts#L6
+ * @returns Promise<bool>
+ */
+function setSuccess ({github, context, core}) {
   return sendCreateCommitStatus({
     github,
     context,
@@ -70,4 +116,57 @@ module.exports.setSuccess = async ({github, context, core}) => {
     description: 'E2e test was passed.',
     url: workflowUrl({core, context}),
   })
-};
+}
+
+/**
+ * Set `e2e was failed` status (success) when e2e was failed
+ * Unfortunately we do not have 'skip' status and use 'success'
+ * Use STATUS_TARGET_COMMIT env var as target commit sha
+ * @param {object} inputs
+ * @param {object} inputs.core - A reference to the '@actions/core' package.
+ * @param {object} inputs.github - A pre-authenticated octokit/rest.js client with pagination plugins.
+ * @param {object} inputs.context - A reference to context https://github.com/actions/toolkit/blob/main/packages/github/src/context.ts#L6
+ * @returns Promise<bool>
+ */
+async function setSkip({github, context, core}){
+  return sendCreateCommitStatus({
+    github,
+    context,
+    core,
+    state: 'success',
+    description: 'E2e test was skipped',
+  })
+}
+
+/**
+ * Set commit status when commit was pushed.
+ * Check label for skipping e2e test and e2e tests should skip set success status
+ * Used in build-and-test_dev workflow
+ * Use STATUS_TARGET_COMMIT env var as target commit sha
+ * Use PR_LABELS env var as list of PR labels
+ * @param {object} inputs
+ * @param {object} inputs.core - A reference to the '@actions/core' package.
+ * @param {object} inputs.github - A pre-authenticated octokit/rest.js client with pagination plugins.
+ * @param {object} inputs.context - A reference to context https://github.com/actions/toolkit/blob/main/packages/github/src/context.ts#L6
+ * @returns Promise<void>
+ */
+async function setInitialStatus ({github, context, core}) {
+  const labels = JSON.parse(process.env.PR_LABELS);
+  core.debug(`Labels: ${labels ? JSON.stringify(labels.map((l) => l.name)) : 'no labels'}`);
+
+  const shouldSkip = labels ? labels.some((l) => l.name === "skip/e2e") : false;
+  core.debug(`Should skip e2e: ${shouldSkip}`);
+
+  const statusSetFunc = (shouldSkip) ? setSkip : setWait;
+
+  const done = await statusSetFunc({github, context, core});
+  if (!done) {
+    core.setFailed('e2e requirement status was not set.');
+  }
+}
+
+module.exports = {
+  setSuccess,
+  setFail,
+  setInitialStatus
+}

--- a/.github/scripts/js/e2e-commit-status.js
+++ b/.github/scripts/js/e2e-commit-status.js
@@ -19,7 +19,9 @@ async function sendCreateCommitStatus({github, context, core, state, description
     });
 
     core.debug(`rest.repos.createCommitStatus response: ${JSON.stringify(response)}`);
+    core.debug(`rest.repos.createCommitStatus response.status: ${response.status}`);
     if (response.status === 201) {
+      core.debug(`rest.repos.createCommitStatus response status is 201. Returns true`);
       return true;
     }
 

--- a/.github/scripts/js/e2e-commit-status.js
+++ b/.github/scripts/js/e2e-commit-status.js
@@ -7,7 +7,7 @@ function workflowUrl({server_url, repository, run_id}) {
 }
 
 async function sendCreateCommitStatus({github, context, core, state, description, url}) {
-  const commit_sha = process.env.INPUT_STATUS_TARGET_COMMIT;
+  const commit_sha = process.env.STATUS_TARGET_COMMIT;
   core.debug(`sendCreateCommitStatus target commit: ${commit_sha}`);
 
   for(let i = 0; i < 3; i++) {

--- a/.github/scripts/js/e2e-commit-status.js
+++ b/.github/scripts/js/e2e-commit-status.js
@@ -24,7 +24,7 @@ async function sendCreateCommitStatus({github, context, core, state, description
       state: state,
       description: description,
       target_url: url,
-      context: 'deckhouse/e2e-requirement'
+      context: 'E2e test'
     });
 
     core.debug(`rest.repos.createCommitStatus response: ${JSON.stringify(response)}`);

--- a/.github/scripts/js/e2e-commit-status.js
+++ b/.github/scripts/js/e2e-commit-status.js
@@ -141,7 +141,10 @@ async function setSkip({github, context, core}){
 /**
  * Set commit status when commit was pushed.
  * Check label for skipping e2e test and e2e tests should skip set success status
+ * If status was not set then fail job
+ *
  * Used in build-and-test_dev workflow
+ *
  * Use STATUS_TARGET_COMMIT env var as target commit sha
  * Use PR_LABELS env var as list of PR labels
  * @param {object} inputs

--- a/.github/scripts/js/e2e-commit-status.js
+++ b/.github/scripts/js/e2e-commit-status.js
@@ -79,7 +79,7 @@ async function setWait ({github, context, core, commitSha}) {
     status: {
       commitSha,
       state: 'pending',
-      description: 'Waiting for run e2e test.'
+      description: 'Waiting for run e2e test'
     }
   })
 }
@@ -102,7 +102,7 @@ async function setFail({github, context, core, commitSha}){
     status: {
       commitSha,
       state: 'failure',
-      description: 'E2e test was failed.',
+      description: 'E2e test was failed',
       url: workflowUrl({core, context}),
     }
   })
@@ -126,7 +126,7 @@ function setSuccess ({github, context, core, commitSha}) {
     status: {
       commitSha,
       state: 'success',
-      description: 'E2e test was passed.',
+      description: 'E2e test was passed',
       url: workflowUrl({core, context}),
     }
   })

--- a/.github/scripts/js/time.js
+++ b/.github/scripts/js/time.js
@@ -1,0 +1,3 @@
+module.exports.sleep = async (ms) => {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -157,7 +157,8 @@ jobs:
 {!{ tmpl.Exec "tests_template" (slice $ctx "validators" "build_deckhouse") | strings.Indent 4 }!}
 
   set_e2e_requirement_status:
-    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
+    # if previous jobs were failed we do not need set status, because checks will be failed
+    if: ${{ success() && needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
     name: Set 'waiting for e2e' commit status
     needs:
       - git_info
@@ -175,6 +176,7 @@ jobs:
       id: set_e2e_requirement_status
       uses: {!{ index (ds "actions") "actions/github-script" }!}
       with:
+        status_target_commit: ${{needs.git_info.outputs.github_sha}}
         github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
         script: |
           const e2eStatus = require('./.github/scripts/js/e2e-commit-status');

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -175,8 +175,9 @@ jobs:
     - name: Set commit status after e2e run
       id: set_e2e_requirement_status
       uses: {!{ index (ds "actions") "actions/github-script" }!}
+      env:
+        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
       with:
-        status_target_commit: ${{needs.git_info.outputs.github_sha}}
         github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
         script: |
           const e2eStatus = require('./.github/scripts/js/e2e-commit-status');

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -177,11 +177,10 @@ jobs:
       uses: {!{ index (ds "actions") "actions/github-script" }!}
       env:
         STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+        PR_LABELS: ${{ needs.pull_request_info.outputs.labels }}
       with:
         github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
         script: |
           const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-          const done = await e2eStatus.setWait({github, context, core});
-          if (!done) {
-            core.setFailed('e2e requirement status was not set.')
-          }
+
+          await e2eStatus.setInitial({github, context, core});

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -183,4 +183,4 @@ jobs:
         script: |
           const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-          await e2eStatus.setInitial({github, context, core});
+          await e2eStatus.setInitialStatus({github, context, core});

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -164,7 +164,6 @@ jobs:
       - pull_request_info
       - build_deckhouse
       - validators
-      - web_links_test
       - openapi_test_cases
       - golangci_lint
       - dhctl_tests

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -155,3 +155,31 @@ jobs:
       - pull_request_info
       - build_deckhouse
 {!{ tmpl.Exec "tests_template" (slice $ctx "validators" "build_deckhouse") | strings.Indent 4 }!}
+
+  set_e2e_requirement_status:
+    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
+    name: Set 'waiting for e2e' commit status
+    needs:
+      - git_info
+      - pull_request_info
+      - build_deckhouse
+      - validators
+      - web_links_test
+      - openapi_test_cases
+      - golangci_lint
+      - dhctl_tests
+      - matrix_tests
+      - tests
+    runs-on: [ self-hosted, regular ]
+    steps:
+    - name: Set commit status after e2e run
+      id: set_e2e_requirement_status
+      uses: {!{ index (ds "actions") "actions/github-script" }!}
+      with:
+        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+        script: |
+          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+          const done = await e2eStatus.setWait({github, context, core});
+          if (!done) {
+            core.setFailed('e2e requirement status was not set.')
+          }

--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -87,7 +87,7 @@ jobs:
 {!{ tmpl.Exec "check_e2e_labels_job" $ctx | strings.Indent 2 }!}
 
 {!{/* Jobs for each CRI and Kubernetes version */}!}
-{!{- $lastCommentNeeds := slice "started_at" -}!}
+{!{- $lastCommentNeeds := slice "started_at" "git_info" -}!}
 {!{- $jobNames := dict -}!}
 {!{- range $criName := $ctx.criNames -}!}
 {!{-   range $kubernetesVersion := $ctx.kubernetesVersions -}!}

--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -115,6 +115,7 @@ jobs:
     steps:
 {!{ tmpl.Exec "checkout_step" $ctx | strings.Indent 6 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "workflow,final,no-skipped,restore-separate" $workflowName) | strings.Indent 6 }!}
+{!{ tmpl.Exec "set_e2e_requirement_status" slice | strings.Indent 4 }!}
 # </template: e2e_workflow_template>
 {!{ end -}!}
 

--- a/.github/workflow_templates/e2e.multi.yml
+++ b/.github/workflow_templates/e2e.multi.yml
@@ -115,7 +115,7 @@ jobs:
     steps:
 {!{ tmpl.Exec "checkout_step" $ctx | strings.Indent 6 }!}
 {!{ tmpl.Exec "update_comment_on_finish" (slice "workflow,final,no-skipped,restore-separate" $workflowName) | strings.Indent 6 }!}
-{!{ tmpl.Exec "set_e2e_requirement_status" slice | strings.Indent 4 }!}
+{!{ tmpl.Exec "set_e2e_requirement_status" slice | strings.Indent 6 }!}
 # </template: e2e_workflow_template>
 {!{ end -}!}
 

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1510,7 +1510,8 @@ jobs:
     # </template: tests_template>
 
   set_e2e_requirement_status:
-    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
+    # if previous jobs were failed we do not need set status, because checks will be failed
+    if: ${{ success() && needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
     name: Set 'waiting for e2e' commit status
     needs:
       - git_info
@@ -1528,6 +1529,7 @@ jobs:
       id: set_e2e_requirement_status
       uses: actions/github-script@v5.0.0
       with:
+        status_target_commit: ${{needs.git_info.outputs.github_sha}}
         github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
         script: |
           const e2eStatus = require('./.github/scripts/js/e2e-commit-status');

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1508,3 +1508,31 @@ jobs:
           echo "⚓️ 🏎 [$(date -u)] Run tests..."
           docker run -w /deckhouse -v ${{env.HOME}}/go-pkg-cache:/go/pkg ${TESTS_IMAGE_NAME} go test -tags=validation -run Validation -timeout=${{env.TEST_TIMEOUT}} ./testing/...
     # </template: tests_template>
+
+  set_e2e_requirement_status:
+    if: ${{ needs.pull_request_info.outputs.changes_not_markdown == 'true' }}
+    name: Set 'waiting for e2e' commit status
+    needs:
+      - git_info
+      - pull_request_info
+      - build_deckhouse
+      - validators
+      - web_links_test
+      - openapi_test_cases
+      - golangci_lint
+      - dhctl_tests
+      - matrix_tests
+      - tests
+    runs-on: [ self-hosted, regular ]
+    steps:
+    - name: Set commit status after e2e run
+      id: set_e2e_requirement_status
+      uses: actions/github-script@v5.0.0
+      with:
+        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+        script: |
+          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+          const done = await e2eStatus.setWait({github, context, core});
+          if (!done) {
+            core.setFailed('e2e requirement status was not set.')
+          }

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1528,8 +1528,9 @@ jobs:
     - name: Set commit status after e2e run
       id: set_e2e_requirement_status
       uses: actions/github-script@v5.0.0
+      env:
+        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
       with:
-        status_target_commit: ${{needs.git_info.outputs.github_sha}}
         github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
         script: |
           const e2eStatus = require('./.github/scripts/js/e2e-commit-status');

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1536,4 +1536,4 @@ jobs:
         script: |
           const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-          await e2eStatus.setInitial({github, context, core});
+          await e2eStatus.setInitialStatus({github, context, core});

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1530,11 +1530,10 @@ jobs:
       uses: actions/github-script@v5.0.0
       env:
         STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+        PR_LABELS: ${{ needs.pull_request_info.outputs.labels }}
       with:
         github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
         script: |
           const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-          const done = await e2eStatus.setWait({github, context, core});
-          if (!done) {
-            core.setFailed('e2e requirement status was not set.')
-          }
+
+          await e2eStatus.setInitial({github, context, core});

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -1517,7 +1517,6 @@ jobs:
       - pull_request_info
       - build_deckhouse
       - validators
-      - web_links_test
       - openapi_test_cases
       - golangci_lint
       - dhctl_tests

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -520,17 +520,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -879,17 +869,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1238,17 +1218,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1597,17 +1567,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1956,17 +1916,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -2315,17 +2265,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -2674,17 +2614,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3033,17 +2963,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3392,17 +3312,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3751,17 +3661,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -514,15 +514,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -874,15 +875,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1234,15 +1236,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1594,15 +1597,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1954,15 +1958,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2314,15 +2319,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2674,15 +2680,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3034,15 +3041,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3394,15 +3402,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3754,15 +3763,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -510,8 +510,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -871,8 +869,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1232,8 +1228,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1593,8 +1587,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1954,8 +1946,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -2315,8 +2305,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -2676,8 +2664,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3037,8 +3023,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3398,8 +3382,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3759,8 +3741,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -505,6 +505,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -837,6 +863,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1169,6 +1221,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1501,6 +1579,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1833,6 +1937,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2165,6 +2295,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2497,6 +2653,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2829,6 +3011,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3161,6 +3369,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3493,6 +3727,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
 

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -510,17 +510,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -868,17 +870,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1226,17 +1230,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1584,17 +1590,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1942,17 +1950,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2300,17 +2310,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2658,17 +2670,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3016,17 +3030,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3374,17 +3390,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3732,17 +3750,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -3543,19 +3543,19 @@ jobs:
       # </template: update_comment_on_finish>
 
 
-    # <template: set_e2e_requirement_status>
-    - name: Set commit status after e2e run
-      id: set_e2e_requirement_status
-      if: ${{ always() }}
-      uses: actions/github-script@v5.0.0
-      env:
-        JOB_STATUS: ${{ job.status }}
-        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-      with:
-        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-        script: |
-          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-          await e2eStatus.setStatusAfterE2eRun({github, context, core});
-    # </template: set_e2e_requirement_status>
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
+      # </template: set_e2e_requirement_status>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -505,23 +505,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -854,23 +837,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1203,23 +1169,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1552,23 +1501,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1901,23 +1833,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2250,23 +2165,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2599,23 +2497,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2948,23 +2829,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3297,23 +3161,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3646,23 +3493,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
 
@@ -3711,4 +3541,21 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+    # <template: set_e2e_requirement_status>
+    - name: Set commit status after e2e run
+      id: set_e2e_requirement_status
+      if: ${{ always() }}
+      uses: actions/github-script@v5.0.0
+      env:
+        JOB_STATUS: ${{ job.status }}
+        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+      with:
+        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+        script: |
+          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+          await e2eStatus.setStatusAfterE2eRun({github, context, core});
+    # </template: set_e2e_requirement_status>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -3498,7 +3498,7 @@ jobs:
 
   last_comment:
     name: Update comment on finish
-    needs: ["started_at","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_docker_1_24","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23","run_containerd_1_24"]
+    needs: ["started_at","git_info","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_docker_1_24","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23","run_containerd_1_24"]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -518,17 +518,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -884,17 +886,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1250,17 +1254,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1616,17 +1622,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1982,17 +1990,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2348,17 +2358,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2714,17 +2726,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3080,17 +3094,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3446,17 +3462,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3812,17 +3830,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -513,6 +513,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -853,6 +879,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1193,6 +1245,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1533,6 +1611,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1873,6 +1977,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2213,6 +2343,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2553,6 +2709,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2893,6 +3075,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3233,6 +3441,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3573,6 +3807,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
 

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -518,8 +518,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -887,8 +885,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1256,8 +1252,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1625,8 +1619,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1994,8 +1986,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -2363,8 +2353,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -2732,8 +2720,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3101,8 +3087,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3470,8 +3454,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3839,8 +3821,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -528,17 +528,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -895,17 +885,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1262,17 +1242,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1629,17 +1599,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1996,17 +1956,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -2363,17 +2313,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -2730,17 +2670,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3097,17 +3027,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3464,17 +3384,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3831,17 +3741,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -522,15 +522,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -890,15 +891,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1258,15 +1260,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1626,15 +1629,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1994,15 +1998,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2362,15 +2367,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2730,15 +2736,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3098,15 +3105,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3466,15 +3474,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3834,15 +3843,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -513,23 +513,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -870,23 +853,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1227,23 +1193,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1584,23 +1533,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1941,23 +1873,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2298,23 +2213,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2655,23 +2553,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3012,23 +2893,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3369,23 +3233,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3726,23 +3573,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
 
@@ -3791,4 +3621,21 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+    # <template: set_e2e_requirement_status>
+    - name: Set commit status after e2e run
+      id: set_e2e_requirement_status
+      if: ${{ always() }}
+      uses: actions/github-script@v5.0.0
+      env:
+        JOB_STATUS: ${{ job.status }}
+        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+      with:
+        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+        script: |
+          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+          await e2eStatus.setStatusAfterE2eRun({github, context, core});
+    # </template: set_e2e_requirement_status>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -3623,19 +3623,19 @@ jobs:
       # </template: update_comment_on_finish>
 
 
-    # <template: set_e2e_requirement_status>
-    - name: Set commit status after e2e run
-      id: set_e2e_requirement_status
-      if: ${{ always() }}
-      uses: actions/github-script@v5.0.0
-      env:
-        JOB_STATUS: ${{ job.status }}
-        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-      with:
-        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-        script: |
-          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-          await e2eStatus.setStatusAfterE2eRun({github, context, core});
-    # </template: set_e2e_requirement_status>
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
+      # </template: set_e2e_requirement_status>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -3578,7 +3578,7 @@ jobs:
 
   last_comment:
     name: Update comment on finish
-    needs: ["started_at","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_docker_1_24","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23","run_containerd_1_24"]
+    needs: ["started_at","git_info","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_docker_1_24","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23","run_containerd_1_24"]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -506,17 +506,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -860,17 +862,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1214,17 +1218,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1568,17 +1574,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1922,17 +1930,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2276,17 +2286,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2630,17 +2642,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2984,17 +2998,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3338,17 +3354,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3692,17 +3710,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -510,15 +510,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -866,15 +867,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1222,15 +1224,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1578,15 +1581,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1934,15 +1938,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2290,15 +2295,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2646,15 +2652,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3002,15 +3009,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3358,15 +3366,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3714,15 +3723,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -516,17 +516,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -871,17 +861,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1226,17 +1206,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1581,17 +1551,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1936,17 +1896,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -2291,17 +2241,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -2646,17 +2586,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3001,17 +2931,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3356,17 +3276,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3711,17 +3621,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -506,8 +506,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -863,8 +861,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1220,8 +1216,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1577,8 +1571,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1934,8 +1926,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -2291,8 +2281,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -2648,8 +2636,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3005,8 +2991,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3362,8 +3346,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3719,8 +3701,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -501,6 +501,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -829,6 +855,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1157,6 +1209,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1485,6 +1563,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1813,6 +1917,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2141,6 +2271,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2469,6 +2625,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2797,6 +2979,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3125,6 +3333,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3453,6 +3687,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
 

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -3458,7 +3458,7 @@ jobs:
 
   last_comment:
     name: Update comment on finish
-    needs: ["started_at","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_docker_1_24","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23","run_containerd_1_24"]
+    needs: ["started_at","git_info","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_docker_1_24","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23","run_containerd_1_24"]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -501,23 +501,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -846,23 +829,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1191,23 +1157,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1536,23 +1485,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1881,23 +1813,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2226,23 +2141,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2571,23 +2469,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2916,23 +2797,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3261,23 +3125,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3606,23 +3453,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
 
@@ -3671,4 +3501,21 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+    # <template: set_e2e_requirement_status>
+    - name: Set commit status after e2e run
+      id: set_e2e_requirement_status
+      if: ${{ always() }}
+      uses: actions/github-script@v5.0.0
+      env:
+        JOB_STATUS: ${{ job.status }}
+        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+      with:
+        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+        script: |
+          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+          await e2eStatus.setStatusAfterE2eRun({github, context, core});
+    # </template: set_e2e_requirement_status>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -3503,19 +3503,19 @@ jobs:
       # </template: update_comment_on_finish>
 
 
-    # <template: set_e2e_requirement_status>
-    - name: Set commit status after e2e run
-      id: set_e2e_requirement_status
-      if: ${{ always() }}
-      uses: actions/github-script@v5.0.0
-      env:
-        JOB_STATUS: ${{ job.status }}
-        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-      with:
-        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-        script: |
-          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-          await e2eStatus.setStatusAfterE2eRun({github, context, core});
-    # </template: set_e2e_requirement_status>
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
+      # </template: set_e2e_requirement_status>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -506,17 +506,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -860,17 +862,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1214,17 +1218,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1568,17 +1574,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1922,17 +1930,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2276,17 +2286,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2630,17 +2642,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2984,17 +2998,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3338,17 +3354,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3692,17 +3710,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -510,15 +510,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -866,15 +867,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1222,15 +1224,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1578,15 +1581,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1934,15 +1938,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2290,15 +2295,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2646,15 +2652,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3002,15 +3009,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3358,15 +3366,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3714,15 +3723,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -516,17 +516,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -871,17 +861,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1226,17 +1206,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1581,17 +1551,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1936,17 +1896,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -2291,17 +2241,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -2646,17 +2586,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3001,17 +2931,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3356,17 +3276,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3711,17 +3621,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -506,8 +506,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -863,8 +861,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1220,8 +1216,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1577,8 +1571,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1934,8 +1926,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -2291,8 +2281,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -2648,8 +2636,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3005,8 +2991,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3362,8 +3346,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3719,8 +3701,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -501,6 +501,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -829,6 +855,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1157,6 +1209,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1485,6 +1563,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1813,6 +1917,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2141,6 +2271,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2469,6 +2625,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2797,6 +2979,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3125,6 +3333,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3453,6 +3687,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
 

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -3458,7 +3458,7 @@ jobs:
 
   last_comment:
     name: Update comment on finish
-    needs: ["started_at","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_docker_1_24","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23","run_containerd_1_24"]
+    needs: ["started_at","git_info","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_docker_1_24","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23","run_containerd_1_24"]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -501,23 +501,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -846,23 +829,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1191,23 +1157,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1536,23 +1485,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1881,23 +1813,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2226,23 +2141,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2571,23 +2469,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2916,23 +2797,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3261,23 +3125,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3606,23 +3453,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
 
@@ -3671,4 +3501,21 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+    # <template: set_e2e_requirement_status>
+    - name: Set commit status after e2e run
+      id: set_e2e_requirement_status
+      if: ${{ always() }}
+      uses: actions/github-script@v5.0.0
+      env:
+        JOB_STATUS: ${{ job.status }}
+        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+      with:
+        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+        script: |
+          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+          await e2eStatus.setStatusAfterE2eRun({github, context, core});
+    # </template: set_e2e_requirement_status>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -3503,19 +3503,19 @@ jobs:
       # </template: update_comment_on_finish>
 
 
-    # <template: set_e2e_requirement_status>
-    - name: Set commit status after e2e run
-      id: set_e2e_requirement_status
-      if: ${{ always() }}
-      uses: actions/github-script@v5.0.0
-      env:
-        JOB_STATUS: ${{ job.status }}
-        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-      with:
-        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-        script: |
-          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-          await e2eStatus.setStatusAfterE2eRun({github, context, core});
-    # </template: set_e2e_requirement_status>
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
+      # </template: set_e2e_requirement_status>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -506,17 +506,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -860,17 +862,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1214,17 +1218,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1568,17 +1574,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1922,17 +1930,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2276,17 +2286,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2630,17 +2642,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2984,17 +2998,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3338,17 +3354,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3692,17 +3710,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -510,15 +510,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -866,15 +867,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1222,15 +1224,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1578,15 +1581,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1934,15 +1938,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2290,15 +2295,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2646,15 +2652,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3002,15 +3009,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3358,15 +3366,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3714,15 +3723,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -516,17 +516,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -871,17 +861,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1226,17 +1206,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1581,17 +1551,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1936,17 +1896,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -2291,17 +2241,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -2646,17 +2586,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3001,17 +2931,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3356,17 +3276,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3711,17 +3621,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -506,8 +506,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -863,8 +861,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1220,8 +1216,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1577,8 +1571,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1934,8 +1926,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -2291,8 +2281,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -2648,8 +2636,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3005,8 +2991,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3362,8 +3346,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3719,8 +3701,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -501,6 +501,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -829,6 +855,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1157,6 +1209,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1485,6 +1563,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1813,6 +1917,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2141,6 +2271,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2469,6 +2625,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2797,6 +2979,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3125,6 +3333,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3453,6 +3687,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
 

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -3458,7 +3458,7 @@ jobs:
 
   last_comment:
     name: Update comment on finish
-    needs: ["started_at","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_docker_1_24","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23","run_containerd_1_24"]
+    needs: ["started_at","git_info","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_docker_1_24","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23","run_containerd_1_24"]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -501,23 +501,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -846,23 +829,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1191,23 +1157,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1536,23 +1485,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1881,23 +1813,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2226,23 +2141,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2571,23 +2469,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2916,23 +2797,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3261,23 +3125,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3606,23 +3453,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
 
@@ -3671,4 +3501,21 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+    # <template: set_e2e_requirement_status>
+    - name: Set commit status after e2e run
+      id: set_e2e_requirement_status
+      if: ${{ always() }}
+      uses: actions/github-script@v5.0.0
+      env:
+        JOB_STATUS: ${{ job.status }}
+        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+      with:
+        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+        script: |
+          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+          await e2eStatus.setStatusAfterE2eRun({github, context, core});
+    # </template: set_e2e_requirement_status>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -3503,19 +3503,19 @@ jobs:
       # </template: update_comment_on_finish>
 
 
-    # <template: set_e2e_requirement_status>
-    - name: Set commit status after e2e run
-      id: set_e2e_requirement_status
-      if: ${{ always() }}
-      uses: actions/github-script@v5.0.0
-      env:
-        JOB_STATUS: ${{ job.status }}
-        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-      with:
-        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-        script: |
-          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-          await e2eStatus.setStatusAfterE2eRun({github, context, core});
-    # </template: set_e2e_requirement_status>
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
+      # </template: set_e2e_requirement_status>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -520,17 +520,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -879,17 +869,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1238,17 +1218,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1597,17 +1567,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1956,17 +1916,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -2315,17 +2265,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -2674,17 +2614,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3033,17 +2963,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3392,17 +3312,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3751,17 +3661,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -514,15 +514,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -874,15 +875,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1234,15 +1236,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1594,15 +1597,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1954,15 +1958,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2314,15 +2319,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2674,15 +2680,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3034,15 +3041,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3394,15 +3402,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3754,15 +3763,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -510,8 +510,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -871,8 +869,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1232,8 +1228,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1593,8 +1587,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1954,8 +1946,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -2315,8 +2305,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -2676,8 +2664,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3037,8 +3023,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3398,8 +3382,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3759,8 +3741,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -505,6 +505,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -837,6 +863,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1169,6 +1221,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1501,6 +1579,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1833,6 +1937,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2165,6 +2295,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2497,6 +2653,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2829,6 +3011,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3161,6 +3369,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3493,6 +3727,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
 

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -510,17 +510,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -868,17 +870,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1226,17 +1230,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1584,17 +1590,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1942,17 +1950,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2300,17 +2310,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2658,17 +2670,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3016,17 +3030,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3374,17 +3390,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3732,17 +3750,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -3543,19 +3543,19 @@ jobs:
       # </template: update_comment_on_finish>
 
 
-    # <template: set_e2e_requirement_status>
-    - name: Set commit status after e2e run
-      id: set_e2e_requirement_status
-      if: ${{ always() }}
-      uses: actions/github-script@v5.0.0
-      env:
-        JOB_STATUS: ${{ job.status }}
-        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-      with:
-        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-        script: |
-          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-          await e2eStatus.setStatusAfterE2eRun({github, context, core});
-    # </template: set_e2e_requirement_status>
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
+      # </template: set_e2e_requirement_status>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -505,23 +505,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -854,23 +837,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1203,23 +1169,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1552,23 +1501,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1901,23 +1833,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2250,23 +2165,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2599,23 +2497,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2948,23 +2829,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3297,23 +3161,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3646,23 +3493,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
 
@@ -3711,4 +3541,21 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+    # <template: set_e2e_requirement_status>
+    - name: Set commit status after e2e run
+      id: set_e2e_requirement_status
+      if: ${{ always() }}
+      uses: actions/github-script@v5.0.0
+      env:
+        JOB_STATUS: ${{ job.status }}
+        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+      with:
+        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+        script: |
+          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+          await e2eStatus.setStatusAfterE2eRun({github, context, core});
+    # </template: set_e2e_requirement_status>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -3498,7 +3498,7 @@ jobs:
 
   last_comment:
     name: Update comment on finish
-    needs: ["started_at","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_docker_1_24","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23","run_containerd_1_24"]
+    needs: ["started_at","git_info","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_docker_1_24","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23","run_containerd_1_24"]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -509,6 +509,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -845,6 +871,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1181,6 +1233,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1517,6 +1595,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1853,6 +1957,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2189,6 +2319,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2525,6 +2681,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2861,6 +3043,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3197,6 +3405,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3533,6 +3767,32 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+            let done = false;
+            const jobStat = process.env.JOB_STATUS;
+            if (jobStat === 'failure' || jobStat === 'cancelled') {
+              done = await e2eStatus.setFail({github, context, core});
+            } else if (jobStat === 'success') {
+              done = await e2eStatus.setSuccess({github, context, core});
+            }
+
+            if (!done) {
+              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
+            }
+      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
 

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -524,17 +524,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -887,17 +877,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1250,17 +1230,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1613,17 +1583,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -1976,17 +1936,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -2339,17 +2289,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -2702,17 +2642,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3065,17 +2995,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3428,17 +3348,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
@@ -3791,17 +3701,7 @@ jobs:
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-            let done = false;
-            const jobStat = process.env.JOB_STATUS;
-            if (jobStat === 'failure' || jobStat === 'cancelled') {
-              done = await e2eStatus.setFail({github, context, core});
-            } else if (jobStat === 'success') {
-              done = await e2eStatus.setSuccess({github, context, core});
-            }
-
-            if (!done) {
-              core.setFailed(`e2e requirement status was not set. Job status ${jobStat}`)
-            }
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
       # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -514,17 +514,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -876,17 +878,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1238,17 +1242,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1600,17 +1606,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1962,17 +1970,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2324,17 +2334,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2686,17 +2698,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3048,17 +3062,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3410,17 +3426,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3772,17 +3790,19 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
+        needs:
+        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          status_target_commit: ${{needs.git_info.outputs.github_sha}}
+          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.JOB_STATUS;
+            const jobStat = process.env.INPUT_JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -514,8 +514,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -879,8 +877,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1244,8 +1240,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1609,8 +1603,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -1974,8 +1966,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -2339,8 +2329,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -2704,8 +2692,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3069,8 +3055,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3434,8 +3418,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:
@@ -3799,8 +3781,6 @@ jobs:
       # <template: set_e2e_requirement_status>
       - name: Set commit status after e2e run
         id: set_e2e_requirement_status
-        needs:
-        - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
         env:

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -518,15 +518,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -882,15 +883,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1246,15 +1248,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1610,15 +1613,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -1974,15 +1978,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2338,15 +2343,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -2702,15 +2708,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3066,15 +3073,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3430,15 +3438,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {
@@ -3794,15 +3803,16 @@ jobs:
         - git_info
         if: ${{ always() }}
         uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
         with:
           github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          status_target_commit: ${{needs.git_info.outputs.github_sha}}
-          job_status: ${{ job.status }}
           script: |
             const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
             let done = false;
-            const jobStat = process.env.INPUT_JOB_STATUS;
+            const jobStat = process.env.JOB_STATUS;
             if (jobStat === 'failure' || jobStat === 'cancelled') {
               done = await e2eStatus.setFail({github, context, core});
             } else if (jobStat === 'success') {

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -3583,19 +3583,19 @@ jobs:
       # </template: update_comment_on_finish>
 
 
-    # <template: set_e2e_requirement_status>
-    - name: Set commit status after e2e run
-      id: set_e2e_requirement_status
-      if: ${{ always() }}
-      uses: actions/github-script@v5.0.0
-      env:
-        JOB_STATUS: ${{ job.status }}
-        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-      with:
-        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-        script: |
-          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+      # <template: set_e2e_requirement_status>
+      - name: Set commit status after e2e run
+        id: set_e2e_requirement_status
+        if: ${{ always() }}
+        uses: actions/github-script@v5.0.0
+        env:
+          JOB_STATUS: ${{ job.status }}
+          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          script: |
+            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
 
-          await e2eStatus.setStatusAfterE2eRun({github, context, core});
-    # </template: set_e2e_requirement_status>
+            await e2eStatus.setStatusAfterE2eRun({github, context, core});
+      # </template: set_e2e_requirement_status>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -509,23 +509,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -862,23 +845,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1215,23 +1181,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1568,23 +1517,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -1921,23 +1853,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2274,23 +2189,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2627,23 +2525,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -2980,23 +2861,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3333,23 +3197,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
   # <template: e2e_run_job_template>
@@ -3686,23 +3533,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-
-      # <template: set_e2e_requirement_status>
-      - name: Set commit status after e2e run
-        id: set_e2e_requirement_status
-        if: ${{ always() }}
-        uses: actions/github-script@v5.0.0
-        env:
-          JOB_STATUS: ${{ job.status }}
-          STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
-        with:
-          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-          script: |
-            const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
-
-            await e2eStatus.setStatusAfterE2eRun({github, context, core});
-      # </template: set_e2e_requirement_status>
   # </template: e2e_run_job_template>
 
 
@@ -3751,4 +3581,21 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
+
+
+    # <template: set_e2e_requirement_status>
+    - name: Set commit status after e2e run
+      id: set_e2e_requirement_status
+      if: ${{ always() }}
+      uses: actions/github-script@v5.0.0
+      env:
+        JOB_STATUS: ${{ job.status }}
+        STATUS_TARGET_COMMIT: ${{needs.git_info.outputs.github_sha}}
+      with:
+        github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+        script: |
+          const e2eStatus = require('./.github/scripts/js/e2e-commit-status');
+
+          await e2eStatus.setStatusAfterE2eRun({github, context, core});
+    # </template: set_e2e_requirement_status>
 # </template: e2e_workflow_template>

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -3538,7 +3538,7 @@ jobs:
 
   last_comment:
     name: Update comment on finish
-    needs: ["started_at","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_docker_1_24","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23","run_containerd_1_24"]
+    needs: ["started_at","git_info","run_docker_1_20","run_docker_1_21","run_docker_1_22","run_docker_1_23","run_docker_1_24","run_containerd_1_20","run_containerd_1_21","run_containerd_1_22","run_containerd_1_23","run_containerd_1_24"]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Description
The [Commit statuses API](https://docs.github.com/en/rest/commits/statuses#about-the-commit-statuses-api) was used when doing this PR.
After all tests pass successfully, a workflow will start and sets the `E2e test` status to 'pending'. In this status PR check will show `Some checks haven’t completed yet` message. 
After running the e2e test, we change the status of the `E2e test` to `success` or `failure` depending on the result of the test. Cancelled test will have `failrue` state.
`failrue` status shows `Some checks were not successful` message in the PR checks,  success - `All checks have passed`. `Details` link follows to e2e action run.
It is also possible to put the label `skip/e2e`, which will change the status of `E2e test` to `success`. Unfortunately the API does not provide a `skipped` state for the status, but check will have description `E2e test was skipped`. If the label `skip/e2e` was switched off, then we put it in the `pending` state.

## Why do we need it, and what problem does it solve?
In some time our PR's break `main` (cluster not bootstrap from `main`).
We can avoid this with running e2e test. This pr add additional check in pr which requires run e2e test before merge.

## What is the expected result?
It tested in test repo.
[push commit](https://github.com/deckhouse/deckhouse-test-2/pull/183) - checks in `pending` status 
[create PR with label](https://github.com/deckhouse/deckhouse-test-2/pull/186) - checks in `success` state with description `E2e test was skipped`
[set `skip/e2e` label](https://github.com/deckhouse/deckhouse-test-2/pull/179) - checks in `success` state with description `E2e test was skipped`
[unset `skip/e2e` label](https://github.com/deckhouse/deckhouse-test-2/pull/184) - checks in `pending` state
[e2e test passed](https://github.com/deckhouse/deckhouse-test-2/pull/182) - checks in `success` status
[e2e test was failed](https://github.com/deckhouse/deckhouse-test-2/pull/180) - checks in `failure` status
[Canceled e2e tests](https://github.com/deckhouse/deckhouse-test-2/pull/185) - checks in `failure` status

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: feature
summary: Make executing a single e2e test mandatory to accept the PR
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
