### PR TITLE
[cloud-provider-aws] remove deprecated standard section from provider…

### DIFF
--- a/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
@@ -203,6 +203,7 @@ apiVersions:
         required: []
         description: Layout is **deprecated**.
         properties: {}
+        deprecated: true
       withoutNAT:
         type: object
         additionalProperties: false

--- a/modules/030-cloud-provider-aws/hooks/migrate_aws_cluster_configuration.go
+++ b/modules/030-cloud-provider-aws/hooks/migrate_aws_cluster_configuration.go
@@ -63,7 +63,7 @@ func providerClusterConfigurationMigration(input *go_hook.HookInput, dc dependen
 	}
 
 	if _, ok := config["standard"]; !ok {
-		input.LogEntry.Info("paramaters for layout Standard not found, migration is not needed")
+		input.LogEntry.Info("parameters for layout Standard not found, migration is not needed")
 		return nil
 	}
 

--- a/modules/030-cloud-provider-aws/hooks/migrate_aws_cluster_configuration.go
+++ b/modules/030-cloud-provider-aws/hooks/migrate_aws_cluster_configuration.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// TODO remove after 1.38 release
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+)
+
+const DataKey = "cloud-provider-cluster-configuration.yaml"
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnStartup: &go_hook.OrderedConfig{Order: 10},
+}, dependency.WithExternalDependencies(providerClusterConfigurationMigration))
+
+func providerClusterConfigurationMigration(input *go_hook.HookInput, dc dependency.Container) error {
+	kubeCl, err := dc.GetK8sClient()
+	if err != nil {
+		return fmt.Errorf("cannot init Kubernetes client: %v", err)
+	}
+
+	secret, err := kubeCl.CoreV1().
+		Secrets("kube-system").
+		Get(context.TODO(), "d8-provider-cluster-configuration", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("cannot get Secret/kube-system/d8-provider-cluster-configuration: %v", err)
+	}
+
+	configYaml, ok := secret.Data[DataKey]
+	if !ok {
+		input.LogEntry.Warnf("key %q not found in Secret/kube-system/d8-provider-cluster-configuration", DataKey)
+		return nil
+	}
+
+	input.LogEntry.Warn(configYaml) // Backup through logs
+
+	config := make(map[string]interface{})
+	if err := yaml.Unmarshal(configYaml, &config); err != nil {
+		return fmt.Errorf("cannot unmarshal %s config: %v", DataKey, err)
+	}
+
+	if _, ok := config["standard"]; !ok {
+		input.LogEntry.Info("paramaters for layout Standard not found, migration is not needed")
+		return nil
+	}
+
+	delete(config, "standard")
+
+	configYaml, err = yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("cannot marshal %s config: %v", DataKey, err)
+	}
+
+	secret.Data[DataKey] = configYaml
+
+	_, err = kubeCl.CoreV1().
+		Secrets("kube-system").
+		Update(context.TODO(), secret, metav1.UpdateOptions{})
+
+	return err
+}

