### PR TITLE
[upmeter] Fix silent status page on empty data

### DIFF
--- a/modules/500-upmeter/images/status/src/App.svelte
+++ b/modules/500-upmeter/images/status/src/App.svelte
@@ -7,6 +7,7 @@
 	async function fetchStatusJSON() {
 		const r = await fetch("/public/api/status", {
 			headers: { accept: "application/json" },
+			mode: "no-cors",
 		});
 		return await r.json();
 	}
@@ -23,11 +24,14 @@
 			data = await fetchStatusJSON();
 			error = null;
 			pendingUpdateText = "";
+			console.log({ data });
 		} catch (e) {
 			console.error(e);
 			error = e;
 			pendingUpdateText = " (pending update...)";
+			console.log({ error });
 		}
+		console.log({ data, error });
 	}
 
 	// The update loop
@@ -45,13 +49,13 @@
 			<h1 class="display-4">Status</h1>
 		</Col>
 		<Col class="text-end">
-			<h2 class="display-4 fw-light">
+			<h4 class="fw-normal text-muted">
 				{#if data == null && error == null}
 					Wait a second...
-				{:else if data != null}
-					<StatusText status={data.status} text={data.status + pendingUpdateText} mute={error != null} />
+				{:else}
+					<StatusText status={data.status} text={data.status + pendingUpdateText} />
 				{/if}
-			</h2>
+			</h4>
 		</Col>
 	</Row>
 

--- a/modules/500-upmeter/images/status/src/App.svelte
+++ b/modules/500-upmeter/images/status/src/App.svelte
@@ -24,14 +24,11 @@
 			data = await fetchStatusJSON();
 			error = null;
 			pendingUpdateText = "";
-			console.log({ data });
 		} catch (e) {
 			console.error(e);
 			error = e;
 			pendingUpdateText = " (pending update...)";
-			console.log({ error });
 		}
-		console.log({ data, error });
 	}
 
 	// The update loop

--- a/modules/500-upmeter/images/status/src/App.svelte
+++ b/modules/500-upmeter/images/status/src/App.svelte
@@ -7,7 +7,6 @@
 	async function fetchStatusJSON() {
 		const r = await fetch("/public/api/status", {
 			headers: { accept: "application/json" },
-			mode: "no-cors",
 		});
 		return await r.json();
 	}
@@ -43,7 +42,7 @@
 <Container style="width: 600px">
 	<Row class="mt-5 align-items-end">
 		<Col>
-			<h1 class="display-4">Status</h1>
+			<h1 class="display-4 m-0">Status</h1>
 		</Col>
 		<Col class="text-end">
 			<h4 class="fw-normal text-muted">

--- a/modules/500-upmeter/images/status/src/lib/StatusText.svelte
+++ b/modules/500-upmeter/images/status/src/lib/StatusText.svelte
@@ -1,14 +1,6 @@
 <script lang="ts">
 	export let text = "";
 	export let status = "";
-	export let mute = false;
-
-	function mutedOrStatusTextClassName(mute, status) {
-		if (mute) {
-			return "text-muted";
-		}
-		return statusTextClassName(status);
-	}
 
 	function statusTextClassName(status) {
 		switch (status) {
@@ -19,9 +11,9 @@
 			case "Outage":
 				return "text-danger";
 			default:
-				return "";
+				return "text-muted";
 		}
 	}
 </script>
 
