### PR TITLE
[node-manager][doc] minPerZone and maxPerZone relations clarification

### DIFF
--- a/candi/openapi/doc-ru-node_group.yaml
+++ b/candi/openapi/doc-ru-node_group.yaml
@@ -146,9 +146,13 @@ spec:
                     minPerZone:
                       description: |
                         Минимальное количество инстансов в зоне. Проставляется в объект `MachineDeployment` и в качестве нижней границы в cluster autoscaler.
+
+                        > **Внимание!** `minPerZone` != 0 и `minPerZone` <= `maxPerZone` или `minPerZone` == `maxPerZone` == 0.
                     maxPerZone:
                       description: |
                         Максимальное количество инстансов в зоне. Проставляется как верхняя граница в cluster-autoscaler.
+
+                        > **Внимание!** `minPerZone` != 0 и `minPerZone` <= `maxPerZone` или `minPerZone` == `maxPerZone` == 0.
                     priority:
                       description: |
                         Приоритет группы узлов.

--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -232,6 +232,8 @@ spec:
                         The minimum number of instances for the group in each zone.
 
                         This value is used in the MachineDeployment object and as a lower bound in cluster-autoscaler.
+
+                        > **Caution!** `minPerZone` != 0 and `minPerZone` <= `maxPerZone` or `minPerZone` == `maxPerZone` == 0.
                       type: integer
                       minimum: 0
                     maxPerZone:
@@ -239,6 +241,8 @@ spec:
                         The maximum number of instances for the group in each zone.
 
                         This value is used as the upper bound in cluster-autoscaler.
+
+                        > **Caution!** `minPerZone` != 0 and `minPerZone` <= `maxPerZone` or `minPerZone` == `maxPerZone` == 0.
                       type: integer
                       minimum: 0
                     maxUnavailablePerZone:

--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -855,6 +855,8 @@ spec:
                         The minimum number of instances for the group in each zone.
 
                         This value is used in the MachineDeployment object and as a lower bound in cluster-autoscaler.
+
+                        > **Caution!** `minPerZone` != 0 and `minPerZone` <= `maxPerZone` or `minPerZone` == `maxPerZone` == 0.
                       type: integer
                       minimum: 0
                     maxPerZone:
@@ -862,6 +864,8 @@ spec:
                         The maximum number of instances for the group in each zone.
 
                         This value is used as the upper bound in cluster-autoscaler.
+
+                        > **Caution!** `minPerZone` != 0 and `minPerZone` <= `maxPerZone` or `minPerZone` == `maxPerZone` == 0.
                       type: integer
                       minimum: 0
                     maxUnavailablePerZone:
@@ -1449,6 +1453,8 @@ spec:
                         The minimum number of instances for the group in each zone.
 
                         This value is used in the MachineDeployment object and as a lower bound in cluster-autoscaler.
+
+                        > **Caution!** `minPerZone` != 0 and `minPerZone` <= `maxPerZone` or `minPerZone` == `maxPerZone` == 0.
                       type: integer
                       minimum: 0
                     maxPerZone:
@@ -1456,6 +1462,8 @@ spec:
                         The maximum number of instances for the group in each zone.
 
                         This value is used as the upper bound in cluster-autoscaler.
+
+                        > **Caution!** `minPerZone` != 0 and `minPerZone` <= `maxPerZone` or `minPerZone` == `maxPerZone` == 0.
                       type: integer
                       minimum: 0
                     priority:


### PR DESCRIPTION
## Description
`minPerZone` and `maxPerZone` relations clarification in NodeGroup CR documentation.

## Why do we need it, and what problem does it solve?
Some users had false expectations, they wanted to set `minPerZone` = 0 and `maxPerZone` > 0 but this case was [restricted](https://github.com/deckhouse/deckhouse/pull/1249).

## What is the expected result?
The doc describes the case.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: `minPerZone` and `maxPerZone` relations clarification in NodeGroup CR documentation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
