### PR TITLE
[dashboard] add per-module highAvailability field to the OpenAPI schema

### DIFF
--- a/modules/500-dashboard/openapi/config-values.yaml
+++ b/modules/500-dashboard/openapi/config-values.yaml
@@ -53,6 +53,13 @@ properties:
           This parameter has no effect if the `externalAuthentication` is enabled.
   https:
     type: object
+    x-examples:
+      - mode: CustomCertificate
+        customCertificate:
+          secretName: "foobar"
+      - mode: CertManager
+        certManager:
+          clusterIssuerName: letsencrypt
     description: |
       What certificate type to use with the dashboard.
 
@@ -89,6 +96,13 @@ properties:
               The name of the Secret in the `d8-system` namespace to use with the dashboard (this Secret must have the [kubernetes.io/tls](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#tls-secrets) format).
 
             x-doc-default: 'false'
+  highAvailability:
+    type: boolean
+    x-examples: [true]
+    description: |
+      Manually enable the high availability mode.
+
+      By default, Deckhouse automatically decides whether to enable the HA mode. Click [here](../../deckhouse-configure-global.html#parameters) to learn more about the HA mode for modules.
   nodeSelector:
     type: object
     description: |

--- a/modules/500-dashboard/openapi/doc-ru-config-values.yaml
+++ b/modules/500-dashboard/openapi/doc-ru-config-values.yaml
@@ -65,6 +65,11 @@ properties:
             description: |
               Имя Secret'а в пространстве имен `d8-system`, который будет использоваться для dashboard (данный Secret должен быть в формате [kubernetes.io/tls](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#tls-secrets)).
             x-doc-default: 'false'
+  highAvailability:
+    description: |
+      Ручное управление режимом отказоустойчивости.
+
+      По умолчанию режим отказоустойчивости определяется автоматически. [Подробнее](../../deckhouse-configure-global.html#параметры) про режим отказоустойчивости.
   nodeSelector:
     description: |
       Аналогично параметру Kubernetes `spec.nodeSelector` у Pod'ов.


### PR DESCRIPTION
## Description

Add 'highAvailability' field to the OpenAPI schema of config values.

## Why do we need it, and what problem does it solve?

Fix regression: #2133 forbids highAvailability while switching module to use the OpenAPI schema for config values.

## What is the expected result?

- dashboard use high availability while global.highAvailability option is not specified.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dashboard
type: fix
summary: "Fix regression - add per-module `highAvailability` field to the OpenAPI schema."
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
