### PR TITLE
[node-manager][early-oom] alert description fix

### DIFF
--- a/modules/040-node-manager/monitoring/prometheus-rules/early-oom.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/early-oom.tpl
@@ -17,5 +17,8 @@
       plk_labels_as_annotations: "pod"
       summary: >
         The {{`{{$labels.pod}}`}} Pod has detected unavailable PSI subsystem.
-        Check logs for additional information: `kubectl -n d8-cloud-instance-manager logs {{`{{$labels.pod}}`}}`
+        Check logs for additional information:
+        ```
+        kubectl -n d8-cloud-instance-manager logs {{`{{$labels.pod}}`}} -c psi-monitor
+        ```
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Andrey Polovov <andrey.polovov@flant.com>

## Description
D8EarlyOOMPodIsNotReady alert description fix

## Why do we need it, and what problem does it solve?
Just more convenient description.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Fixed the `D8EarlyOOMPodIsNotReady` alert description.
```

