### PR TITLE
[log-shipper] Loki fix extra labels

### DIFF
--- a/modules/460-log-shipper/hooks/internal/vector/transform/destination.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/destination.go
@@ -46,6 +46,10 @@ func CreateLogDestinationTransforms(name string, dest v1alpha1.ClusterLogDestina
 	switch dest.Spec.Type {
 	case v1alpha1.DestElasticsearch, v1alpha1.DestLogstash, v1alpha1.DestVector:
 		transforms = append(transforms, CleanUpParsedDataTransform())
+	case v1alpha1.DestLoki:
+		if len(dest.Spec.ExtraLabels) > 0 {
+			transforms = append(transforms, CreateParseDataTransforms())
+		}
 	}
 
 	dTransforms, err := BuildFromMapSlice("destination", name, transforms)

--- a/modules/460-log-shipper/hooks/testdata/multiple-dest/result.json
+++ b/modules/460-log-shipper/hooks/testdata/multiple-dest/result.json
@@ -67,6 +67,14 @@
       "source": "if exists(.parsed_data) {\n    del(.parsed_data)\n}",
       "type": "remap"
     },
+    "transform/destination/test-loki-dest/00_parse_json": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/test-source/14_log_filter"
+      ],
+      "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
+      "type": "remap"
+    },
     "transform/source/test-source/00_owner_ref": {
       "drop_on_abort": false,
       "inputs": [
@@ -241,7 +249,7 @@
     "destination/cluster/test-loki-dest": {
       "type": "loki",
       "inputs": [
-        "transform/source/test-source/14_log_filter"
+        "transform/destination/test-loki-dest/00_parse_json"
       ],
       "healthcheck": {
         "enabled": false

--- a/modules/460-log-shipper/hooks/testdata/namespaced-source/result.json
+++ b/modules/460-log-shipper/hooks/testdata/namespaced-source/result.json
@@ -19,6 +19,14 @@
     }
   },
   "transforms": {
+    "transform/destination/loki-storage/00_parse_json": {
+      "drop_on_abort": false,
+      "inputs": [
+        "transform/source/tests-whispers_whispers-logs/08_log_filter"
+      ],
+      "source": "if !exists(.parsed_data) {\n    structured, err = parse_json(.message)\n    if err == null {\n        .parsed_data = structured\n    } else {\n        .parsed_data = .message\n    }\n}",
+      "type": "remap"
+    },
     "transform/destination/test-es-dest/00_elastic_dedot": {
       "drop_on_abort": false,
       "inputs": [
@@ -114,7 +122,7 @@
     "destination/cluster/loki-storage": {
       "type": "loki",
       "inputs": [
-        "transform/source/tests-whispers_whispers-logs/08_log_filter"
+        "transform/destination/loki-storage/00_parse_json"
       ],
       "healthcheck": {
         "enabled": false


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Loki extra labels depends on `parsed_data`

## Why do we need it, and what problem does it solve?
There is a bug with the extraLabels option for Loki when users want to dynamically add labels.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: log-shipper
type: fix
summary: Loki fix extra labels.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
