### PR TITLE
[istio] add an alert for deprecated tlsMode param

### DIFF
--- a/ee/modules/110-istio/hooks/deprecated_module_params_monitoring.go
+++ b/ee/modules/110-istio/hooks/deprecated_module_params_monitoring.go
@@ -6,16 +6,17 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 package hooks
 
 import (
-	"github.com/deckhouse/deckhouse/ee/modules/110-istio/hooks/internal"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
 	"github.com/flant/addon-operator/sdk"
+
+	"github.com/deckhouse/deckhouse/ee/modules/110-istio/hooks/internal"
 )
 
 const (
 	deprecatedModuleParamMetricName             = "d8_istio_deprecated_module_param"
 	deprecatedModuleParamMonitoringMetricsGroup = "deprecated_module_param"
-	istioTlsModePath                            = "istio.tlsMode"
+	istioTLSModePath                            = "istio.tlsMode"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -25,7 +26,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 
 func getRidOfDeprecatedParams(input *go_hook.HookInput) error {
 	input.MetricsCollector.Expire(deprecatedModuleParamMonitoringMetricsGroup)
-	if input.ConfigValues.Get(istioTlsModePath).Exists() {
+	if input.ConfigValues.Get(istioTLSModePath).Exists() {
 		labels := map[string]string{
 			"param": "tlsMode",
 		}

--- a/ee/modules/110-istio/hooks/deprecated_module_params_monitoring.go
+++ b/ee/modules/110-istio/hooks/deprecated_module_params_monitoring.go
@@ -9,8 +9,6 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
 	"github.com/flant/addon-operator/sdk"
-
-	"github.com/deckhouse/deckhouse/ee/modules/110-istio/hooks/internal"
 )
 
 const (
@@ -20,13 +18,12 @@ const (
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	Queue:        internal.Queue("deprecated-parameters-monitoring"),
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
 }, getRidOfDeprecatedParams)
 
 func getRidOfDeprecatedParams(input *go_hook.HookInput) error {
 	input.MetricsCollector.Expire(deprecatedModuleParamMonitoringMetricsGroup)
-	if input.ConfigValues.Get(istioTLSModePath).Exists() {
+	if input.ConfigValues.Exists(istioTLSModePath) {
 		labels := map[string]string{
 			"param": "tlsMode",
 		}

--- a/ee/modules/110-istio/hooks/deprecated_module_params_monitoring.go
+++ b/ee/modules/110-istio/hooks/deprecated_module_params_monitoring.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	"github.com/deckhouse/deckhouse/ee/modules/110-istio/hooks/internal"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
+	"github.com/flant/addon-operator/sdk"
+)
+
+const (
+	deprecatedModuleParamMetricName             = "d8_istio_deprecated_module_param"
+	deprecatedModuleParamMonitoringMetricsGroup = "deprecated_module_param"
+	istioTlsModePath                            = "istio.tlsMode"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue:        internal.Queue("deprecated-parameters-monitoring"),
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+}, getRidOfDeprecatedParams)
+
+func getRidOfDeprecatedParams(input *go_hook.HookInput) error {
+	input.MetricsCollector.Expire(deprecatedModuleParamMonitoringMetricsGroup)
+	if input.ConfigValues.Get(istioTlsModePath).Exists() {
+		labels := map[string]string{
+			"param": "tlsMode",
+		}
+		input.MetricsCollector.Set(deprecatedModuleParamMetricName, 1, labels, metrics.WithGroup(deprecatedModuleParamMonitoringMetricsGroup))
+	}
+	return nil
+}

--- a/ee/modules/110-istio/hooks/deprecated_module_params_monitoring_test.go
+++ b/ee/modules/110-istio/hooks/deprecated_module_params_monitoring_test.go
@@ -59,7 +59,6 @@ var _ = Describe("Istio hooks :: deprecated_module_params_monitoring ::", func()
 					"param": "tlsMode",
 				},
 			}))
-
 		})
 	})
 })

--- a/ee/modules/110-istio/hooks/deprecated_module_params_monitoring_test.go
+++ b/ee/modules/110-istio/hooks/deprecated_module_params_monitoring_test.go
@@ -6,11 +6,12 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 package hooks
 
 import (
-	. "github.com/deckhouse/deckhouse/testing/hooks"
 	"github.com/flant/shell-operator/pkg/metric_storage/operation"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
 var _ = Describe("Istio hooks :: deprecated_module_params_monitoring ::", func() {

--- a/ee/modules/110-istio/hooks/deprecated_module_params_monitoring_test.go
+++ b/ee/modules/110-istio/hooks/deprecated_module_params_monitoring_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+	"github.com/flant/shell-operator/pkg/metric_storage/operation"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("Istio hooks :: deprecated_module_params_monitoring ::", func() {
+	f := HookExecutionConfigInit(`{"istio":{}}`, "")
+	Context("Empty cluster and minimal settings", func() {
+		BeforeEach(func() {
+			f.RunHook()
+		})
+
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(string(f.LogrusOutput.Contents())).To(HaveLen(0))
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(1))
+			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
+				Group:  deprecatedModuleParamMonitoringMetricsGroup,
+				Action: "expire",
+			}))
+		})
+	})
+
+	Context("mtlsNode param exists", func() {
+		BeforeEach(func() {
+			f.ConfigValuesSet("istio.tlsMode", "MutualPermissive")
+			f.RunHook()
+		})
+
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(string(f.LogrusOutput.Contents())).To(HaveLen(0))
+
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(2))
+			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
+				Group:  deprecatedModuleParamMonitoringMetricsGroup,
+				Action: "expire",
+			}))
+			Expect(m[1]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   deprecatedModuleParamMetricName,
+				Group:  deprecatedModuleParamMonitoringMetricsGroup,
+				Action: "set",
+				Value:  pointer.Float64Ptr(1.0),
+				Labels: map[string]string{
+					"param": "tlsMode",
+				},
+			}))
+
+		})
+	})
+})

