### PR TITLE
[upmeter] Fix statuspage backend URL

### DIFF
--- a/modules/500-upmeter/images/status/src/App.svelte
+++ b/modules/500-upmeter/images/status/src/App.svelte
@@ -5,7 +5,7 @@
 	import { getGroupData } from "./en";
 
 	async function fetchStatusJSON() {
-		const r = await fetch("http://localhost:8091/public/api/status", {
+		const r = await fetch("/public/api/status", {
 			headers: { accept: "application/json" },
 		});
 		return await r.json();


### PR DESCRIPTION
## Description

Fix hardcoded localhost in upmeter statuspage

## Why do we need it, and what problem does it solve?

It does no fetch the data in clusters

## What is the expected result?

Statupage works again

## Checklist
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: upmeter
type: fix
summary: Fix non-working statuspage by removing hardcoded localhost in backend URL
```
