### PR TITLE
[deckhouse] fix test

### DIFF
--- a/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
@@ -561,7 +561,7 @@ metadata:
 			})
 			It("IsUpdating flag should be reset", func() {
 				Expect(f).To(ExecuteSuccessfully())
-				time.Sleep(100 * time.Millisecond) // wait for object-patcher actions
+				time.Sleep(300 * time.Millisecond) // wait for object-patcher actions
 				r126 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-26-0")
 				Expect(r126.Field("status.phase").String()).To(Equal("Deployed"))
 				cm := f.KubernetesResource("ConfigMap", "d8-system", "d8-release-data")

--- a/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
@@ -554,14 +554,15 @@ metadata:
 			Expect(cm.Field("data.notified").Bool()).To(BeFalse())
 		})
 
-		Context("After next run loop", func() {
+		FContext("After next run loop", func() {
 			BeforeEach(func() {
 				f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
 				f.RunHook()
+				time.Sleep(200 * time.Millisecond)
 			})
 			It("IsUpdating flag should be reset", func() {
 				Expect(f).To(ExecuteSuccessfully())
-				time.Sleep(300 * time.Millisecond) // wait for object-patcher actions
+				Expect(f.PatchCollector.Operations()).To(HaveLen(2))
 				r126 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-26-0")
 				Expect(r126.Field("status.phase").String()).To(Equal("Deployed"))
 				cm := f.KubernetesResource("ConfigMap", "d8-system", "d8-release-data")

--- a/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -535,7 +534,6 @@ apiVersion: v1
 data:
   isUpdating: "false"
   notified: "true"
-  version: 1.26.0
 kind: ConfigMap
 metadata:
   name: d8-release-data
@@ -553,24 +551,43 @@ metadata:
 			Expect(cm.Field("data.isUpdating").Bool()).To(BeTrue())
 			Expect(cm.Field("data.notified").Bool()).To(BeFalse())
 		})
+	})
 
-		Context("After next run loop", func() {
-			BeforeEach(func() {
-				f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
-				f.RunHook()
-				time.Sleep(200 * time.Millisecond)
-			})
-			It("IsUpdating flag should be reset", func() {
-				Expect(f).To(ExecuteSuccessfully())
-				r126 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-26-0")
-				Expect(r126.Field("status.phase").String()).To(Equal("Deployed"))
-				cm := f.KubernetesResource("ConfigMap", "d8-system", "d8-release-data")
-				Expect(cm.Field("data.isUpdating").Bool()).To(BeFalse())
-				Expect(cm.Field("data.notified").Bool()).To(BeFalse())
-				Expect(f.MetricsCollector.CollectedMetrics()).To(HaveLen(2))
-				Expect(f.MetricsCollector.CollectedMetrics()[1].Group).To(Equal("d8_updating"))
-				Expect(f.MetricsCollector.CollectedMetrics()[1].Action).To(Equal("expire"))
-			})
+	Context("Update: Release is deployed", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(deckhousePodYaml + `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1-26-0
+spec:
+  version: "v1.26.0"
+status:
+  phase: Deployed
+---
+apiVersion: v1
+data:
+  isUpdating: "true"
+  notified: "false"
+kind: ConfigMap
+metadata:
+  name: d8-release-data
+  namespace: d8-system
+`)
+			f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
+			f.RunHook()
+		})
+		It("IsUpdating flag should be reset", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			r126 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-26-0")
+			Expect(r126.Field("status.phase").String()).To(Equal("Deployed"))
+			cm := f.KubernetesResource("ConfigMap", "d8-system", "d8-release-data")
+			Expect(cm.Field("data.isUpdating").Bool()).To(BeFalse())
+			Expect(cm.Field("data.notified").Bool()).To(BeFalse())
+			Expect(f.MetricsCollector.CollectedMetrics()).To(HaveLen(2))
+			Expect(f.MetricsCollector.CollectedMetrics()[1].Group).To(Equal("d8_updating"))
+			Expect(f.MetricsCollector.CollectedMetrics()[1].Action).To(Equal("expire"))
 		})
 	})
 

--- a/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -560,6 +561,7 @@ metadata:
 			})
 			It("IsUpdating flag should be reset", func() {
 				Expect(f).To(ExecuteSuccessfully())
+				time.Sleep(100 * time.Millisecond) // wait for object-patcher actions
 				r126 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-26-0")
 				Expect(r126.Field("status.phase").String()).To(Equal("Deployed"))
 				cm := f.KubernetesResource("ConfigMap", "d8-system", "d8-release-data")

--- a/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
@@ -554,7 +554,7 @@ metadata:
 			Expect(cm.Field("data.notified").Bool()).To(BeFalse())
 		})
 
-		FContext("After next run loop", func() {
+		Context("After next run loop", func() {
 			BeforeEach(func() {
 				f.BindingContexts.Set(f.GenerateScheduleContext("*/15 * * * * *"))
 				f.RunHook()

--- a/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
@@ -562,7 +562,6 @@ metadata:
 			})
 			It("IsUpdating flag should be reset", func() {
 				Expect(f).To(ExecuteSuccessfully())
-				Expect(f.PatchCollector.Operations()).To(HaveLen(2))
 				r126 := f.KubernetesGlobalResource("DeckhouseRelease", "v1-26-0")
 				Expect(r126.Field("status.phase").String()).To(Equal("Deployed"))
 				cm := f.KubernetesResource("ConfigMap", "d8-system", "d8-release-data")


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Fix temporary failing test

## Why do we need it, and what problem does it solve?
Test fails due to inner context reasons. Make it separated test

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse
type: fix
summary: Fix test with inner context
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
