### PR TITLE
[dhctl] Add version in dhctl image

### DIFF
--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -126,7 +126,7 @@ func main() {
 		return nil
 	})
 
-	kpApp.Version("v0.0.0").Author("Flant")
+	kpApp.Version(app.AppVersion).Author("Flant")
 
 	go func() {
 		command, err := kpApp.Parse(os.Args[1:])

--- a/dhctl/pkg/app/app.go
+++ b/dhctl/pkg/app/app.go
@@ -15,13 +15,19 @@
 package app
 
 import (
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-const AppName = "dhctl"
+const (
+	AppName     = "dhctl"
+	VersionFile = "/deckhouse/version"
+)
 
 var TmpDirName = filepath.Join(os.TempDir(), "dhctl")
 
@@ -37,6 +43,17 @@ var (
 func init() {
 	if os.Getenv("DHCTL_DEBUG") == "yes" {
 		IsDebug = true
+	}
+	file, err := os.OpenFile(VersionFile, os.O_RDONLY, 0644)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+	buf := make([]byte, 30)
+	n, err := file.Read(buf)
+	if n > 0 && (errors.Is(err, io.EOF) || err == nil) {
+		AppVersion = strings.TrimSpace(string(buf))
+		AppVersion = strings.Replace(AppVersion, "\n", "", -1)
 	}
 }
 

--- a/werf.yaml
+++ b/werf.yaml
@@ -571,6 +571,8 @@ shell:
 
     echo 'eval "$(dhctl --completion-script-bash)"' >> /etc/bashrc
 
+    echo '{{- env "CI_COMMIT_TAG" | default "dev" }}' > /deckhouse/version
+
 ---
 artifact: release-channel-version-artifact
 from: {{ .Images.BASE_ALPINE }}


### PR DESCRIPTION
## Description

Add version file to install image and dhctl command.

## Why do we need it, and what problem does it solve?

New users want's to have easy method to determine installer version.

## What is the expected result?

File with version in image and built-in version string for dhctl

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: feature
summary: Add version in dhctl image
impact_level: default
```

