### PR TITLE
[cni-cilium] Revert bpf masquerade for all cilium installations except openstack.

### DIFF
--- a/candi/bashible/common-steps/node-group/041_configure_sysctl_tuner.sh.tpl
+++ b/candi/bashible/common-steps/node-group/041_configure_sysctl_tuner.sh.tpl
@@ -71,6 +71,7 @@ sysctl -w vm.overcommit_memory=1
 sysctl -w kernel.panic=10
 sysctl -w kernel.panic_on_oops=1
 
+# we use tee for work with globs
 echo 256 | tee /sys/block/*/queue/nr_requests >/dev/null # put more in the request queue, increase throughput
 echo 256 | tee /sys/block/*/queue/read_ahead_kb >/dev/null # the most controversial thing, Netflix recommends increasing a little, but you need to test on different setups, this number looks safe
 echo never | tee /sys/kernel/mm/transparent_hugepage/enabled >/dev/null

--- a/candi/bashible/common-steps/node-group/041_configure_sysctl_tuner.sh.tpl
+++ b/candi/bashible/common-steps/node-group/041_configure_sysctl_tuner.sh.tpl
@@ -27,56 +27,57 @@ CONNTRACK_MAX_PER_CORE=131072
 # If this value turns out to be greater than the `nf_conntrack_max` obtained above, then it is applied
 CONNTRACK_MIN=524288
 
-CPU_NUM=`cat /proc/cpuinfo | grep -E '^processor\s+:\s+[0-9]+$' | wc -l` ;
-CONNTRACK_BY_CPU=$(( $CPU_NUM * $CONNTRACK_MAX_PER_CORE )) ;
-NF_CONNTRACK_MAX=$(( $CONNTRACK_BY_CPU > $CONNTRACK_MIN ? $CONNTRACK_BY_CPU : $CONNTRACK_MIN )) ;
+CPU_NUM=`cat /proc/cpuinfo | grep -E '^processor\s+:\s+[0-9]+$' | wc -l`
+CONNTRACK_BY_CPU=$(( $CPU_NUM * $CONNTRACK_MAX_PER_CORE ))
+NF_CONNTRACK_MAX=$(( $CONNTRACK_BY_CPU > $CONNTRACK_MIN ? $CONNTRACK_BY_CPU : $CONNTRACK_MIN ))
 
-sysctl -w net.netfilter.nf_conntrack_max=$NF_CONNTRACK_MAX ; # set a limit on the number of conntracks
-sysctl -w net.nf_conntrack_max=$NF_CONNTRACK_MAX ;           #
-echo $(( $NF_CONNTRACK_MAX / 4 )) > /sys/module/nf_conntrack/parameters/hashsize ; # set the proportional size of the hash table for search by contact
+sysctl -w net.netfilter.nf_conntrack_max=$NF_CONNTRACK_MAX # set a limit on the number of conntracks
+sysctl -w net.nf_conntrack_max=$NF_CONNTRACK_MAX
+echo $(( $NF_CONNTRACK_MAX / 4 )) > /sys/module/nf_conntrack/parameters/hashsize # set the proportional size of the hash table for search by contact
 
 # http://www.brendangregg.com/blog/2017-12-31/reinvent-netflix-ec2-tuning.html
