### PR TITLE
[linstor] fix image tag regression

### DIFF
--- a/modules/041-linstor/templates/linstor-controller/linstorcontroller.yaml
+++ b/modules/041-linstor/templates/linstor-controller/linstorcontroller.yaml
@@ -68,7 +68,7 @@ spec:
   dbUseClientCert: false
   drbdRepoCred: deckhouse-registry
   serviceAccountName: linstor-controller
-  controllerImage: {{ include "helm_lib_module_image" (list . "listorServer") }}
+  controllerImage: {{ include "helm_lib_module_image" (list . "linstorServer") }}
   imagePullPolicy: IfNotPresent
   linstorHttpsClientSecret: linstor-client-https-cert
   linstorHttpsControllerSecret: linstor-controller-https-cert

--- a/modules/041-linstor/templates/linstor-scheduler/deployment.yaml
+++ b/modules/041-linstor/templates/linstor-scheduler/deployment.yaml
@@ -100,7 +100,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: {{ include "helm_lib_module_image" (list . (list "kubeScheduler" $kubeVersion.Major $kubeVersion.Minor | join "")) }}
+          {{- /* Here we use kube-scheduler image from control-plane-manager module */}}
+          image: {{ include "helm_lib_module_image" (list (dict "Chart" (dict "Name" "control-plane-manager") "Values" .Values) (list "kubeScheduler" $kubeVersion.Major $kubeVersion.Minor | join "")) }}
           imagePullPolicy: IfNotPresent
           startupProbe:
             failureThreshold: 24

--- a/modules/041-linstor/templates/tests/03-pod-with-volume.yaml
+++ b/modules/041-linstor/templates/tests/03-pod-with-volume.yaml
@@ -24,7 +24,7 @@ spec:
       containers:
         - name: test
           {{- include "helm_lib_module_container_security_context_not_allow_privilege_escalation" . | nindent 10 }}
-          image: {{ include "helm_lib_module_image" (list . "listorServer") }}
+          image: {{ include "helm_lib_module_image" (list . "linstorServer") }}
           imagePullPolicy: "IfNotPresent"
           command: [ "/bin/bash" ]
           args:


### PR DESCRIPTION
## Description

Correct image tags for LINSTOR

## Why do we need it, and what problem does it solve?

https://github.com/deckhouse/deckhouse/pull/2033 introduced new way of specifying docker image. However some images are not specified correctly.

## What is the expected result?

Make linstor module able to deploy

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: linstor
type: fix
summary: fix image tag regression
impact: default
```
