### PR TITLE
[global] memory validation fix — float support for dimensioned digits

### DIFF
--- a/candi/openapi/node_group.yaml
+++ b/candi/openapi/node_group.yaml
@@ -287,7 +287,7 @@ spec:
                                 Describes the amount of memory that will not be held by standby holder on Nodes from this NodeGroup.
 
                                 The value can be an absolute number of bytes (for example, 128974848) as well as a fixed-point number using one of memory suffixes: G, Gi, M, Mi.
-                              pattern: '^[0-9]+(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+                              pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$'
                               x-kubernetes-int-or-string: true
                     classReference:
                       description: |
@@ -911,7 +911,7 @@ spec:
                                 Describes the amount of memory that will not be held by standby holder on Nodes from this NodeGroup.
 
                                 The value can be an absolute number of bytes (for example, 128974848) as well as a fixed-point number using one of memory suffixes: G, Gi, M, Mi.
-                              pattern: '^[0-9]+(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+                              pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$'
                               x-kubernetes-int-or-string: true
                     classReference:
                       description: |
@@ -1518,7 +1518,7 @@ spec:
                                 Describes the amount of memory that will not be held by standby holder on Nodes from this NodeGroup.
 
                                 The value can be an absolute number of bytes (for example, 128974848) as well as a fixed-point number using one of memory suffixes: G, Gi, M, Mi.
-                              pattern: '^[0-9]+(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+                              pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$'
                               x-kubernetes-int-or-string: true
                     classReference:
                       description: |

--- a/ee/modules/110-istio/openapi/config-values.yaml
+++ b/ee/modules/110-istio/openapi/config-values.yaml
@@ -392,7 +392,7 @@ properties:
                     default: '2Gi'
                     oneOf:
                     - type: string
-                      pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                      pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
                     - type: number
                   min:
                     description: |
@@ -400,7 +400,7 @@ properties:
                     default: '256Mi'
                     oneOf:
                     - type: string
-                      pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                      pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
                     - type: number
                   limitRatio:
                     type: number
@@ -427,7 +427,7 @@ properties:
                   memory:
                     oneOf:
                     - type: string
-                      pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                      pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
                     - type: number
                     description: |
                       Memory requests.
@@ -446,7 +446,7 @@ properties:
                   memory:
                     oneOf:
                     - type: string
-                      pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                      pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
                     - type: number
                     description: |
                       Memory limits.

--- a/ee/modules/110-istio/openapi/openapi-case-tests.yaml
+++ b/ee/modules/110-istio/openapi/openapi-case-tests.yaml
@@ -4,8 +4,8 @@ positive:
         resourcesManagement:
           vpa:
             memory:
-              max: "2G"
-              min: "1G"
+              max: "2.000G"
+              min: "1.123G"
     - controlPlane:
         resourcesManagement:
           static:

--- a/ee/modules/110-istio/openapi/openapi-case-tests.yaml
+++ b/ee/modules/110-istio/openapi/openapi-case-tests.yaml
@@ -1,5 +1,14 @@
 positive:
   configValues:
-    - {}
+    - controlPlane:
+        resourcesManagement:
+          vpa:
+            memory:
+              max: "2G"
+              min: "1G"
+    - controlPlane:
+        resourcesManagement:
+          static:
+            memory: "2G"
   values:
     - {}

--- a/global-hooks/openapi/config-values.yaml
+++ b/global-hooks/openapi/config-values.yaml
@@ -148,7 +148,7 @@ properties:
                 description: |
                   The combined memory requests for control-plane components on each master node.
                 type: string
-                pattern: '^[0-9]+(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+                pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$'
           everyNode:
             type: object
             default: {}
@@ -173,7 +173,7 @@ properties:
                   The combined memory requests for all the Deckhouse components on each node.
                 type: string
                 default: "512Mi"
-                pattern: '^[0-9]+(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+                pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$'
           masterNode:
             type: object
             additionalProperties: false
@@ -201,7 +201,7 @@ properties:
                     * For a Deckhouse-managed cluster, the default value is calculated automatically: `.status.allocatable.memory` of the smallest master node (no more than `8Gi`) minus `everyNode.memory`.
                     * For a managed cluster, the default value is `1Gi` minus `everyNode.memory`.
                 type: string
-                pattern: '^[0-9]+(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+                pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$'
       proxy:
         additionalProperties: false
         description: |

