### PR TITLE
[candi] docker logout on nodes if registry auth is removed

### DIFF
--- a/candi/bashible/common-steps/node-group/050_configure_and_start_docker.sh.tpl
+++ b/candi/bashible/common-steps/node-group/050_configure_and_start_docker.sh.tpl
@@ -58,10 +58,12 @@ EOF
 {{- end }}
 {{- end }}
 
-{{- if .registry.auth }}
 if docker version >/dev/null 2>/dev/null; then
+{{- if .registry.auth }}
   username="$(base64 -d <<< "{{ .registry.auth }}" | awk -F ":" '{print $1}')"
   password="$(base64 -d <<< "{{ .registry.auth }}" | awk -F ":" '{print $2}')"
   HOME=/ docker login --username "${username}" --password "${password}" {{ .registry.address }}
-fi
+{{- else }}
+  HOME=/ docker logout {{ .registry.address }}
 {{- end }}
+fi


### PR DESCRIPTION
Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
docker logout on nodes if registry auth is removed.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When kubelet downloads kubernetes-api-proxy, pause images, static prod images, it needs 
access to registry. So we execute docker login to registry on nodes. But when we change Deckhouse release from EE to CE, registry authentication is not needed anymore. This PR removes unused credentials for docker. 
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: chore
summary: docker logout on nodes if registry auth is removed
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
