### PR TITLE
[ci] Add timeout for bootstrap and cleanup e2e cluster steps

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -298,6 +298,7 @@ check_e2e_labels:
         echo '::echo::off'
 
     - name: "Run e2e test: {!{ $ctx.providerName }!}/{!{ $ctx.criName }!}/{!{ $ctx.kubernetesVersion }!}"
+      timeout-minutes: 60
       env:
         PROVIDER: {!{ $ctx.providerName }!}
         CRI: {!{ $ctx.criName }!}
@@ -314,6 +315,7 @@ check_e2e_labels:
 
     - name: Cleanup bootstrapped cluster
       if: always()
+      timeout-minutes: 60
       env:
         PROVIDER: {!{ $ctx.providerName }!}
         CRI: {!{ $ctx.criName }!}

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -368,6 +368,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: AWS/Docker/1.20"
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -422,6 +423,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -715,6 +717,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: AWS/Docker/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -769,6 +772,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -1062,6 +1066,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: AWS/Docker/1.22"
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -1116,6 +1121,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -1409,6 +1415,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: AWS/Docker/1.23"
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -1463,6 +1470,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -1756,6 +1764,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: AWS/Docker/1.24"
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -1810,6 +1819,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Docker
@@ -2103,6 +2113,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: AWS/Containerd/1.20"
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -2157,6 +2168,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -2450,6 +2462,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: AWS/Containerd/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -2504,6 +2517,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -2797,6 +2811,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: AWS/Containerd/1.22"
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -2851,6 +2866,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -3144,6 +3160,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: AWS/Containerd/1.23"
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -3198,6 +3215,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -3491,6 +3509,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: AWS/Containerd/1.24"
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -3545,6 +3564,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Containerd

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -368,6 +368,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Azure/Docker/1.20"
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -426,6 +427,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -723,6 +725,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Azure/Docker/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -781,6 +784,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -1078,6 +1082,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Azure/Docker/1.22"
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -1136,6 +1141,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -1433,6 +1439,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Azure/Docker/1.23"
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -1491,6 +1498,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -1788,6 +1796,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Azure/Docker/1.24"
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -1846,6 +1855,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Docker
@@ -2143,6 +2153,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Azure/Containerd/1.20"
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -2201,6 +2212,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -2498,6 +2510,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Azure/Containerd/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -2556,6 +2569,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -2853,6 +2867,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Azure/Containerd/1.22"
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -2911,6 +2926,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -3208,6 +3224,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Azure/Containerd/1.23"
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -3266,6 +3283,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -3563,6 +3581,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Azure/Containerd/1.24"
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -3621,6 +3640,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Containerd

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -288,6 +288,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: AWS/Containerd/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -342,6 +343,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: AWS
           CRI: Containerd
@@ -646,6 +648,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Azure/Containerd/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -704,6 +707,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Azure
           CRI: Containerd
