### PR TITLE
[snapshot-controller] Fix maxSurge for snapshot-validation-webhook

### DIFF
--- a/modules/045-snapshot-controller/templates/snapshot-validation-webhook/deployment.yaml
+++ b/modules/045-snapshot-controller/templates/snapshot-validation-webhook/deployment.yaml
@@ -52,7 +52,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "snapshot-validation-webhook" )) | nindent 2 }}
 spec:
   revisionHistoryLimit: 2
-  {{- include "helm_lib_deployment_strategy_and_replicas_for_ha" . | nindent 2 }}
+  {{- include "helm_lib_deployment_on_master_strategy_and_replicas_for_ha" . | nindent 2 }}
   selector:
     matchLabels:
       app: snapshot-validation-webhook


### PR DESCRIPTION
## Description

## Why do we need it, and what problem does it solve?

Snapshot-validation-webhook deployed on master but uses maxSurge value for system nodes.

## What is the expected result?

Snapshot-validation-webhook able to update with single master

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: snapshot-controller
type: fix
summary: Fix `maxSurge` for `snapshot-validation-webhook`.
impact_level: low
```