### PR TITLE
[doc] Fix command parameters for editing configuration

### DIFF
--- a/candi/openapi/cluster_configuration.yaml
+++ b/candi/openapi/cluster_configuration.yaml
@@ -11,7 +11,7 @@ apiVersions:
       To change the `ClusterConfiguration` resource in a running cluster, run the following command:
 
       ```shell
-      kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller edit cluster-configuration
+      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit cluster-configuration
       ```
     additionalProperties: false
     required: [apiVersion, kind, clusterType, kubernetesVersion, podSubnetCIDR, serviceSubnetCIDR, clusterDomain]

--- a/candi/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/openapi/doc-ru-cluster_configuration.yaml
@@ -10,7 +10,7 @@ apiVersions:
       Чтобы изменить содержимое ресурса `ClusterConfiguration` в работающем кластере, выполните следующую команду:
 
       ```shell
-      kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller edit cluster-configuration
+      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit cluster-configuration
       ```
     properties:
       apiVersion:

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -232,7 +232,7 @@ The general cluster parameters are stored in the `ClusterConfiguration` structur
 To change the general cluster parameters, run the command:
 
 ```shell
-kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller edit cluster-configuration
+kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit cluster-configuration
 ```
 
 ## How do I change the configuration of a cloud provider in a cluster?
@@ -242,7 +242,7 @@ Cloud provider setting of a cloud of hybrid cluster are stored in the `<PROVIDER
 Regardless of the cloud provider used, its settings can be changed using the command:
 
 ```shell
-kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
 ```
 
 ## How do I change the configuration of a static cluster?
@@ -252,7 +252,7 @@ Settings of a static cluster are stored in the `StaticClusterConfiguration` stru
 To change the settings of a static cluster, run the command:
 
 ```shell
-kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller edit static-cluster-configuration
+kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit static-cluster-configuration
 ```
 
 ## How do I upgrade the Kubernetes version in a cluster?
@@ -261,7 +261,7 @@ To upgrade the Kubernetes version in a cluster change the `kubernetesVersion` pa
 1. Run the command:
 
    ```shell
-   kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller edit cluster-configuration
+   kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit cluster-configuration
    ```
 
 1. Change the `kubernetesVersion` field.

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -236,7 +236,7 @@ chmod 700 d8-push.sh
 Чтобы изменить общие параметры кластера, выполните команду:
 
 ```shell
-kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller edit cluster-configuration
+kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit cluster-configuration
 ```
 
 ## Как изменить конфигурацию облачного провайдера в кластере?
@@ -246,7 +246,7 @@ kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller edit cluster-
 Независимо от используемого облачного провайдера, его настройки можно изменить с помощью команды:
 
 ```shell
-kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
 ```
 
 ## Как изменить конфигурацию статического кластера?
@@ -256,7 +256,7 @@ kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller edit provider
 Чтобы изменить параметры статического кластера, выполните команду:
 
 ```shell
-kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller edit static-cluster-configuration
+kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit static-cluster-configuration
 ```
 
 ## Как обновить версию Kubernetes в кластере?
@@ -265,7 +265,7 @@ kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller edit static-c
 1. Выполните команду:
 
    ```shell
-   kubectl -n d8-system exec deploy/deckhouse -- deckhouse-controller edit cluster-configuration
+   kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit cluster-configuration
    ```
 
 1. Измените параметр `kubernetesVersion`.


### PR DESCRIPTION
## Description
Fixed command parameters for editing configuration (added `-ti` to the `kubectl exec` command).

## Changelog entries
```changes
section: docs
type: fix
summary: Fixed command parameters for editing configuration (added `-ti` to the kubectl exec command).
impact_level: low
```
