### PR TITLE
[deckhouse] remove messages on deckhouse releases

### DIFF
--- a/modules/002-deckhouse/hooks/internal/updater/updater.go
+++ b/modules/002-deckhouse/hooks/internal/updater/updater.go
@@ -350,13 +350,15 @@ func (du *DeckhouseUpdater) runReleaseDeploy(predictedRelease, currentRelease *D
 	du.updateStatus(predictedRelease, "", v1alpha1.PhaseDeployed, true)
 
 	if currentRelease != nil {
-		du.updateStatus(currentRelease, "Last Deployed release outdated", v1alpha1.PhaseOutdated)
+		// skip last deployed release
+		du.updateStatus(currentRelease, "", v1alpha1.PhaseOutdated)
 	}
 
 	if len(du.skippedPatchesIndexes) > 0 {
 		for _, index := range du.skippedPatchesIndexes {
 			release := du.releases[index]
-			du.updateStatus(&release, "Skipped because of new patches", v1alpha1.PhaseOutdated, true)
+			// skip not-deployed patches
+			du.updateStatus(&release, "", v1alpha1.PhaseOutdated, true)
 		}
 	}
 }
@@ -502,7 +504,7 @@ func (du *DeckhouseUpdater) patchSuspendedStatus(release DeckhouseRelease) Deckh
 	}
 
 	du.input.PatchCollector.MergePatch(annotationsPatch, "deckhouse.io/v1alpha1", "DeckhouseRelease", "", release.Name)
-	du.updateStatus(&release, "Release is suspended", v1alpha1.PhaseSuspended, false)
+	du.updateStatus(&release, "", v1alpha1.PhaseSuspended, false)
 
 	return release
 }


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Remove useless messages

## Why do we need it, and what problem does it solve?
We have status and message for it. Left messages only for Pending status, because spamming with common messages does not look comfortable for reading
```
v1-34-13   true       Outdated   25d              Last Deployed release outdated
v1-35-0    true       Outdated   20d              Last Deployed release outdated
v1-35-1    true       Outdated   20d              Last Deployed release outdated
v1-35-2    true       Outdated   20d              Last Deployed release outdated
v1-35-3    true       Outdated   19d              Last Deployed release outdated
v1-35-4    true       Outdated   12d              Last Deployed release outdated
v1-35-5    true       Outdated   7d21h            Last Deployed release outdated
v1-35-6    true       Outdated   4d20h            Last Deployed release outdated
v1-35-7    true       Outdated   18h              Last Deployed release outdated
v1-36-0    true       Deployed   18h
```

We can get the status for `phase` field. And for decision tracking maybe we should use events

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse
type: fix 
summary: Fix messages for outdated/deployed releases.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
