### PR TITLE
Add disableAutoDiscovery option to okmeter module

### DIFF
--- a/modules/500-okmeter/openapi/config-values.yaml
+++ b/modules/500-okmeter/openapi/config-values.yaml
@@ -8,6 +8,10 @@ properties:
 
       You can get the key for your project on the `okmeter` installation page (`OKMETER_API_TOKEN`).
     x-examples: [5ff9z2a3-9127-1sh4-2192-06a3fc6e13e3]
+  disableAutoDiscovery:
+    description: |
+      Disables okagent autodiscovery. Setting this option to `true` will leave only basic host monitoring, all other plugins (postgresql/mysql/redis/etc.) will be disabled.
+      Default value is `false`
   nodeSelector:
     type: object
     additionalProperties:

--- a/modules/500-okmeter/openapi/doc-ru-config-values.yaml
+++ b/modules/500-okmeter/openapi/doc-ru-config-values.yaml
@@ -4,6 +4,10 @@ properties:
       Ключ для доступа к API Okmeter.
 
       Можно взять на странице документации по установке `okmeter` (`OKMETER_API_TOKEN`).
+  disableAutoDiscovery:
+    description: |
+      Отключает автоматическое обнаружение сервисов, которые способен мониторить okmeter. Установка опции в `true` оставит лишь базовый мониторинг хоста, прочие плагины (postgresql/mysql/redis/etc.) будут отключены.
+      По-умолчанию `false`
   nodeSelector:
     description: |
       Структура, аналогичная `spec.nodeSelector` в Kubernetes Pod.

--- a/modules/500-okmeter/templates/daemonset.yaml
+++ b/modules/500-okmeter/templates/daemonset.yaml
@@ -71,6 +71,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+{{- if .Values.okmeter.disableAutoDiscovery }}
+        - name: DISABLE_AUTO_DISCOVER
+          value: "1"
+{{- end }}
         volumeMounts:
         - name: dockersocket
           mountPath: /var/run/docker.sock


### PR DESCRIPTION
## Description
This PR brings an opportunity to disable auto-discovery in okagent deployed by deckhouse module

## Why do we need it, and what problem does it solve?
Okagent is deployed as a DaemonSet and runs on each host of a cluster. It continuously watches host process list and discovers services it can monitor, e.g: postgresql, redis, etc. The dynamic nature of Kubernetes is still not well tolerated by the Okmeter. For example, simple rollout of the newer version of redis deployment will cause alerts to fire due to redis pod name change. Okagent has feature to disable plugins auto-discovery leaving only basic monitoring, so we can support it on the Deckhouse side.

Solves https://github.com/deckhouse/deckhouse/issues/2429