### PR TITLE
[docs] Fix schema render

### DIFF
--- a/docs/documentation/_data/i18n.yml
+++ b/docs/documentation/_data/i18n.yml
@@ -65,6 +65,9 @@ common:
   examples:
     en: examples
     ru: примеры
+  element_of_array:
+    en: element of the array
+    ru: элемент массива
   x-kubernetes-int-or-string:
     en: integer or string
     ru: строка или число


### PR DESCRIPTION
## Description
Show more info about attributes of array elements in the OpenAPI schemas in the documentation.

## Why do we need it, and what problem does it solve?
If a parameter is an array of items (not of objects), the attributes of the item are not displayed on the page (e.g `enum`, `description`, `pattern`, etc).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: Show more info about attributes of array elements in the OpenAPI schemas in the documentation.
impact_level: low
```
