### PR TITLE
[prometheus] Improove Prometheus Retain alerts

### DIFF
--- a/modules/300-prometheus/hooks/metrics_storage_retention.go
+++ b/modules/300-prometheus/hooks/metrics_storage_retention.go
@@ -31,7 +31,6 @@ func storageRetentionMetricHandler(input *go_hook.HookInput) error {
 	retentionDaysMain := input.Values.Get("prometheus.retentionDays")
 	retentionDaysLongterm := input.Values.Get("prometheus.longtermRetentionDays")
 
-
 	input.MetricsCollector.Set(
 		"d8_prometheus_main_storage_retention_days",
 		retentionDaysMain.Float(),

--- a/modules/300-prometheus/hooks/metrics_storage_retention.go
+++ b/modules/300-prometheus/hooks/metrics_storage_retention.go
@@ -31,6 +31,8 @@ func storageRetentionMetricHandler(input *go_hook.HookInput) error {
 	retentionDaysMain := input.Values.Get("prometheus.retentionDays")
 	retentionDaysLongterm := input.Values.Get("prometheus.longtermRetentionDays")
 
+	input.MetricsCollector.Expire("prometheus_disk_hook")
+
 	input.MetricsCollector.Set(
 		"d8_prometheus_storage_retention_days",
 		retentionDaysMain.Float(),

--- a/modules/300-prometheus/hooks/metrics_storage_retention.go
+++ b/modules/300-prometheus/hooks/metrics_storage_retention.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
+	"github.com/flant/addon-operator/sdk"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue:        "/modules/prometheus/metrics_storage_retention",
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+}, storageRetentionMetricHandler)
+
+func storageRetentionMetricHandler(input *go_hook.HookInput) error {
+	retentionDaysMain := input.Values.Get("prometheus.retentionDays")
+	retentionDaysLongterm := input.Values.Get("prometheus.longtermRetentionDays")
+
+
+	input.MetricsCollector.Set(
+		"d8_prometheus_main_storage_retention_days",
+		retentionDaysMain.Float(),
+		map[string]string{
+			"prometheus": "main",
+		},
+		metrics.WithGroup("prometheus_disk_hook"),
+	)
+
+	input.MetricsCollector.Set(
+		"d8_prometheus_longterm_storage_retention_days",
+		retentionDaysLongterm.Float(),
+		map[string]string{
+			"prometheus": "longterm",
+		},
+		metrics.WithGroup("prometheus_disk_hook"),
+	)
+
+	return nil
+}

--- a/modules/300-prometheus/hooks/metrics_storage_retention.go
+++ b/modules/300-prometheus/hooks/metrics_storage_retention.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Flant JSC
+Copyright 2022 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ func storageRetentionMetricHandler(input *go_hook.HookInput) error {
 	retentionDaysLongterm := input.Values.Get("prometheus.longtermRetentionDays")
 
 	input.MetricsCollector.Set(
-		"d8_prometheus_main_storage_retention_days",
+		"d8_prometheus_storage_retention_days",
 		retentionDaysMain.Float(),
 		map[string]string{
 			"prometheus": "main",
@@ -41,7 +41,7 @@ func storageRetentionMetricHandler(input *go_hook.HookInput) error {
 	)
 
 	input.MetricsCollector.Set(
-		"d8_prometheus_longterm_storage_retention_days",
+		"d8_prometheus_storage_retention_days",
 		retentionDaysLongterm.Float(),
 		map[string]string{
 			"prometheus": "longterm",

--- a/modules/300-prometheus/hooks/metrics_storage_retention_test.go
+++ b/modules/300-prometheus/hooks/metrics_storage_retention_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/flant/shell-operator/pkg/metric_storage/operation"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: prometheus :: hooks :: metrics_storage_retention ::", func() {
+
+	f := HookExecutionConfigInit(`{"prometheus": {"internal":{"prometheusMain":{}, "prometheusLongterm":{} }, "retentionDays": 14, "longtermRetentionDays": 300}}`, `{}`)
+
+	Context("Empty cluster and minimal settings", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Hook must execute successfully", func() {
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(3))
+			Expect(f).To(ExecuteSuccessfully())
+
+			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
+				Group:  "prometheus_disk_hook",
+				Action: "expire",
+			}))
+
+			Expect(m[1]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_prometheus_storage_retention_days",
+				Group:  "prometheus_disk_hook",
+				Action: "set",
+				Value:  pointer.Float64Ptr(14.0),
+				Labels: map[string]string{
+					"prometheus": "main",
+				},
+			}))
+
+			Expect(m[2]).To(BeEquivalentTo(operation.MetricOperation{
+				Name:   "d8_prometheus_storage_retention_days",
+				Group:  "prometheus_disk_hook",
+				Action: "set",
+				Value:  pointer.Float64Ptr(300.0),
+				Labels: map[string]string{
+					"prometheus": "longterm",
+				},
+			}))
+
+		})
+	})
+
+})

