### PR TITLE
[docs] Fix broken link to the blog

### DIFF
--- a/docs/site/pages/community.html
+++ b/docs/site/pages/community.html
@@ -111,7 +111,7 @@ anchors_disabled: true
                     Follow Deckhouse on <a href="https://twitter.com/deckhouseio" target="_blank">Twitter</a> to stay informed about everything that's going on.
                 </li>
                 <li>
-                    Read and dive into the nuts and bolts of Deckhouse in Flant's <a href="https://blog.flant.com/tag/deckhouse/" target="_blank">tech blog</a> posts.
+                    Read and dive into the nuts and bolts of Deckhouse in Flant's <a href="https://blog.deckhouse.io" target="_blank">tech blog</a> posts.
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
## Description
Fix broken site link to the blog.

## Changelog entries
```changes
section: docs
type: fix
summary: Fix broken site link to the blog.
impact_level: low
```
