### PR TITLE
[log-shipper] Vector 0.24.2

### DIFF
--- a/modules/460-log-shipper/hooks/validate_test.go
+++ b/modules/460-log-shipper/hooks/validate_test.go
@@ -27,7 +27,7 @@ func TestValidateConfigWithVector(t *testing.T) {
 		t.Skip("Do not run this on CI")
 	}
 
-	dockerImage := "timberio/vector:0.24.1-debian"
+	dockerImage := "timberio/vector:0.24.2-debian"
 
 	script := `
 	set -e

--- a/modules/460-log-shipper/images/vector/Dockerfile
+++ b/modules/460-log-shipper/images/vector/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
       ca-certificates make bash cmake libclang1-9 llvm-9 libsasl2-dev librdkafka-dev
 
 WORKDIR /vector
-RUN git clone --depth 1 --branch v0.24.1 https://github.com/vectordotdev/vector.git \
+RUN git clone --depth 1 --branch v0.24.2 https://github.com/vectordotdev/vector.git \
     && cd vector
 
 # Download and cache dependencies


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Fix https://vector.dev/releases/0.24.2/

## Why do we need it, and what problem does it solve?
The key point to update
> The expire_metrics_secs setting is now correctly applied to expire timeseries not seen in the configured number of seconds.


## What is the expected result?

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: log-shipper
type: chore
summary: Bump Vector to 0.24.2
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
