### PR TITLE
[log-shipper] Add Kafka destination

### DIFF
--- a/modules/460-log-shipper/apis/v1alpha1/cluster_log_destination.go
+++ b/modules/460-log-shipper/apis/v1alpha1/cluster_log_destination.go
@@ -49,6 +49,9 @@ type ClusterLogDestinationSpec struct {
 	// Logstash spec for the Logstash endpoint
 	Logstash LogstashSpec `json:"logstash"`
 
+	// Kafka spec for the Kafka endpoint
+	Kafka KafkaSpec `json:"kafka"`
+
 	// Vector spec for the Vector endpoint
 	Vector VectorSpec `json:"vector"`
 
@@ -101,6 +104,14 @@ type LokiSpec struct {
 	Endpoint string `json:"endpoint,omitempty"`
 
 	Auth LokiAuthSpec `json:"auth,omitempty"`
+
+	TLS CommonTLSSpec `json:"tls,omitempty"`
+}
+
+type KafkaSpec struct {
+	BootstrapServers []string `json:"bootstrapServers,omitempty"`
+
+	Topic string `json:"topic,omitempty"`
 
 	TLS CommonTLSSpec `json:"tls,omitempty"`
 }

--- a/modules/460-log-shipper/apis/v1alpha1/types.go
+++ b/modules/460-log-shipper/apis/v1alpha1/types.go
@@ -21,6 +21,7 @@ const (
 	DestLogstash      = "Logstash"
 	DestLoki          = "Loki"
 	DestVector        = "Vector"
+	DestKafka         = "Kafka"
 )
 
 const (

--- a/modules/460-log-shipper/crds/cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/cluster-log-destination.yaml
@@ -61,10 +61,18 @@ spec:
                   required:
                     - type
                     - vector
+                - properties:
+                    kafka: {}
+                    type:
+                      enum:
+                        - Kafka
+                  required:
+                    - type
+                    - kafka
               properties:
                 type:
                   type: string
-                  enum: ["Loki", "Elasticsearch", "Logstash", "Vector"]
+                  enum: ["Loki", "Elasticsearch", "Logstash", "Vector", "Kafka"]
                   description: Type of a log storage backend.
                 loki:
                   type: object
@@ -288,6 +296,67 @@ spec:
                     endpoint:
                       type: string
                       description: The base URL of the Logstash instance.
+                    tls:
+                      type: object
+                      description: Configures the TLS options for outgoing connections.
+                      properties:
+                        caFile:
+                          type: string
+                          description: Base64 encoded CA certificate in PEM format.
+                        clientCrt:
+                          type: object
+                          description: Configures client certificate for outgoing connections.
+                          required:
+                            - crtFile
+                            - keyFile
+                          properties:
+                            crtFile:
+                              type: string
+                              description: |
+                                Base64 encoded certificate in PEM format.
+
+                                You must also set the `keyFile` parameter.
+                            keyFile:
+                              type: string
+                              format: password
+                              description: |
+                                Base64 encoded private key in PEM format (PKCS#8).
+
+                                You must also set the `crtFile` parameter.
+                            keyPass:
+                              type: string
+                              format: string
+                              description: Base64 encoded pass phrase used to unlock the encrypted key file.
+                        verifyHostname:
+                          type: boolean
+                          default: true
+                          description: Validate the configured remote host name against the remote host's TLS certificate.
+                        verifyCertificate:
+                          type: boolean
+                          default: true
+                          description: Validate the TLS certificate of the remote host.
+                kafka:
+                  type: object
+                  required:
+                    - topic
+                    - bootstrapServers
+                  properties:
+                    topic:
+                      type: string
+                      description: |
+                        The Kafka topic name to write events to.
+                        This parameter supports template syntax, which enables you to use dynamic per-event values.
+                      x-doc-examples: ["logs", "logs-{{unit}}-%Y-%m-%d"]
+                    bootstrapServers:
+                      type: array
+                      description: |
+                        A list of host and port pairs that are the addresses of the Kafka brokers in a “bootstrap” Kafka cluster that a Kafka client connects to initially to bootstrap itself.
+                      default: []
+                      x-doc-examples:
+                      - ["10.14.22.123:9092", "10.14.23.332:9092"]
+                      items:
+                        type: string
+                        pattern: '^(.+)\:\d{1,5}$'
                     tls:
                       type: object
                       description: Configures the TLS options for outgoing connections.

--- a/modules/460-log-shipper/crds/doc-ru-cluster-log-destination.yaml
+++ b/modules/460-log-shipper/crds/doc-ru-cluster-log-destination.yaml
@@ -139,6 +139,41 @@ spec:
                           description: Проверка соответствия имени удаленного хоста и имени, указанного в TLS-сертификате удалённого хоста.
                         verifyCertificate:
                           description: Проверка действия TLS-сертификата удаленного хоста.
+                kafka:
+                  properties:
+                    topic:
+                      type: string
+                      description: |
+                        Имя топика в Kafka для записи событий.
+                        Этот параметр поддерживает синтаксис шаблонов, что дает возможность динамического создания топиков.
+                    bootstrapServers:
+                      type: array
+                      description: |
+                        Список пар адресов (хост:порт) Kafka брокеров в кластере Kafka, к которым должны подключиться клиенты для получения метаданных (топиков и партиций).
+                    tls:
+                      description: Настройки защищённого TLS-соединения.
+                      properties:
+                        caFile:
+                          description: Закодированный в Base64 сертификат CA в формате PEM.
+                        clientCrt:
+                          description: Конфигурация клиентского сертификата.
+                          properties:
+                            crtFile:
+                              description: |
+                                Закодированный в Base64 сертификат в формате PEM.
+
+                                Также, необходимо указать ключ в параметре `keyFile`.
+                            keyFile:
+                              description: |
+                                Закодированный в Base64 ключ в формате PEM.
+
+                                Также, необходимо указать сертификат в параметре `crtFile`.
+                            keyPass:
+                              description: Закодированный в Base64 пароль для ключа.
+                        verifyHostname:
+                          description: Проверка соответствия имени удаленного хоста и имени, указанного в TLS-сертификате удалённого хоста.
+                        verifyCertificate:
+                          description: Проверка действия TLS-сертификата удаленного хоста.
                 vector:
                   properties:
                     endpoint:

--- a/modules/460-log-shipper/hooks/generate_config_test.go
+++ b/modules/460-log-shipper/hooks/generate_config_test.go
@@ -133,6 +133,7 @@ spec:
 		Entry("Throttle Transform", "throttle"),
 		Entry("File to Elasticsearch", "file-to-elastic"),
 		Entry("File to Vector", "file-to-vector"),
+		Entry("File to Kafka", "file-to-kafka"),
 		Entry("Two sources to single destination", "many-to-one"),
 	)
 })

