### PR TITLE
[deckhouse] Fix deckhouse update cm

### DIFF
--- a/modules/002-deckhouse/hooks/internal/updater/updater.go
+++ b/modules/002-deckhouse/hooks/internal/updater/updater.go
@@ -657,7 +657,7 @@ func (du *DeckhouseUpdater) createReleaseDataCM() {
 		Data: map[string]string{
 			// current release is updating
 			"isUpdating": strconv.FormatBool(du.releaseData.IsUpdating),
-			// notification about next release is sent, flat will be reset when new release is deployed
+			// notification about next release is sent, flag will be reset when new release is deployed
 			"notified": strconv.FormatBool(du.releaseData.Notified),
 		},
 	}

--- a/modules/002-deckhouse/hooks/internal/updater/updater.go
+++ b/modules/002-deckhouse/hooks/internal/updater/updater.go
@@ -343,7 +343,7 @@ func (du *DeckhouseUpdater) runReleaseDeploy(predictedRelease, currentRelease *D
 	du.ChangeUpdatingFlag(true)
 	du.changeNotifiedFlag(false)
 
-	// patch deckhouse deployment is faster then set internal values and then upgrade by helm
+	// patch deckhouse deployment is faster than set internal values and then upgrade by helm
 	// we can set "deckhouse.internal.currentReleaseImageName" value but lets left it this way
 	du.input.PatchCollector.Filter(func(u *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 		var depl appsv1.Deployment
@@ -642,14 +642,6 @@ func (du *DeckhouseUpdater) changeNotifiedFlag(fl bool) {
 }
 
 func (du *DeckhouseUpdater) createReleaseDataCM() {
-	release := du.predictedRelease()
-	if release == nil {
-		release = du.deployedRelease()
-		if release == nil {
-			return
-		}
-	}
-
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -663,9 +655,10 @@ func (du *DeckhouseUpdater) createReleaseDataCM() {
 			},
 		},
 		Data: map[string]string{
-			"version":    release.Version.String(),
+			// current release is updating
 			"isUpdating": strconv.FormatBool(du.releaseData.IsUpdating),
-			"notified":   strconv.FormatBool(du.releaseData.Notified),
+			// notification about next release is sent, flat will be reset when new release is deployed
+			"notified": strconv.FormatBool(du.releaseData.Notified),
 		},
 	}
 

--- a/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
@@ -558,7 +558,7 @@ metadata:
 				f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
 				f.RunHook()
 			})
-			It("IsUpdating flag should be resetted", func() {
+			It("IsUpdating flag should be reset", func() {
 				Expect(f).To(ExecuteSuccessfully())
 				r126 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-26-0")
 				Expect(r126.Field("status.phase").String()).To(Equal("Deployed"))

--- a/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
@@ -544,7 +544,7 @@ metadata:
 			f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
 			f.RunHook()
 		})
-		It("ffo", func() {
+		It("Release should be deployed", func() {
 			cm := f.KubernetesResource("ConfigMap", "d8-system", "d8-release-data")
 			r126 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-26-0")
 			Expect(r126.Field("status.phase").String()).To(Equal("Deployed"))


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Remove version data from release updating cm. This field is unused and was added for more verbosity. At the moment it creates problems and does not generate useful load

## Why do we need it, and what problem does it solve?
Avoid stucked D8IsUpdating alert

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse
type: fix 
summary: Fix stucked `DeckhouseUpdating` alert during the deckhouse update process.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
