### PR TITLE
[docs][cloud-provider-yandex] Update docs about parameters

### DIFF
--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -241,12 +241,12 @@ apiVersions:
         type: object
         description: |
           One or more pre-existing subnets mapped to respective zone.
-          ```yaml
-          ru-central1-a: e2lu8r1tbbtryhdpa9ro
-          ru-central1-b: e2lu8r1tbbtryhdpa9ro
-          ru-central1-c: e2lu8r1tbbtryhdpa9ro
-          ```
-          !!!Warning!!! Deckhouse will create route table that must be manually attached to these subnets!
+
+          > **Warning!** Deckhouse will create a route table that must be manually attached to these subnets.
+        x-examples:
+          - ru-central1-a: e2lu8r1tbbtryhdpa9ro
+            ru-central1-b: e2lu8r1tbbtryhdpa9ro
+            ru-central1-c: e2lu8r1tbbtryhdpa9ro
         additionalProperties:
           type: string
         pattern: '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$'
@@ -292,10 +292,11 @@ apiVersions:
           exporterAPIKey:
             description: |
               API-key for cloud metrics exporter.
-              If parameter is empty cloud metrics exporter will not be deployed in the cluster.
-              If parameter is `Auto`, Deckhouse will create service account with role `monitoring.viewer` and create API-key manually. Provider service account should have `admin` role.
-              Any other value is considered a valid API-key. See [this instruction](https://cloud.yandex.ru/docs/iam/operations/api-key/create) for creating API-key.
-              Service account should have `monitoring.viewer` role.
+
+              - If parameter is empty, cloud metrics exporter will not be deployed in the cluster.
+              - If parameter is `Auto`, Deckhouse will create service account with the `monitoring.viewer` role and create API-key manually. Provider service account should have the `admin` role.
+              - Any other value is considered a valid API-key. See [this instruction](https://cloud.yandex.ru/docs/iam/operations/api-key/create) for creating API-key.
+                Service account should have `monitoring.viewer` role.
             type: string
             default: ""
           natInstanceExternalAddress:
@@ -355,7 +356,7 @@ apiVersions:
       zones:
         type: array
         description: |
-          The globally restricted set of zones that this Cloud Provider works with.
+          The globally restricted set of zones that this cloud provider works with.
         items:
           enum:
             - ru-central1-a

--- a/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
@@ -107,12 +107,8 @@ apiVersions:
       existingZoneToSubnetIDMap:
         description: |
           Одна или несколько ранее существовавших подсетей, сопоставленных с соответствующей зоной.
-          ```yaml
-          ru-central1-a: e2lu8r1tbbtryhdpa9ro
-          ru-central1-b: e2lu8r1tbbtryhdpa9ro
-          ru-central1-c: e2lu8r1tbbtryhdpa9ro
-          ```
-          !!!Внимание!!! Deckhouse создаст таблицу маршрутизации, которую необходимо вручную привязать к указанными подсетям!
+
+          > **Внимание!** Deckhouse создаст таблицу маршрутизации, которую необходимо вручную привязать к указанными подсетям.
       labels:
         description: |
           Лейблы, проставляемые на ресурсы, создаваемые в Yandex.Cloud.
@@ -142,10 +138,11 @@ apiVersions:
           exporterAPIKey:
             description: |
               API-ключ для экспортера метрик Яндекс Облака.
-              Если значение равно пустой строке, то экспортер не будет задеплоен в кластер.
-              Если значение равно `Auto`, то Deckhouse создаст сервис-аккаунт c ролью `monitoring.viewer` и API-ключ для него. Для основного сервис-аккаунта требуется роль `admin`.
-              Любое другое значение считается валидным API-ключем. Используйте [эту инструкцию](https://cloud.yandex.ru/docs/iam/operations/api-key/create) для создания API-ключа.
-              Сервисный аккаунту для которого будет создан ключ необходимо назначить роль `monitoring.viewer`.
+
+              - Если значение ключа — пустая строка, то экспортер не будет развернут в кластере.
+              - Если значение ключа — `Auto`, то Deckhouse создаст service account c ролью `monitoring.viewer` и API-ключ для него. Для основного service account'а требуется роль `admin`.
+              - Любое другое значение ключа считается допустимым API-ключем. Используйте [инструкцию](https://cloud.yandex.ru/docs/iam/operations/api-key/create) для создания API-ключа.
+                Service account'у, для которого будет создан ключ, необходимо назначить роль `monitoring.viewer`.
           natInstanceExternalAddress:
             description: |
               Внешний [зарезервированный IP-адрес](https://deckhouse.io/ru/documentation/v1/modules/030-cloud-provider-yandex/faq.html#как-зарезервировать-публичный-ip-адрес) или адрес из `externalSubnetID` при указании опции.
@@ -173,4 +170,4 @@ apiVersions:
               Ключ к Service Account'у в JSON-формате, выдаваемый [yc iam key create](environment.html).
       zones:
         description: |
-          Глобальное ограничение набора зон, с которыми работает данный cloud-provider.
+          Глобальное ограничение набора зон, с которыми работает данный cloud provider.


### PR DESCRIPTION
## Description
Update docs about the `existingZoneToSubnetIDMap` and `exporterAPIKey` parameters.

Ref: #2563

## Changelog entries
```changes
section: cloud-provider-yandex
type: fix
summary: Update docs about the `existingZoneToSubnetIDMap` and `exporterAPIKey` parameters.
impact_level: low
```
