### PR TITLE
[cni-cilium] Fixed alert templating

### DIFF
--- a/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
+++ b/modules/021-cni-cilium/monitoring/prometheus-rules/agent.yaml
@@ -12,9 +12,9 @@
       plk_markup_format: "markdown"
       plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
       plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
-      summary: Some controllers (internal logical loops) are failing in agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}`
+      summary: Some controllers (internal logical loops) are failing in agent {{ $labels.namespace }}/{{ $labels.pod }}
       description: |
-        Check what's going on: `kubectl -n `{{`{{ $labels.namespace }}`}}` logs `{{`{{ $labels.pod }}`}}``
+        Check what's going on: `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}`
 
   - alert: CiliumAgentUnreachableNodes
     expr: max by (namespace, pod) (cilium_unreachable_nodes) > 0
@@ -28,9 +28,9 @@
       plk_markup_format: "markdown"
       plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
       plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
-      summary: Some nodes are not reachable by agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}`.
+      summary: Some nodes are not reachable by agent {{ $labels.namespace }}/{{ $labels.pod }}.
       description: |
-        Check what's going on: `kubectl -n `{{`{{ $labels.namespace }}`}}` logs `{{`{{ $labels.pod }}`}}``
+        Check what's going on: `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}`
 
   - alert: CiliumAgentUnreachableHealthEndpoints
     expr: max by (namespace, pod) (cilium_unreachable_health_endpoints) > 0
@@ -44,9 +44,9 @@
       plk_markup_format: "markdown"
       plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
       plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
-      summary: Some nodes' health endpoints are not reachable by agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}`.
+      summary: Some nodes' health endpoints are not reachable by agent {{ $labels.namespace }}/{{ $labels.pod }}.
       description: |
-        Check what's going on: `kubectl -n `{{`{{ $labels.namespace }}`}}` logs `{{`{{ $labels.pod }}`}}``
+        Check what's going on: `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}`
 
   - alert: CiliumAgentEndpointsNotReady
     expr: sum by (namespace, pod) (cilium_endpoint_state{endpoint_state="ready"} / cilium_endpoint_state) < 0.5
@@ -60,9 +60,9 @@
       plk_markup_format: "markdown"
       plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
       plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
-      summary: More than half of all known Endpoints are not ready in agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}`.
+      summary: More than half of all known Endpoints are not ready in agent {{ $labels.namespace }}/{{ $labels.pod }}.
       description: |
-        Check what's going on: `kubectl -n `{{`{{ $labels.namespace }}`}}` logs `{{`{{ $labels.pod }}`}}``
+        Check what's going on: `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}`
 
   - alert: CiliumAgentMapPressureCritical
     expr: sum by (namespace, pod, map_name) (cilium_bpf_map_pressure > 0.8)
@@ -76,7 +76,7 @@
       plk_markup_format: "markdown"
       plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
       plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
-      summary: eBPF map `{{`{{ $labels.map_name }}`}}` is more than 80% full in agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}`.
+      summary: eBPF map {{ $labels.map_name }} is more than 80% full in agent {{ $labels.namespace }}/{{ $labels.pod }}.
       description: We've reached resource limit of eBPF maps. Consult with vendor for possible remediation steps.
   - alert: CiliumAgentPolicyImportErrors
     expr: sum by (namespace, pod) (rate(cilium_policy_import_errors_total[2m]) > 0)
@@ -90,6 +90,6 @@
       plk_markup_format: "markdown"
       plk_grouped_by__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
       plk_create_group_if_not_exists__main: CiliumAgentMalfunctioning,prometheus=deckhouse,tier=~tier,kubernetes=~kubernetes
-      summary: Agent `{{`{{ $labels.namespace }}`}}`/`{{`{{ $labels.pod }}`}}` fails to import policies.
+      summary: Agent {{ $labels.namespace }}/{{ $labels.pod }} fails to import policies.
       description: |
-        Check what's going on: `kubectl -n `{{`{{ $labels.namespace }}`}}` logs `{{`{{ $labels.pod }}`}}``
+        Check what's going on: `kubectl -n {{ $labels.namespace }} logs {{ $labels.pod }}`


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixed alert templating.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Alerts were incorrectly escaped.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Alert labels are templated properly now.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cni-cilium
type: fix
summary: Fixed alert templating.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
