### PR TITLE
[candi][cloud-provider-yandex] Fix routes for multi-zonal clusters when using WithNATInstance layout

### DIFF
--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
@@ -82,6 +82,9 @@ locals {
             use-hostname: false
             use-routes: false
             use-domains: false
+          routes:
+          - to: "${var.node_network_cidr}"
+            link
     EOF
 
     netplan apply


### PR DESCRIPTION
Signed-off-by: Konstantin Aksenov <konstantin.aksenov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add routes to netplan config in user-data for NAT instance.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
If we have `nodeNetworkCIDR` set to 192.168.199.0/24 then we have 3 subnets. NAT instance knows only routes to the subnet where it's located, but has no routes to other subnets in VPC. So network on nodes in other subnets doesn't work properly. This pr creates correct routes for the whole VPC:
```
192.168.199.0/24 dev eth1 proto static scope link
```
Network is already configured similarly for master nodes using bashible:
```
root@p-k-aksenov-tmp-ks-master-0:~# cat /etc/netplan/999-cim-eth1.yaml 
network:
  version: 2
  ethernets:
    eth1:
      dhcp4: true
      dhcp4-overrides:
        use-hostname: false
        use-routes: false
      match:
        macaddress: d0:1d:10:f8:95:5d
      routes:
      - to: 192.168.199.0/24
        scope: link
```

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
There must be no new alerts D8TerraformStateExporterClusterStateChanged in Yandex Cloud clusters using layout `WithNatInstance`

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: Fix routes for multi-zonal clusters when using WithNATInstance layout
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
