### PR TITLE
[prometheus] fix disk retention size calc

### DIFF
--- a/modules/300-prometheus/hooks/calculate_storage_capacity.go
+++ b/modules/300-prometheus/hooks/calculate_storage_capacity.go
@@ -89,9 +89,6 @@ func prometheusDisk(input *go_hook.HookInput) error {
 	var main storage
 	var longterm storage
 
-	main.VolumeSizeGiB = defaultDiskSizeGiB
-	longterm.VolumeSizeGiB = defaultDiskSizeGiB
-
 	for _, obj := range input.Snapshots["pvcs"] {
 		pvc := obj.(PersistentVolumeClaim)
 		switch pvc.PrometheusName {
@@ -106,6 +103,14 @@ func prometheusDisk(input *go_hook.HookInput) error {
 		default:
 			continue
 		}
+	}
+
+	if main.VolumeSizeGiB == 0 {
+		main.VolumeSizeGiB = defaultDiskSizeGiB
+	}
+
+	if longterm.VolumeSizeGiB == 0 {
+		longterm.VolumeSizeGiB = defaultDiskSizeGiB
 	}
 
 	main.RetentionSizeGiB = int(math.Round(float64(main.VolumeSizeGiB) * float64(retentionPercent) / 100.0))

--- a/modules/300-prometheus/hooks/calculate_storage_capacity_test.go
+++ b/modules/300-prometheus/hooks/calculate_storage_capacity_test.go
@@ -181,7 +181,7 @@ spec:
 		})
 	})
 
-	FContext("Cluster with Small PVC", func() {
+	Context("Cluster with Small PVC", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(pvcSmall))
 			f.RunHook()


### PR DESCRIPTION
Signed-off-by: Vitaliy Snurnitsin <vitaliy.snurnitsin@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

- Fixed disk retention size calculation for small disks.
- Added tests for disks smaller than the default size.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This fixes a bug.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: fix
summary: Fixed disk retention size calculation for small disks.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