-sysctl -w vm.swappiness=0 ;
-sysctl -w net.core.somaxconn=1000 ;
-sysctl -w net.core.netdev_max_backlog=5000 ; # increase the backlog of packets taken from the ring buffer of the network card, but not yet transmitted up the network stack kernel
-sysctl -w net.core.rmem_max=16777216 ;
-sysctl -w net.core.wmem_max=16777216 ;
-sysctl -w net.ipv4.tcp_wmem="4096 12582912 16777216" ;
-sysctl -w net.ipv4.tcp_rmem="4096 12582912 16777216" ;
-sysctl -w net.ipv4.tcp_max_syn_backlog=8096 ;
-sysctl -w net.ipv4.tcp_no_metrics_save=1 ; # do not cache TCP metrics for subsequent connections using the same (dst_ip, src_ip, dst_port, src_port) tuple, because it is harmful and unnecessary in modern WAN networks
-sysctl -w net.ipv4.tcp_slow_start_after_idle=0 ; # not needed in modern networks, because it begins to aggressively reduce TCP cwnd on idle connections
-sysctl -w net.ipv4.tcp_tw_reuse=1 ; # secure option to reuse TIME-WAIT socket on outgoing connection
-sysctl -w net.ipv4.ip_local_port_range="10500 65535" ; # we are using ports lower than 10500 for binding deckhouse modules components
-sysctl -w net.ipv4.neigh.default.gc_thresh1=16384 ; #fix neighbour: arp_cache: neighbor table overflow!
-sysctl -w net.ipv4.neigh.default.gc_thresh2=28672 ;
-sysctl -w net.ipv4.neigh.default.gc_thresh3=32768 ;
-sysctl -w net.bridge.bridge-nf-call-iptables=1 ; # this parameter is needed for kube-proxy to work
-sysctl -w net.bridge.bridge-nf-call-arptables=1 ; # this parameter is needed for kube-proxy to work
-sysctl -w net.bridge.bridge-nf-call-ip6tables=1 ; # this parameter is needed for kube-proxy to work
-sysctl -w vm.dirty_ratio=80 ; # enable synchronous writeback of dirty pages as late as possible
-sysctl -w vm.dirty_background_ratio=5 ; # enable parallel writeback as early as possible
-sysctl -w vm.dirty_expire_centisecs=12000 ; # after 12 seconds we writeback dirty pages
-sysctl -w fs.file-max=1000000 ;
-sysctl -w vm.min_free_kbytes=131072 ; # increase the safe limit for immediate page allocations in the kernel (Jumbo Frames, different IRQ handlers)
-sysctl -w kernel.numa_balancing=0 ; # disable the overly smart NUMA node balancer so that there are no sags. NUMA affinity is better configured in advance and differently
+sysctl -w vm.swappiness=0
+sysctl -w net.core.somaxconn=1000
+sysctl -w net.core.netdev_max_backlog=5000 # increase the backlog of packets taken from the ring buffer of the network card, but not yet transmitted up the network stack kernel
+sysctl -w net.core.rmem_max=16777216
+sysctl -w net.core.wmem_max=16777216
+sysctl -w net.ipv4.tcp_wmem="4096 12582912 16777216"
+sysctl -w net.ipv4.tcp_rmem="4096 12582912 16777216"
+sysctl -w net.ipv4.tcp_max_syn_backlog=8096
+sysctl -w net.ipv4.tcp_no_metrics_save=1 # do not cache TCP metrics for subsequent connections using the same (dst_ip, src_ip, dst_port, src_port) tuple, because it is harmful and unnecessary in modern WAN networks
+sysctl -w net.ipv4.tcp_slow_start_after_idle=0 # not needed in modern networks, because it begins to aggressively reduce TCP cwnd on idle connections
+sysctl -w net.ipv4.tcp_tw_reuse=1 # secure option to reuse TIME-WAIT socket on outgoing connection
+sysctl -w net.ipv4.ip_local_port_range="10500 65535" # we are using ports lower than 10500 for binding deckhouse modules components
+sysctl -w net.ipv4.neigh.default.gc_thresh1=16384 # fix neighbour: arp_cache: neighbor table overflow!
+sysctl -w net.ipv4.neigh.default.gc_thresh2=28672
+sysctl -w net.ipv4.neigh.default.gc_thresh3=32768
+sysctl -w net.bridge.bridge-nf-call-iptables=1 # this parameter is needed for kube-proxy to work
+sysctl -w net.bridge.bridge-nf-call-arptables=1 # this parameter is needed for kube-proxy to work
+sysctl -w net.bridge.bridge-nf-call-ip6tables=1 # this parameter is needed for kube-proxy to work
+sysctl -w vm.dirty_ratio=80 # enable synchronous writeback of dirty pages as late as possible
+sysctl -w vm.dirty_background_ratio=5 # enable parallel writeback as early as possible
+sysctl -w vm.dirty_expire_centisecs=12000 # after 12 seconds we writeback dirty pages
+sysctl -w fs.file-max=1000000
+sysctl -w vm.min_free_kbytes=131072 # increase the safe limit for immediate page allocations in the kernel (Jumbo Frames, different IRQ handlers)
+sysctl -w kernel.numa_balancing=0 # disable the overly smart NUMA node balancer so that there are no sags. NUMA affinity is better configured in advance and differently
 sysctl -w fs.inotify.max_user_watches=524288 # Increase inotify (https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers#the-technical-details)
 sysctl -w fs.inotify.max_user_instances=5120
 sysctl -w kernel.pid_max=2000000
 {{- if eq .bundle "centos" }}
