### PR TITLE
[cni-cilium] Improved PodMonitors

### DIFF
--- a/modules/021-cni-cilium/templates/agent/podmonitor.yaml
+++ b/modules/021-cni-cilium/templates/agent/podmonitor.yaml
@@ -20,9 +20,8 @@ spec:
     relabelings:
     - targetLabel: tier
       replacement: cluster
-    - action: replace
-      target_label: job
-      replacement: "cilium-agent"
+    - targetLabel: job
+      replacement: "cilium-operator"
   selector:
     matchLabels:
       app: agent

--- a/modules/021-cni-cilium/templates/agent/podmonitor.yaml
+++ b/modules/021-cni-cilium/templates/agent/podmonitor.yaml
@@ -21,7 +21,7 @@ spec:
     - targetLabel: tier
       replacement: cluster
     - targetLabel: job
-      replacement: "cilium-operator"
+      replacement: "cilium-agent"
   selector:
     matchLabels:
       app: agent

--- a/modules/021-cni-cilium/templates/agent/podmonitor.yaml
+++ b/modules/021-cni-cilium/templates/agent/podmonitor.yaml
@@ -1,8 +1,9 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: agent
+  name: cilium-agent
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "agent" "prometheus" "main")) | nindent 2 }}
 spec:
@@ -25,3 +26,4 @@ spec:
   namespaceSelector:
     matchNames:
     - d8-{{ .Chart.Name }}
+{{- end }}

--- a/modules/021-cni-cilium/templates/agent/podmonitor.yaml
+++ b/modules/021-cni-cilium/templates/agent/podmonitor.yaml
@@ -20,6 +20,9 @@ spec:
     relabelings:
     - targetLabel: tier
       replacement: cluster
+    - action: replace
+      target_label: job
+      replacement: "cilium-agent"
   selector:
     matchLabels:
       app: agent

--- a/modules/021-cni-cilium/templates/operator/podmonitor.yaml
+++ b/modules/021-cni-cilium/templates/operator/podmonitor.yaml
@@ -20,6 +20,9 @@ spec:
     relabelings:
     - targetLabel: tier
       replacement: cluster
+    - action: replace
+      target_label: job
+      replacement: "cilium-operator"
   selector:
     matchLabels:
       app: operator

--- a/modules/021-cni-cilium/templates/operator/podmonitor.yaml
+++ b/modules/021-cni-cilium/templates/operator/podmonitor.yaml
@@ -20,8 +20,7 @@ spec:
     relabelings:
     - targetLabel: tier
       replacement: cluster
-    - action: replace
-      target_label: job
+    - targetLabel: job
       replacement: "cilium-operator"
   selector:
     matchLabels:

--- a/modules/021-cni-cilium/templates/operator/podmonitor.yaml
+++ b/modules/021-cni-cilium/templates/operator/podmonitor.yaml
@@ -1,8 +1,9 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus-crd") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: operator
+  name: cilium-operator
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "operator" "prometheus" "main")) | nindent 2 }}
 spec:
@@ -25,3 +26,4 @@ spec:
   namespaceSelector:
     matchNames:
     - d8-{{ .Chart.Name }}
+{{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Naming and apply them only if operator-prometheus-crd is enabled.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

PodMonitors were not appropriately named. This resulted in non-transparent understanding of metrics labels and their source.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Metrics are now appropriately named.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cni-cilium
type: fix
summary: Improved PodMonitors. Naming and apply them only if operator-prometheus-crd is enabled.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
