### PR TITLE
[testing] support FOCUS for tests-modules target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,13 @@ else ifeq ($(PLATFORM_NAME), arm64)
 	CRANE_ARCH = arm64
 endif
 
+# Set testing path for tests-modules
+ifeq ($(FOCUS),"")
+       TESTS_PATH = ./modules/... ./global-hooks/... ./ee/modules/... ./ee/fe/modules/...
+else
+       TESTS_PATH = $(wildcard ./modules/*-${FOCUS} ./ee/modules/*-${FOCUS} ./ee/fe/modules/*-${FOCUS})/...
+endif
+
 # Set host arch & OS for golang-based programs, e.g. Prometheus
 ifneq (, $(shell which go))
 	GOHOSTARCH := $(shell go env GOHOSTARCH)
@@ -107,7 +114,8 @@ bin/gator: bin/gator-${GATOR_VERSION}/gator
 
 .PHONY: tests-modules tests-matrix tests-openapi tests-prometheus
 tests-modules: ## Run unit tests for modules hooks and templates.
-	go test -timeout=${TESTS_TIMEOUT} -vet=off ./modules/... ./global-hooks/... ./ee/modules/... ./ee/fe/modules/...
+  ##~ Options: FOCUS=module-name
+	go test -timeout=${TESTS_TIMEOUT} -vet=off ${TESTS_PATH}
 
 tests-matrix: bin/promtool bin/gator ## Test how helm templates are rendered with different input values generated from values examples.
   ##~ Options: FOCUS=module-name


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

## Description
Allow specifying FOCUS for tests-modules, eg.:

```
make tests-modules FOCUS=cloud-provider-yandex
```

## Why do we need it, and what problem does it solve?

Better DX

## What is the expected result?

Ability to test specific module via makefile

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: testing
type: chore
summary: support FOCUS for tests-modules target
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
