### PR TITLE
[user-authn] Fix bug in Dex with the connectorData field

### DIFF
--- a/modules/150-user-authn/images/dex/Dockerfile
+++ b/modules/150-user-authn/images/dex/Dockerfile
@@ -4,11 +4,12 @@ ARG BASE_ALPINE
 FROM $BASE_GOLANG_18_ALPINE as artifact
 RUN apk add --no-cache git ca-certificates gcc build-base sqlite patch make curl
 WORKDIR /dex
-COPY patches/client-groups.patch patches/static-user-groups.patch patches/gitlab-refresh-context.patch /
+COPY patches/client-groups.patch patches/static-user-groups.patch patches/gitlab-refresh-context.patch patches/connector-data.patch /
 RUN wget https://github.com/dexidp/dex/archive/v2.35.1.tar.gz -O - | tar -xz --strip-components=1 \
   && git apply /client-groups.patch \
   && git apply /static-user-groups.patch \
-  && git apply /gitlab-refresh-context.patch
+  && git apply /gitlab-refresh-context.patch \
+  && git apply /connector-data.patch
 RUN go build ./cmd/dex
 
 FROM $BASE_ALPINE

--- a/modules/150-user-authn/images/dex/patches/README.md
+++ b/modules/150-user-authn/images/dex/patches/README.md
@@ -18,3 +18,7 @@ This problem is not solved in upstream, and our patch will not be accepted.
 Refresh can be called only one. By propagating a context of the user request, refresh can accidentally canceled.
 
 To avoid this, this patch makes refresh requests to declare and utilize their own contexts.
+
+### Connector data patch
+
+There is a bug in Dex that it saves connector data to the refresh token object and reads it first then the date from offline session.

--- a/modules/150-user-authn/images/dex/patches/connector-data.patch
+++ b/modules/150-user-authn/images/dex/patches/connector-data.patch
@@ -1,8 +1,16 @@
 diff --git a/server/refreshhandlers.go b/server/refreshhandlers.go
-index ecfda137..af7bc019 100644
+index ecfda137..f4b5df62 100644
 --- a/server/refreshhandlers.go
 +++ b/server/refreshhandlers.go
-@@ -245,7 +245,6 @@ func (s *Server) updateRefreshToken(ctx context.Context, rCtx *refreshContext) (
+@@ -186,6 +186,7 @@ func (s *Server) refreshWithConnector(ctx context.Context, rCtx *refreshContext,
+ 	// TODO(ericchiang): We may want a strict mode where connectors that don't implement
+ 	// this interface can't perform refreshing.
+ 	if refreshConn, ok := rCtx.connector.Connector.(connector.RefreshConnector); ok {
++		ident.ConnectorData = rCtx.connectorData
+ 		s.logger.Debugf("connector data before refresh: %s", ident.ConnectorData)
+
+ 		newIdent, err := refreshConn.Refresh(ctx, parseScopes(rCtx.scopes), ident)
+@@ -245,7 +246,6 @@ func (s *Server) updateRefreshToken(ctx context.Context, rCtx *refreshContext) (
  		Email:             rCtx.storageToken.Claims.Email,
  		EmailVerified:     rCtx.storageToken.Claims.EmailVerified,
  		Groups:            rCtx.storageToken.Claims.Groups,
@@ -10,7 +18,7 @@ index ecfda137..af7bc019 100644
  	}
 
  	refreshTokenUpdater := func(old storage.RefreshToken) (storage.RefreshToken, error) {
-@@ -255,6 +254,7 @@ func (s *Server) updateRefreshToken(ctx context.Context, rCtx *refreshContext) (
+@@ -255,6 +255,7 @@ func (s *Server) updateRefreshToken(ctx context.Context, rCtx *refreshContext) (
  		switch {
  		case !rotationEnabled && reusingAllowed:
  			// If rotation is disabled and the offline session was updated not so long ago - skip further actions.
@@ -18,7 +26,7 @@ index ecfda137..af7bc019 100644
  			return old, nil
 
  		case rotationEnabled && reusingAllowed:
-@@ -269,7 +269,7 @@ func (s *Server) updateRefreshToken(ctx context.Context, rCtx *refreshContext) (
+@@ -269,7 +270,7 @@ func (s *Server) updateRefreshToken(ctx context.Context, rCtx *refreshContext) (
 
  			// Do not update last used time for offline session if token is allowed to be reused
  			lastUsed = old.LastUsed
@@ -27,7 +35,7 @@ index ecfda137..af7bc019 100644
  			return old, nil
 
  		case rotationEnabled && !reusingAllowed:
-@@ -286,7 +286,7 @@ func (s *Server) updateRefreshToken(ctx context.Context, rCtx *refreshContext) (
+@@ -286,7 +287,7 @@ func (s *Server) updateRefreshToken(ctx context.Context, rCtx *refreshContext) (
  		old.LastUsed = lastUsed
 
  		// ConnectorData has been moved to OfflineSession

--- a/modules/150-user-authn/images/dex/patches/connector-data.patch
+++ b/modules/150-user-authn/images/dex/patches/connector-data.patch
@@ -1,0 +1,38 @@
+diff --git a/server/refreshhandlers.go b/server/refreshhandlers.go
+index ecfda137..af7bc019 100644
+--- a/server/refreshhandlers.go
++++ b/server/refreshhandlers.go
+@@ -245,7 +245,6 @@ func (s *Server) updateRefreshToken(ctx context.Context, rCtx *refreshContext) (
+ 		Email:             rCtx.storageToken.Claims.Email,
+ 		EmailVerified:     rCtx.storageToken.Claims.EmailVerified,
+ 		Groups:            rCtx.storageToken.Claims.Groups,
+-		ConnectorData:     rCtx.connectorData,
+ 	}
+
+ 	refreshTokenUpdater := func(old storage.RefreshToken) (storage.RefreshToken, error) {
+@@ -255,6 +254,7 @@ func (s *Server) updateRefreshToken(ctx context.Context, rCtx *refreshContext) (
+ 		switch {
+ 		case !rotationEnabled && reusingAllowed:
+ 			// If rotation is disabled and the offline session was updated not so long ago - skip further actions.
++			old.ConnectorData = nil
+ 			return old, nil
+
+ 		case rotationEnabled && reusingAllowed:
+@@ -269,7 +269,7 @@ func (s *Server) updateRefreshToken(ctx context.Context, rCtx *refreshContext) (
+
+ 			// Do not update last used time for offline session if token is allowed to be reused
+ 			lastUsed = old.LastUsed
+-			ident.ConnectorData = nil
++			old.ConnectorData = nil
+ 			return old, nil
+
+ 		case rotationEnabled && !reusingAllowed:
+@@ -286,7 +286,7 @@ func (s *Server) updateRefreshToken(ctx context.Context, rCtx *refreshContext) (
+ 		old.LastUsed = lastUsed
+
+ 		// ConnectorData has been moved to OfflineSession
+-		old.ConnectorData = []byte{}
++		old.ConnectorData = nil
+
+ 		// Call  only once if there is a request which is not in the reuse interval.
+ 		// This is required to avoid multiple calls to the external IdP for concurrent requests.


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
It fixes the problem, that in some cases connector data is picked from the refresh token instead of offline session

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: user-authn
type: fix
summary: Do not use connectorData field of refresh token objects to refresh tokens
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
