### PR TITLE
[dhctl] Wait readiness control plane manager pod while creating new control-plane node. Fix no control new nodes in internal state.

### DIFF
--- a/dhctl/pkg/kubernetes/actions/converge/node.go
+++ b/dhctl/pkg/kubernetes/actions/converge/node.go
@@ -248,17 +248,12 @@ func WaitForNodesListBecomeReady(kubeCl *client.KubernetesClient, nodes []string
 		}
 
 		message := fmt.Sprintf("Nodes Ready %v of %v\n", len(readyNodes), desiredReadyNodes)
-		notReadyNodes := make([]string, 0, 0)
 		for _, node := range nodesList.Items {
 			condition := "NotReady"
 			if _, ok := readyNodes[node.Name]; ok {
 				condition = "Ready"
 			}
 			message += fmt.Sprintf("* %s | %s\n", node.Name, condition)
-		}
-
-		for _, n := range notReadyNodes {
-			delete(readyNodes, n)
 		}
 
 		if len(readyNodes) >= desiredReadyNodes {

--- a/dhctl/pkg/system/ssh/checks.go
+++ b/dhctl/pkg/system/ssh/checks.go
@@ -55,6 +55,9 @@ func CheckSSHHosts(userPassedHosts []string, nodesNames []string, runConfirm fun
 If you lose connection to node, converge may not be finished.
 Also, SSH connectivity to another nodes will not check before converge node.
 
+AAnd be attentive when you create new control-plane nodes and change another control-plane instances both.
+dhctl can not add new master IP's for connection.
+
 Do you want to continue?
 `, warnMsg)
 

--- a/dhctl/pkg/system/ssh/checks.go
+++ b/dhctl/pkg/system/ssh/checks.go
@@ -55,7 +55,7 @@ func CheckSSHHosts(userPassedHosts []string, nodesNames []string, runConfirm fun
 If you lose connection to node, converge may not be finished.
 Also, SSH connectivity to another nodes will not check before converge node.
 
-AAnd be attentive when you create new control-plane nodes and change another control-plane instances both.
+And be attentive when you create new control-plane nodes and change another control-plane instances both.
 dhctl can not add new master IP's for connection.
 
 Do you want to continue?


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Add control-plane-manager pod check after creating control-plane nodes.

## Why do we need it, and what problem does it solve?
Creating 2 additional control-plane nodes (doing multimaster) and change first control-plane node both can break a cluster because we cannot check control-plane readiness before recreate first node.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: fix
summary: Wait readiness control plane manager pod while creating new control-plane node. Fix no control new nodes in internal state.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
