### PR TITLE
[upmeter] Optimize control-plane preflight check

### DIFF
--- a/modules/500-upmeter/images/upmeter/pkg/agent/agent.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/agent.go
@@ -98,9 +98,12 @@ func (a *Agent) Start(ctx context.Context) error {
 		return fmt.Errorf("starting node monitor: %v", err)
 	}
 
-	// The interval is chosen as the smallest period among probes consuming this preflight check.
-	controlPlanePreflight := checker.NewK8sVersionGetter(kubeAccess, time.Second)
+	// The preflight interval is chosen as the smallest period among probe runs which use the
+	// preflight check.
+	preflightInterval := 5 * time.Second
+	controlPlanePreflight := checker.NewK8sVersionGetter(kubeAccess, preflightInterval)
 	controlPlanePreflight.Start()
+
 	runnerLoader := probe.NewLoader(ftr, kubeAccess, nodeMon, dynamicConfig, controlPlanePreflight, a.logger)
 	calcLoader := calculated.NewLoader(ftr, a.logger)
 	registry := registry.New(runnerLoader, calcLoader)

--- a/modules/500-upmeter/images/upmeter/pkg/agent/agent.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/agent.go
@@ -32,6 +32,7 @@ import (
 	"d8.io/upmeter/pkg/monitor/node"
 	"d8.io/upmeter/pkg/probe"
 	"d8.io/upmeter/pkg/probe/calculated"
+	"d8.io/upmeter/pkg/probe/checker"
 	"d8.io/upmeter/pkg/registry"
 )
 
@@ -97,7 +98,10 @@ func (a *Agent) Start(ctx context.Context) error {
 		return fmt.Errorf("starting node monitor: %v", err)
 	}
 
-	runnerLoader := probe.NewLoader(ftr, kubeAccess, nodeMon, dynamicConfig, a.logger)
+	// The interval is chosen as the smallest period among probes consuming this preflight check.
+	controlPlanePreflight := checker.NewK8sVersionGetter(kubeAccess, time.Second)
+
+	runnerLoader := probe.NewLoader(ftr, kubeAccess, nodeMon, dynamicConfig, controlPlanePreflight, a.logger)
 	calcLoader := calculated.NewLoader(ftr, a.logger)
 	registry := registry.New(runnerLoader, calcLoader)
 

