### PR TITLE
[node-group] Fix master node taint

### DIFF
--- a/modules/040-node-manager/hooks/handle_node_templates.go
+++ b/modules/040-node-manager/hooks/handle_node_templates.go
@@ -238,7 +238,7 @@ func fixMasterTaints(nodeTaints []v1.Taint, ngTaints []v1.Taint) []v1.Taint {
 		_, existsInNG := ngTaintsMap[masterNodeRoleKey]
 		_, existsInNodeSpec := nodeTaintsMap[masterNodeRoleKey]
 		if existsInNodeSpec && !existsInNG {
-			delete(nodeTaintsMap, "node-role.kubernetes.io/master")
+			delete(nodeTaintsMap, masterNodeRoleKey)
 			newTaints := make([]v1.Taint, 0, len(nodeTaintsMap))
 			for _, v := range nodeTaintsMap {
 				newTaints = append(newTaints, *v)

--- a/modules/040-node-manager/hooks/handle_node_templates_test.go
+++ b/modules/040-node-manager/hooks/handle_node_templates_test.go
@@ -794,4 +794,51 @@ spec:
 			Expect(taints.Array()).To(HaveLen(0))
 		})
 	})
+
+	Context("NG has master taint but does not have control-plane", func() {
+		BeforeEach(func() {
+			state := `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: master
+spec:
+  nodeTemplate:
+    labels:
+      node-role.kubernetes.io/control-plane: ""
+      node-role.kubernetes.io/master: ""
+    taints:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+  nodeType: CloudPermanent
+---
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    node.deckhouse.io/configuration-checksum: 3ef180a2b2cce73299012a049437bfef447b031ccfbb6c7d26913124a9ac1c1e
+  labels:
+    kubernetes.io/hostname: kube-master-0
+    node-role.kubernetes.io/control-plane: ""
+    node-role.kubernetes.io/master: ""
+    node.deckhouse.io/group: master
+    node.deckhouse.io/type: CloudPermanent
+  name: kube-master-0
+spec:
+  podCIDR: 10.111.0.0/24
+  podCIDRs:
+  - 10.111.0.0/24
+  providerID: aws:///eu-central-1a/i-05724e80e8b61b339
+`
+			f.BindingContexts.Set(f.KubeStateSet(state))
+			f.RunHook()
+		})
+
+		It("Node should have master taint", func() {
+			taints := f.KubernetesGlobalResource("Node", "kube-master-0").Parse().Get("spec.taints")
+			Expect(taints.Array()).To(HaveLen(1))
+			Expect(taints.Array()[0].String()).To(Equal(`{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"}`))
+		})
+	})
 })


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Fix node taints when NG master has `"node-role.kubernetes.io/master"` set explicitly

## Why do we need it, and what problem does it solve?
We have made fix for single node installations with taint removal but it can affect old cluster with only `"node-role.kubernetes.io/master"` taint set in the `master` NG

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-group
type: fix
summary: Avoid "node-role.kubernetes.io/master" taint removal when it is explicitly set in the master NG
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
