### PR TITLE
[testing] Fix complains about missing go binary during some workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,10 @@ else ifeq ($(PLATFORM_NAME), arm64)
 endif
 
 # Set host arch & OS for golang-based programs, e.g. Prometheus
-GOHOSTARCH := $(shell go env GOHOSTARCH)
-GOHOSTOS := $(shell go env GOHOSTOS)
+ifneq (, $(shell which go))
+	GOHOSTARCH := $(shell go env GOHOSTARCH)
+	GOHOSTOS := $(shell go env GOHOSTOS)
+endif
 
 help:
 	@printf -- "${FORMATTING_BEGIN_BLUE}%s${FORMATTING_END}\n" \


### PR DESCRIPTION
Signed-off-by: Gleb Maiorov <gleb.maiorov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR fixes a bug introduced in #2426 that causes `make` to complain about missing `go` binary when running in workflows without golang installed, e.g. [this test run](https://github.com/deckhouse/deckhouse-test-2/actions/runs/3327302190/jobs/5501973788#step:9:22).

Changes were tested localy.
- Prior that changes:
![before](https://user-images.githubusercontent.com/111346521/197994436-b550d03f-3ed9-4e80-82a4-56719987561f.png)

- After that changes:
![after](https://user-images.githubusercontent.com/111346521/197994695-bc38cd6e-ca2a-4033-bce1-e0a9261a930a.png)



## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This PR makes filling `GOHOSTARCH` and `GOHOSTOS` optional depending upon `go` binary installed.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

- Targets not requiring `GOHOSTARCH` and `GOHOSTOS` are executed without makefile complaining about missing `go` executable whether system has that executable.
- Targets that actually use `GOHOSTARCH` and `GOHOSTOS` will fail if executed on a system without `go` binary due to empty variables.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: testing
type: chore
summary: Fix complains about missing go binary during some workflows
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
