### PR TITLE
[log-shipper] Expire metrics more frequently

### DIFF
--- a/modules/460-log-shipper/templates/configmap.yaml
+++ b/modules/460-log-shipper/templates/configmap.yaml
@@ -8,7 +8,7 @@ data:
   defaults.json: |
     {
       "data_dir": "/vector-data",
-      "expire_metrics_secs": 1200,
+      "expire_metrics_secs": 60,
       "api" : {
         "address" : "127.0.0.1:8686",
         "enabled" : true,


### PR DESCRIPTION
## Description
Reduce interval of metrics expirations checks

## Why do we need it, and what problem does it solve?
In frequently auto-scaling environments, expiring metrics once, e.g., in ten minutes, can cause memory shakes that look like a saw.

Since vector has a smart expiration mechanism that only expires stale metrics, we do not need to care much about the frequency.

## What is the expected result?
Log shipper pods will be restarted.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: log-shipper
type: fix
impact: Expire metrics more frequently
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