--- a/global-hooks/openapi/openapi-case-tests.yaml
+++ b/global-hooks/openapi/openapi-case-tests.yaml
@@ -24,6 +24,12 @@ positive:
           controlPlane:
             cpu: 1.25
             memory: "1G"
+    # decimal CPU and memory with dot
+    - modules:
+        resourcesRequests:
+          controlPlane:
+            cpu: 1.25
+            memory: "1.5G"
     # modules.https.mode Disabled work properly
     - modules:
         https:
@@ -175,6 +181,12 @@ negative:
       resourcesRequests:
         controlPlane:
           memory: "0ne"
+
+  # incorrect resource request: memory with incorrect value
+  - modules:
+      resourcesRequests:
+        controlPlane:
+          memory: "1.Gi"
 
   # incorrect resource request: cpu for master node
   - modules:

--- a/modules/021-cni-cilium/openapi/config-values.yaml
+++ b/modules/021-cni-cilium/openapi/config-values.yaml
@@ -135,7 +135,7 @@ properties:
                 default: '4Gi'
                 oneOf:
                 - type: string
-                  pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                  pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
                 - type: number
               min:
                 description: |
@@ -143,7 +143,7 @@ properties:
                 default: '512Mi'
                 oneOf:
                 - type: string
-                  pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                  pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
                 - type: number
               limitRatio:
                 type: number
@@ -170,7 +170,7 @@ properties:
               memory:
                 oneOf:
                 - type: string
-                  pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                  pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
                 - type: number
                 description: |
                   Memory requests.
@@ -189,7 +189,7 @@ properties:
               memory:
                 oneOf:
                 - type: string
-                  pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                  pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
                 - type: number
                 description: |
                   Memory limits.

--- a/modules/021-cni-cilium/openapi/openapi-case-tests.yaml
+++ b/modules/021-cni-cilium/openapi/openapi-case-tests.yaml
@@ -21,6 +21,39 @@ positive:
             ca: CACACA
             cert: CERT
             key: KEY
+  - internal:
+      - resourcesManagement:
+          mode: "VPA"
+          vpa:
+            memory:
+              max: "512Mi"
+              min: "16Mi"
+            cpu:
+              max: "2000m"
+              min: "200m"
+      - resourcesManagement:
+          mode: "VPA"
+          vpa:
+            memory:
+              max: 512
+              min: 16
+            cpu:
+              max: 2
+              min: 0.2
+      - resourcesManagement:
+          mode: "VPA"
+          vpa:
+            memory:
+              max: 1.5Gi
+              min: 2.0Ki
+            cpu:
+              max: 2
+              min: 0.2
+      - resourcesManagement:
+          mode: "Static"
+          static:
+            memory: 1.5Gi
+            cpu: 0.2
 negative:
   values:
   - internal:

--- a/modules/300-prometheus/openapi/config-values.yaml
+++ b/modules/300-prometheus/openapi/config-values.yaml
@@ -183,7 +183,7 @@ properties:
       maxMemory:
         oneOf:
           - type: string
-            pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+            pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
           - type: number
         x-examples: ["3Mi"]
         description: |
@@ -203,7 +203,7 @@ properties:
       longtermMaxMemory:
         oneOf:
           - type: string
-            pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+            pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
           - type: number
         x-examples: ["4Mi"]
         description: |
@@ -281,7 +281,7 @@ properties:
     description: |
       Deprecated and will be removed. Doesn't affect anything.
       The maximum size (in GiB) that the main Prometheus' volume can automatically resize to.
-    x-doc-deprecated: true      
+    x-doc-deprecated: true
   longtermMaxDiskSizeGigabytes:
     type: integer
     default: 300

--- a/modules/300-prometheus/openapi/openapi-case-tests.yaml
+++ b/modules/300-prometheus/openapi/openapi-case-tests.yaml
@@ -10,8 +10,16 @@ positive:
           maxMemory: "100"
     - internal:
         vpa:
+          maxCPU: "1400m"
+          maxMemory: "1.5Gi"
+    - internal:
+        vpa:
           longtermMaxCPU: "1m"
           longtermMaxMemory: "100Mi"
+    - internal:
+        vpa:
+          longtermMaxCPU: "1m"
+          longtermMaxMemory: "1.5Gi"
     - internal:
         vpa:
           longtermMaxCPU: 4096
