### PR TITLE
[candi] fix discover node ip on debian-based distros

### DIFF
--- a/candi/bashible/common-steps/node-group/003_discover_node_ip.sh.tpl
+++ b/candi/bashible/common-steps/node-group/003_discover_node_ip.sh.tpl
@@ -39,7 +39,7 @@ internal_network_cidrs={{ .nodeGroup.static.internalNetworkCIDRs | join " " | qu
   {{- end }}
 if [[ -z "$internal_network_cidrs" ]]; then
   # if internal network cidrs is not set, and the node has one interface, use its network as internal_network_cidr
-  physical_iface="$(ls -l /sys/class/net/ | grep -vE "virtual|total" | awk '{print $9}')"
+  physical_iface="$(ls -l /sys/class/net/ | grep -vE "virtual|total" | grep "devices" | awk '{print $9}')"
   if [[ "$(wc -l <<< "${physical_iface}")" -eq 1 ]]; then
     internal_network_cidrs="$(ip route show scope link proto kernel dev "${physical_iface}" | awk '{print $1}')"
   else


### PR DESCRIPTION
Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix discover node ip on debian-based distros
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In discover node ip step we detect node physical interface by `ls -l /sys/class/net/ | grep -vE "virtual|total" | awk '{print $9}'`.
But output of `ls -l /sys/class/net/ | grep -vE "virtual|total"` differs between rh-based and ubuntu-based distros.
In ubuntu:
```
root@dev-master-0:~# ls -l /sys/class/net/ | grep -vE "virtual|total"
lrwxrwxrwx 1 root root 0 Sep 14 18:26 ens3 -> ../../devices/pci0000:00/0000:00:03.0/virtio0/net/ens3
```
in debian:
```
root@dev-master-0:~# ls -l /sys/class/net/ | grep -vE "virtual|total"
total 0
lrwxrwxrwx 1 root root 0 Sep 14 22:04 eth0 -> ../../devices/pci0000:00/0000:00:03.0/virtio0/net/eth0
```

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->


```changes
section: candi
type: fix
summary: fix discover node ip on debian-based distros
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