--- a/ee/modules/110-istio/monitoring/prometheus-rules/deprecated_params.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/deprecated_params.yaml
@@ -1,0 +1,44 @@
+- name: d8.istio.deprecated.params
+  rules:
+    - alert: D8IstioDeprecatedModuleParamMtlsModeFound
+      expr: d8_istio_deprecated_module_param{param="tlsMode"}==1
+      for: 1m
+      labels:
+        severity_level: "6"
+        tier: cluster
+        d8_module: istio
+      annotations:
+        plk_protocol_version: "1"
+        plk_markup_format: markdown
+        plk_create_group_if_not_exists__d8istio_operator_malfunctioning: "D8IstioDeprecatedModuleParaMtlsModeFound,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8istio_operator_malfunctioning: "D8IstioDeprecatedModuleParaMtlsModeFound,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        summary: deprecated `tlsMode` parameter will be removed in deckhouse version 1.38.0
+        description: |
+          The `tlsMode` parameter is now deprecated, it will be removed in deckhouse version 1.38.0.
+          If necessary, create the necessary PeerAuthentication, DestinationsRule resources for pods using istio.
+
+          PeerAuthentication:
+          ```
+            apiVersion: security.istio.io/v1beta1
+            kind: PeerAuthentication
+            metadata:
+              name: <name>
+              namespace: <namespace>
+            spec:
+              mtls:
+                mode: <mtls mode>
+          ```
+
+          DestinationRule:
+          ```
+            apiVersion: networking.istio.io/v1beta1
+            kind: DestinationRule
+            metadata:
+              name: <name>
+              namespace: <namespace>
+            spec:
+              host: "<host name>"
+              trafficPolicy:
+                tls:
+                  mode: <mtls mode>
+          ```

--- a/ee/modules/110-istio/monitoring/prometheus-rules/deprecated_params.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/deprecated_params.yaml
@@ -1,10 +1,10 @@
 - name: d8.istio.deprecated.params
   rules:
-    - alert: D8IstioDeprecatedModuleParamMtlsModeFound
+    - alert: D8IstioTLSModeModuleParamIsDeprecated
       expr: d8_istio_deprecated_module_param{param="tlsMode"}==1
       for: 1m
       labels:
-        severity_level: "6"
+        severity_level: "4"
         tier: cluster
         d8_module: istio
       annotations:

--- a/ee/modules/110-istio/monitoring/prometheus-rules/deprecated_params.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/deprecated_params.yaml
@@ -10,12 +10,12 @@
       annotations:
         plk_protocol_version: "1"
         plk_markup_format: markdown
-        plk_create_group_if_not_exists__d8istio_operator_malfunctioning: "D8IstioDeprecatedModuleParaMtlsModeFound,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8istio_operator_malfunctioning: "D8IstioDeprecatedModuleParaMtlsModeFound,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_create_group_if_not_exists__d8istio_operator_malfunctioning: "D8IstioTLSModeModuleParamIsDeprecated,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+        plk_grouped_by__d8istio_operator_malfunctioning: "D8IstioTLSModeModuleParamIsDeprecated,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
         summary: deprecated `tlsMode` parameter will be removed in deckhouse version 1.38.0
         description: |
           The `tlsMode` parameter is now deprecated, it will be removed in deckhouse version 1.38.0.
-          If necessary, create the necessary PeerAuthentication, DestinationsRule resources for pods using istio.
+          If necessary, create the PeerAuthentication and DestinationsRule resources for configuring mTLS manually.
 
           PeerAuthentication:
           ```


### PR DESCRIPTION
## Description
Added an alert that config parameter `tlsMode` will be removed in deckhouse version 1.38.0. 

## Why do we need it, and what problem does it solve?
This alert is needed to warn users using that  config parameter.

## What is the expected result?
Users using the `tlsMode` parameter will receive a warning alert
The part of https://github.com/deckhouse/deckhouse/issues/2562

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: Added an alert that `tlsMode` module parameter will be removed in deckhouse v1.38.0. 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