--- a/modules/460-log-shipper/hooks/internal/composer/composer.go
+++ b/modules/460-log-shipper/hooks/internal/composer/composer.go
@@ -147,6 +147,8 @@ func newLogDest(typ, name string, spec v1alpha1.ClusterLogDestinationSpec) apis.
 		return destination.NewLogstash(name, spec)
 	case v1alpha1.DestVector:
 		return destination.NewVector(name, spec)
+	case v1alpha1.DestKafka:
+		return destination.NewKafka(name, spec)
 	}
 	return nil
 }

--- a/modules/460-log-shipper/hooks/internal/composer/testdata/config_1.json
+++ b/modules/460-log-shipper/hooks/internal/composer/testdata/config_1.json
@@ -46,10 +46,10 @@
         "enabled": false
       },
       "encoding": {
-        "codec": "text",
         "only_fields": [
           "message"
         ],
+        "codec": "text",
         "timestamp_format": "rfc3339"
       },
       "endpoint": "http://testmeip:9000",

--- a/modules/460-log-shipper/hooks/internal/vector/destination/common.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/common.go
@@ -36,6 +36,12 @@ type CommonSettings struct {
 type Healthcheck struct {
 	Enabled bool `json:"enabled"`
 }
+type Encoding struct {
+	ExceptFields    []string `json:"except_fields,omitempty"`
+	OnlyFields      []string `json:"only_fields,omitempty"`
+	Codec           string   `json:"codec,omitempty"`
+	TimestampFormat string   `json:"timestamp_format,omitempty"`
+}
 
 type CommonTLS struct {
 	CAFile            string `json:"ca_file,omitempty"`

--- a/modules/460-log-shipper/hooks/internal/vector/destination/elasticsearch.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/elasticsearch.go
@@ -28,7 +28,7 @@ type Elasticsearch struct {
 
 	Endpoint string `json:"endpoint"`
 
-	Encoding ElasticsearchEncoding `json:"encoding,omitempty"`
+	Encoding Encoding `json:"encoding,omitempty"`
 
 	Batch ElasticsearchBatch `json:"batch,omitempty"`
 
@@ -48,12 +48,6 @@ type Elasticsearch struct {
 
 	DocType          string `json:"doc_type,omitempty"`
 	SuppressTypeName bool   `json:"suppress_type_name"`
-}
-
-type ElasticsearchEncoding struct {
-	ExceptFields    []string `json:"except_fields,omitempty"`
-	OnlyFields      []string `json:"only_fields,omitempty"`
-	TimestampFormat string   `json:"timestamp_format,omitempty"`
 }
 
 type ElasticsearchAuth struct {
@@ -126,7 +120,7 @@ func NewElasticsearch(name string, cspec v1alpha1.ClusterLogDestinationSpec) *El
 			Password:      decodeB64(spec.Auth.Password),
 			Strategy:      strings.ToLower(spec.Auth.Strategy),
 		},
-		Encoding: ElasticsearchEncoding{
+		Encoding: Encoding{
 			TimestampFormat: "rfc3339",
 		},
 		TLS: tls,

--- a/modules/460-log-shipper/hooks/internal/vector/destination/loki.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/loki.go
@@ -31,7 +31,7 @@ var validMustacheTemplate = regexp.MustCompile(`^\{\{\ ([a-zA-Z0-9][a-zA-Z0-9\[\
 type Loki struct {
 	CommonSettings
 
-	Encoding LokiEncoding `json:"encoding,omitempty"`
+	Encoding Encoding `json:"encoding,omitempty"`
 
 	Endpoint string `json:"endpoint"`
 
@@ -44,12 +44,6 @@ type Loki struct {
 	RemoveLabelFields bool `json:"remove_label_fields"`
 
 	OutOfOrderAction string `json:"out_of_order_action"`
-}
-
-type LokiEncoding struct {
-	Codec           string   `json:"codec,omitempty"`
-	OnlyFields      []string `json:"only_fields,omitempty"`
-	TimestampFormat string   `json:"timestamp_format,omitempty"`
 }
 
 type LokiAuth struct {
@@ -131,7 +125,7 @@ func NewLoki(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Loki {
 		TLS:      tls,
 		Labels:   labels,
 		Endpoint: spec.Endpoint,
-		Encoding: LokiEncoding{
+		Encoding: Encoding{
 			Codec:           "text",
 			TimestampFormat: "rfc3339",
 			OnlyFields:      []string{"message"},

--- a/modules/460-log-shipper/hooks/internal/vector/transform/destination.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/destination.go
@@ -29,7 +29,8 @@ func CreateLogDestinationTransforms(name string, dest v1alpha1.ClusterLogDestina
 	switch dest.Spec.Type {
 	case v1alpha1.DestElasticsearch, v1alpha1.DestLogstash:
 		transforms = append(transforms, DeDotTransform())
-
+		fallthrough
+	case v1alpha1.DestVector, v1alpha1.DestKafka:
 		if len(dest.Spec.ExtraLabels) > 0 {
 			transforms = append(transforms, ExtraFieldTransform(dest.Spec.ExtraLabels))
 		}

--- a/modules/460-log-shipper/hooks/testdata/file-to-kafka/manifests.yaml
+++ b/modules/460-log-shipper/hooks/testdata/file-to-kafka/manifests.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLoggingConfig
+metadata:
+  name: test-source
+spec:
+  type: File
+  file:
+    include: ["/var/log/kube-audit/audit.log"]
+  destinationRefs:
+    - test-kafka-dest
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLogDestination
+metadata:
+  name: test-kafka-dest
+spec:
+  type: Kafka
+  kafka:
+    bootstrapServers:
+    - "192.168.1.1:9200"
+    topic: "logs"

--- a/modules/460-log-shipper/hooks/testdata/file-to-kafka/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-kafka/result.json
@@ -1,0 +1,45 @@
+{
+  "sources": {
+    "cluster_logging_config/test-source": {
+      "type": "file",
+      "include": [
+        "/var/log/kube-audit/audit.log"
+      ]
+    }
+  },
+  "transforms": {
+    "transform/source/test-source/00_clean_up": {
+      "drop_on_abort": false,
+      "inputs": [
+        "cluster_logging_config/test-source"
+      ],
+      "source": "if exists(.pod_labels.\"controller-revision-hash\") {\n    del(.pod_labels.\"controller-revision-hash\")\n}\nif exists(.pod_labels.\"pod-template-hash\") {\n    del(.pod_labels.\"pod-template-hash\")\n}\nif exists(.kubernetes) {\n    del(.kubernetes)\n}\nif exists(.file) {\n    del(.file)\n}",
+      "type": "remap"
+    }
+  },
+  "sinks": {
+    "destination/cluster/test-kafka-dest": {
+      "type": "kafka",
+      "inputs": [
+        "transform/source/test-source/00_clean_up"
+      ],
+      "healthcheck": {
+        "enabled": false
+      },
+      "bootstrap_servers": "192.168.1.1:9200",
+      "encoding": {
+        "only_fields": [
+          "message"
+        ],
+        "codec": "text",
+        "timestamp_format": "rfc3339"
+      },
+      "topic": "logs",
+      "compression": "gzip",
+      "tls": {
+        "verify_hostname": true,
+        "verify_certificate": true
+      }
+    }
+  }
+}

--- a/modules/460-log-shipper/hooks/testdata/multiple-dest/result.json
+++ b/modules/460-log-shipper/hooks/testdata/multiple-dest/result.json
@@ -255,10 +255,10 @@
         "enabled": false
       },
       "encoding": {
-        "codec": "text",
         "only_fields": [
           "message"
         ],
+        "codec": "text",
         "timestamp_format": "rfc3339"
       },
       "endpoint": "http://192.168.1.1:9000",

--- a/modules/460-log-shipper/hooks/testdata/namespaced-source/result.json
+++ b/modules/460-log-shipper/hooks/testdata/namespaced-source/result.json
@@ -128,10 +128,10 @@
         "enabled": false
       },
       "encoding": {
-        "codec": "text",
         "only_fields": [
           "message"
         ],
+        "codec": "text",
         "timestamp_format": "rfc3339"
       },
       "endpoint": "http://loki.loki:3100",

--- a/modules/460-log-shipper/images/vector/Dockerfile
+++ b/modules/460-log-shipper/images/vector/Dockerfile
@@ -20,7 +20,7 @@ RUN cargo build \
     -j $(($(nproc) /2)) \
     --offline \
     --no-default-features \
-    --features "api,api-client,enrichment-tables,sources-host_metrics,sources-internal_metrics,sources-file,sources-kubernetes_logs,transforms,sinks-prometheus,sinks-blackhole,sinks-elasticsearch,sinks-file,sinks-loki,sinks-socket,sinks-console,sinks-vector,unix,rdkafka?/gssapi-vendored,vrl-cli" \
+    --features "api,api-client,enrichment-tables,sources-host_metrics,sources-internal_metrics,sources-file,sources-kubernetes_logs,transforms,sinks-prometheus,sinks-blackhole,sinks-elasticsearch,sinks-file,sinks-loki,sinks-socket,sinks-console,sinks-vector,sinks-kafka,unix,rdkafka?/gssapi-vendored,vrl-cli" \
     && strip target/release/vector
 
 FROM $BASE_DEBIAN_BULLSEYE


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
* Add new destination - [Kafka](https://vector.dev/docs/reference/configuration/sinks/kafka)
* Use a common struct for encoding - `Encoding`.

## Why do we need it, and what problem does it solve?
Closes https://github.com/deckhouse/deckhouse/issues/560

## What is the expected result?

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: log-shipper
type: feature
summary: Add Kafka destination.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
