### PR TITLE
[node-manager] added pattern and length limit for NodeGroup name check

### DIFF
--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -73,6 +73,17 @@ spec:
           required:
             - spec
           properties:
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+                  pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" # In Amazon cloud, AWSMachineClass name can't contain dots.
+                  maxLength: 42 # One of labels assigned by the cloud instance manager contains full node name,
+                                # the same time, kubernetes labels keys and values can't be longer than 63 characters.
+                                # Length of hashes is 21 characters, so we leave 63-21=42 characters.
+                                # Further, validation webhook will check that length of <cluster prefix>-<group node name>
+                                # fits the 42 characters limitation.
             status:
               type: object
               required: []
@@ -670,6 +681,17 @@ spec:
           required:
             - spec
           properties:
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+                  pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" # In Amazon cloud, AWSMachineClass name can't contain dots.
+                  maxLength: 42 # One of labels assigned by the cloud instance manager contains full node name,
+                                # the same time, kubernetes labels keys and values can't be longer than 63 characters.
+                                # Length of hashes is 21 characters, so we leave 63-21=42 characters.
+                                # Further, validation webhook will check that length of <cluster prefix>-<group node name>
+                                # fits the 42 characters limitation.
             status:
               type: object
               required: []
@@ -1263,6 +1285,17 @@ spec:
           required:
             - spec
           properties:
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+                  pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" # In Amazon cloud, AWSMachineClass name can't contain dots.
+                  maxLength: 42 # One of labels assigned by the cloud instance manager contains full node name,
+                                # the same time, kubernetes labels keys and values can't be longer than 63 characters.
+                                # Length of hashes is 21 characters, so we leave 63-21=42 characters.
+                                # Further, validation webhook will check that length of <cluster prefix>-<group node name>
+                                # fits the 42 characters limitation.
             status:
               type: object
               required: []

--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -49,7 +49,12 @@ kubernetes:
     nameSelector:
       matchNames:
         - d8-cluster-configuration
-    jqFilter: '.data."cluster-configuration.yaml" // ""'
+    jqFilter: |
+      {
+        "defaultCRI": (.data."cluster-configuration.yaml" // "" | @base64d | match("[ ]*defaultCRI:[ ]+(.*)\n").captures[0].string),
+        "clusterPrefixLen": (.data."cluster-configuration.yaml" // "" | @base64d | match("[ ]*prefix:[ ]+(.*)\n").captures[0].string | length),
+        "clusterType": (.data."cluster-configuration.yaml" // "" | @base64d | match("clusterType:[ ]+(.*)\n").captures[0].string)
+      }
   - name: deckhouse_config
     apiVersion: v1
     kind: ConfigMap
@@ -76,6 +81,20 @@ EOF
 }
 
 function __main__() {
+  clusterType="$(context::jq -r '.snapshots.cluster_config[0].filterResult.clusterType')"
+  if [[ "$clusterType" == "Cloud" ]]; then
+    clusterPrefixLen="$(context::jq -r '.snapshots.cluster_config[0].filterResult.clusterPrefixLen')"
+    nodeGroupNameLen=$(context::jq -r '.review.request.object.metadata.name | length')
+    # Dynamic node name is <clusterPrefix>-<nodeGroupName>-<hashes> and one of kubernetes node label contains it.
+    # Label value must be >= 63 characters
+    if $(( 63 - $clusterPrefixLen - 1 - $nodeGroupNameLen - 21 )) < 0; then
+      cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"it is forbidden for this cluster to set (cluster prefix + node group name) longer then 42 symbols"}
+EOF
+      return 0
+    fi
+  fi
+
   minPerZone=$(context::jq -r '.review.request.object.spec.cloudInstances.minPerZone // 0')
   maxPerZone=$(context::jq -r '.review.request.object.spec.cloudInstances.maxPerZone // 0')
 
@@ -88,7 +107,7 @@ EOF
 
   # cri.type cannot be changed if count of endpoints < 3
   if context::jq -e -r '.review.request.name == "master"' >/dev/null 2>&1; then
-    defaultCRI="$(context::jq -r '.snapshots.cluster_config[0].filterResult' | base64 -d | grep "defaultCRI" | cut -d" " -f2)"
+    defaultCRI="$(context::jq -r '.snapshots.cluster_config[0].filterResult.defaultCRI')"
     if [[ -z "${defaultCRI}" ]]; then
       defaultCRI="Containerd"
     fi


### PR DESCRIPTION
## Description
Additional NodeGroup name validation

## Why do we need it, and what problem does it solve?
One of labels assigned by the cloud instance manager contains full node name.
Kubernetes label can't be longer than 63 characters. 
Also, in Amazon cloud AWSMachineClass name can't contain dots.
We limit node names to 63 characters and restrict dots usage.
Fix #2726

## What is the expected result?
It is forbidden to use dots in the NodeGroup name. Length of clusterPrefix and NodeGroup name sum limited to 42 characters.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: node-manager
type: chore
summary: Added pattern and limit of 42 characters in NodeGroup name check in CRD.
impact_level: low
```