### PR TITLE
[istio] exclude d8-upmeter ns from istio discovery

### DIFF
--- a/ee/modules/110-istio/templates/control-plane/iop.yaml
+++ b/ee/modules/110-istio/templates/control-plane/iop.yaml
@@ -70,6 +70,7 @@ spec:
     discoverySelectors:
     - matchExpressions:
       - {key: "heritage", operator: NotIn, values: [upmeter]}
+      - {key: "module", operator: NotIn, values: [upmeter]}
 
     outboundTrafficPolicy:
   {{- $outboundTrafficPolicyModeDict := dict "AllowAny" "ALLOW_ANY" "RegistryOnly" "REGISTRY_ONLY" }}


### PR DESCRIPTION
## Description
Exclude d8-upmeter ns from istio discovery

## Why do we need it, and what problem does it solve?
Periodically created resources in ns d8-upmeter create unnecessary load on istiod service

## What is the expected result?
Endpoints from ns d8-upmeter no longer appear in updates from istiod for istio-proxy

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Exclude the `d8-upmeter` namespace from the istio discovery process.
impact_level: default
```

