### PR TITLE
[global_hooks][testing] Fix matrix tests duplication in global_hooks/openapi/config_values.yaml

### DIFF
--- a/global-hooks/openapi/config-values.yaml
+++ b/global-hooks/openapi/config-values.yaml
@@ -42,7 +42,8 @@ properties:
           **Do not use** DNS names (nor do create Ingress resources) that match this template to avoid conflicts with the Ingress resources created by Deckhouse.
 
           If this parameter is omitted, no Ingress resources will be created.
-        x-examples: [ "%s.kube.company.my" , "kube-%s.company.my" ]
+        x-doc-examples: [ "%s.kube.company.my", "kube-%s.company.my" ]
+        x-examples: [ "%s.kube.company.my" ]
       placement:
         description: |
           Parameters regulating the layout of Deckhouse module components.


### PR DESCRIPTION
Signed-off-by: Gleb Maiorov <gleb.maiorov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR speeds up matrix test by moving "kube-%s.company.my" `publicDomainTemplate` example from `x-examples` to `x-doc-examples`.

Change was tested locally using `time make tests-matrix`:
- before:
![before](https://user-images.githubusercontent.com/111346521/196929840-28987eb0-1936-44f9-aa60-5d7eaaf32e60.png)

- after:
![after](https://user-images.githubusercontent.com/111346521/196929998-7b840e94-67d2-4a97-b4a0-f58df76f9caf.png)


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Matrix testing time has greatly increased since #2415 was merged.
This PR fixes this effect, still leaving proposed `publicDomainTemplate` example in docs.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: testing
type: fix
summary: Fix matrix tests duplication in global_hooks/openapi/config_values.yaml
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