--- a/modules/500-upmeter/images/upmeter/pkg/agent/agent.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/agent.go
@@ -100,7 +100,7 @@ func (a *Agent) Start(ctx context.Context) error {
 
 	// The interval is chosen as the smallest period among probes consuming this preflight check.
 	controlPlanePreflight := checker.NewK8sVersionGetter(kubeAccess, time.Second)
-
+	controlPlanePreflight.Start()
 	runnerLoader := probe.NewLoader(ftr, kubeAccess, nodeMon, dynamicConfig, controlPlanePreflight, a.logger)
 	calcLoader := calculated.NewLoader(ftr, a.logger)
 	registry := registry.New(runnerLoader, calcLoader)

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/certificate_secret.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/certificate_secret.go
@@ -32,7 +32,8 @@ import (
 
 // CertificateSecretLifecycle is a checker constructor and configurator
 type CertificateSecretLifecycle struct {
-	Access kubernetes.Access
+	Access    kubernetes.Access
+	Preflight Doer
 
 	Namespace string
 	AgentID   string
@@ -44,8 +45,6 @@ type CertificateSecretLifecycle struct {
 }
 
 func (c CertificateSecretLifecycle) Checker() check.Checker {
-	preflight := newK8sVersionGetter(c.Access)
-
 	certGetter := &certificateGetter{access: c.Access, namespace: c.Namespace, name: c.Name}
 
 	certCreator := doWithTimeout(
@@ -70,7 +69,7 @@ func (c CertificateSecretLifecycle) Checker() check.Checker {
 	}
 
 	checker := &KubeControllerObjectLifecycle{
-		preflight: preflight,
+		preflight: c.Preflight,
 
 		parentGetter:  certGetter,
 		parentCreator: certCreator,

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_basic_lifecycle.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_basic_lifecycle.go
@@ -28,10 +28,10 @@ import (
 // kube-apiserver. Hence, all errors in kube-apiserver calls result in probe
 // fails.
 type KubeObjectBasicLifecycle struct {
-	preflight doer
-	getter    doer
-	creator   doer
-	deleter   doer
+	preflight Doer
+	getter    Doer
+	creator   Doer
+	deleter   Doer
 }
 
 func (c *KubeObjectBasicLifecycle) Check() check.Error {

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_basic_lifecycle_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_basic_lifecycle_test.go
@@ -51,10 +51,10 @@ func doer404() *failDoer {
 
 func TestKubeObjectBasicLifecycle_Check(t *testing.T) {
 	type fields struct {
-		preflight doer
-		getter    doer
-		creator   doer
-		deleter   doer
+		preflight Doer
+		getter    Doer
+		creator   Doer
+		deleter   Doer
 	}
 	tests := []struct {
 		name   string

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_configmap.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_configmap.go
@@ -30,6 +30,7 @@ import (
 // ConfigMapLifecycle is a checker constructor and configurator
 type ConfigMapLifecycle struct {
 	Access    kubernetes.Access
+	Preflight Doer
 	Namespace string
 
 	AgentID string
@@ -39,15 +40,13 @@ type ConfigMapLifecycle struct {
 }
 
 func (c ConfigMapLifecycle) Checker() check.Checker {
-	preflight := newK8sVersionGetter(c.Access)
-
 	cm := createConfigMapObject(c.Name, c.AgentID)
 	creator := &configmapCreator{access: c.Access, namespace: c.Namespace, cm: cm}
 	getter := &configmapGetter{access: c.Access, namespace: c.Namespace, name: c.Name}
 	deleter := &configmapDeleter{access: c.Access, namespace: c.Namespace, name: c.Name}
 
 	checker := &KubeObjectBasicLifecycle{
-		preflight: preflight,
+		preflight: c.Preflight,
 		creator:   creator,
 		getter:    getter,
 		deleter:   deleter,

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_controller_lifecycle.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_controller_lifecycle.go
@@ -30,14 +30,14 @@ import (
 // creation of parent object leads to the creation of a child one, and the same
 // with deletion.
 type KubeControllerObjectLifecycle struct {
-	preflight doer
+	preflight Doer
 
-	parentGetter  doer
-	parentCreator doer
-	parentDeleter doer
+	parentGetter  Doer
+	parentCreator Doer
+	parentDeleter Doer
 
-	childGetter          doer
-	childDeleter         doer
+	childGetter          Doer
+	childDeleter         Doer
 	childPollingInterval time.Duration
 	childPollingTimeout  time.Duration
 }
@@ -85,7 +85,7 @@ func (c *KubeControllerObjectLifecycle) Check() check.Error {
 	return nil
 }
 
-func (c *KubeControllerObjectLifecycle) cleanGarbage(ctx context.Context, getter, deleter doer) error {
+func (c *KubeControllerObjectLifecycle) cleanGarbage(ctx context.Context, getter, deleter Doer) error {
 	if getErr := getter.Do(ctx); getErr != nil && !apierrors.IsNotFound(getErr) {
 		return fmt.Errorf("getting garbage: %v", getErr)
 	} else if getErr == nil {
@@ -98,7 +98,7 @@ func (c *KubeControllerObjectLifecycle) cleanGarbage(ctx context.Context, getter
 	return nil
 }
 
-func (c *KubeControllerObjectLifecycle) childGetterUntilPresent() doer {
+func (c *KubeControllerObjectLifecycle) childGetterUntilPresent() Doer {
 	return &pollingDoer{
 		doer:     c.childGetter,
 		catch:    isNil,
@@ -107,7 +107,7 @@ func (c *KubeControllerObjectLifecycle) childGetterUntilPresent() doer {
 	}
 }
 
-func (c *KubeControllerObjectLifecycle) childGetterUntilAbsent() doer {
+func (c *KubeControllerObjectLifecycle) childGetterUntilAbsent() Doer {
 	return &pollingDoer{
 		doer:     c.childGetter,
 		catch:    apierrors.IsNotFound,
@@ -119,7 +119,7 @@ func (c *KubeControllerObjectLifecycle) childGetterUntilAbsent() doer {
 func isNil(err error) bool { return err == nil }
 
 type pollingDoer struct {
-	doer     doer
+	doer     Doer
 	catch    func(error) bool
 	timeout  time.Duration
 	interval time.Duration

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_controller_lifecycle_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_controller_lifecycle_test.go
@@ -29,14 +29,14 @@ import (
 
 func TestKubeControllerObjectLifecycle_Check(t *testing.T) {
 	type fields struct {
-		preflight doer
+		preflight Doer
 
-		parentGetter  doer
-		parentCreator doer
-		parentDeleter doer
+		parentGetter  Doer
+		parentCreator Doer
+		parentDeleter Doer
 
-		childGetter  doer
-		childDeleter doer
+		childGetter  Doer
+		childDeleter Doer
 	}
 	tests := []struct {
 		name   string

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_daemonset.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_daemonset.go
@@ -48,8 +48,8 @@ type DaemonSetPodsReady struct {
 	PodCreationTimeout time.Duration
 	PodDeletionTimeout time.Duration
 
-	// ControlPlaneAccessTimeout is the timeout to verify apiserver availability
-	ControlPlaneAccessTimeout time.Duration
+	// PreflightChecker verifies preconditions before running the check
+	PreflightChecker check.Checker
 }
 
 func (c DaemonSetPodsReady) Checker() check.Checker {
@@ -68,7 +68,7 @@ func (c DaemonSetPodsReady) Checker() check.Checker {
 	}
 
 	return sequence(
-		newControlPlaneChecker(c.Access, c.ControlPlaneAccessTimeout),
+		c.PreflightChecker,
 		withTimeout(dsChecker, c.RequestTimeout),
 	)
 }
@@ -216,8 +216,8 @@ func isNodeReady(node *v1.Node) bool {
 
 // isTolerated checks if the given tolerations tolerates all taints
 //
-//      Copied from https://github.com/kubernetes/component-helpers/blob/v0.21.0/scheduling/corev1/helpers.go
-//      It is not imported since k8s dependencies versions would require to rise to at least 0.20.
+//	Copied from https://github.com/kubernetes/component-helpers/blob/v0.21.0/scheduling/corev1/helpers.go
+//	It is not imported since k8s dependencies versions would require to rise to at least 0.20.
 func isTolerated(taints []v1.Taint, tolerations []v1.Toleration) bool {
 	for _, taint := range taints {
 		if !tolerationsTolerateTaint(tolerations, &taint) {
@@ -229,8 +229,8 @@ func isTolerated(taints []v1.Taint, tolerations []v1.Toleration) bool {
 
 // tolerationsTolerateTaint checks if taint is tolerated by any of the tolerations.
 //
-//      Copied from https://github.com/kubernetes/component-helpers/blob/v0.21.0/scheduling/corev1/helpers.go
-//      It is not imported since k8s dependencies versions would require to rise to at least 0.20.
+//	Copied from https://github.com/kubernetes/component-helpers/blob/v0.21.0/scheduling/corev1/helpers.go
+//	It is not imported since k8s dependencies versions would require to rise to at least 0.20.
 func tolerationsTolerateTaint(tolerations []v1.Toleration, taint *v1.Taint) bool {
 	for i := range tolerations {
 		if tolerations[i].ToleratesTaint(taint) {

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_namespace.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_namespace.go
@@ -67,9 +67,8 @@ func (c NamespaceLifecycle) Checker() check.Checker {
 }
 
 type namespaceCreator struct {
-	access  kubernetes.Access
-	ns      *v1.Namespace
-	timeout time.Duration
+	access kubernetes.Access
+	ns     *v1.Namespace
 }
 
 func (c *namespaceCreator) Do(ctx context.Context) error {

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_namespace.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_namespace.go
@@ -30,7 +30,8 @@ import (
 
 // NamespaceLifecycle is a checker constructor and configurator
 type NamespaceLifecycle struct {
-	Access kubernetes.Access
+	Access    kubernetes.Access
+	preflight Doer
 
 	AgentID string
 	Name    string
@@ -40,8 +41,6 @@ type NamespaceLifecycle struct {
 }
 
 func (c NamespaceLifecycle) Checker() check.Checker {
-	preflight := newK8sVersionGetter(c.Access)
-
 	getter := &namespaceGetter{access: c.Access, name: c.Name}
 
 	ns := createNamespaceObject(c.Name, c.AgentID)
@@ -58,7 +57,7 @@ func (c NamespaceLifecycle) Checker() check.Checker {
 	)
 
 	checker := &KubeObjectBasicLifecycle{
-		preflight: preflight,
+		preflight: c.preflight,
 		creator:   creator,
 		getter:    getter,
 		deleter:   deleter,

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_namespace.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_namespace.go
@@ -31,7 +31,7 @@ import (
 // NamespaceLifecycle is a checker constructor and configurator
 type NamespaceLifecycle struct {
 	Access    kubernetes.Access
-	preflight Doer
+	Preflight Doer
 
 	AgentID string
 	Name    string
@@ -57,7 +57,7 @@ func (c NamespaceLifecycle) Checker() check.Checker {
 	)
 
 	checker := &KubeObjectBasicLifecycle{
-		preflight: c.preflight,
+		preflight: c.Preflight,
 		creator:   creator,
 		getter:    getter,
 		deleter:   deleter,

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_nodegroup.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_nodegroup.go
@@ -44,8 +44,9 @@ type NodegroupHasDesiredAmountOfNodes struct {
 
 	// RequestTimeout is common for api operations
 	RequestTimeout time.Duration
-	// ControlPlaneAccessTimeout is the timeout to verify apiserver availability
-	ControlPlaneAccessTimeout time.Duration
+
+	// PreflightChecker verifies preconditions before running the check
+	PreflightChecker check.Checker
 }
 
 func (c NodegroupHasDesiredAmountOfNodes) Checker() check.Checker {
@@ -63,7 +64,7 @@ func (c NodegroupHasDesiredAmountOfNodes) Checker() check.Checker {
 	}
 
 	return sequence(
-		newControlPlaneChecker(c.Access, c.ControlPlaneAccessTimeout),
+		c.PreflightChecker,
 		withTimeout(ngChecker, c.RequestTimeout),
 	)
 }

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_pod.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_pod.go
@@ -58,8 +58,10 @@ type AtLeastOnePodReady struct {
 	Namespace     string
 	LabelSelector string
 
-	Timeout                   time.Duration
-	ControlPlaneAccessTimeout time.Duration
+	Timeout time.Duration
+
+	// PreflightChecker verifies preconditions before running the check
+	PreflightChecker check.Checker
 }
 
 func (c AtLeastOnePodReady) Checker() check.Checker {
@@ -70,7 +72,7 @@ func (c AtLeastOnePodReady) Checker() check.Checker {
 	}
 
 	return sequence(
-		newControlPlaneChecker(c.Access, c.ControlPlaneAccessTimeout),
+		c.PreflightChecker,
 		withTimeout(podsChecker, c.Timeout),
 	)
 }

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_pod.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_pod.go
@@ -27,31 +27,6 @@ import (
 	"d8.io/upmeter/pkg/kubernetes"
 )
 
-// Checks that at least one Pod is in "Pending" state.
-// FIXME by the task, should check it is not PodUnknown ???
-type pendingPodChecker struct {
-	access    kubernetes.Access
-	namespace string
-	listOpts  *metav1.ListOptions
-}
-
-func (c *pendingPodChecker) Check() check.Error {
-	client := c.access.Kubernetes()
-
-	podList, err := client.CoreV1().Pods(c.namespace).List(context.TODO(), *c.listOpts)
-	if err != nil {
-		return check.ErrUnknown("listing pods %s/%s: %v", c.namespace, c.listOpts, err)
-	}
-
-	for _, pod := range podList.Items {
-		if pod.Status.Phase == v1.PodPending {
-			return nil
-		}
-	}
-
-	return check.ErrFail("did not find pod %s/%s", c.namespace, c.listOpts)
-}
-
 // AtLeastOnePodReady is a checker constructor and configurator
 type AtLeastOnePodReady struct {
 	Access        kubernetes.Access

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_scheduling_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_scheduling_test.go
@@ -185,9 +185,7 @@ func Test_pollingPodNodeFetcher_Node(t *testing.T) {
 		timeout  time.Duration
 		interval time.Duration
 	}
-	type args struct {
-		ctx context.Context
-	}
+
 	tests := []struct {
 		name     string
 		fields   fields

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_scheduling_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_scheduling_test.go
@@ -29,10 +29,10 @@ import (
 
 func TestPodSchedulingChecker_Check(t *testing.T) {
 	type fields struct {
-		preflight   doer
-		getter      doer
-		creator     doer
-		deleter     doer
+		preflight   Doer
+		getter      Doer
+		creator     Doer
+		deleter     Doer
 		nodeFetcher nodeNameFetcher
 		node        string
 	}

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_statefulset.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_statefulset.go
@@ -32,6 +32,7 @@ import (
 // StatefulSetPodLifecycle is a checker constructor and configurator
 type StatefulSetPodLifecycle struct {
 	Access    kubernetes.Access
+	Preflight Doer
 	Namespace string
 
 	AgentID string
@@ -43,8 +44,6 @@ type StatefulSetPodLifecycle struct {
 }
 
 func (c StatefulSetPodLifecycle) Checker() check.Checker {
-	preflight := newK8sVersionGetter(c.Access)
-
 	stsName, podName := c.Name, c.Name+"-0"
 	sts := createStatefulSetObject(stsName, c.AgentID)
 
@@ -72,7 +71,7 @@ func (c StatefulSetPodLifecycle) Checker() check.Checker {
 	}
 
 	checker := &KubeControllerObjectLifecycle{
-		preflight: preflight,
+		preflight: c.Preflight,
 
 		parentGetter:  stsGetter,
 		parentCreator: stsCreator,

--- a/modules/500-upmeter/images/upmeter/pkg/probe/group_controlplane.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/group_controlplane.go
@@ -24,7 +24,7 @@ import (
 	"d8.io/upmeter/pkg/probe/run"
 )
 
-func initControlPlane(access kubernetes.Access) []runnerConfig {
+func initControlPlane(access kubernetes.Access, preflight checker.Doer) []runnerConfig {
 	const (
 		groupControlPlane = "control-plane"
 		namespace         = "d8-upmeter"
@@ -39,8 +39,8 @@ func initControlPlane(access kubernetes.Access) []runnerConfig {
 			check:  "_",
 			period: 5 * time.Second,
 			config: checker.ControlPlaneAvailable{
-				Access:  access,
-				Timeout: cpTimeout,
+				VersionGetter: preflight,
+				Timeout:       cpTimeout,
 			},
 		}, {
 			group:  groupControlPlane,
@@ -49,6 +49,7 @@ func initControlPlane(access kubernetes.Access) []runnerConfig {
 			period: 5 * time.Second,
 			config: checker.ConfigMapLifecycle{
 				Access:    access,
+				Preflight: preflight,
 				Namespace: namespace,
 
 				AgentID: run.ID(),
@@ -77,6 +78,7 @@ func initControlPlane(access kubernetes.Access) []runnerConfig {
 			period: time.Minute,
 			config: checker.StatefulSetPodLifecycle{
 				Access:    access,
+				Preflight: preflight,
 				Namespace: namespace,
 
 				AgentID: run.ID(),
@@ -93,6 +95,7 @@ func initControlPlane(access kubernetes.Access) []runnerConfig {
 			period: time.Minute,
 			config: checker.PodScheduling{
 				Access:    access,
+				Preflight: preflight,
 				Namespace: namespace,
 
 				Node:  access.SchedulerProbeNode(),
@@ -112,6 +115,7 @@ func initControlPlane(access kubernetes.Access) []runnerConfig {
 			period: time.Minute,
 			config: checker.CertificateSecretLifecycle{
 				Access:    access,
+				Preflight: preflight,
 				Namespace: namespace,
 
 				AgentID: run.ID(),

--- a/modules/500-upmeter/images/upmeter/pkg/probe/group_controlplane.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/group_controlplane.go
@@ -63,7 +63,8 @@ func initControlPlane(access kubernetes.Access, preflight checker.Doer) []runner
 			check:  "_",
 			period: time.Minute,
 			config: checker.NamespaceLifecycle{
-				Access: access,
+				Access:    access,
+				Preflight: preflight,
 
 				AgentID: run.ID(),
 				Name:    run.StaticIdentifier("upmeter-probe-namespace"),

--- a/modules/500-upmeter/images/upmeter/pkg/probe/group_extensions.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/group_extensions.go
@@ -23,11 +23,13 @@ import (
 	"d8.io/upmeter/pkg/probe/checker"
 )
 
-func initExtensions(access kubernetes.Access) []runnerConfig {
+func initExtensions(access kubernetes.Access, preflight checker.Doer) []runnerConfig {
 	const (
-		groupExtensions = "extensions"
-		cpTimeout       = 5 * time.Second
+		groupExtensions     = "extensions"
+		controlPlaneTimeout = 5 * time.Second
 	)
+
+	controlPlanePinger := checker.DoOrUnknown(controlPlaneTimeout, preflight)
 
 	return []runnerConfig{
 		{
@@ -36,11 +38,11 @@ func initExtensions(access kubernetes.Access) []runnerConfig {
 			check:  "bashible-apiserver",
 			period: 10 * time.Second,
 			config: checker.AtLeastOnePodReady{
-				Access:                    access,
-				Timeout:                   5 * time.Second,
-				Namespace:                 "d8-cloud-instance-manager",
-				LabelSelector:             "app=bashible-apiserver",
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:           access,
+				Timeout:          5 * time.Second,
+				Namespace:        "d8-cloud-instance-manager",
+				LabelSelector:    "app=bashible-apiserver",
+				PreflightChecker: controlPlanePinger,
 			},
 		}, {
 			group:  groupExtensions,
@@ -48,11 +50,11 @@ func initExtensions(access kubernetes.Access) []runnerConfig {
 			check:  "machine-controller-manager",
 			period: 10 * time.Second,
 			config: checker.AtLeastOnePodReady{
-				Access:                    access,
-				Timeout:                   5 * time.Second,
-				Namespace:                 "d8-cloud-instance-manager",
-				LabelSelector:             "app=machine-controller-manager",
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:           access,
+				Timeout:          5 * time.Second,
+				Namespace:        "d8-cloud-instance-manager",
+				LabelSelector:    "app=machine-controller-manager",
+				PreflightChecker: controlPlanePinger,
 			},
 		}, {
 			group:  groupExtensions,
@@ -60,11 +62,11 @@ func initExtensions(access kubernetes.Access) []runnerConfig {
 			check:  "cloud-controller-manager",
 			period: 10 * time.Second,
 			config: checker.AtLeastOnePodReady{
-				Access:                    access,
-				Timeout:                   5 * time.Second,
-				Namespace:                 access.CloudControllerManagerNamespace(),
-				LabelSelector:             "app=cloud-controller-manager",
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:           access,
+				Timeout:          5 * time.Second,
+				Namespace:        access.CloudControllerManagerNamespace(),
+				LabelSelector:    "app=cloud-controller-manager",
+				PreflightChecker: controlPlanePinger,
 			},
 		}, {
 			group:  groupExtensions,
@@ -72,11 +74,11 @@ func initExtensions(access kubernetes.Access) []runnerConfig {
 			check:  "cluster-autoscaler",
 			period: 10 * time.Second,
 			config: checker.AtLeastOnePodReady{
-				Access:                    access,
-				Timeout:                   5 * time.Second,
-				Namespace:                 "d8-cloud-instance-manager",
-				LabelSelector:             "app=cluster-autoscaler",
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:           access,
+				Timeout:          5 * time.Second,
+				Namespace:        "d8-cloud-instance-manager",
+				LabelSelector:    "app=cluster-autoscaler",
+				PreflightChecker: controlPlanePinger,
 			},
 		}, {
 			group:  groupExtensions,
@@ -84,11 +86,11 @@ func initExtensions(access kubernetes.Access) []runnerConfig {
 			check:  "pod",
 			period: 10 * time.Second,
 			config: checker.AtLeastOnePodReady{
-				Access:                    access,
-				Timeout:                   5 * time.Second,
-				Namespace:                 "d8-monitoring",
-				LabelSelector:             "app=grafana",
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:           access,
+				Timeout:          5 * time.Second,
+				Namespace:        "d8-monitoring",
+				LabelSelector:    "app=grafana",
+				PreflightChecker: controlPlanePinger,
 			},
 		}, {
 			group:  groupExtensions,
@@ -96,11 +98,11 @@ func initExtensions(access kubernetes.Access) []runnerConfig {
 			check:  "pod",
 			period: 10 * time.Second,
 			config: checker.AtLeastOnePodReady{
-				Access:                    access,
-				Timeout:                   5 * time.Second,
-				Namespace:                 "d8-openvpn",
-				LabelSelector:             "app=openvpn",
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:           access,
+				Timeout:          5 * time.Second,
+				Namespace:        "d8-openvpn",
+				LabelSelector:    "app=openvpn",
+				PreflightChecker: controlPlanePinger,
 			},
 		}, {
 			group:  groupExtensions,
@@ -108,11 +110,11 @@ func initExtensions(access kubernetes.Access) []runnerConfig {
 			check:  "pod",
 			period: 10 * time.Second,
 			config: checker.AtLeastOnePodReady{
-				Access:                    access,
-				Timeout:                   5 * time.Second,
-				Namespace:                 "d8-monitoring",
-				LabelSelector:             "prometheus=longterm",
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:           access,
+				Timeout:          5 * time.Second,
+				Namespace:        "d8-monitoring",
+				LabelSelector:    "prometheus=longterm",
+				PreflightChecker: controlPlanePinger,
 			},
 		}, {
 			group:  groupExtensions,
@@ -130,11 +132,11 @@ func initExtensions(access kubernetes.Access) []runnerConfig {
 			check:  "pod",
 			period: 10 * time.Second,
 			config: checker.AtLeastOnePodReady{
-				Access:                    access,
-				Timeout:                   5 * time.Second,
-				Namespace:                 "d8-dashboard",
-				LabelSelector:             "app=dashboard",
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:           access,
+				Timeout:          5 * time.Second,
+				Namespace:        "d8-dashboard",
+				LabelSelector:    "app=dashboard",
+				PreflightChecker: controlPlanePinger,
 			},
 		}, {
 			group:  groupExtensions,
@@ -142,11 +144,11 @@ func initExtensions(access kubernetes.Access) []runnerConfig {
 			check:  "pod",
 			period: 10 * time.Second,
 			config: checker.AtLeastOnePodReady{
-				Access:                    access,
-				Timeout:                   5 * time.Second,
-				Namespace:                 "d8-user-authn",
-				LabelSelector:             "app=dex",
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:           access,
+				Timeout:          5 * time.Second,
+				Namespace:        "d8-user-authn",
+				LabelSelector:    "app=dex",
+				PreflightChecker: controlPlanePinger,
 			},
 		}, {
 			group:  groupExtensions,

--- a/modules/500-upmeter/images/upmeter/pkg/probe/group_monitoring_and_autoscaling.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/group_monitoring_and_autoscaling.go
@@ -24,11 +24,13 @@ import (
 	"d8.io/upmeter/pkg/probe/checker"
 )
 
-func initMonitoringAndAutoscaling(access kubernetes.Access, nodeLister node.Lister) []runnerConfig {
+func initMonitoringAndAutoscaling(access kubernetes.Access, nodeLister node.Lister, preflight checker.Doer) []runnerConfig {
 	const (
 		groupMonitoringAndAutoscaling = "monitoring-and-autoscaling"
-		cpTimeout                     = 5 * time.Second
+		controlPlaneTimeout           = 5 * time.Second
 	)
+
+	controlPlanePinger := checker.DoOrUnknown(controlPlaneTimeout, preflight)
 
 	return []runnerConfig{
 		{
@@ -37,11 +39,11 @@ func initMonitoringAndAutoscaling(access kubernetes.Access, nodeLister node.List
 			check:  "pod",
 			period: 10 * time.Second,
 			config: checker.AtLeastOnePodReady{
-				Access:                    access,
-				Timeout:                   5 * time.Second,
-				Namespace:                 "d8-monitoring",
-				LabelSelector:             "prometheus=main",
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:           access,
+				Timeout:          5 * time.Second,
+				Namespace:        "d8-monitoring",
+				LabelSelector:    "prometheus=main",
+				PreflightChecker: controlPlanePinger,
 			},
 		}, {
 			group:  groupMonitoringAndAutoscaling,
@@ -59,11 +61,11 @@ func initMonitoringAndAutoscaling(access kubernetes.Access, nodeLister node.List
 			check:  "pod",
 			period: 10 * time.Second,
 			config: checker.AtLeastOnePodReady{
-				Access:                    access,
-				Timeout:                   5 * time.Second,
-				Namespace:                 "d8-monitoring",
-				LabelSelector:             "app=trickster",
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:           access,
+				Timeout:          5 * time.Second,
+				Namespace:        "d8-monitoring",
+				LabelSelector:    "app=trickster",
+				PreflightChecker: controlPlanePinger,
 			},
 		}, {
 			group:  groupMonitoringAndAutoscaling,
@@ -81,11 +83,11 @@ func initMonitoringAndAutoscaling(access kubernetes.Access, nodeLister node.List
 			check:  "pod",
 			period: 5 * time.Second,
 			config: checker.AtLeastOnePodReady{
-				Access:                    access,
-				Timeout:                   5 * time.Second,
-				Namespace:                 "d8-monitoring",
-				LabelSelector:             "app=prometheus-metrics-adapter",
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:           access,
+				Timeout:          5 * time.Second,
+				Namespace:        "d8-monitoring",
+				LabelSelector:    "app=prometheus-metrics-adapter",
+				PreflightChecker: controlPlanePinger,
 			},
 		}, {
 			group:  groupMonitoringAndAutoscaling,
@@ -103,11 +105,11 @@ func initMonitoringAndAutoscaling(access kubernetes.Access, nodeLister node.List
 			check:  "vpa-updater",
 			period: 10 * time.Second,
 			config: checker.AtLeastOnePodReady{
-				Access:                    access,
-				Timeout:                   5 * time.Second,
-				Namespace:                 "kube-system",
-				LabelSelector:             "app=vpa-updater",
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:           access,
+				Timeout:          5 * time.Second,
+				Namespace:        "kube-system",
+				LabelSelector:    "app=vpa-updater",
+				PreflightChecker: controlPlanePinger,
 			},
 		}, {
 			group:  groupMonitoringAndAutoscaling,
@@ -115,11 +117,11 @@ func initMonitoringAndAutoscaling(access kubernetes.Access, nodeLister node.List
 			check:  "vpa-recommender",
 			period: 10 * time.Second,
 			config: checker.AtLeastOnePodReady{
-				Access:                    access,
-				Timeout:                   5 * time.Second,
-				Namespace:                 "kube-system",
-				LabelSelector:             "app=vpa-recommender",
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:           access,
+				Timeout:          5 * time.Second,
+				Namespace:        "kube-system",
+				LabelSelector:    "app=vpa-recommender",
+				PreflightChecker: controlPlanePinger,
 			},
 		}, {
 			group:  groupMonitoringAndAutoscaling,
@@ -127,11 +129,11 @@ func initMonitoringAndAutoscaling(access kubernetes.Access, nodeLister node.List
 			check:  "vpa-admission-controller",
 			period: 10 * time.Second,
 			config: checker.AtLeastOnePodReady{
-				Access:                    access,
-				Timeout:                   5 * time.Second,
-				Namespace:                 "kube-system",
-				LabelSelector:             "app=vpa-admission-controller",
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:           access,
+				Timeout:          5 * time.Second,
+				Namespace:        "kube-system",
+				LabelSelector:    "app=vpa-admission-controller",
+				PreflightChecker: controlPlanePinger,
 			},
 		}, {
 			group:  groupMonitoringAndAutoscaling,
@@ -139,14 +141,14 @@ func initMonitoringAndAutoscaling(access kubernetes.Access, nodeLister node.List
 			check:  "node-exporter",
 			period: 10 * time.Second,
 			config: checker.DaemonSetPodsReady{
-				Access:                    access,
-				NodeLister:                nodeLister,
-				Namespace:                 "d8-monitoring",
-				Name:                      "node-exporter",
-				RequestTimeout:            5 * time.Second,
-				PodCreationTimeout:        time.Minute,
-				PodDeletionTimeout:        5 * time.Second,
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:             access,
+				NodeLister:         nodeLister,
+				Namespace:          "d8-monitoring",
+				Name:               "node-exporter",
+				RequestTimeout:     5 * time.Second,
+				PodCreationTimeout: time.Minute,
+				PodDeletionTimeout: 5 * time.Second,
+				PreflightChecker:   controlPlanePinger,
 			},
 		}, {
 			group:  groupMonitoringAndAutoscaling,
@@ -154,11 +156,11 @@ func initMonitoringAndAutoscaling(access kubernetes.Access, nodeLister node.List
 			check:  "kube-state-metrics",
 			period: 10 * time.Second,
 			config: checker.AtLeastOnePodReady{
-				Access:                    access,
-				Timeout:                   5 * time.Second,
-				Namespace:                 "d8-monitoring",
-				LabelSelector:             "app=kube-state-metrics",
-				ControlPlaneAccessTimeout: cpTimeout,
+				Access:           access,
+				Timeout:          5 * time.Second,
+				Namespace:        "d8-monitoring",
+				LabelSelector:    "app=kube-state-metrics",
+				PreflightChecker: controlPlanePinger,
 			},
 		}, {
 			group:  groupMonitoringAndAutoscaling,

--- a/modules/500-upmeter/images/upmeter/pkg/probe/load_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/load_test.go
@@ -25,6 +25,7 @@ import (
 
 	"d8.io/upmeter/pkg/check"
 	"d8.io/upmeter/pkg/kubernetes"
+	"d8.io/upmeter/pkg/probe/checker"
 )
 
 func Test_NewProbeFilter(t *testing.T) {
@@ -122,6 +123,7 @@ func TestLoader_Probes(t *testing.T) {
 			IngressNginxControllers: []string{"main", "main-w-pp"},
 			NodeGroups:              []string{"system", "frontend", "worker", "spot"},
 		},
+		checker.NoopDoer{},
 		newDummyLogger().Logger,
 	)
 

--- a/modules/500-upmeter/images/upmeter/pkg/server/server.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/server.go
@@ -35,6 +35,7 @@ import (
 	"d8.io/upmeter/pkg/monitor/downtime"
 	"d8.io/upmeter/pkg/probe"
 	"d8.io/upmeter/pkg/probe/calculated"
+	"d8.io/upmeter/pkg/probe/checker"
 	"d8.io/upmeter/pkg/registry"
 	"d8.io/upmeter/pkg/server/api"
 	"d8.io/upmeter/pkg/server/remotewrite"
@@ -224,7 +225,8 @@ func newProbeLister(disabled []string, dynamic *DynamicProbesConfig) *registry.R
 		IngressNginxControllers: dynamic.IngressControllers,
 		NodeGroups:              dynamic.NodeGroups,
 	}
-	runLoader := probe.NewLoader(noFilter, noAccess, nil, dynamicConfig, noLogger)
+	dummyDoer := checker.NoopDoer{}
+	runLoader := probe.NewLoader(noFilter, noAccess, nil, dynamicConfig, dummyDoer, noLogger)
 	calcLoader := calculated.NewLoader(noFilter, noLogger)
 
 	return registry.NewProbeLister(runLoader, calcLoader)


### PR DESCRIPTION
## Description

Optimizes the preflight check to reduce the load of similar /version requests.

## Why do we need it, and what problem does it solve?

Reduces the throttling in checks.

## What is the expected result?

Less throttling in upmeter-agent resulting in more frequent update of probe results

## Checklist
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: upmeter
type: fix
summary: Reduced API calls throttling by the deduplication of preflight checks in probes.
```