-sysctl -w fs.may_detach_mounts=1; # For Centos to avoid problems with unmount when container stops # https://bugzilla.redhat.com/show_bug.cgi?id=1441737
+sysctl -w fs.may_detach_mounts=1 # For Centos to avoid problems with unmount when container stops # https://bugzilla.redhat.com/show_bug.cgi?id=1441737
 {{- end }}
 # kubelet parameters
 sysctl -w vm.overcommit_memory=1
 sysctl -w kernel.panic=10
 sysctl -w kernel.panic_on_oops=1
 
-echo 256 | tee /sys/block/*/queue/nr_requests >/dev/null ; # put more in the request queue, increase throughput
-echo 256 | tee /sys/block/*/queue/read_ahead_kb >/dev/null ; # the most controversial thing, Netflix recommends increasing a little, but you need to test on different setups, this number looks safe
-echo never | tee /sys/kernel/mm/transparent_hugepage/enabled >/dev/null ;
-echo never | tee /sys/kernel/mm/transparent_hugepage/defrag >/dev/null ;
-echo 0 | tee /sys/kernel/mm/transparent_hugepage/use_zero_page >/dev/null ;
-echo 0 | tee /sys/kernel/mm/transparent_hugepage/khugepaged/defrag >/dev/null ;
+echo 256 | tee /sys/block/*/queue/nr_requests >/dev/null # put more in the request queue, increase throughput
+echo 256 | tee /sys/block/*/queue/read_ahead_kb >/dev/null # the most controversial thing, Netflix recommends increasing a little, but you need to test on different setups, this number looks safe
+echo never | tee /sys/kernel/mm/transparent_hugepage/enabled >/dev/null
+echo never | tee /sys/kernel/mm/transparent_hugepage/defrag >/dev/null
+echo 0 | tee /sys/kernel/mm/transparent_hugepage/use_zero_page >/dev/null
+echo 0 | tee /sys/kernel/mm/transparent_hugepage/khugepaged/defrag >/dev/null
+for i in /proc/sys/net/ipv4/conf/*/rp_filter ; do echo 0 > $i; done # disable reverse-path filtering on all interfaces
 EOF
 chmod +x /usr/local/bin/sysctl-tuner
 

--- a/candi/bashible/common-steps/node-group/041_configure_sysctl_tuner.sh.tpl
+++ b/candi/bashible/common-steps/node-group/041_configure_sysctl_tuner.sh.tpl
@@ -77,7 +77,7 @@ echo never | tee /sys/kernel/mm/transparent_hugepage/enabled >/dev/null
 echo never | tee /sys/kernel/mm/transparent_hugepage/defrag >/dev/null
 echo 0 | tee /sys/kernel/mm/transparent_hugepage/use_zero_page >/dev/null
 echo 0 | tee /sys/kernel/mm/transparent_hugepage/khugepaged/defrag >/dev/null
-for i in /proc/sys/net/ipv4/conf/*/rp_filter ; do echo 0 > $i; done # disable reverse-path filtering on all interfaces
+echo 0 | tee /proc/sys/net/ipv4/conf/*/rp_filter >/dev/null # disable reverse-path filtering on all interfaces
 EOF
 chmod +x /usr/local/bin/sysctl-tuner
 

--- a/ee/modules/030-cloud-provider-openstack/templates/cni.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cni.yaml
@@ -10,5 +10,5 @@ data:
   {{- .Values.cloudProviderOpenstack.internal.cniSecretData | b64dec | nindent 2 }}
 {{- else }}
   cni: {{ b64enc "cilium" | quote }}
-  cilium: {{ b64enc "{\"mode\": \"DirectWithNodeRoutes\"}" | quote }}
+  cilium: {{ b64enc "{\"mode\": \"DirectWithNodeRoutes\", \"masqueradeMode\": \"Netfilter\"}" | quote }}
 {{- end }}

--- a/modules/021-cni-cilium/hooks/migrate_cni_secret.go
+++ b/modules/021-cni-cilium/hooks/migrate_cni_secret.go
@@ -24,6 +24,7 @@ package hooks
 import (
 	"encoding/base64"
 	"encoding/json"
+
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
@@ -119,7 +120,7 @@ func patchCniConfigSecret(input *go_hook.HookInput, mode string, masqueradeMode 
 	var (
 		patch = map[string]interface{}{
 			"data": map[string]string{
-				"cilium": base64.StdEncoding.EncodeToString([]byte(jsonByte)),
+				"cilium": base64.StdEncoding.EncodeToString(jsonByte),
 			},
 		}
 	)

--- a/modules/021-cni-cilium/hooks/set_cilium_mode.go
+++ b/modules/021-cni-cilium/hooks/set_cilium_mode.go
@@ -91,18 +91,21 @@ func setCiliumMode(input *go_hook.HookInput) error {
 	if input.ConfigValues.Exists("cniCilium.tunnelMode") {
 		if input.ConfigValues.Get("cniCilium.tunnelMode").String() == "VXLAN" {
 			input.Values.Set("cniCilium.internal.mode", "VXLAN")
+			return nil
 		}
 	}
 
 	value, ok := input.ConfigValues.GetOk("cniCilium.createNodeRoutes")
 	if ok && value.Bool() {
 		input.Values.Set("cniCilium.internal.mode", "DirectWithNodeRoutes")
+		return nil
 	}
 
 	// for static clusters we should use DirectWithNodeRoutes mode
 	value, ok = input.Values.GetOk("global.clusterConfiguration.clusterType")
 	if ok && value.String() == "Static" {
 		input.Values.Set("cniCilium.internal.mode", "DirectWithNodeRoutes")
+		return nil
 	}
 	// default = Direct
 	return nil

--- a/modules/021-cni-cilium/hooks/set_cilium_mode.go
+++ b/modules/021-cni-cilium/hooks/set_cilium_mode.go
@@ -27,8 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-type CiliumConfig struct {
-	Mode string `json:"mode"`
+type CiliumConfigStruct struct {
+	Mode           string `json:"mode,omitempty"`
+	MasqueradeMode string `json:"masqueradeMode,omitempty"`
 }
 
 func applyCNIConfigurationSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -42,7 +43,7 @@ func applyCNIConfigurationSecretFilter(obj *unstructured.Unstructured) (go_hook.
 		return nil, nil
 	}
 
-	var ciliumConfig CiliumConfig
+	var ciliumConfig CiliumConfigStruct
 	ciliumConfigJSON, ok := secret.Data["cilium"]
 	if !ok {
 		return nil, nil
@@ -82,8 +83,13 @@ func setCiliumMode(input *go_hook.HookInput) error {
 
 	if ok && len(cniConfigurationSecrets) > 0 {
 		if cniConfigurationSecrets[0] != nil {
-			ciliumConfig := cniConfigurationSecrets[0].(CiliumConfig)
-			input.Values.Set("cniCilium.internal.mode", ciliumConfig.Mode)
+			ciliumConfig := cniConfigurationSecrets[0].(CiliumConfigStruct)
+			if ciliumConfig.Mode != "" {
+				input.Values.Set("cniCilium.internal.mode", ciliumConfig.Mode)
+			}
+			if ciliumConfig.MasqueradeMode != "" {
+				input.Values.Set("cniCilium.internal.masqueradeMode", ciliumConfig.MasqueradeMode)
+			}
 			return nil
 		}
 	}

--- a/modules/021-cni-cilium/hooks/set_cilium_mode_test.go
+++ b/modules/021-cni-cilium/hooks/set_cilium_mode_test.go
@@ -30,53 +30,77 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: set_cilium_mode", func() {
 			f.KubeStateSet("")
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
+			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
 			f.RunHook()
 		})
 		It("hook should run successfully, cilium mode should be `Direct`", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("Direct"))
+			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("BPF"))
 		})
 	})
 
 	Context("kube-system/d8-cni-configuration is present, but cni != `cilium`", func() {
-		cniSecret := generateCniConfigurationSecret("flannel", "")
+		cniSecret := generateCniConfigurationSecret("flannel", "", "")
 		BeforeEach(func() {
 			f.KubeStateSet(cniSecret)
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
+			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
 			f.RunHook()
 		})
 		It("hook should run successfully, cilium mode should be `Direct`", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("Direct"))
+			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("BPF"))
 		})
 	})
 
 	Context("kube-system/d8-cni-configuration is present, cni == `cilium`, but cilium field is not set", func() {
-		cniSecret := generateCniConfigurationSecret("cilium", "")
+		cniSecret := generateCniConfigurationSecret("cilium", "", "")
 		BeforeEach(func() {
 			f.KubeStateSet(cniSecret)
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
+			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
 			f.RunHook()
 		})
 		It("hook should run successfully, cilium mode should be `Direct`", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("Direct"))
+			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("BPF"))
 		})
 	})
 
 	Context("kube-system/d8-cni-configuration is present, cni = `cilium`, cilium mode = VXLAN", func() {
-		cniSecret := generateCniConfigurationSecret("cilium", "VXLAN")
+		cniSecret := generateCniConfigurationSecret("cilium", "VXLAN", "")
 		BeforeEach(func() {
 			f.KubeStateSet(cniSecret)
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
+			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
 			f.RunHook()
 		})
 		It("hook should run successfully, cilium mode should be set to `VXLAN`", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("VXLAN"))
+			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("BPF"))
+		})
+	})
+
+	Context("kube-system/d8-cni-configuration is present, cni = `cilium`, cilium mode = DirectWithNodeRoutes, masqueradeMode = Netfilter", func() {
+		cniSecret := generateCniConfigurationSecret("cilium", "DirectWithNodeRoutes", "Netfilter")
+		BeforeEach(func() {
+			f.KubeStateSet(cniSecret)
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ValuesSet("cniCilium.internal.mode", "Direct")
+			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
+			f.RunHook()
+		})
+		It("hook should run successfully, cilium mode should be set to `VXLAN`", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("DirectWithNodeRoutes"))
+			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("Netfilter"))
 		})
 	})
 
@@ -86,11 +110,13 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: set_cilium_mode", func() {
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.ConfigValuesSet("cniCilium.tunnelMode", "VXLAN")
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
+			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
 			f.RunHook()
 		})
 		It("hook should run successfully, secret should be changed", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("VXLAN"))
+			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("BPF"))
 		})
 	})
 
@@ -100,11 +126,13 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: set_cilium_mode", func() {
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.ConfigValuesSet("cniCilium.createNodeRoutes", true)
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
+			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
 			f.RunHook()
 		})
 		It("hook should run successfully, cilium mode should be `DirectWithNodeRoutes`", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("DirectWithNodeRoutes"))
+			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("BPF"))
 		})
 	})
 
@@ -114,11 +142,13 @@ var _ = Describe("Modules :: cni-cilium :: hooks :: set_cilium_mode", func() {
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.ConfigValuesSet("cniCilium.createNodeRoutes", false)
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
+			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
 			f.RunHook()
 		})
 		It("hook should run successfully, cilium mode should be `Direct`", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("Direct"))
+			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("BPF"))
 		})
 	})
 
@@ -135,11 +165,13 @@ podSubnetCIDR: 10.231.0.0/16
 serviceSubnetCIDR: 10.232.0.0/16
 `))
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
+			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
 			f.RunHook()
 		})
 		It("hook should run successfully, cilium mode should be `DirectWithNodeRoutes`", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("DirectWithNodeRoutes"))
+			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("BPF"))
 		})
 	})
 
@@ -160,11 +192,13 @@ podSubnetCIDR: 10.231.0.0/16
 serviceSubnetCIDR: 10.232.0.0/16
 `))
 			f.ValuesSet("cniCilium.internal.mode", "Direct")
+			f.ValuesSet("cniCilium.internal.masqueradeMode", "BPF")
 			f.RunHook()
 		})
 		It("hook should run successfully, cilium mode should be `Direct`", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("cniCilium.internal.mode").String()).To(Equal("Direct"))
+			Expect(f.ValuesGet("cniCilium.internal.masqueradeMode").String()).To(Equal("BPF"))
 		})
 	})
 

--- a/modules/021-cni-cilium/openapi/values.yaml
+++ b/modules/021-cni-cilium/openapi/values.yaml
@@ -18,6 +18,15 @@ properties:
                create routes to Pods on other Nodes.
                All Nodes must be located in the same L2 domain.
           * - `VXLAN` - VxLAN encapsulation.
+      masqueradeMode:
+        type: string
+        enum: ["Netfilter", "BPF"]
+        default: "BPF"
+        description: |
+          Cilium masquerade work mode.
+
+          * - `Netfilter` - use kernel Netfilter(iptables/nf_tables).
+          * - `BPF` - use cilium BPF.
       hubble:
         type: object
         default: {}

--- a/modules/021-cni-cilium/template_tests/module_test.go
+++ b/modules/021-cni-cilium/template_tests/module_test.go
@@ -72,6 +72,7 @@ modules:
 bpfLBMode: "DSR"
 internal:
   mode: "Direct"
+  masqueradeMode: "BPF"
   hubble:
     certs:
       ca:

--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -29,8 +29,6 @@ data:
 
   {{- if eq .Values.cniCilium.internal.mode "VXLAN" }}
   tunnel: "vxlan"
-  enable-bpf-masquerade: "true"
-  enable-ipv4-egress-gateway: "true"
   {{- else if eq .Values.cniCilium.internal.mode "DirectWithNodeRoutes" }}
   tunnel: "disabled"
   auto-direct-node-routes: "true"
@@ -39,6 +37,13 @@ data:
   {{- else }}
     {{- fail (printf "unknown mode %s" .Values.cniCilium.internal.mode) }}
   {{- end }}
+
+  {{- if eq .Values.cniCilium.internal.masqueradeMode "BPF" }}
+  enable-bpf-masquerade: "true"
+  enable-ipv4-egress-gateway: "true"
+  install-no-conntrack-iptables-rules: "true"
+  {{- end }}
+
   enable-ipv4-masquerade: "true"
 
   enable-xt-socket-fallback: "true"


### PR DESCRIPTION
Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
1. Revert bpf masquerading mode for all cilium installations except openstack.
2. Added setting rp_filter to 0 for all interfaces in sysctl_tuner script.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
1. on openstack installations with bpf masquerading traffic from cluster to external floating ip does not work (floating ip added as node ExternalIP, and cilium does not masquerade traffic from another node to node with floating ip).  For all another installations bpf masquerade mode is preferred.
2. In systemd >=245 default rp_filter = 2, so in some cases without bpf masquerading traffic from pods to another pods on the same node does not work.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cni-cilium
type: chore
summary: |
  Reverted bpf masquerading mode for all cilium installations except in OpenStack.
  Set `rp_filter` to 0 for all interfaces in the `sysctl_tuner` script.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
