### PR TITLE
[go_lib] Re-issue certificates 15 days before expiration

### DIFF
--- a/go_lib/hooks/tls_certificate/order_certificate.go
+++ b/go_lib/hooks/tls_certificate/order_certificate.go
@@ -184,7 +184,7 @@ func certificateHandlerWithRequests(input *go_hook.HookInput, dc dependency.Cont
 
 			if secret != nil && len(secret.Crt) > 0 && len(secret.Key) > 0 {
 				// Check that certificate is not expired and has the same order request
-				genNew, err := shouldGenerateNewCert(secret.Crt, request, time.Hour*24*7)
+				genNew, err := shouldGenerateNewCert(secret.Crt, request, time.Hour*24*15)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
## Description

Re-issue certificate 15 dayes before expiration

## Why do we need it, and what problem does it solve?

We have prometheus alert `CertificateSecretExpiredSoon` that starts firing 14 days before
ceertificate expiration. We need to re-issue certificate earlier to avoid useless alerts.

## What is the expected result?

Useless `CertificateSecretExpiredSoon` alerts do not fire.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: go_lib
type: fix
summary: Changed certificate re-issue time to 15 days before expiration to avoid useless `CertificateSecretExpiredSoon` alerts.
```
