### PR TITLE
[istio] fix D8IstioAdditionalControlplaneDoesntWork alert

### DIFF
--- a/ee/modules/110-istio/monitoring/prometheus-rules/controlplane.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/controlplane.yaml
@@ -58,7 +58,7 @@
                 (
                   (
                     kube_pod_status_phase{namespace="d8-istio", pod=~"istiod-.+", phase="Running"}
-                    * on (pod) group_left (label_istio_io_rev) kube_pod_labels{} == 0
+                    * on (pod) group_left (label_istio_io_rev) kube_pod_labels{namespace="d8-istio", pod=~"istiod-.+"} == 0
                   )
                 * on (label_istio_io_rev) group_left kube_service_labels{namespace="d8-istio", service=~"istiod-.+"}
                 # exclude global revision


### PR DESCRIPTION
## Description
fix `D8IstioAdditionalControlplaneDoesntWork` alert

## Why do we need it, and what problem does it solve?
Inaccurate label selection leads to erroneous triggering of the alert

## What is the expected result?
No false alarms

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: fix `D8IstioAdditionalControlplaneDoesntWork` alert
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
