### PR TITLE
[ingress-nginx] reload controller config on custom headers change

### DIFF
--- a/modules/402-ingress-nginx/template_tests/controller_test.go
+++ b/modules/402-ingress-nginx/template_tests/controller_test.go
@@ -113,6 +113,8 @@ var _ = Describe("Module :: ingress-nginx :: helm template :: controllers ", fun
       - 2.2.2.2
     maxReplicas: 6
     minReplicas: 2
+    additionalHeaders:
+      X-Foo: bar
 - name: test-without-hpa
   spec:
     inlet: LoadBalancer
@@ -173,6 +175,9 @@ memory: 200Mi`))
 			Expect(hec.KubernetesResource("ConfigMap", "d8-ingress-nginx", "test-custom-headers").Exists()).To(BeTrue())
 			Expect(hec.KubernetesResource("Secret", "d8-ingress-nginx", "ingress-nginx-test-auth-tls").Exists()).To(BeTrue())
 
+			fakeIng := hec.KubernetesResource("Ingress", "d8-ingress-nginx", "test-custom-headers-reload")
+			Expect(fakeIng.Field("spec.rules.0.http.paths.0.path").String()).To(Equal("/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+
 			Expect(hec.KubernetesResource("Service", "d8-ingress-nginx", "test-load-balancer").Exists()).To(BeTrue())
 			Expect(hec.KubernetesResource("Service", "d8-ingress-nginx", "test-admission").Exists()).To(BeTrue())
 			Expect(hec.KubernetesGlobalResource("ValidatingWebhookConfiguration", "d8-ingress-nginx-admission").Exists()).To(BeTrue())
@@ -210,7 +215,8 @@ memory: 200Mi`))
 			Expect(hec.KubernetesResource("Service", "d8-ingress-nginx", "test-lbwpp-load-balancer").Field("spec.loadBalancerSourceRanges")).To(MatchJSON(`["1.1.1.1","2.2.2.2"]`))
 
 			configMapData = hec.KubernetesResource("ConfigMap", "d8-ingress-nginx", "test-lbwpp-config").Field("data")
-
+			fakeIng = hec.KubernetesResource("Ingress", "d8-ingress-nginx", "test-lbwpp-custom-headers-reload")
+			Expect(fakeIng.Field("spec.rules.0.http.paths.0.path").String()).To(Equal("/d18475119d75d3c873bd30e53f4615ef66bf84d9ae1508df173dcc114cfecbb4"))
 			// Use the Raw property to check is value quoted correctly
 			Expect(configMapData.Get("use-proxy-protocol").Raw).To(Equal(`"true"`))
 			Expect(configMapData.Get("body-size").Raw).To(Equal(`"64m"`))

