### PR TITLE
[cloud-provider-yandex] Fix allowing additional properties for nodeGroups[*] and nodeGroups[*].instanceClass

### DIFF
--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -140,6 +140,7 @@ apiVersions:
         items:
           type: object
           required: [name, replicas, instanceClass]
+          additionalProperties: false
           properties:
             name:
               description: |
@@ -215,6 +216,7 @@ apiVersions:
                         type: string
             instanceClass:
               required: [cores, memory, imageID]
+              additionalProperties: false
               type: object
               description: |
                 Partial contents of the fields of the [YandexInstanceClass](https://deckhouse.io/en/documentation/v1/modules/030-cloud-provider-yandex/cr.html#yandexinstanceclass).


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Forbid using additional properties in `nodeGroups[*]` and `nodeGroups[*].instanceClass` for YandexClusterConfiguration

## Why do we need it, and what problem does it solve?
For example, next configuration was passed but configuration was incorrect.
```
nodeGroups:
- name: khm
  replicas: 1
  externalIPAddresses: # should not allow
  - Auto
  instanceClass:
    cores: 2
    memory: 4096
    imageID: fd8vqk0bcfhn31stn2ts
    coreFraction: 50
    zones:  # should not allow
    - ru-central1-c
```
Static node was created but was not bootstrapped with above configuration in WithoutNAT layout.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provide-yandex
type: fix
summary: Fix allowing additional properties for nodeGroups[*] and nodeGroups[*].instanceClass
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
