### PR TITLE
[upmeter] Reduce QPS and busrt for kube-client

### DIFF
--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -139,10 +139,11 @@ spec:
             value: "json"
           - name: UPMETER_EXPORT_TIMEOUT
             value: "15s"
+          # https://github.com/flant/addon-operator/blob/main/RUNNING.md#environment-variables
           - name: KUBE_CLIENT_QPS
-            value: "30"
+            value: "5"
           - name: KUBE_CLIENT_BURST
-            value: "60"
+            value: "10"
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}


### PR DESCRIPTION
## Description

Reducing QPS and burst

## Why do we need it, and what problem does it solve?

Reduces the load on etcd and apiserver in multi-control-plane clusters. The change decreases the
latency by the cost of throttling in Upmeter Agent. We'll need to investigate the issue and probably
optimize the Agent code.

## What is the expected result?

Kube-apiserver latency decreases.

## Checklist

- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: upmeter
type: fix
summary: Reduces QPS and burst in `upmeter-agent` to reduce `kube-apiserver` latency in multi-control-plane setups.
```
