### PR TITLE
[log-shipper] Ignore pipelines without destinations

### DIFF
--- a/modules/460-log-shipper/hooks/internal/composer/composer.go
+++ b/modules/460-log-shipper/hooks/internal/composer/composer.go
@@ -83,18 +83,24 @@ func (c *Composer) Do() ([]byte, error) {
 			Transforms: transforms,
 		}
 
-		destinations := make([]PipelineDestination, 0, len(s.Spec.DestinationRefs))
+		var destinations []PipelineDestination
 
 		for _, ref := range s.Spec.DestinationRefs {
-			destinations = append(destinations, destinationRefs[destination.ComposeName(ref)])
+			dst := destinationRefs[destination.ComposeName(ref)]
+
+			if dst.Destination != nil {
+				destinations = append(destinations, dst)
+			}
 		}
 
-		err = file.AppendLogPipeline(&Pipeline{
-			Source:       src,
-			Destinations: destinations,
-		})
-		if err != nil {
-			return nil, err
+		if len(destinations) > 0 {
+			err = file.AppendLogPipeline(&Pipeline{
+				Source:       src,
+				Destinations: destinations,
+			})
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Skip pipeline if it has no existed destinations

## Why do we need it, and what problem does it solve?
The `generate_configuration` hook panics if lined destination is not in the cluster.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: log-shipper
type: fix
summary: Ignore pipelines without destinations
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
