### PR TITLE
[linstor] Improve kernel-headers detection for centos

### DIFF
--- a/modules/041-linstor/templates/nodegroupconfiguration-install-kernel-headers.yaml
+++ b/modules/041-linstor/templates/nodegroupconfiguration-install-kernel-headers.yaml
@@ -21,27 +21,31 @@ spec:
     # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     # See the License for the specific language governing permissions and
     # limitations under the License.
-    
+
     # DRBD kernel-module-injector requires the kernel sources to be installed.
 
-    # Install actual kernel headers
     version_in_use="$(uname -r)"
     if bb-is-distro-like? centos; then
-      bb-yum-install "kernel-devel-${version_in_use}"
-    fi
-    if bb-is-distro-like? debian; then
-      bb-apt-install "linux-headers-${version_in_use}"
-    fi
+      # Install actual kernel headers
+      #   kernel         --> kernel-devel
+      #   kernel-core    --> kernel-devel
+      #   kernel-lt      --> kernel-lt-devel
+      #   kernel-lt-core --> kernel-lt-devel
+      package_name="$(rpm -qf --qf "%{NAME}" "/lib/modules/${version_in_use}" | sed 's/\(-core\)\?$/-devel/')"
+      bb-yum-install "${package_name}-${version_in_use}"
 
-    # Remove unused kernel-headers
-    if bb-is-distro-like? centos; then
-      packages_to_remove="$(rpm -q kernel-devel | grep -Ev "^kernel-devel-${version_in_use}$" || true)"
+      # Remove unused kernel-headers
+      packages_to_remove="$(rpm -q "$package_name" | grep -Ev "^${package_name}-${version_in_use}$" || true)"
       if [ -n "$packages_to_remove" ]; then
         bb-yum-remove $packages_to_remove
       fi
     fi
 
     if bb-is-distro-like? debian; then
+      # Install actual kernel headers
+      bb-apt-install "linux-headers-${version_in_use}"
+
+      # Remove unused kernel-headers
       version_in_use_pattern="$(echo "$version_in_use" | sed -r 's/([0-9\.-]+)-([^0-9]+)$/^linux-[a-z0-9\.-]+(\1|\1-\2)$/')"
       packages_to_remove="$(
         dpkg --get-selections | grep -E '^linux-headers-.*\s(install|hold)$' | awk '{print $1}' | grep -Ev "$version_in_use_pattern" | grep -Ev 'linux-headers-[^0-9]+$' || true


### PR DESCRIPTION
## Description

This PR improves logic for detecting kernel-headers package

## Why do we need it, and what problem does it solve?

Unlike DEB, RPM based distros does not include package name into kernel version.
We need additional detection for package name.

## What is the expected result?

RPM-based distros using non-default kernel able to install kernel-headers for it.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: linstor
type: fix
summary: Improve kernel-headers detection for СentOS.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
