### PR TITLE
[extended-monitoring] Remove `D8CertExporterStuck` alert

### DIFF
--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificates-exporter-health.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificates-exporter-health.yaml
@@ -75,25 +75,3 @@
         The recommended course of action:
         1. Retrieve details of the Deployment: `kubectl -n d8-monitoring describe deploy cert-exporter`
         2. View the status of the Pod and try to figure out why it is not running: `kubectl -n d8-monitoring describe pod -l app=cert-exporter`
-
-- name: d8.extended-monitoring.cert-exporter.malfunctioning
-  rules:
-
-  - alert: D8CertExporterStuck
-    expr: |
-      increase(promhttp_metric_handler_requests_total{job="cert-exporter", code="200"}[10m])
-    for: 20m
-    labels:
-      severity_level: "8"
-      d8_module: extended-monitoring
-      d8_component: cert-exporter
-    annotations:
-      plk_protocol_version: "1"
-      plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_cert_exporter_malfunctioning: "D8CertExporterMalfunctioning,prometheus=deckhouse,kubernetes=~kubernetes"
-      plk_grouped_by__d8_cert_exporter_malfunctioning: "D8CertExporterMalfunctioning,prometheus=deckhouse,kubernetes=~kubernetes"
-      description: |
-        The `cert-exporter` failed to perform any checks for the certificates expiration for over 20 minutes.
-
-        You need to analyze its logs: `kubectl -n d8-monitoring logs -l app=cert-exporter -c cert-exporter`
-      summary: image-cert-exporter has crashed.


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Remove D8CertExporterStuck alert.

## Why do we need it, and what problem does it solve?
1. `D8CertExporterStuck` alert contains mistake.
2. We have named [TargetDown alert](https://github.com/deckhouse/deckhouse/blob/af6a01a90a0e79a0a4242b0c58ca0a3a940cb7ac/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificates-exporter-health.yaml#L4) for cert-exporter and `D8CertExporterStuck` alert is unnecessary.

## What is the expected result?
`D8CertExporterStuck` should go out

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: extended-monitoring
type: fix
summary: Remove D8CertExporterStuck alert
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