-<p class={mutedOrStatusTextClassName(mute, status) + " fw-light m-0"}>{text}</p>
+<p class={`${statusTextClassName(status)} m-0`}>{text || "No data for 15 min"}</p>

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
@@ -72,7 +72,7 @@ func (h *PublicStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	statuses, status, err := h.getStatusSummary()
 	if err != nil {
-		log.Errorf("Cannot get current status: %w\n", err)
+		log.Errorf("Cannot get current status: %v\n", err)
 		// Skipping the error because the JSON structure is defined in advance.
 		out, _ := json.Marshal(&PublicStatusResponse{
 			Rows:   []GroupStatus{},
@@ -107,7 +107,7 @@ func (h *PublicStatusHandler) getStatusSummary() ([]GroupStatus, PublicStatus, e
 	}
 
 	groups := h.ProbeLister.Groups()
-	groupStatuses := make([]GroupStatus, 0)
+	groupStatuses := make([]GroupStatus, 0, len(groups))
 	for _, group := range groups {
 		ref := check.ProbeRef{
 			Group: group,
@@ -168,7 +168,7 @@ func pickSummary(ref check.ProbeRef, statuses map[string]map[string][]entity.Epi
 	episodeSummaries := statuses[g][p]
 	n := len(episodeSummaries) - 1 // ignore summary column in the end
 	if n != 3 {
-		return nil, fmt.Errorf("bad results count %d for group '%s' probe '%s'", n, g, p)
+		return nil, fmt.Errorf("unexpected count %d!=3 for probe '%s/%s'", n, g, p)
 	}
 
 	return episodeSummaries[:3], nil

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
@@ -72,29 +72,22 @@ func (h *PublicStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	statuses, status, err := h.getStatusSummary()
 	if err != nil {
-		// if errors.Is(err, ErrNoData) {
-		// w.WriteHeader(http.StatusOK)
-		// } else {
-		w.WriteHeader(http.StatusInternalServerError)
-		// }
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, jsonError(err.Error()))
-		log.Errorln("Cannot get current status: %w", err)
+		log.Errorf("Cannot get current status: %w\n", err)
+		// Skipping the error because the JSON structure is defined in advance.
+		out, _ := json.Marshal(&PublicStatusResponse{
+			Rows:   []GroupStatus{},
+			Status: "No data",
+		})
+		w.WriteHeader(http.StatusOK)
+		w.Write(out)
 		return
 	}
 
-	out, err := json.Marshal(&PublicStatusResponse{
+	// Skipping the error because the JSON structure is defined in advance.
+	out, _ := json.Marshal(&PublicStatusResponse{
 		Rows:   statuses,
 		Status: status,
 	})
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		message := fmt.Sprintf("%d Error: %s\n", http.StatusInternalServerError, err)
-		fmt.Fprint(w, jsonError(message))
-		log.Errorln("Cannot marshal status summary to JSON: %w", err)
-		return
-	}
-
 	w.Write(out)
 }
 

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
@@ -63,7 +63,7 @@ func (h *PublicStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 	if r.Method != http.MethodGet {
 		w.WriteHeader(http.StatusMethodNotAllowed)
-		fmt.Fprintf(w, "%s is not allowed, use GET\n", http.StatusMethodNotAllowed, r.Method)
+		fmt.Fprintf(w, "%s not allowed, use GET\n", r.Method)
 		return
 	}
 
@@ -72,14 +72,14 @@ func (h *PublicStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		if errors.Is(err, ErrNoData) {
 			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "application/json")
-			out, jsonerr := json.Marshal(map[string]string{"error": err.Error()})
-			if jsonerr != nil {
+			out, err := json.Marshal(map[string]string{"error": err.Error()})
+			if err != nil {
 				w.Write(out)
 				return
 			}
 		}
 		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "Cannot get current status\n", http.StatusInternalServerError)
+		fmt.Fprintf(w, "Cannot get current status\n")
 		log.Errorln("Cannot get current status: %w", err)
 		return
 	}

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
@@ -76,7 +76,7 @@ func (h *PublicStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		// Skipping the error because the JSON structure is defined in advance.
 		out, _ := json.Marshal(&PublicStatusResponse{
 			Rows:   []GroupStatus{},
-			Status: "No data",
+			Status: "No data for last 15 min",
 		})
 		w.WriteHeader(http.StatusOK)
 		w.Write(out)


### PR DESCRIPTION
## Description

The status page is empty when the upmeter server responds with status 500 due to empty data.
That is being fixed.

## Why do we need it, and what problem does it solve?

Fixes #2611

## What is the expected result?

Status page explicitly sais it has no data to show

## Checklist
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: upmeter
type: fix
summary: Fixed empty status page when there is no data in the upmeter server.
```