@@ -1012,6 +1016,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: GCP/Containerd/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -1064,6 +1069,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -1366,6 +1372,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -1422,6 +1429,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -1728,6 +1736,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Containerd/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -1780,6 +1789,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -2082,6 +2092,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Containerd/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -2136,6 +2147,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -2440,6 +2452,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Static/Containerd/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -2492,6 +2505,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Containerd

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -368,6 +368,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: GCP/Docker/1.20"
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -420,6 +421,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -711,6 +713,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: GCP/Docker/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -763,6 +766,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -1054,6 +1058,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: GCP/Docker/1.22"
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -1106,6 +1111,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -1397,6 +1403,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: GCP/Docker/1.23"
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -1449,6 +1456,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -1740,6 +1748,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: GCP/Docker/1.24"
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -1792,6 +1801,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Docker
@@ -2083,6 +2093,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: GCP/Containerd/1.20"
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -2135,6 +2146,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -2426,6 +2438,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: GCP/Containerd/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -2478,6 +2491,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -2769,6 +2783,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: GCP/Containerd/1.22"
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -2821,6 +2836,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -3112,6 +3128,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: GCP/Containerd/1.23"
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -3164,6 +3181,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -3455,6 +3473,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: GCP/Containerd/1.24"
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Containerd
@@ -3507,6 +3526,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: GCP
           CRI: Containerd

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -368,6 +368,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Docker/1.20"
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -420,6 +421,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -711,6 +713,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Docker/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -763,6 +766,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -1054,6 +1058,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Docker/1.22"
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -1106,6 +1111,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -1397,6 +1403,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Docker/1.23"
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -1449,6 +1456,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -1740,6 +1748,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Docker/1.24"
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -1792,6 +1801,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Docker
@@ -2083,6 +2093,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Containerd/1.20"
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -2135,6 +2146,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -2426,6 +2438,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Containerd/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -2478,6 +2491,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -2769,6 +2783,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Containerd/1.22"
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -2821,6 +2836,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -3112,6 +3128,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Containerd/1.23"
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -3164,6 +3181,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -3455,6 +3473,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: OpenStack/Containerd/1.24"
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Containerd
@@ -3507,6 +3526,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: OpenStack
           CRI: Containerd

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -368,6 +368,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Static/Docker/1.20"
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Docker
@@ -420,6 +421,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Docker
@@ -711,6 +713,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Static/Docker/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Docker
@@ -763,6 +766,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Docker
@@ -1054,6 +1058,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Static/Docker/1.22"
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Docker
@@ -1106,6 +1111,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Docker
@@ -1397,6 +1403,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Static/Docker/1.23"
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Docker
@@ -1449,6 +1456,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Docker
@@ -1740,6 +1748,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Static/Docker/1.24"
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Docker
@@ -1792,6 +1801,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Docker
@@ -2083,6 +2093,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Static/Containerd/1.20"
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -2135,6 +2146,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -2426,6 +2438,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Static/Containerd/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -2478,6 +2491,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -2769,6 +2783,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Static/Containerd/1.22"
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -2821,6 +2836,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -3112,6 +3128,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Static/Containerd/1.23"
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -3164,6 +3181,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -3455,6 +3473,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Static/Containerd/1.24"
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Containerd
@@ -3507,6 +3526,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Static
           CRI: Containerd

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -368,6 +368,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Docker/1.20"
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -422,6 +423,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -715,6 +717,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Docker/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -769,6 +772,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -1062,6 +1066,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Docker/1.22"
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -1116,6 +1121,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -1409,6 +1415,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Docker/1.23"
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -1463,6 +1470,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -1756,6 +1764,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Docker/1.24"
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -1810,6 +1819,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Docker
@@ -2103,6 +2113,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Containerd/1.20"
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -2157,6 +2168,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -2450,6 +2462,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Containerd/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -2504,6 +2517,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -2797,6 +2811,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Containerd/1.22"
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -2851,6 +2866,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -3144,6 +3160,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Containerd/1.23"
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -3198,6 +3215,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -3491,6 +3509,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: vSphere/Containerd/1.24"
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Containerd
@@ -3545,6 +3564,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: vSphere
           CRI: Containerd

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -368,6 +368,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.20"
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -424,6 +425,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -719,6 +721,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -775,6 +778,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -1070,6 +1074,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.22"
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -1126,6 +1131,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -1421,6 +1427,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.23"
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -1477,6 +1484,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -1772,6 +1780,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Docker/1.24"
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -1828,6 +1837,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Docker
@@ -2123,6 +2133,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.20"
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -2179,6 +2190,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -2474,6 +2486,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.21"
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -2530,6 +2543,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -2825,6 +2839,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.22"
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -2881,6 +2896,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -3176,6 +3192,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.23"
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -3232,6 +3249,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -3527,6 +3545,7 @@ jobs:
           echo '::echo::off'
 
       - name: "Run e2e test: Yandex.Cloud/Containerd/1.24"
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd
@@ -3583,6 +3602,7 @@ jobs:
 
       - name: Cleanup bootstrapped cluster
         if: always()
+        timeout-minutes: 60
         env:
           PROVIDER: Yandex.Cloud
           CRI: Containerd


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Add timeout for bootstrap and cleanup e2e cluster steps

## Why do we need it, and what problem does it solve?
Cluster bootstrap/cleanup jobs can stuck. For example, we had situation when e2e for static cluster can not finish because ssh-client stuck without responsibility and job did not finish. Now, we limit job execution with [timeout-minutes field](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes)

## What is the expected result?
[Tested here](https://github.com/deckhouse/deckhouse-test-2/actions/runs/3130665891)

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: feature
summary: Add timeout for bootstrap and cleanup e2e cluster steps
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
