### PR TITLE
[tools] fix d8-pull.sh script for CE edition

### DIFF
--- a/tools/release/d8-pull.sh
+++ b/tools/release/d8-pull.sh
@@ -125,12 +125,14 @@ check_requirements() {
     return 1
   fi
 
-  if [[ "$EDITION" == "ee" ]] && [[ "$LICENSE" == "" ]]; then
-    echo "License is required to download Deckhouse Enterprise Edition. Please provide it with CLI argument --license."
-    return 1
-  else
-    docker login -u license-token -p "$LICENSE" $REGISTRY_ROOT
-    crane auth login $REGISTRY_ROOT -u license-token -p "$LICENSE"
+  if [[ "$EDITION" == "ee" ]]; then
+    if [[ "$LICENSE" == "" ]]; then
+      echo "License is required to download Deckhouse Enterprise Edition. Please provide it with CLI argument --license."
+      return 1
+    else
+      docker login -u license-token -p "$LICENSE" $REGISTRY_ROOT
+      crane auth login $REGISTRY_ROOT -u license-token -p "$LICENSE"
+    fi
   fi
 
   mkdir -p "$OUTPUT_DIR"


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
CE does not need docker login

## Why do we need it, and what problem does it solve?
Currently script fails on CE without license

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: tools
type: fix 
summary: Fix d8-pull.sh script for CE
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
