### PR TITLE
[cni-cilium] Avoid panic

### DIFF
--- a/modules/021-cni-cilium/images/cilium/patches/003-fix-bwmap-delete-errors.patch
+++ b/modules/021-cni-cilium/images/cilium/patches/003-fix-bwmap-delete-errors.patch
@@ -22,8 +22,8 @@ index 1ed031108ee..4c26c1ffa9c 100644
 -	<-ch
 +
 +	updateRes := <-ch
-+	regenResult := updateRes.(*EndpointRegenerationResult)
-+	if regenResult.err != nil {
++	regenResult, ok := updateRes.(*EndpointRegenerationResult)
++	if ok && regenResult.err != nil {
 +		e.getLogger().WithError(regenResult.err).Error("EndpointNoTrackEvent event failed")
 +	}
  }
@@ -36,8 +36,8 @@ index 1ed031108ee..4c26c1ffa9c 100644
 -	<-ch
 +
 +	updateRes := <-ch
-+	regenResult := updateRes.(*EndpointRegenerationResult)
-+	if regenResult.err != nil {
++	regenResult, ok := updateRes.(*EndpointRegenerationResult)
++	if ok && regenResult.err != nil {
 +		e.getLogger().WithError(regenResult.err).Error("EndpointPolicyVisibilityEvent event failed")
 +	}
  }
@@ -50,8 +50,8 @@ index 1ed031108ee..4c26c1ffa9c 100644
 -	<-ch
 +
 +	updateRes := <-ch
-+	regenResult := updateRes.(*EndpointRegenerationResult)
-+	if regenResult.err != nil {
++	regenResult, ok:= updateRes.(*EndpointRegenerationResult)
++	if ok && regenResult.err != nil {
 +		e.getLogger().WithError(regenResult.err).Error("EndpointPolicyBandwidthEvent event failed")
 +	}
  }


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
https://github.com/cilium/cilium/commit/125591a72328659237bcde4c81868df655b9a3a8

## Why do we need it, and what problem does it solve?
An unexpected error forces the container to exit.

## What is the expected result?
cilium-agents will be restarted.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cni-cilium
type: fix
summary: Fix panic in the cilium-agent code.
impact: Cilium Agent pods will be restarted.
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
