### PR TITLE
[prometheus] Bump grafana to 8.5.13 to fix input lag

### DIFF
--- a/modules/300-prometheus/images/grafana/Dockerfile
+++ b/modules/300-prometheus/images/grafana/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_ALPINE
 ARG BASE_NODE_16_ALPINE
 ARG BASE_GOLANG_17_BUSTER
 ARG BASE_DEBIAN
-ARG GRAFANA_VERSION="8.5.9"
+ARG GRAFANA_VERSION="8.5.13"
 ARG STATUSMAP_VERSION="0.5.1"
 ARG BUNDLED_PLUGINS="grafana-image-renderer,petrslavotinek-carpetplot-panel,vonage-status-panel,btplc-status-dot-panel,natel-plotly-panel,savantly-heatmap-panel,grafana-piechart-panel,grafana-worldmap-panel"
 


### PR DESCRIPTION
## Description

Input lags in Grafana were reported by users. This PR bumps Grafana patch version that fixes the problem.

## Why do we need it, and what problem does it solve?

Fix UX in Grafana.

## What is the expected result?

No input lag in grafana inputs.

## Checklist
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: prometheus
type: fix
summary: Fixed input lag by bumping grafana version to 8.5.13
```
