### PR TITLE
Add rsyslog unit check

### DIFF
--- a/candi/bashible/common-steps/all/083_disable_rsyslog_for_docker_and_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/083_disable_rsyslog_for_docker_and_kubelet.sh.tpl
@@ -19,7 +19,7 @@ _on_rsyslog_config_changed() {
 }
 {{- end }}
 
-if [ systemctl -q is-enabled rsyslog >/dev/null 2>&1 ]; then
+if systemctl -q is-enabled rsyslog 2>/dev/null; then
   exit 0
 fi
 

--- a/candi/bashible/common-steps/all/083_disable_rsyslog_for_docker_and_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/083_disable_rsyslog_for_docker_and_kubelet.sh.tpl
@@ -23,6 +23,8 @@ if [ systemctl -q is-enabled rsyslog >/dev/null 2>&1 ]; then
   exit 0
 fi
 
+if [ -d /etc/rsyslog.d ]; then
+
 bb-sync-file /etc/rsyslog.d/10-kubelet.conf - <<END
 :programname,isequal, "kubelet" ~
 END
@@ -30,3 +32,5 @@ END
 bb-sync-file /etc/rsyslog.d/10-dockerd.conf - <<END
 :programname,isequal, "dockerd" ~
 END
+
+fi

--- a/candi/bashible/common-steps/all/083_disable_rsyslog_for_docker_and_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/083_disable_rsyslog_for_docker_and_kubelet.sh.tpl
@@ -24,13 +24,11 @@ if systemctl -q is-enabled rsyslog 2>/dev/null; then
 fi
 
 if [ -d /etc/rsyslog.d ]; then
-
-bb-sync-file /etc/rsyslog.d/10-kubelet.conf - <<END
+  bb-sync-file /etc/rsyslog.d/10-kubelet.conf - <<END
 :programname,isequal, "kubelet" ~
 END
 
-bb-sync-file /etc/rsyslog.d/10-dockerd.conf - <<END
+  bb-sync-file /etc/rsyslog.d/10-dockerd.conf - <<END
 :programname,isequal, "dockerd" ~
 END
-
 fi

--- a/candi/bashible/common-steps/all/083_disable_rsyslog_for_docker_and_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/083_disable_rsyslog_for_docker_and_kubelet.sh.tpl
@@ -19,7 +19,7 @@ _on_rsyslog_config_changed() {
 }
 {{- end }}
 
-if systemctl -q is-enabled rsyslog 2>/dev/null; then
+if ! systemctl -q is-enabled rsyslog 2>/dev/null; then
   exit 0
 fi
 

--- a/candi/bashible/common-steps/all/083_disable_rsyslog_for_docker_and_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/083_disable_rsyslog_for_docker_and_kubelet.sh.tpl
@@ -19,6 +19,10 @@ _on_rsyslog_config_changed() {
 }
 {{- end }}
 
+if [ systemctl -q is-enabled rsyslog >/dev/null 2>&1 ]; then
+  exit 0
+fi
+
 bb-sync-file /etc/rsyslog.d/10-kubelet.conf - <<END
 :programname,isequal, "kubelet" ~
 END


### PR DESCRIPTION
## Description

This PR updates rsyslog modification step to work on systems without rsyslog by default.

Closes #2756

## Why do we need it, and what problem does it solve?

Allows installation on systems without rsyslog.
## What is the expected result?

Install on minimal ubuntu 22.04 without any problems.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.