### PR TITLE
[global-hooks] Reduce static requests for control-plane pods

### DIFF
--- a/global-hooks/calculate_resources_requests.go
+++ b/global-hooks/calculate_resources_requests.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	controlPlanePercent     = 50                     // %
+	controlPlanePercent     = 40                     // %
 	configEveryNodeMilliCPU = 300                    // 0.3 Cpu
 	configEveryNodeMemory   = 512 * 1024 * 1024      // 512Mb
 	hardLimitMilliCPU       = 4 * 1000               // 4 Cpu

--- a/global-hooks/calculate_resources_requests_test.go
+++ b/global-hooks/calculate_resources_requests_test.go
@@ -99,10 +99,10 @@ var _ = Describe("Global hooks :: calculate_resources_requests", func() {
 			f.RunHook()
 		})
 
-		It("Hook should run, control-plane resource values should be equal (master-node with less resources - resources for components working on every node) divided by 2", func() {
+		It(fmt.Sprintf("Hook should run, control-plane resource values should be equal %d%% of (master-node with less resources - resources for components working on every node)", controlPlanePercent), func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.milliCpuControlPlane").Int()).To(Equal(int64(850)))
-			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.memoryControlPlane").Int()).To(Equal(int64(1792 * 1024 * 1024)))
+			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.milliCpuControlPlane").Int()).To(Equal(int64((2000 - configEveryNodeMilliCPU) * controlPlanePercent / 100)))
+			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.memoryControlPlane").Int()).To(Equal(int64((4096*1024*1024 - configEveryNodeMemory) * controlPlanePercent / 100)))
 		})
 
 	})

--- a/global-hooks/calculate_resources_requests_test.go
+++ b/global-hooks/calculate_resources_requests_test.go
@@ -71,10 +71,10 @@ var _ = Describe("Global hooks :: calculate_resources_requests", func() {
 			f.RunHook()
 		})
 
-		It("Hook should run, control-plane resource values should be equal (master-node resources - resources for components working on every node) divided by 2", func() {
+		It(fmt.Sprintf("Hook should run, control-plane resource values should be equal %d%% of (master-node resources - resources for components working on every node)", controlPlanePercent), func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.milliCpuControlPlane").Int()).To(Equal(int64(1850)))
-			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.memoryControlPlane").Int()).To(Equal(int64(3840 * 1024 * 1024)))
+			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.milliCpuControlPlane").Int()).To(Equal(int64((4000 - configEveryNodeMilliCPU) * controlPlanePercent / 100)))
+			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.memoryControlPlane").Int()).To(Equal(int64((8192*1024*1024 - configEveryNodeMemory) * controlPlanePercent / 100)))
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: Konstantin Aksenov <konstantin.aksenov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Reduce percent from 50 to 40.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
There was refactoring of resources requests in 1.36. Several problems with over-requests occurred after release, and because of it, some DaemonSet pods get stuck in pending state. It seems correct to just reduce percent.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: global-hooks
type: fix
summary: Reduce static requests for control-plane pods
impact: Control-plane components will restart.
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
