### PR TITLE
[istio] fix patch injector configmap hook 

### DIFF
--- a/ee/modules/110-istio/hooks/patch_injector_configmap.go
+++ b/ee/modules/110-istio/hooks/patch_injector_configmap.go
@@ -70,10 +70,9 @@ func applyInjectorConfigmapFilter(obj *unstructured.Unstructured) (go_hook.Filte
 	if !ok {
 		return nil, nil
 	}
-	if gjson.Get(values, istioInjectorCPULimitPath).String() == "" {
+	if !gjson.Get(values, istioInjectorCPULimitPath).Exists() {
 		return nil, nil
 	}
-
 	return injectorConfigMap{
 		Name:   cm.Name,
 		Values: values,

--- a/ee/modules/110-istio/hooks/patch_injector_configmap_test.go
+++ b/ee/modules/110-istio/hooks/patch_injector_configmap_test.go
@@ -58,12 +58,12 @@ metadata:
     operator.istio.io/managed: Reconcile
     operator.istio.io/version: 1.33.7
     release: istio
-  name: istio-sidecar-injector-v1x33
+  name: istio-sidecar-injector-v1x33-limits-exists
   namespace: d8-istio
 `
 
 		patchedValues := `
-{ 
+{
   "global": {
     "proxy": {
       "resources": {
@@ -86,9 +86,9 @@ metadata:
 
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33").ToYaml()).NotTo(MatchYAML(cm))
-			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33").Field("data.config").String()).To(Equal("test_config_data"))
-			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33").Field("data.values").String()).To(MatchJSON(patchedValues))
+			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33-limits-exists").ToYaml()).NotTo(MatchYAML(cm))
+			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33-limits-exists").Field("data.config").String()).To(Equal("test_config_data"))
+			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33-limits-exists").Field("data.values").String()).To(MatchJSON(patchedValues))
 		})
 	})
 
@@ -121,7 +121,7 @@ metadata:
     operator.istio.io/managed: Reconcile
     operator.istio.io/version: 1.33.7
     release: istio
-  name: istio-sidecar-injector-v1x33
+  name: istio-sidecar-injector-v1x33-limits-absent
   namespace: d8-istio
 `
 		BeforeEach(func() {
@@ -131,7 +131,7 @@ metadata:
 
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33").ToYaml()).To(MatchYAML(cm))
+			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33-limits-absent").ToYaml()).To(MatchYAML(cm))
 		})
 	})
 
@@ -152,7 +152,7 @@ metadata:
     operator.istio.io/managed: Reconcile
     operator.istio.io/version: 1.33.7
     release: istio
-  name: istio-sidecar-injector-v1x33
+  name: istio-sidecar-injector-v1x33-wrong-data
   namespace: d8-istio
 `
 		BeforeEach(func() {
@@ -162,7 +162,7 @@ metadata:
 
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33").ToYaml()).To(MatchYAML(cm))
+			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33-wrong-data").ToYaml()).To(MatchYAML(cm))
 		})
 	})
 
@@ -183,7 +183,7 @@ metadata:
     operator.istio.io/managed: Reconcile
     operator.istio.io/version: 1.33.7
     release: istio
-  name: istio-sidecar-injector-v1x33
+  name: istio-sidecar-injector-v1x33-no-fields
   namespace: d8-istio
 `
 		BeforeEach(func() {
@@ -193,7 +193,7 @@ metadata:
 
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33").ToYaml()).To(MatchYAML(cm))
+			Expect(f.KubernetesResource("ConfigMap", "d8-istio", "istio-sidecar-injector-v1x33-no-fields").ToYaml()).To(MatchYAML(cm))
 		})
 	})
 

--- a/werf.yaml
+++ b/werf.yaml
@@ -341,7 +341,7 @@ ansible:
 
   - raw: rm -rf /var/cache/apk/*
 
-  setupCacheVersion: "7"
+  setupCacheVersion: "8"
   setup:
   - name: "Migrate ee/fe internal packages imports"
     shell: |


### PR DESCRIPTION
## Description
Fixed filter and hook logic

## Why do we need it, and what problem does it solve?
Improving the hook performance

## What is the expected result?
-

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Fixed filter and hook logic
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
