### PR TITLE
[ci] add documentation on how to run e2e test with switch releases

### DIFF
--- a/.github/scripts/js/ci.js
+++ b/.github/scripts/js/ci.js
@@ -1122,6 +1122,10 @@ You can trigger release related actions by commenting on this issue:
 - \`/e2e/run/<provider> git_ref\` will run e2e using provider and an \`install\` image built from git_ref.
   - \`provider\` is one of \`${availableProviders}\`
   - \`git_ref\` is ${possibleGitRefs}
+- \`/e2e/run/<provider> git_ref_1 git_ref_2\` will run e2e using provider and git_ref_1 and then switch to git_ref_2.
+  - \`provider\` is one of \`${availableProviders}\`
+  - \`git_ref_1\` is a release-* or main branch
+  - \`git_ref_2\` is a release-* or main branch
 - \`/e2e/use/cri/<cri_name>\` specifies which CRI to use for e2e test.
   - \`cri_name\` is one of \`${availableCRI}\`
 - \`/e2e/use/k8s/<version>\` specifies which Kubernetes version to use for e2e test.
@@ -1143,6 +1147,16 @@ Put \`/e2e/use\` options below \`/e2e/run\` command to set specific CRI and Kube
 
 This comment will run 4 e2e jobs on AWS with Docker and containerd
 and with Kubernetes version 1.20 and 1.23 using image built from main branch.
+\`\`\`
+
+\`\`\`
+/e2e/run/aws release-1.35 release-1.36
+/e2e/use/cri/containerd
+/e2e/use/k8s/1.23
+
+This comment will create cluster in AWS using Deckhouse built from release-1.35 branch
+and then switch to images built from release-1.36 branch.
+'use' options are supported, cluster will use containerd and Kubernetes version 1.23.
 \`\`\`
 
 **Note 2:**


### PR DESCRIPTION

## Description

Add example to release issue template on how to run e2e test with switch releases.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

Fix absent documentation in #2283.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

Command to run e2e test with switch release should be in new release issue.
 
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: fix
summary: Add example to release issue template on how to run e2e test with switch releases.
impact: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
