### PR TITLE
[linstor] fix: scheduling cni on tainted nodes

### DIFF
--- a/helm_lib/templates/_node_affinity.tpl
+++ b/helm_lib/templates/_node_affinity.tpl
@@ -17,6 +17,9 @@
 - key: node.kubernetes.io/out-of-disk
 - key: node.kubernetes.io/memory-pressure
 - key: node.kubernetes.io/disk-pressure
+- key: drbd.linbit.com/lost-quorum
+- key: drbd.linbit.com/force-io-error
+- key: drbd.linbit.com/ignore-fail-over
 {{- end }}
 
 {{- define "helm_lib_node_selector" }}

--- a/modules/101-cert-manager/template_tests/module_test.go
+++ b/modules/101-cert-manager/template_tests/module_test.go
@@ -198,6 +198,9 @@ var _ = Describe("Module :: cert-manager :: helm template ::", func() {
 - key: node.kubernetes.io/out-of-disk
 - key: node.kubernetes.io/memory-pressure
 - key: node.kubernetes.io/disk-pressure
+- key: drbd.linbit.com/lost-quorum
+- key: drbd.linbit.com/force-io-error
+- key: drbd.linbit.com/ignore-fail-over
 `))
 			Expect(cainjector.Field("spec.replicas").Int()).To(BeEquivalentTo(1))
 			Expect(cainjector.Field("spec.strategy").Exists()).To(BeTrue())
@@ -252,6 +255,9 @@ var _ = Describe("Module :: cert-manager :: helm template ::", func() {
 - key: node.kubernetes.io/out-of-disk
 - key: node.kubernetes.io/memory-pressure
 - key: node.kubernetes.io/disk-pressure
+- key: drbd.linbit.com/lost-quorum
+- key: drbd.linbit.com/force-io-error
+- key: drbd.linbit.com/ignore-fail-over
 `))
 			Expect(cainjector.Field("spec.replicas").Int()).To(BeEquivalentTo(5))
 			Expect(cainjector.Field("spec.strategy").String()).To(MatchYAML(`
@@ -329,6 +335,9 @@ podAntiAffinity:
 - key: node.kubernetes.io/out-of-disk
 - key: node.kubernetes.io/memory-pressure
 - key: node.kubernetes.io/disk-pressure
+- key: drbd.linbit.com/lost-quorum
+- key: drbd.linbit.com/force-io-error
+- key: drbd.linbit.com/ignore-fail-over
 `))
 			Expect(cainjector.Field("spec.replicas").Int()).To(BeEquivalentTo(1))
 			Expect(cainjector.Field("spec.strategy").Exists()).To(BeTrue())
@@ -383,6 +392,9 @@ podAntiAffinity:
 - key: node.kubernetes.io/out-of-disk
 - key: node.kubernetes.io/memory-pressure
 - key: node.kubernetes.io/disk-pressure
+- key: drbd.linbit.com/lost-quorum
+- key: drbd.linbit.com/force-io-error
+- key: drbd.linbit.com/ignore-fail-over
 `))
 			Expect(cainjector.Field("spec.replicas").Int()).To(BeEquivalentTo(3))
 			Expect(cainjector.Field("spec.strategy").String()).To(MatchYAML(`


### PR DESCRIPTION
## Description

This PR adds linstor taints to `helm_lib_internal_node_problems_tolerations`:

```yaml
- key: drbd.linbit.com/lost-quorum
- key: drbd.linbit.com/force-io-error
- key: drbd.linbit.com/ignore-fail-over
```

## Why do we need it, and what problem does it solve?
LINSTOR module can add specific taints on nodes which will prevent CNI pods scheduled

fixes https://github.com/deckhouse/deckhouse/issues/2518

## What is the expected result?
Able to schedule CNI-plugin pod on nodes with storage problems 

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: linstor
type: fix
summary: fix scheduling cni pods on tainted nodes
impact: CNI plugin pods and kube-proxy will be restarted
impact_level: default
```