### PR TITLE
[log-shipper] Fix Elasticsearch 8.X

### DIFF
--- a/modules/460-log-shipper/hooks/internal/composer/testdata/config_3.json
+++ b/modules/460-log-shipper/hooks/internal/composer/testdata/config_3.json
@@ -38,7 +38,8 @@
         "index": "{{ kubernetes.namespace }}-%F"
       },
       "pipeline": "test-pipe",
-      "mode": "bulk"
+      "mode": "bulk",
+      "suppress_type_name": true
     }
   }
 }

--- a/modules/460-log-shipper/hooks/internal/vector/destination/elasticsearch.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/elasticsearch.go
@@ -46,7 +46,8 @@ type Elasticsearch struct {
 
 	Mode string `json:"mode,omitempty"`
 
-	DocType string `json:"doc_type,omitempty"`
+	DocType          string `json:"doc_type,omitempty"`
+	SuppressTypeName bool   `json:"suppress_type_name"`
 }
 
 type ElasticsearchEncoding struct {
@@ -140,10 +141,11 @@ func NewElasticsearch(name string, cspec v1alpha1.ClusterLogDestinationSpec) *El
 			Action: bulkAction,
 			Index:  spec.Index,
 		},
-		Endpoint:    spec.Endpoint,
-		Pipeline:    spec.Pipeline,
-		Compression: "gzip",
-		DocType:     spec.DocType,
-		Mode:        mode,
+		Endpoint:         spec.Endpoint,
+		Pipeline:         spec.Pipeline,
+		Compression:      "gzip",
+		DocType:          spec.DocType,
+		SuppressTypeName: spec.DocType == "",
+		Mode:             mode,
 	}
 }

--- a/modules/460-log-shipper/hooks/testdata/es-5x/result.json
+++ b/modules/460-log-shipper/hooks/testdata/es-5x/result.json
@@ -146,7 +146,8 @@
       },
       "pipeline": "testpipe",
       "mode": "bulk",
-      "doc_type": "_doc"
+      "doc_type": "_doc",
+      "suppress_type_name": false
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/file-to-elastic/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-elastic/result.json
@@ -60,7 +60,8 @@
         "index": "logs-%F"
       },
       "pipeline": "testpipe",
-      "mode": "bulk"
+      "mode": "bulk",
+      "suppress_type_name": true
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/multiline/result.json
+++ b/modules/460-log-shipper/hooks/testdata/multiline/result.json
@@ -109,7 +109,8 @@
         "index": "logs-%F"
       },
       "pipeline": "testpipe",
-      "mode": "bulk"
+      "mode": "bulk",
+      "suppress_type_name": true
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/multiple-dest/result.json
+++ b/modules/460-log-shipper/hooks/testdata/multiple-dest/result.json
@@ -210,7 +210,8 @@
         "action": "index",
         "index": "logs-%F"
       },
-      "mode": "bulk"
+      "mode": "bulk",
+      "suppress_type_name": true
     },
     "destination/cluster/test-logstash-dest": {
       "type": "socket",

--- a/modules/460-log-shipper/hooks/testdata/namespaced-source/result.json
+++ b/modules/460-log-shipper/hooks/testdata/namespaced-source/result.json
@@ -171,7 +171,8 @@
         "action": "index",
         "index": "logs-%F"
       },
-      "mode": "bulk"
+      "mode": "bulk",
+      "suppress_type_name": true
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/one-dest/result.json
+++ b/modules/460-log-shipper/hooks/testdata/one-dest/result.json
@@ -112,7 +112,8 @@
         "action": "index",
         "index": "logs-%F"
       },
-      "mode": "bulk"
+      "mode": "bulk",
+      "suppress_type_name": true
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/pair-datastream/result.json
+++ b/modules/460-log-shipper/hooks/testdata/pair-datastream/result.json
@@ -153,7 +153,8 @@
         "index": "logs-%F"
       },
       "pipeline": "testpipe",
-      "mode": "data_stream"
+      "mode": "data_stream",
+      "suppress_type_name": true
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/simple-pair/result.json
+++ b/modules/460-log-shipper/hooks/testdata/simple-pair/result.json
@@ -145,7 +145,8 @@
         "index": "logs-%F"
       },
       "pipeline": "testpipe",
-      "mode": "bulk"
+      "mode": "bulk",
+      "suppress_type_name": true
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/throttle/result.json
+++ b/modules/460-log-shipper/hooks/testdata/throttle/result.json
@@ -96,7 +96,8 @@
         "index": "logs-%F"
       },
       "pipeline": "testpipe",
-      "mode": "bulk"
+      "mode": "bulk",
+      "suppress_type_name": true
     }
   }
 }


### PR DESCRIPTION
## Description
https://vector.dev/docs/reference/configuration/sinks/elasticsearch/#suppress_type_name

## Why do we need it, and what problem does it solve?
Fixes https://github.com/deckhouse/deckhouse/issues/2737

## What is the expected result?

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: log-shipper
type: fix
summary: Fix Elasticsearch 8.X and Opensearch
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
