### PR TITLE
[istio] fix D8IstioActualDataPlaneRevisionNeDesired alert

### DIFF
--- a/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/revisions.yaml
@@ -128,7 +128,7 @@
         There are Pods with istio data-plane revision `{{$labels.revision}}`,
         but desired revision is `{{$labels.desired_revision}}`
     expr: |
-      d8_istio_pod_revision{desired_revision!="absent"}
+      d8_istio_pod_revision{revision!="absent", desired_revision!="absent"}
       unless on (revision, dataplane_pod, namespace) label_replace(d8_istio_pod_revision{}, "revision", "$1", "desired_revision", "(.+)")
     for: 5m
     labels:


### PR DESCRIPTION
## Description
fixed `D8IstioActualDataPlaneRevisionNeDesired` alert 

## Why do we need it, and what problem does it solve?
This alert also triggers if there is no istio-sidecar in the pod, although there is a separate alert for this `D8IstioPodsWithoutIstioSidecar`

## What is the expected result?
Alert does not triggers on pods without istio-sidecar

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Fixed `D8IstioActualDataPlaneRevisionNeDesired` alert.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
