### PR TITLE
[istio] fix tlsMode MutialPermissive

### DIFF
--- a/ee/modules/110-istio/template_tests/module_test.go
+++ b/ee/modules/110-istio/template_tests/module_test.go
@@ -217,9 +217,7 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 			Expect(paDefault.Exists()).To(BeTrue())
 			Expect(paDefault.Field("spec.mtls.mode").String()).To(Equal(`PERMISSIVE`))
 
-			Expect(drDefault.Exists()).To(BeTrue())
-			Expect(drDefault.Field("spec.host").String()).To(Equal(`*.my.domain`))
-			Expect(drDefault.Field("spec.trafficPolicy.tls.mode").String()).To(Equal(`ISTIO_MUTUAL`))
+			Expect(drDefault.Exists()).To(BeFalse())
 
 			Expect(drApiserver.Exists()).To(BeTrue())
 			Expect(drApiserver.Field("spec.host").String()).To(Equal(`kubernetes.default.svc.my.domain`))

--- a/ee/modules/110-istio/templates/global-auth-policy.yaml
+++ b/ee/modules/110-istio/templates/global-auth-policy.yaml
@@ -16,6 +16,7 @@ spec:
 ---
 # Corresponding destination rule to configure client side to use mutual TLS when talking to
 # any service (host) in the mesh.
+{{- if has .Values.istio.tlsMode (list "Mutual" "Off") }}
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
@@ -26,10 +27,11 @@ spec:
   host: "*.{{ .Values.global.discovery.clusterDomain }}"
   trafficPolicy:
     tls:
-{{- if has .Values.istio.tlsMode (list "Mutual" "MutualPermissive") }}
+  {{- if eq .Values.istio.tlsMode "Mutual" }}
       mode: ISTIO_MUTUAL
-{{ else }}
+  {{ else }}
       mode: DISABLE
+  {{- end }}
 {{- end }}
 ---
 # Destination rule to disable (m)TLS when talking to API server, as API server doesn't have sidecar.


### PR DESCRIPTION
## Description
Wrong behavior of the default DestinationRule with istio tlsMode: MutualPermissive.

## Why do we need it, and what problem does it solve?
We don't need default DestinationRule at all when istio tlsMode is MutualPerissive.

## What is the expected result?
Default DestinationRule will not be created if istio tlsMode = MutualPerissive

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: istio
type: fix
summary: Fix default `tlsMode` behavior.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
