### PR TITLE
[istio] disable anti-affinity for non-ha clusters

### DIFF
--- a/ee/modules/110-istio/templates/control-plane/iop.yaml
+++ b/ee/modules/110-istio/templates/control-plane/iop.yaml
@@ -142,25 +142,37 @@ spec:
             cpu: 10m
             memory: 10Mi
 
-      {{- include "helm_lib_priority_class" (tuple $ "system-cluster-critical") | nindent 6 }}
+  {{- include "helm_lib_priority_class" (tuple $ "system-cluster-critical") | nindent 6 }}
 
     pilot:
       autoscaleEnabled: false
       replicaCount: {{ include "helm_lib_is_ha_to_value" (list $ 2 1) }}
       rollingMaxUnavailable: {{ include "helm_lib_is_ha_to_value" (list $ 1 0) }}
+  {{- if (include "helm_lib_ha_enabled" $) }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: istiod
+                istio.io/rev: {{ $revision }}
+            topologyKey: kubernetes.io/hostname
+  {{- else }}
+      affinity: {}
+  {{- end }}
       image: {{ include "helm_lib_module_image" (list $ (printf "pilot%s" ($revision | title))) }}
       configNamespace: d8-{{ $.Chart.Name }}
       resources:
-{{ include "helm_lib_resources_management_pod_resources" (list $.Values.istio.controlPlane.resourcesManagement) | nindent 8 }}
+  {{ include "helm_lib_resources_management_pod_resources" (list $.Values.istio.controlPlane.resourcesManagement) | nindent 8 }}
   {{- if $.Values.istio.controlPlane.nodeSelector }}
       nodeSelector:
-{{ $.Values.istio.controlPlane.nodeSelector | toYaml | nindent 8 }}
+    {{ $.Values.istio.controlPlane.nodeSelector | toYaml | nindent 8 }}
   {{- else }}
       {{- include "helm_lib_node_selector" (tuple $ "master") | nindent 6 }}
   {{- end }}
   {{- if $.Values.istio.controlPlane.tolerations }}
       tolerations:
-{{ $.Values.istio.controlPlane.tolerations | toYaml | nindent 8 }}
+    {{ $.Values.istio.controlPlane.tolerations | toYaml | nindent 8 }}
   {{- else }}
       {{- include "helm_lib_tolerations" (tuple $ "master") | nindent 6 }}
   {{- end }}

--- a/ee/modules/110-istio/templates/control-plane/iop.yaml
+++ b/ee/modules/110-istio/templates/control-plane/iop.yaml
@@ -37,7 +37,6 @@ spec:
         - name: PILOT_HTTP10
           value: "1"
   {{- end }}
-{{- include "helm_lib_pod_anti_affinity_for_ha" (list $ (dict "app" "istiod" "istio.io/rev" $revision)) | nindent 8 }}
 
     ingressGateways:
     - name: istio-ingressgateway

--- a/ee/modules/110-istio/templates/control-plane/iop.yaml
+++ b/ee/modules/110-istio/templates/control-plane/iop.yaml
@@ -147,18 +147,7 @@ spec:
       autoscaleEnabled: false
       replicaCount: {{ include "helm_lib_is_ha_to_value" (list $ 2 1) }}
       rollingMaxUnavailable: {{ include "helm_lib_is_ha_to_value" (list $ 1 0) }}
-  {{- if (include "helm_lib_ha_enabled" $) }}
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                app: istiod
-                istio.io/rev: {{ $revision }}
-            topologyKey: kubernetes.io/hostname
-  {{- else }}
-      affinity: {}
-  {{- end }}
+  {{- include "helm_lib_pod_anti_affinity_for_ha" (list $ (dict "app" "istiod" "istio.io/rev" $revision)) | nindent 6 }}
       image: {{ include "helm_lib_module_image" (list $ (printf "pilot%s" ($revision | title))) }}
       configNamespace: d8-{{ $.Chart.Name }}
       resources:


### PR DESCRIPTION
## Description
disable anti-affinity for non-ha clusters

## Why do we need it, and what problem does it solve?
It isn't possible to do rolling update with a single master — anti-affinity blocks it.

## What is the expected result?
Istiod will be rolling-updated without stucks.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: istio
type: fix
summary: Disable anti-affinity for non-ha clusters.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
