### PR TITLE
[linstor] fix linstor-affinity-controller leader election

### DIFF
--- a/modules/041-linstor/templates/linstor-affinity-controller/deployment.yaml
+++ b/modules/041-linstor/templates/linstor-affinity-controller/deployment.yaml
@@ -102,9 +102,9 @@ spec:
           imagePullPolicy: "IfNotPresent"
           args:
             - --leader-election=true
-            - --leader-election-lease-name=$(NAME)
-            - --leader-election-namespace=$(NAMESPACE)
-            - --leader-election-resource-name=linstor-ha-controller
+            - --leader-election-id=$(NAME)
+            - --lease-lock-namespace=$(NAMESPACE)
+            - --lease-lock-name=linstor-affinity-controller
             - --v=5
           env:
             - name: LEASE_LOCK_NAME


### PR DESCRIPTION
## Description


## Why do we need it, and what problem does it solve?

linstor-affinity-controller can't start:
```
Error: unknown flag: --leader-election-lease-name
```

## What is the expected result?

linstor-affinity-controller is starting and working with no errors


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: linstor
type: fix
summary: Fix linstor-affinity-controller leader election.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
