### PR TITLE
[istio] remove cpu limist for istio-proxy

### DIFF
--- a/ee/modules/110-istio/hooks/patch_injector_configmap.go
+++ b/ee/modules/110-istio/hooks/patch_injector_configmap.go
@@ -9,14 +9,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/deckhouse/deckhouse/ee/modules/110-istio/hooks/internal"
-	_ "github.com/evanphx/json-patch"
+
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/ee/modules/110-istio/hooks/internal"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -50,7 +51,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	},
 }, patchInjectorConfigmap)
 
-var injectorConfigMapJsonPatch = []byte(`[ {"op": "remove", "path": "/global/proxy/resources/limits/cpu"} ]`)
+var injectorConfigMapJSONPatch = []byte(`[ {"op": "remove", "path": "/global/proxy/resources/limits/cpu"} ]`)
 
 func applyInjectorConfigmapFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	cm := v1.ConfigMap{}
@@ -71,7 +72,7 @@ func patchInjectorConfigmap(input *go_hook.HookInput) error {
 		if !ok {
 			continue
 		}
-		decodedPatch, err := jsonpatch.DecodePatch(injectorConfigMapJsonPatch)
+		decodedPatch, err := jsonpatch.DecodePatch(injectorConfigMapJSONPatch)
 		if err != nil {
 			return err
 		}

--- a/ee/modules/110-istio/hooks/patch_injector_configmap.go
+++ b/ee/modules/110-istio/hooks/patch_injector_configmap.go
@@ -14,7 +14,6 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
-	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -28,9 +27,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			ApiVersion: "v1",
 			Kind:       "ConfigMap",
 			FilterFunc: applyInjectorConfigmapFilter,
-			NameSelector: &types.NameSelector{
-				MatchNames: []string{"istio-sidecar-injector"},
-			},
 			LabelSelector: &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{

--- a/ee/modules/110-istio/hooks/patch_injector_configmap.go
+++ b/ee/modules/110-istio/hooks/patch_injector_configmap.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2022 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/deckhouse/deckhouse/ee/modules/110-istio/hooks/internal"
+	_ "github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: internal.Queue("patch-injector-configmap"),
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "injector_configmap",
+			ApiVersion: "v1",
+			Kind:       "ConfigMap",
+			FilterFunc: applyInjectorConfigmapFilter,
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"istio-sidecar-injector"},
+			},
+			LabelSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "operator.istio.io/version",
+						Operator: metav1.LabelSelectorOpExists,
+					},
+					{
+						Key:      "operator.istio.io/component",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"Pilot"},
+					},
+					{
+						Key:      "release",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"istio"},
+					},
+				},
+			},
+			NamespaceSelector: internal.NsSelector(),
+		},
+	},
+}, patchInjectorConfigmap)
+
+var injectorConfigMapJsonPatch = []byte(`[ {"op": "remove", "path": "/global/proxy/resources/limits/cpu"} ]`)
+
+func applyInjectorConfigmapFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	cm := v1.ConfigMap{}
+	err := sdk.FromUnstructured(obj, &cm)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert ConfigMap object to ConfigMap: %v", err)
+	}
+
+	return cm, nil
+}
+
+func patchInjectorConfigmap(input *go_hook.HookInput) error {
+	var patcherValuesPrettyJSON bytes.Buffer
+	for _, cmRaw := range input.Snapshots["injector_configmap"] {
+		cm := cmRaw.(v1.ConfigMap)
+		values, ok := cm.Data["values"]
+		// missing values to Patch -> skip it
+		if !ok {
+			continue
+		}
+		decodedPatch, err := jsonpatch.DecodePatch(injectorConfigMapJsonPatch)
+		if err != nil {
+			return err
+		}
+		patchedValues, err := decodedPatch.Apply([]byte(values))
+		// missing values to Patch or can't patch -> skip it
+		if err != nil {
+			continue
+		}
+		if err := json.Indent(&patcherValuesPrettyJSON, patchedValues, "", "  "); err != nil {
+			return err
+		}
+		cmPatch := map[string]interface{}{
+			"data": map[string]interface{}{
+				"values": patcherValuesPrettyJSON.String(),
+			},
+		}
+		input.PatchCollector.MergePatch(cmPatch, "v1", "ConfigMap", cm.Namespace, cm.Name)
+	}
+	return nil
+}

--- a/ee/modules/110-istio/hooks/patch_injector_configmap.go
+++ b/ee/modules/110-istio/hooks/patch_injector_configmap.go
@@ -3,6 +3,8 @@ Copyright 2022 Flant JSC
 Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 */
 