--- a/modules/300-prometheus/hooks/metrics_storage_retention_test.go
+++ b/modules/300-prometheus/hooks/metrics_storage_retention_test.go
@@ -18,7 +18,6 @@ package hooks
 
 import (
 	"github.com/flant/shell-operator/pkg/metric_storage/operation"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"

--- a/modules/300-prometheus/monitoring/prometheus-rules/prometheus-storage.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/prometheus-storage.yaml
@@ -18,7 +18,7 @@
         ```
         Consider increasing it https://deckhouse.io/en/documentation/v1/modules/300-prometheus/faq.html#how-to-expand-disk-size
   # If there was retention in the last 24 hours and the oldest metric was recorded less than 10 days ago and storage.tsdb.retention.size has not been changed.
-  - alert: PrometheusMainRetainLessThanRequiredDays
+  - alert: PrometheusMainRotatingEarlierThanConfiguredRetentionDays
     expr: |
       group by (service) (increase(prometheus_tsdb_size_retentions_total{service="prometheus"}[24h]) > 0)
       and
@@ -35,7 +35,7 @@
       summary: Prometheus-main data is being rotated earlier than configured retention days
       description: |
         You need to increase the disk size, reduce the number of metrics or decrease `retentionDays` module parameter.
-  - alert: PrometheusLongtermRetainLessThanRequiredDays
+  - alert: PrometheusLongtermRotatingEarlierThanConfiguredRetentionDays
     expr: |
       group by (service) (increase(prometheus_tsdb_size_retentions_total{service="prometheus-longterm"}[24h]) > 0)
       and

--- a/modules/300-prometheus/monitoring/prometheus-rules/prometheus-storage.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/prometheus-storage.yaml
@@ -22,7 +22,7 @@
     expr: |
       group by (service) (increase(prometheus_tsdb_size_retentions_total{service="prometheus"}[24h]) > 0)
       and
-      group by (service) ((time() - prometheus_tsdb_lowest_timestamp_seconds{service="prometheus"}) / 60 / 60 / 24 < d8_prometheus_main_storage_retention_days)
+      group by (service) ((time() - prometheus_tsdb_lowest_timestamp_seconds{service="prometheus"}) / 60 / 60 / 24 < d8_prometheus_storage_retention_days{prometheus="main"})
       and
       group by (service) (delta(prometheus_tsdb_retention_limit_bytes{service="prometheus"}[24h]) == 0)
     labels:
@@ -32,14 +32,14 @@
       plk_markup_format: markdown
       plk_protocol_version: "1"
       for: "10m"
-      summary: Prometheus-main data is retained for less than retention days
+      summary: Prometheus-main data is being rotated earlier than configured retention days
       description: |
-        You need to increase the disk size or reduce the number of metrics
+        You need to increase the disk size, reduce the number of metrics or decrease `retentionDays` module parameter.
   - alert: PrometheusLongtermRetainLessThanRequiredDays
     expr: |
       group by (service) (increase(prometheus_tsdb_size_retentions_total{service="prometheus-longterm"}[24h]) > 0)
       and
-      group by (service) ((time() - prometheus_tsdb_lowest_timestamp_seconds{service="prometheus-longterm"}) / 60 / 60 / 24 < d8_prometheus_longterm_storage_retention_days)
+      group by (service) ((time() - prometheus_tsdb_lowest_timestamp_seconds{service="prometheus-longterm"}) / 60 / 60 / 24 < d8_prometheus_longterm_storage_retention_days{prometheus="longterm"})
       and
       group by (service) (delta(prometheus_tsdb_retention_limit_bytes{service="prometheus-longterm"}[24h]) == 0)
     labels:
@@ -49,6 +49,6 @@
       plk_markup_format: markdown
       plk_protocol_version: "1"
       for: "10m"
-      summary: Prometheus-longterm data is retained for less than retention days
+      summary: Prometheus-longterm data is being rotated earlier than configured retention days
       description: |
-        You need to increase the disk size or reduce the number of metrics
+        You need to increase the disk size, reduce the number of metrics or decrease `longtermRetentionDays` module parameter.

--- a/modules/300-prometheus/monitoring/prometheus-rules/prometheus-storage.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/prometheus-storage.yaml
@@ -18,7 +18,7 @@
         ```
         Consider increasing it https://deckhouse.io/en/documentation/v1/modules/300-prometheus/faq.html#how-to-expand-disk-size
   # If there was retention in the last 24 hours and the oldest metric was recorded less than 10 days ago and storage.tsdb.retention.size has not been changed.
-  - alert: PrometheusMainRetainLessThan10Days
+  - alert: PrometheusMainRetainLessThanSettedDays
     expr: |
       group by (service) (increase(prometheus_tsdb_size_retentions_total{service="prometheus"}[24h]) > 0)
       and
@@ -35,7 +35,7 @@
       summary: Prometheus-main data is retained for less than 10 days
       description: |
         You need to increase the disk size or reduce the number of metrics
-  - alert: PrometheusLongtermRetainLessThan30Days
+  - alert: PrometheusLongtermRetainLessThanSettedDays
     expr: |
       group by (service) (increase(prometheus_tsdb_size_retentions_total{service="prometheus-longterm"}[24h]) > 0)
       and

--- a/modules/300-prometheus/monitoring/prometheus-rules/prometheus-storage.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/prometheus-storage.yaml
@@ -22,7 +22,7 @@
     expr: |
       group by (service) (increase(prometheus_tsdb_size_retentions_total{service="prometheus"}[24h]) > 0)
       and
-      group by (service) ((time() - prometheus_tsdb_lowest_timestamp_seconds{service="prometheus"}) / 60 / 60 / 24 < 10)
+      group by (service) ((time() - prometheus_tsdb_lowest_timestamp_seconds{service="prometheus"}) / 60 / 60 / 24 < d8_prometheus_main_storage_retention_days)
       and
       group by (service) (delta(prometheus_tsdb_retention_limit_bytes{service="prometheus"}[24h]) == 0)
     labels:
@@ -32,14 +32,14 @@
       plk_markup_format: markdown
       plk_protocol_version: "1"
       for: "10m"
-      summary: Prometheus-main data is retained for less than 10 days
+      summary: Prometheus-main data is retained for less than retention days
       description: |
         You need to increase the disk size or reduce the number of metrics
   - alert: PrometheusLongtermRetainLessThanSettedDays
     expr: |
       group by (service) (increase(prometheus_tsdb_size_retentions_total{service="prometheus-longterm"}[24h]) > 0)
       and
-      group by (service) ((time() - prometheus_tsdb_lowest_timestamp_seconds{service="prometheus-longterm"}) / 60 / 60 / 24 < 30)
+      group by (service) ((time() - prometheus_tsdb_lowest_timestamp_seconds{service="prometheus-longterm"}) / 60 / 60 / 24 < d8_prometheus_longterm_storage_retention_days)
       and
       group by (service) (delta(prometheus_tsdb_retention_limit_bytes{service="prometheus-longterm"}[24h]) == 0)
     labels:
@@ -49,6 +49,6 @@
       plk_markup_format: markdown
       plk_protocol_version: "1"
       for: "10m"
-      summary: Prometheus-longterm data is retained for less than 30 days
+      summary: Prometheus-longterm data is retained for less than retention days
       description: |
         You need to increase the disk size or reduce the number of metrics

--- a/modules/300-prometheus/monitoring/prometheus-rules/prometheus-storage.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/prometheus-storage.yaml
@@ -18,7 +18,7 @@
         ```
         Consider increasing it https://deckhouse.io/en/documentation/v1/modules/300-prometheus/faq.html#how-to-expand-disk-size
   # If there was retention in the last 24 hours and the oldest metric was recorded less than 10 days ago and storage.tsdb.retention.size has not been changed.
-  - alert: PrometheusMainRetainLessThanSettedDays
+  - alert: PrometheusMainRetainLessThanRequiredDays
     expr: |
       group by (service) (increase(prometheus_tsdb_size_retentions_total{service="prometheus"}[24h]) > 0)
       and
@@ -35,7 +35,7 @@
       summary: Prometheus-main data is retained for less than retention days
       description: |
         You need to increase the disk size or reduce the number of metrics
-  - alert: PrometheusLongtermRetainLessThanSettedDays
+  - alert: PrometheusLongtermRetainLessThanRequiredDays
     expr: |
       group by (service) (increase(prometheus_tsdb_size_retentions_total{service="prometheus-longterm"}[24h]) > 0)
       and


### PR DESCRIPTION
Signed-off-by: Vitaliy Snurnitsin <vitaliy.snurnitsin@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Prometheus Retain alerts now respect the retentionDays parameters.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Ignoring the retentionDays parameters leads to false alerts.


## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: fix
summary: Improve Prometheus Retain alerts.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