--- a/modules/402-ingress-nginx/template_tests/controller_test.go
+++ b/modules/402-ingress-nginx/template_tests/controller_test.go
@@ -62,6 +62,7 @@ var _ = Describe("Module :: ingress-nginx :: helm template :: controllers ", fun
   data:
     certificate: teststring
     key: teststring
+    certificate_updated: true
 `, ingressName)
 			}
 			hec.ValuesSetFromYaml("ingressNginx.internal.nginxAuthTLS", certificates)
@@ -177,6 +178,10 @@ memory: 200Mi`))
 
 			fakeIng := hec.KubernetesResource("Ingress", "d8-ingress-nginx", "test-custom-headers-reload")
 			Expect(fakeIng.Field("spec.rules.0.http.paths.0.path").String()).To(Equal("/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+
+			fakeIng = hec.KubernetesResource("Ingress", "d8-ingress-nginx", "test-cert-update-reload")
+			Expect(fakeIng.Exists()).To(BeTrue())
+			Expect(fakeIng.Field("spec.rules.0.http.paths.0.path").String()).To(Equal("/fake-path"))
 
 			Expect(hec.KubernetesResource("Service", "d8-ingress-nginx", "test-load-balancer").Exists()).To(BeTrue())
 			Expect(hec.KubernetesResource("Service", "d8-ingress-nginx", "test-admission").Exists()).To(BeTrue())

--- a/modules/402-ingress-nginx/templates/controller/configmap.yaml
+++ b/modules/402-ingress-nginx/templates/controller/configmap.yaml
@@ -225,6 +225,10 @@ data:
   {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- end }}
+
+{{/*include fake ingress for triggering config reload on custom headers change*/}}
+{{- $headersChecksum := join "," $crd.spec.additionalHeaders | sha256sum }}
+{{ include "fake-ingress" (list $context $crd.name $crd.spec.ingressClass "custom-headers" (printf "/%s" $headersChecksum) )}}
 {{- end }}
 ---
 apiVersion: v1

--- a/modules/402-ingress-nginx/templates/controller/fake-ingress.yaml
+++ b/modules/402-ingress-nginx/templates/controller/fake-ingress.yaml
@@ -1,0 +1,31 @@
+{{- /* This ignress triggers "nginx reload". It is required to update client certififcates or custom headers. */ -}}
+{{- define "fake-ingress" }}
+{{- $context := index . 0 }}
+{{- $name := index . 1 }}
+{{- $ingressClass := index . 2 }}
+{{- $sourceName := index . 3 }}
+{{- $path := "/fake-path" }}
+{{- if gt (len .) 4 }}
+{{- $path = index . 4}}
+{{- end}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $name }}-{{ $sourceName }}-reload
+  namespace: d8-ingress-nginx
+  {{- include "helm_lib_module_labels" (list $context ) | nindent 2 }}
+spec:
+  ingressClassName: {{ $ingressClass }}
+  rules:
+    - host: reload-{{ $name }}.deckhouse.io
+      http:
+        paths:
+          - path: {{ $path }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: fakeservice
+                port:
+                  name: https
+{{- end }}

--- a/modules/402-ingress-nginx/templates/controller/secret.yaml
+++ b/modules/402-ingress-nginx/templates/controller/secret.yaml
@@ -14,25 +14,6 @@ data:
 
 {{- /* By deploying and deleting this ingress we trigger "nginx reload". It is required to update client certififcates. */ -}}
   {{ if $cert.data.certificate_updated }}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: fakeingress-{{ $cert.controllerName }}
-  namespace: d8-ingress-nginx
-  {{- include "helm_lib_module_labels" (list $context ) | nindent 2 }}
-spec:
-  ingressClassName: {{ $cert.ingressClass }}
-  rules:
-  - host: reload.deckhouse.io
-    http:
-      paths:
-        - path: /fake-path-to-trigger-ingress-controller-config-reload
-          pathType: ImplementationSpecific
-          backend:
-            service:
-              name: fakeservice
-              port:
-                name: https
+    {{ include "fake-ingress" (list $context $cert.controllerName $cert.ingressClass "cert-update") }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Generate ingress for tracking IngressNginxController `additionalHeaders` field like this:
```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  labels:
    heritage: deckhouse
    module: ingress-nginx
  name: testname-custom-headers-reload
  namespace: d8-ingress-nginx
spec:
  ingressClassName: nginx
  rules:
  - host: reload-testname.deckhouse.io
    http:
      paths:
      - backend:
          service:
            name: fakeservice
            port:
              name: https
        path: /d18475119d75d3c873bd30e53f4615ef66bf84d9ae1508df173dcc114cfecbb4
        pathType: ImplementationSpecific
```

where:
`testname` - the name on IngressNginxController CR
`path` - checksum of all additionalHeaders

## Why do we need it, and what problem does it solve?
When we change a list of additionalHeaders in a IngressNginxController CR it does not trigger configuration reload and new/removed headers would not appear in the nginx.conf until the ingress object change / controller restart. We want to change fake ingress on a headers change and trigger the reload

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ingress-nginx
type: fix 
summary: Reload ingress controller configuration on `additionalHeaders` field change.  This will automatically add configured custom headers to the nginx.conf without the need of restarting a controller
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