@@ -79,3 +87,7 @@ negative:
       vpa:
         maxCPU: "123Hz"
         maxMemory: "3445J"
+  - internal:
+      vpa:
+        maxCPU: "123Pz"
+        maxMemory: "3.Gi"

--- a/modules/300-prometheus/openapi/values.yaml
+++ b/modules/300-prometheus/openapi/values.yaml
@@ -24,7 +24,7 @@ properties:
           maxMemory:
             oneOf:
               - type: string
-                pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
               - type: number
             x-examples: ["1500Mi"]
           longtermMaxCPU:
@@ -36,7 +36,7 @@ properties:
           longtermMaxMemory:
             oneOf:
               - type: string
-                pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
               - type: number
             x-examples: ["1500Gi"]
       prometheusMain:

--- a/modules/340-monitoring-kubernetes/openapi/config-values.yaml
+++ b/modules/340-monitoring-kubernetes/openapi/config-values.yaml
@@ -63,7 +63,7 @@ properties:
         x-examples: ["3Mi"]
         oneOf:
           - type: string
-            pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+            pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
           - type: number
         description: |
           Memory requests.

--- a/modules/340-monitoring-kubernetes/openapi/openapi-case-tests.yaml
+++ b/modules/340-monitoring-kubernetes/openapi/openapi-case-tests.yaml
@@ -5,6 +5,9 @@ positive:
         kubeStateMetricsMaxCPU: "100m"
         kubeStateMetricsMaxMemory: "150Mi"
     - vpa:
+        kubeStateMetricsMaxCPU: "100m"
+        kubeStateMetricsMaxMemory: "1.5Gi"
+    - vpa:
         kubeStateMetricsMaxCPU: 1
         kubeStateMetricsMaxMemory: 26214400
   values:
@@ -15,6 +18,9 @@ negative:
     - vpa:
         kubeStateMetricsMaxCPU: "512Hz"
         kubeStateMetricsMaxMemory: "16m"
+    - vpa:
+        kubeStateMetricsMaxCPU: "512Hz"
+        kubeStateMetricsMaxMemory: "16.m"
     - vpa:
         kubeStateMetricsMaxCPU: "512cpu"
   values:

--- a/modules/460-log-shipper/openapi/config-values.yaml
+++ b/modules/460-log-shipper/openapi/config-values.yaml
@@ -127,7 +127,7 @@ properties:
               max:
                 oneOf:
                   - type: string
-                    pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                    pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
                   - type: number
                 description: |
                   Maximum allowed memory requests.
@@ -135,7 +135,7 @@ properties:
               min:
                 oneOf:
                   - type: string
-                    pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                    pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
                   - type: number
                 description: |
                   Minimum allowed memory requests.
@@ -160,7 +160,7 @@ properties:
           memory:
             oneOf:
               - type: string
-                pattern: "^[0-9]+(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+                pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
               - type: number
             description: |
               Memory requests.

--- a/modules/460-log-shipper/openapi/openapi-case-tests.yaml
+++ b/modules/460-log-shipper/openapi/openapi-case-tests.yaml
@@ -19,6 +19,20 @@ positive:
           cpu:
             max: 2
             min: 0.2
+    - resourcesRequests:
+        mode: "VPA"
+        vpa:
+          memory:
+            max: 1.5Gi
+            min: 2.0Ki
+          cpu:
+            max: 2
+            min: 0.2
+    - resourcesRequests:
+        mode: "Static"
+        static:
+          memory: 1.5Gi
+          cpu: 0.2
   values:
     - internal: {}
 negative:
@@ -36,5 +50,11 @@ negative:
           cpu:
             max: "512cpu"
             min: "16Mi"
+    - resourcesRequests:
+        mode: "VPA"
+        vpa:
+          memory:
+            max: "1Hi"
+            min: "1.Mi"
   values:
     - somethingInConfig: yes


### PR DESCRIPTION
## Description
memory validation fix — float support for dimensioned digits like 3.5Gi.

## Why do we need it, and what problem does it solve?

We couldn't use the dot in values with units.
Closes issue #2233

## What is the expected result?
Memory validation allows using notations like '5.0Gi'

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: openapi
type: chore
summary: Memory validation allows to use notation like '5.0Gi'
impact: no impact expected
impact_level: low
```