+// The hook will lose relevance after solving the issue — https://github.com/istio/istio/issues/40078.
+
 package hooks
 
 import (

--- a/ee/modules/110-istio/hooks/patch_injector_configmap_test.go
+++ b/ee/modules/110-istio/hooks/patch_injector_configmap_test.go
@@ -61,6 +61,24 @@ metadata:
   name: istio-sidecar-injector-v1x33
   namespace: d8-istio
 `
+
+		patchedValues := `
+{ 
+  "global": {
+    "proxy": {
+      "resources": {
+        "limits": {
+          "memory": "1024Mi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "128Mi"
+        }
+      }
+    }
+  }
+}
+`
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(cm))
 			f.RunHook()
@@ -70,6 +88,7 @@ metadata:
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33").ToYaml()).NotTo(MatchYAML(cm))
 			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33").Field("data.config").String()).To(Equal("test_config_data"))
+			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33").Field("data.values").String()).To(MatchJSON(patchedValues))
 		})
 	})
 

--- a/ee/modules/110-istio/hooks/patch_injector_configmap_test.go
+++ b/ee/modules/110-istio/hooks/patch_injector_configmap_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2022 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: istio :: hooks :: patch_injector_configmap ", func() {
+	f := HookExecutionConfigInit(`{}`, `{}`)
+	Context("Empty cluster and minimal settings", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+
+	Context("Injector configmap for revision v1x33, limits are exists", func() {
+		cm := `
+---
+apiVersion: v1
+data:
+  config: test_config_data
+  values: |-
+    {
+      "global": {
+        "proxy": {
+          "resources": {
+            "limits": {
+              "cpu": "2000m",
+              "memory": "1024Mi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            }
+          }
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    install.operator.istio.io/owning-resource: v1x33
+    install.operator.istio.io/owning-resource-namespace: d8-istio
+    istio.io/rev: v1x13
+    operator.istio.io/component: Pilot
+    operator.istio.io/managed: Reconcile
+    operator.istio.io/version: 1.33.7
+    release: istio
+  name: istio-sidecar-injector-v1x33
+  namespace: d8-istio
+`
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(cm))
+			f.RunHook()
+		})
+
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33").ToYaml()).NotTo(MatchYAML(cm))
+			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33").Field("data.config").String()).To(Equal("test_config_data"))
+		})
+	})
+
+	Context("Injector configmap for revision v1x33, limits are absent", func() {
+		cm := `
+---
+apiVersion: v1
+data:
+  config: test_config_data
+  values: |-
+    {
+      "global": {
+        "proxy": {
+          "resources": {
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            }
+          }
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    install.operator.istio.io/owning-resource: v1x33
+    install.operator.istio.io/owning-resource-namespace: d8-istio
+    istio.io/rev: v1x13
+    operator.istio.io/component: Pilot
+    operator.istio.io/managed: Reconcile
+    operator.istio.io/version: 1.33.7
+    release: istio
+  name: istio-sidecar-injector-v1x33
+  namespace: d8-istio
+`
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(cm))
+			f.RunHook()
+		})
+
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33").ToYaml()).To(MatchYAML(cm))
+		})
+	})
+
+	Context("Configmap with values field but with wrong data", func() {
+		cm := `
+---
+apiVersion: v1
+data:
+  config: test_config_data
+  values: test_values
+kind: ConfigMap
+metadata:
+  labels:
+    install.operator.istio.io/owning-resource: v1x33
+    install.operator.istio.io/owning-resource-namespace: d8-istio
+    istio.io/rev: v1x13
+    operator.istio.io/component: Pilot
+    operator.istio.io/managed: Reconcile
+    operator.istio.io/version: 1.33.7
+    release: istio
+  name: istio-sidecar-injector-v1x33
+  namespace: d8-istio
+`
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(cm))
+			f.RunHook()
+		})
+
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33").ToYaml()).To(MatchYAML(cm))
+		})
+	})
+
+	Context("Configmap without needed fields", func() {
+		cm := `
+---
+apiVersion: v1
+data:
+  config1: test_config_data
+  values1: test_values
+kind: ConfigMap
+metadata:
+  labels:
+    install.operator.istio.io/owning-resource: v1x33
+    install.operator.istio.io/owning-resource-namespace: d8-istio
+    istio.io/rev: v1x13
+    operator.istio.io/component: Pilot
+    operator.istio.io/managed: Reconcile
+    operator.istio.io/version: 1.33.7
+    release: istio
+  name: istio-sidecar-injector-v1x33
+  namespace: d8-istio
+`
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(cm))
+			f.RunHook()
+		})
+
+		It("Hook must execute successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33").ToYaml()).To(MatchYAML(cm))
+		})
+	})
+
+})

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/cloudflare/cfssl v1.5.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
+	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
 	github.com/fatih/color v1.9.0
 	github.com/flant/addon-operator v1.0.7-0.20220907111408-26890e1b0322 // branch: main
 	github.com/flant/kube-client v0.0.6

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/cloudflare/cfssl v1.5.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
-	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
 	github.com/fatih/color v1.9.0
 	github.com/flant/addon-operator v1.0.7-0.20220907111408-26890e1b0322 // branch: main
 	github.com/flant/kube-client v0.0.6


### PR DESCRIPTION
## Description
Cpu limits for istio-proxy sidecars has been removed.

## Why do we need it, and what problem does it solve?
In some cases the isiot-proxy gets throttled, we want to get rid of the CPU limits set for istio-proxy.

## What is the expected result?
All istio-proxy sidecars will be creater without cpu limits.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: Cpu limits for istio-proxy sidecars has been removed.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
