### PR TITLE
[log-shipper] Fix many source to one destination pipelines

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,6 +18,8 @@ linters-settings:
       - standard
       - default
       - prefix(github.com/deckhouse/)
+  goimports:
+    local-prefixes: github.com/deckhouse/
   errcheck:
     ignore: fmt:.*,[rR]ead|[wW]rite|[cC]lose,io:Copy
 

--- a/go_lib/set/set.go
+++ b/go_lib/set/set.go
@@ -17,6 +17,7 @@ limitations under the License.
 package set
 
 import (
+	"encoding/json"
 	"sort"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -103,4 +104,8 @@ func (s Set) Slice() []string {
 
 func (s Set) Size() int {
 	return len(s)
+}
+
+func (s Set) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.Slice())
 }

--- a/modules/460-log-shipper/hooks/generate_config_test.go
+++ b/modules/460-log-shipper/hooks/generate_config_test.go
@@ -912,4 +912,67 @@ spec:
 			})
 		})
 	})
+
+	Context("Two sources to single destination", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLoggingConfig
+metadata:
+  name: test-file
+spec:
+  type: File
+  file:
+    include: ["/var/log/kube-audit/audit.log"]
+  destinationRefs:
+    - test-vector-dest
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLoggingConfig
+metadata:
+  name: test-kubernetes
+spec:
+  type: KubernetesPods
+  destinationRefs:
+    - test-vector-dest
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLogDestination
+metadata:
+  name: test-vector-dest
+spec:
+  type: Vector
+  vector:
+    endpoint: "192.168.1.1:9200"
+    tls:
+      verifyCertificate: false
+      verifyHostname: false
+---
+`))
+			f.RunHook()
+		})
+
+		It("Should create secret", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			Expect(f.ValuesGet("logShipper.internal.activated").Bool()).To(BeTrue())
+
+			secret := f.KubernetesResource("Secret", "d8-log-shipper", "d8-log-shipper-config")
+			Expect(secret).To(Not(BeEmpty()))
+
+			assertConfig(secret, "many-to-one.json")
+		})
+		Context("With deleting object", func() {
+			BeforeEach(func() {
+				f.BindingContexts.Set(f.KubeStateSet(""))
+				f.RunHook()
+			})
+			It("Should delete secret and deactivate module", func() {
+				Expect(f).To(ExecuteSuccessfully())
+				Expect(f.ValuesGet("logShipper.internal.activated").Bool()).To(BeFalse())
+				Expect(f.KubernetesResource("Secret", "d8-log-shipper", "d8-log-shipper-config").Exists()).To(BeFalse())
+			})
+		})
+	})
+
 })

--- a/modules/460-log-shipper/hooks/internal/vector/destination/common.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/common.go
@@ -18,13 +18,17 @@ package destination
 
 import (
 	"encoding/base64"
-	"sort"
+
+	"github.com/deckhouse/deckhouse/go_lib/set"
+	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis"
 )
+
+var _ apis.LogDestination = (*CommonSettings)(nil)
 
 type CommonSettings struct {
 	Name        string      `json:"-"`
 	Type        string      `json:"type"`
-	Inputs      []string    `json:"inputs,omitempty"`
+	Inputs      set.Set     `json:"inputs,omitempty"`
 	Healthcheck Healthcheck `json:"healthcheck"`
 	Buffer      Buffer      `json:"buffer,omitempty"`
 }
@@ -48,8 +52,7 @@ type Buffer struct {
 }
 
 func (cs *CommonSettings) SetInputs(inp []string) {
-	sort.Strings(inp)
-	cs.Inputs = inp
+	cs.Inputs.Add(inp...)
 }
 
 func (cs *CommonSettings) GetName() string {

--- a/modules/460-log-shipper/hooks/internal/vector/destination/elasticsearch.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/elasticsearch.go
@@ -19,6 +19,7 @@ package destination
 import (
 	"strings"
 
+	"github.com/deckhouse/deckhouse/go_lib/set"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis/v1alpha1"
 )
 
@@ -112,8 +113,9 @@ func NewElasticsearch(name string, cspec v1alpha1.ClusterLogDestinationSpec) *El
 
 	return &Elasticsearch{
 		CommonSettings: CommonSettings{
-			Name: ComposeName(name),
-			Type: "elasticsearch",
+			Name:   ComposeName(name),
+			Type:   "elasticsearch",
+			Inputs: set.New(),
 		},
 		Auth: ElasticsearchAuth{
 			AwsAccessKey:  decodeB64(spec.Auth.AwsAccessKey),

--- a/modules/460-log-shipper/hooks/internal/vector/destination/logstash.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/logstash.go
@@ -17,6 +17,7 @@ limitations under the License.
 package destination
 
 import (
+	"github.com/deckhouse/deckhouse/go_lib/set"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis/v1alpha1"
 )
 
@@ -72,8 +73,9 @@ func NewLogstash(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Logstas
 
 	return &Logstash{
 		CommonSettings: CommonSettings{
-			Name: ComposeName(name),
-			Type: "socket",
+			Name:   ComposeName(name),
+			Type:   "socket",
+			Inputs: set.New(),
 		},
 		Encoding: LogstashEncoding{
 			Codec:           "json",

--- a/modules/460-log-shipper/hooks/internal/vector/destination/loki.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/loki.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/deckhouse/deckhouse/go_lib/set"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis/v1alpha1"
 )
 
@@ -117,8 +118,9 @@ func NewLoki(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Loki {
 
 	return &Loki{
 		CommonSettings: CommonSettings{
-			Name: ComposeName(name),
-			Type: "loki",
+			Name:   ComposeName(name),
+			Type:   "loki",
+			Inputs: set.New(),
 		},
 		Auth: LokiAuth{
 			User:     spec.Auth.User,

--- a/modules/460-log-shipper/hooks/internal/vector/destination/vector.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/vector.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package destination
 
-import "github.com/deckhouse/deckhouse/modules/460-log-shipper/apis/v1alpha1"
+import (
+	"github.com/deckhouse/deckhouse/go_lib/set"
+	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis/v1alpha1"
+)
 
 type Vector struct {
 	CommonSettings
@@ -61,8 +64,9 @@ func NewVector(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Vector {
 
 	return &Vector{
 		CommonSettings: CommonSettings{
-			Name: ComposeName(name),
-			Type: "vector",
+			Name:   ComposeName(name),
+			Type:   "vector",
+			Inputs: set.New(),
 		},
 		TLS:     tls,
 		Version: "2",

--- a/modules/460-log-shipper/hooks/internal/vector/source/file.go
+++ b/modules/460-log-shipper/hooks/internal/vector/source/file.go
@@ -21,6 +21,8 @@ import (
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis/v1alpha1"
 )
 
+var _ apis.LogSource = (*File)(nil)
+
 // File represents `file` vector source
 // https://vector.dev/docs/reference/configuration/sources/file/
 type File struct {

--- a/modules/460-log-shipper/hooks/internal/vector/source/kubernetes.go
+++ b/modules/460-log-shipper/hooks/internal/vector/source/kubernetes.go
@@ -27,6 +27,8 @@ import (
 
 const defaultGlobCooldownMs = 1000
 
+var _ apis.LogSource = (*Kubernetes)(nil)
+
 // Kubernetes represents a source for collecting Kubernetes logs.
 //
 // Because of how selectors work in Kubernetes, it is not possible to declare OR selector.

--- a/modules/460-log-shipper/hooks/internal/vector/transform/elasticsearch.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/elasticsearch.go
@@ -17,14 +17,16 @@ limitations under the License.
 package transform
 
 import (
+	"github.com/deckhouse/deckhouse/go_lib/set"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/hooks/internal/vrl"
 )
 
 func DeDotTransform() *DynamicTransform {
 	return &DynamicTransform{
 		CommonTransform: CommonTransform{
-			Name: "elastic_dedot",
-			Type: "remap",
+			Name:   "elastic_dedot",
+			Type:   "remap",
+			Inputs: set.New(),
 		},
 		DynamicArgsMap: map[string]interface{}{
 			"source":        vrl.DeDotRule.String(),
@@ -36,8 +38,9 @@ func DeDotTransform() *DynamicTransform {
 func DataStreamTransform() *DynamicTransform {
 	return &DynamicTransform{
 		CommonTransform: CommonTransform{
-			Name: "elastic_stream",
-			Type: "remap",
+			Name:   "elastic_stream",
+			Type:   "remap",
+			Inputs: set.New(),
 		},
 		DynamicArgsMap: map[string]interface{}{
 			"source":        vrl.StreamRule.String(),
@@ -49,8 +52,9 @@ func DataStreamTransform() *DynamicTransform {
 func CleanUpParsedDataTransform() *DynamicTransform {
 	return &DynamicTransform{
 		CommonTransform: CommonTransform{
-			Name: "del_parsed_data",
-			Type: "remap",
+			Name:   "del_parsed_data",
+			Type:   "remap",
+			Inputs: set.New(),
 		},
 		DynamicArgsMap: map[string]interface{}{
 			"source":        vrl.ParsedDataCleanUpRule.String(),

--- a/modules/460-log-shipper/hooks/internal/vector/transform/extra_fields.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/extra_fields.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/deckhouse/deckhouse/go_lib/set"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/hooks/internal/vrl"
 )
 
@@ -95,8 +96,9 @@ func ExtraFieldTransform(extraFields map[string]string) *DynamicTransform {
 
 	extraFieldsTransform := DynamicTransform{
 		CommonTransform: CommonTransform{
-			Name: "extra_fields",
-			Type: "remap",
+			Name:   "extra_fields",
+			Type:   "remap",
+			Inputs: set.New(),
 		},
 		DynamicArgsMap: map[string]interface{}{
 			"source":        vrl.Combine(vrl.ParseJSONRule, vrl.Rule(strings.Join(tmpFields, ""))).String(),

--- a/modules/460-log-shipper/hooks/internal/vector/transform/filter.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/filter.go
@@ -19,6 +19,7 @@ package transform
 import (
 	"strings"
 
+	"github.com/deckhouse/deckhouse/go_lib/set"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis/v1alpha1"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/hooks/internal/vrl"
@@ -27,8 +28,9 @@ import (
 func CreateParseDataTransforms() *DynamicTransform {
 	return &DynamicTransform{
 		CommonTransform: CommonTransform{
-			Name: "parse_json",
-			Type: "remap",
+			Name:   "parse_json",
+			Type:   "remap",
+			Inputs: set.New(),
 		},
 		DynamicArgsMap: map[string]interface{}{
 			"source":        vrl.ParseJSONRule.String(),
@@ -48,7 +50,10 @@ func CreateLogFilterTransforms(filters []v1alpha1.Filter) ([]apis.LogTransform, 
 	if err != nil {
 		return nil, err
 	}
-	return append([]apis.LogTransform{CreateParseDataTransforms()}, transforms...), nil
+	if len(transforms) > 0 {
+		transforms = append([]apis.LogTransform{CreateParseDataTransforms()}, transforms...)
+	}
+	return transforms, nil
 }
 
 func CreateLabelFilterTransforms(filters []v1alpha1.Filter) ([]apis.LogTransform, error) {
@@ -75,8 +80,9 @@ func createFilterTransform(name string, filters []v1alpha1.Filter, mutate mutate
 
 		transforms = append(transforms, &DynamicTransform{
 			CommonTransform: CommonTransform{
-				Name: name,
-				Type: "filter",
+				Name:   name,
+				Type:   "filter",
+				Inputs: set.New(),
 			},
 			DynamicArgsMap: map[string]interface{}{
 				"condition": condition,

--- a/modules/460-log-shipper/hooks/internal/vector/transform/multiline.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/multiline.go
@@ -17,6 +17,7 @@ limitations under the License.
 package transform
 
 import (
+	"github.com/deckhouse/deckhouse/go_lib/set"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis/v1alpha1"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/hooks/internal/vrl"
@@ -25,8 +26,9 @@ import (
 func CreateMultiLineTransforms(multiLineType v1alpha1.MultiLineParserType) []apis.LogTransform {
 	multiLineTransform := DynamicTransform{
 		CommonTransform: CommonTransform{
-			Name: "multiline",
-			Type: "reduce",
+			Name:   "multiline",
+			Type:   "reduce",
+			Inputs: set.New(),
 		},
 		DynamicArgsMap: map[string]interface{}{
 			"group_by": []string{

--- a/modules/460-log-shipper/hooks/internal/vector/transform/source.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/source.go
@@ -19,6 +19,7 @@ package transform
 import (
 	"fmt"
 
+	"github.com/deckhouse/deckhouse/go_lib/set"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis/v1alpha1"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/hooks/internal/vrl"
@@ -27,8 +28,9 @@ import (
 func OwnerReferenceSourceTransform() *DynamicTransform {
 	return &DynamicTransform{
 		CommonTransform: CommonTransform{
-			Name: "owner_ref",
-			Type: "remap",
+			Name:   "owner_ref",
+			Type:   "remap",
+			Inputs: set.New(),
 		},
 		DynamicArgsMap: map[string]interface{}{
 			"source":        vrl.OwnerReferenceRule.String(),
@@ -40,8 +42,9 @@ func OwnerReferenceSourceTransform() *DynamicTransform {
 func CleanUpAfterSourceTransform() *DynamicTransform {
 	return &DynamicTransform{
 		CommonTransform: CommonTransform{
-			Name: "clean_up",
-			Type: "remap",
+			Name:   "clean_up",
+			Type:   "remap",
+			Inputs: set.New(),
 		},
 		DynamicArgsMap: map[string]interface{}{
 			"source":        vrl.CleanUpAfterSourceRule.String(),

--- a/modules/460-log-shipper/hooks/internal/vector/transform/testdata/extra-labels.json
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/testdata/extra-labels.json
@@ -1,9 +1,7 @@
 [
 	{
 		"drop_on_abort": false,
-		"inputs": [
-			"testit"
-		],
+		"inputs": [],
 		"source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}\n\nif exists(.parsed_data.\"pay-load\"[0].a) { .aaa=.parsed_data.\"pay-load\"[0].a } \n .aba=\"bbb\" \n if exists(.parsed_data.test.\"pay.lo.ad\".\"hel.lo\".world) { .aca=.parsed_data.test.\"pay.lo.ad\".\"hel.lo\".world } \n if exists(.parsed_data.\"pay.lo\".test) { .adc=.parsed_data.\"pay.lo\".test } \n if exists(.parsed_data.test.\"pay.lo\") { .add=.parsed_data.test.\"pay.lo\" } \n if exists(.parsed_data.\"pay.lo\"[3].\"te.st\") { .bdc=.parsed_data.\"pay.lo\"[3].\"te.st\" }",
 		"type": "remap"
 	}

--- a/modules/460-log-shipper/hooks/internal/vector/transform/testdata/filters.json
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/testdata/filters.json
@@ -1,9 +1,7 @@
 [
 	{
 		"drop_on_abort": false,
-		"inputs": [
-			"testit"
-		],
+		"inputs": [],
 		"source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
 		"type": "remap"
 	},

--- a/modules/460-log-shipper/hooks/internal/vector/transform/testdata/multiline.json
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/testdata/multiline.json
@@ -4,9 +4,7 @@
 			"file",
 			"stream"
 		],
-		"inputs": [
-			"testit"
-		],
+		"inputs": [],
 		"merge_strategies": {
 			"message": "concat"
 		},

--- a/modules/460-log-shipper/hooks/internal/vector/transform/throttle.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/throttle.go
@@ -17,6 +17,7 @@ limitations under the License.
 package transform
 
 import (
+	"github.com/deckhouse/deckhouse/go_lib/set"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis/v1alpha1"
 )
 
@@ -24,8 +25,9 @@ import (
 func ThrottleTransform(rl v1alpha1.RateLimitSpec) *DynamicTransform {
 	throttleTransform := DynamicTransform{
 		CommonTransform: CommonTransform{
-			Name: "ratelimit",
-			Type: "throttle",
+			Name:   "ratelimit",
+			Type:   "throttle",
+			Inputs: set.New(),
 		},
 		DynamicArgsMap: map[string]interface{}{
 			"exclude":     "null",

--- a/modules/460-log-shipper/hooks/internal/vector/transform/transforms.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/transforms.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/clarketm/json"
+
 	"github.com/deckhouse/deckhouse/go_lib/set"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis"
 )

--- a/modules/460-log-shipper/hooks/internal/vector/transform/transforms.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/transforms.go
@@ -17,32 +17,35 @@ limitations under the License.
 package transform
 
 import (
-	"errors"
 	"fmt"
-	"sort"
 
 	"github.com/clarketm/json"
-
+	"github.com/deckhouse/deckhouse/go_lib/set"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis"
 )
 
-func BuildFromMapSlice(prefix, inputName string, trans []apis.LogTransform) ([]apis.LogTransform, error) {
-	prevInput := inputName
+func BuildFromMapSlice(prefix, inputName string, transforms []apis.LogTransform) ([]apis.LogTransform, error) {
+	prevInput := ""
 
-	for i, trm := range trans {
-		trm.SetName(fmt.Sprintf("transform/%s/%s/%02d_%s", prefix, inputName, i, trm.GetName()))
-		trm.SetInputs([]string{prevInput})
-		prevInput = trm.GetName()
-		trans[i] = trm
+	for i, transform := range transforms {
+		name := fmt.Sprintf("transform/%s/%s/%02d_%s", prefix, inputName, i, transform.GetName())
+
+		transform.SetName(name)
+		if prevInput != "" {
+			transform.SetInputs([]string{prevInput})
+		}
+
+		prevInput = transform.GetName()
+		transforms[i] = transform
 	}
 
-	return trans, nil
+	return transforms, nil
 }
 
 type CommonTransform struct {
-	Name   string   `json:"-"`
-	Type   string   `json:"type"`
-	Inputs []string `json:"inputs"`
+	Name   string  `json:"-"`
+	Type   string  `json:"type"`
+	Inputs set.Set `json:"inputs"`
 }
 
 func (cs *CommonTransform) GetName() string {
@@ -57,12 +60,11 @@ func (cs *CommonTransform) SetName(name string) {
 }
 
 func (cs *CommonTransform) SetInputs(inp []string) {
-	sort.Strings(inp)
-	cs.Inputs = inp
+	cs.Inputs.Add(inp...)
 }
 
 func (cs *CommonTransform) GetInputs() []string {
-	return cs.Inputs
+	return cs.Inputs.Slice()
 }
 
 type DynamicTransform struct {
@@ -85,37 +87,4 @@ func (t *DynamicTransform) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(m)
-}
-
-func (t *DynamicTransform) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	// TODO(nabokihms): I fixed this function, but it previously did not work, yet results are the same in all tests
-	var transformMap map[string]interface{}
-	err := unmarshal(&transformMap)
-	if err != nil {
-		return err
-	}
-
-	tstr, ok := transformMap["type"].(string)
-	if !ok {
-		return errors.New("the `type` is required and it has to be of the string type")
-	}
-
-	inp, ok := transformMap["inputs"].([]string)
-	if !ok {
-		inp = make([]string, 0)
-	}
-
-	delete(transformMap, "inputs")
-	delete(transformMap, "type")
-
-	// nolint: ineffassign
-	t = &DynamicTransform{
-		CommonTransform: CommonTransform{
-			Type:   tstr,
-			Inputs: inp,
-		},
-		DynamicArgsMap: transformMap,
-	}
-
-	return nil
 }

--- a/modules/460-log-shipper/hooks/internal/vector/transform/transforms_test.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/transforms_test.go
@@ -88,7 +88,7 @@ func TestTransformSnippet(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Len(t, tr, 5)
-		assert.Equal(t, (tr[0].GetInputs())[0], "testit")
+		assert.Len(t, tr[0].GetInputs(), 0)
 
 		data, err := json.MarshalIndent(tr, "", "\t")
 		require.NoError(t, err)
@@ -113,7 +113,7 @@ func TestTransformSnippet(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Len(t, tr, 1)
-		assert.Equal(t, (tr[0].GetInputs())[0], "testit")
+		assert.Len(t, tr[0].GetInputs(), 0)
 
 		data, err := json.MarshalIndent(tr, "", "\t")
 		require.NoError(t, err)
@@ -148,7 +148,7 @@ func TestTransformSnippet(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Len(t, tr, 1)
-		assert.Equal(t, (tr[0].GetInputs())[0], "testit")
+		assert.Len(t, tr[0].GetInputs(), 0)
 
 		data, err := json.MarshalIndent(tr, "", "\t")
 		require.NoError(t, err)

--- a/modules/460-log-shipper/hooks/testdata/file-to-elastic.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-elastic.json
@@ -11,7 +11,7 @@
     "transform/destination/test-es-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/01_parse_json"
+        "transform/source/test-source/00_clean_up"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -30,14 +30,6 @@
         "cluster_logging_config/test-source"
       ],
       "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
-      "type": "remap"
-    },
-    "transform/source/test-source/01_parse_json": {
-      "drop_on_abort": false,
-      "inputs": [
-        "transform/source/test-source/00_clean_up"
-      ],
-      "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
       "type": "remap"
     }
   },

--- a/modules/460-log-shipper/hooks/testdata/file-to-vector.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-vector.json
@@ -11,7 +11,7 @@
     "transform/destination/test-vector-dest/00_del_parsed_data": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/01_parse_json"
+        "transform/source/test-source/00_clean_up"
       ],
       "source": "if exists(.parsed_data) {\n    del(.parsed_data)\n}",
       "type": "remap"
@@ -22,14 +22,6 @@
         "cluster_logging_config/test-source"
       ],
       "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
-      "type": "remap"
-    },
-    "transform/source/test-source/01_parse_json": {
-      "drop_on_abort": false,
-      "inputs": [
-        "transform/source/test-source/00_clean_up"
-      ],
-      "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
       "type": "remap"
     }
   },

--- a/modules/460-log-shipper/hooks/testdata/many-to-one.json
+++ b/modules/460-log-shipper/hooks/testdata/many-to-one.json
@@ -1,0 +1,75 @@
+{
+  "sources": {
+    "cluster_logging_config/test-file": {
+      "type": "file",
+      "include": [
+        "/var/log/kube-audit/audit.log"
+      ]
+    },
+    "cluster_logging_config/test-kubernetes": {
+      "type": "kubernetes_logs",
+      "extra_label_selector": "log-shipper.deckhouse.io/exclude notin (true)",
+      "extra_field_selector": "metadata.name!=$VECTOR_SELF_POD_NAME",
+      "extra_namespace_label_selector": "log-shipper.deckhouse.io/exclude notin (true)",
+      "annotation_fields": {
+        "container_image": "image",
+        "container_name": "container",
+        "pod_ip": "pod_ip",
+        "pod_labels": "pod_labels",
+        "pod_name": "pod",
+        "pod_namespace": "namespace",
+        "pod_node_name": "node",
+        "pod_owner": "pod_owner"
+      },
+      "glob_minimum_cooldown_ms": 1000
+    }
+  },
+  "transforms": {
+    "transform/destination/test-vector-dest/00_del_parsed_data": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/test-file/00_clean_up",
+        "transform/source/test-kubernetes/01_clean_up"
+      ],
+      "source": "if exists(.parsed_data) {\n    del(.parsed_data)\n}",
+      "type": "remap"
+    },
+    "transform/source/test-file/00_clean_up": {
+      "drop_on_abort": false,
+      "inputs": [
+        "cluster_logging_config/test-file"
+      ],
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "type": "remap"
+    },
+    "transform/source/test-kubernetes/00_owner_ref": {
+      "drop_on_abort": false,
+      "inputs": [
+        "cluster_logging_config/test-kubernetes"
+      ],
+      "source": "if exists(.pod_owner) {\n    .pod_owner = string!(.pod_owner)\n\n    if starts_with(.pod_owner, \"ReplicaSet/\") {\n        hash = \"-\"\n        if exists(.pod_labels.\"pod-template-hash\") {\n            hash = hash + string!(.pod_labels.\"pod-template-hash\")\n        }\n\n        if hash != \"-\" \u0026\u0026 ends_with(.pod_owner, hash) {\n            .pod_owner = replace(.pod_owner, \"ReplicaSet/\", \"Deployment/\")\n            .pod_owner = replace(.pod_owner, hash, \"\")\n        }\n    }\n\n    if starts_with(.pod_owner, \"Job/\") {\n        if match(.pod_owner, r'-[0-9]{8,11}$') {\n            .pod_owner = replace(.pod_owner, \"Job/\", \"CronJob/\")\n            .pod_owner = replace(.pod_owner, r'-[0-9]{8,11}$', \"\")\n        }\n    }\n}",
+      "type": "remap"
+    },
+    "transform/source/test-kubernetes/01_clean_up": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/test-kubernetes/00_owner_ref"
+      ],
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "type": "remap"
+    }
+  },
+  "sinks": {
+    "destination/cluster/test-vector-dest": {
+      "type": "vector",
+      "inputs": [
+        "transform/destination/test-vector-dest/00_del_parsed_data"
+      ],
+      "healthcheck": {
+        "enabled": false
+      },
+      "version": "2",
+      "address": "192.168.1.1:9200"
+    }
+  }
+}

--- a/modules/460-log-shipper/hooks/testdata/multiline.json
+++ b/modules/460-log-shipper/hooks/testdata/multiline.json
@@ -22,7 +22,7 @@
     "transform/destination/test-es-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/tests-whispers_whispers-logs/03_parse_json"
+        "transform/source/tests-whispers_whispers-logs/02_multiline"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -72,14 +72,6 @@
       },
       "starts_when": "matched, err = match(.message, r'^\\{');\nif err != null {\n    false;\n} else {\n    matched;\n}",
       "type": "reduce"
-    },
-    "transform/source/tests-whispers_whispers-logs/03_parse_json": {
-      "drop_on_abort": false,
-      "inputs": [
-        "transform/source/tests-whispers_whispers-logs/02_multiline"
-      ],
-      "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
-      "type": "remap"
     }
   },
   "sinks": {

--- a/modules/460-log-shipper/hooks/testdata/one-dest.json
+++ b/modules/460-log-shipper/hooks/testdata/one-dest.json
@@ -39,7 +39,7 @@
     "transform/destination/test-es-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/02_parse_json"
+        "transform/source/test-source/01_clean_up"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -75,14 +75,6 @@
         "transform/source/test-source/00_owner_ref"
       ],
       "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
-      "type": "remap"
-    },
-    "transform/source/test-source/02_parse_json": {
-      "drop_on_abort": false,
-      "inputs": [
-        "transform/source/test-source/01_clean_up"
-      ],
-      "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
       "type": "remap"
     }
   },

--- a/modules/460-log-shipper/hooks/testdata/throttle.json
+++ b/modules/460-log-shipper/hooks/testdata/throttle.json
@@ -22,7 +22,7 @@
     "transform/destination/test-es-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
-        "transform/source/test-source/02_parse_json"
+        "transform/source/test-source/01_clean_up"
       ],
       "source": "if exists(.pod_labels) {\n    .pod_labels = map_keys(object!(.pod_labels), recursive: true) -\u003e |key| { replace(key, \".\", \"_\") }\n}",
       "type": "remap"
@@ -58,14 +58,6 @@
         "transform/source/test-source/00_owner_ref"
       ],
       "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
-      "type": "remap"
-    },
-    "transform/source/test-source/02_parse_json": {
-      "drop_on_abort": false,
-      "inputs": [
-        "transform/source/test-source/01_clean_up"
-      ],
-      "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
       "type": "remap"
     }
   },


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Two bugs were spotted and fixed:
* Parse JSON rule is added even if there are no log filter rules.
* Only the last works for many sources that point to a single destination.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: log-shipper
type: fix
summary: Stop generating pointless 'parse_json' transform, which improves performance.
impact_level: default
---
section: log-shipper
type: fix
summary: Fix the bug when the many sources point to the same input and only the last is working.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
