### PR TITLE
[flant-integration] Fix erronous control-plane accounting in VMs

### DIFF
--- a/ee/modules/600-flant-integration/images/flant-pricing/hooks/node_metrics.sh
+++ b/ee/modules/600-flant-integration/images/flant-pricing/hooks/node_metrics.sh
@@ -24,9 +24,9 @@ function __config__() {
           operator: Exists
 
       # We do not charge for control plane nodes which are in desired state
-      #   1. we check it is from non-master node group, we charge for it
+      #   1. we check the node is NOT control plane node group, so we charge for it
       #   OR
-      #   2. we check it is from master node group, BUT has unexpected taints
+      #   2. the node is from control plane node group, BUT has no expected taints
       #      meaning they were reconfigured by user
 
       jqFilter: |

--- a/ee/modules/600-flant-integration/images/flant-pricing/hooks/node_metrics.sh
+++ b/ee/modules/600-flant-integration/images/flant-pricing/hooks/node_metrics.sh
@@ -22,12 +22,37 @@ function __config__() {
         matchExpressions:
         - key: "node.deckhouse.io/group"
           operator: Exists
+
+      # We do not charge for control plane nodes which are in desired state
+      #   1. we check it is from non-master node group, we charge for it
+      #   OR
+      #   2. we check it is from master node group, BUT has unexpected taints
+      #      meaning they were reconfigured by user
+
       jqFilter: |
-        select((.metadata.labels."node.deckhouse.io/group" == "master" and (.spec.taints == null or .spec.taints[].key != "node-role.kubernetes.io/control-plane")) or .metadata.labels."node.deckhouse.io/group" != "master") |
-        {
-          "nodeGroup": .metadata.labels."node.deckhouse.io/group",
-          "pricingNodeType": (.metadata.annotations."pricing.flant.com/nodeType" // "unknown"),
-          "virtualization": (.metadata.annotations."node.deckhouse.io/virtualization" // "unknown")
+        select(
+          (
+            .metadata.labels."node.deckhouse.io/group" != "master"
+            or
+            (
+              .spec.taints == null
+              or
+              (
+                [
+                  .spec.taints[]
+                  | select(
+                    .key == "node-role.kubernetes.io/control-plane" or
+                    .key == "node-role.kubernetes.io/master"
+                  )
+                ]
+                | length == 0
+              )
+            )
+          )
+        | {
+          "nodeGroup":        .metadata.labels."node.deckhouse.io/group",
+          "pricingNodeType": (.metadata.annotations."pricing.flant.com/nodeType"       // "unknown"),
+          "virtualization":  (.metadata.annotations."node.deckhouse.io/virtualization" // "unknown")
         }
     - name: ngs
       group: main

--- a/ee/modules/600-flant-integration/images/flant-pricing/hooks/node_metrics.sh
+++ b/ee/modules/600-flant-integration/images/flant-pricing/hooks/node_metrics.sh
@@ -31,24 +31,23 @@ function __config__() {
 
       jqFilter: |
         select(
+          .metadata.labels."node.deckhouse.io/group" != "master"
+          or
           (
-            .metadata.labels."node.deckhouse.io/group" != "master"
+            .spec.taints == null
             or
             (
-              .spec.taints == null
-              or
-              (
-                [
-                  .spec.taints[]
-                  | select(
-                    .key == "node-role.kubernetes.io/control-plane" or
-                    .key == "node-role.kubernetes.io/master"
-                  )
-                ]
-                | length == 0
-              )
+              [
+                .spec.taints[]
+                | select(
+                  .key == "node-role.kubernetes.io/control-plane" or
+                  .key == "node-role.kubernetes.io/master"
+                )
+              ]
+              | length == 0
             )
           )
+        )
         | {
           "nodeGroup":        .metadata.labels."node.deckhouse.io/group",
           "pricingNodeType": (.metadata.annotations."pricing.flant.com/nodeType"       // "unknown"),


### PR DESCRIPTION
## Description

Fixes the bug where we count control plane nodes as VMs for charge.

## Why do we need it, and what problem does it solve?

Fixes telemetry correctness

## Checklist
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: flant-integration
type: fix
summary: Fixed telemetry reporting control-plane nodes as nodes for charge.
```
