### PR TITLE
[candi] Fix Yandex NAT Instance netplan config

### DIFF
--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
@@ -84,7 +84,7 @@ locals {
             use-domains: false
           routes:
           - to: "${var.node_network_cidr}"
-            link
+            scope: link
     EOF
 
     netplan apply


### PR DESCRIPTION
Signed-off-by: Konstantin Aksenov <konstantin.aksenov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix invalid yaml. Should be `scope: link`
```
cat /etc/netplan/49-second-interface.yaml 
network:
  version: 2
  ethernets:
    eth1:
      dhcp4: yes
      dhcp4-overrides:
        use-dns: false
        use-ntp: false
        use-hostname: false
        use-routes: false
        use-domains: false
      routes:
      - to: "192.168.0.0/16"
        link
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Invalid yaml in netplan
```
root@s-yc-obs-metrics-stage-ks-nat:~# netplan generate
/etc/netplan/49-second-interface.yaml:15:1: Invalid YAML: aliases are not supported:


^
```

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: Fix Yandex NAT Instance netplan config
impact: No impact for existing cluster. Only fixes cluster bootstap of WithNATInstance layot in Yandex Cloud.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