--- a/modules/030-cloud-provider-aws/hooks/migrate_aws_cluster_configuration_test.go
+++ b/modules/030-cloud-provider-aws/hooks/migrate_aws_cluster_configuration_test.go
@@ -1,0 +1,188 @@
+// Copyright 2022 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO remove after 1.38 release
+
+package hooks
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const (
+	providerClusterConfigurationWithoutStandard = `
+apiVersion: deckhouse.io/v1alpha1
+kind: AWSClusterConfiguration
+layout: Standard
+masterNodeGroup:
+  instanceClass:
+    ami: ami-0943382e114f188e8
+    instanceType: m5.xlarge
+  replicas: 3
+nodeNetworkCIDR: 10.240.0.0/20
+provider:
+  providerAccessKeyId: XXXXXXXXXXXXXX
+  providerSecretAccessKey: XXXXXXXXXXXXXX
+  region: eu-west-1
+sshPublicKey: ssh-rsa XXXXXXXXXXXXXX
+tags:
+  Usage: test
+vpcNetworkCIDR: 10.240.0.0/16
+`
+
+	providerClusterConfigurationWithStandard = `
+apiVersion: deckhouse.io/v1alpha1
+kind: AWSClusterConfiguration
+layout: Standard
+masterNodeGroup:
+  instanceClass:
+    ami: ami-0943382e114f188e8
+    instanceType: m5.xlarge
+  replicas: 3
+nodeNetworkCIDR: 10.240.0.0/20
+provider:
+  providerAccessKeyId: XXXXXXXXXXXXXX
+  providerSecretAccessKey: XXXXXXXXXXXXXX
+  region: eu-west-1
+standard:
+  associatePublicIPToMasters: true
+  associatePublicIPToNodes: true
+sshPublicKey: ssh-rsa XXXXXXXXXXXXXX
+tags:
+  Usage: test
+vpcNetworkCIDR: 10.240.0.0/16
+`
+)
+
+func createProviderClusterConfigurationSecret(providerClusterConfiguration string) error {
+	var secretTemplate = `
+---
+apiVersion: v1
+data:
+  %s: %s
+kind: Secret
+metadata:
+  labels:
+    heritage: deckhouse
+    name: d8-provider-cluster-configuration
+  name: d8-provider-cluster-configuration
+  namespace: kube-system
+type: Opaque
+`
+	secret := fmt.Sprintf(secretTemplate, DataKey, base64.StdEncoding.EncodeToString([]byte(providerClusterConfiguration)))
+	var s v1.Secret
+	err := yaml.Unmarshal([]byte(secret), &s)
+	if err != nil {
+		return err
+	}
+	_, err = dependency.TestDC.MustGetK8sClient().
+		CoreV1().
+		Secrets("kube-system").
+		Create(context.TODO(), &s, metav1.CreateOptions{})
+	return err
+}
+
+var _ = Describe("Cloud-provider-aws :: migrate_aws_cluster_configuration ::", func() {
+	const (
+		initValuesString       = `{}`
+		initConfigValuesString = `{}`
+	)
+
+	Context("No config", func() {
+		f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
+
+		BeforeEach(func() {
+			f.KubeStateSet("")
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+			f.RunHook()
+		})
+
+		It("Hook should fail", func() {
+			Expect(f).To(Not(ExecuteSuccessfully()))
+		})
+
+		It("Hook does not generate secret", func() {
+			_, err := dependency.TestDC.K8sClient.CoreV1().
+				Secrets("kube-system").
+				Get(context.TODO(), "d8-provider-cluster-configuration", metav1.GetOptions{})
+			Expect(err).To(Not(BeNil()))
+		})
+	})
+
+	Context("Config exists, field "+DataKey+" does not contain standard section", func() {
+		f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
+
+		BeforeEach(func() {
+
+			f.KubeStateSet("")
+
+			err := createProviderClusterConfigurationSecret(providerClusterConfigurationWithoutStandard)
+			Expect(err).To(BeNil())
+
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+			f.RunHook()
+		})
+
+		It("Hook does not fail", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("Hook does not change secret", func() {
+			s, err := dependency.TestDC.K8sClient.CoreV1().
+				Secrets("kube-system").
+				Get(context.TODO(), "d8-provider-cluster-configuration", metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			Expect(s.Data[DataKey]).To(MatchYAML(providerClusterConfigurationWithoutStandard))
+		})
+	})
+
+	Context("Config exists, field "+DataKey+" contains standard section", func() {
+		f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
+
+		BeforeEach(func() {
+
+			f.KubeStateSet("")
+
+			err := createProviderClusterConfigurationSecret(providerClusterConfigurationWithStandard)
+			Expect(err).To(BeNil())
+
+			f.BindingContexts.Set(f.GenerateOnStartupContext())
+			f.RunHook()
+		})
+
+		It("Hook does not fail", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("Hook changes secret, standard section is removed", func() {
+			s, err := dependency.TestDC.K8sClient.CoreV1().
+				Secrets("kube-system").
+				Get(context.TODO(), "d8-provider-cluster-configuration", metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			Expect(s.Data[DataKey]).To(MatchYAML(providerClusterConfigurationWithoutStandard))
+		})
+	})
+
+})


### PR DESCRIPTION
… cluster configuration

Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Remove deprecated standard section from provider cluster configuration.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In #2231  we set standard section of aws provider cluster configuration as deprecated and removed two parameters - associatePublicIPToMasters and associatePublicIPToNodes. But in some clusters we have this paramters in secret d8-provider-cluster-configuration. So we need a migration to remove this parameters from secret.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: Remove deprecated standard section from provider cluster configuration.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
