### PR TITLE
[prometheus] Fix calculation of pvc size and retention size

### DIFF
--- a/modules/300-prometheus/hooks/calculate_storage_capacity.go
+++ b/modules/300-prometheus/hooks/calculate_storage_capacity.go
@@ -18,13 +18,14 @@ package hooks
 
 import (
 	"fmt"
+	"math"
+	"strings"
+
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"math"
-	"strings"
 )
 
 const defaultDiskSizeGiB = 40

--- a/modules/300-prometheus/hooks/calculate_storage_capacity.go
+++ b/modules/300-prometheus/hooks/calculate_storage_capacity.go
@@ -86,10 +86,10 @@ func prometheusDisk(input *go_hook.HookInput) error {
 	highAvailability := false
 
 	if input.Values.Exists("global.highAvailability") {
-		highAvailability = input.Values.Get("global.highAvailability")
+		highAvailability = input.Values.Get("global.highAvailability").Bool()
 	}
 	if input.Values.Exists("prometheus.highAvailability") {
-		highAvailability = input.Values.Get("prometheus.highAvailability")
+		highAvailability = input.Values.Get("prometheus.highAvailability").Bool()
 	}
 
 	for _, obj := range input.Snapshots["pvcs"] {

--- a/modules/300-prometheus/hooks/calculate_storage_capacity_test.go
+++ b/modules/300-prometheus/hooks/calculate_storage_capacity_test.go
@@ -133,7 +133,7 @@ spec:
     `
 	)
 
-	f := HookExecutionConfigInit(`{"prometheus": {"internal":{"prometheusMain":{}, "prometheusLongterm":{} }}}`, `{}`)
+	f := HookExecutionConfigInit(`{"prometheus": {"highAvailability": true, "internal":{"prometheusMain":{}, "prometheusLongterm":{} }}}`, `{}`)
 	f.RegisterCRD("monitoring.coreos.com", "v1", "Prometheus", true)
 
 	Context("Empty cluster", func() {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed calculation of pvc size and retention size.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In pr #1446, the `app` label was renamed, causing pvc size and retention to be calculated using the default values.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: fix
summary: Fixed calculation of pvc size and retention size.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
