### PR TITLE
switch control-plane labels to master

### DIFF
--- a/ee/modules/600-flant-integration/hooks/pricing/envs_from_nodes.go
+++ b/ee/modules/600-flant-integration/hooks/pricing/envs_from_nodes.go
@@ -51,7 +51,7 @@ func ApplyPricingNodeFilter(obj *unstructured.Unstructured) (go_hook.FilterResul
 		n.Type = t
 	}
 
-	if _, ok := node.ObjectMeta.Labels["node-role.kubernetes.io/control-plane"]; !ok {
+	if _, ok := node.ObjectMeta.Labels["node.deckhouse.io/group: master"]; !ok {
 		return n, err
 	}
 


### PR DESCRIPTION
Switch kubernetes control-plane label to deckhouse's master one.