### PR TITLE
[monitoring-kubernetes] removed unschedulable nodes from K8SNodeNotReady and K8SManyNodesNotReady alerts

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/kubelet.tpl
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/kubelet.tpl
@@ -14,7 +14,7 @@
   - alert: K8SManyNodesNotReady
     expr: count(kube_node_status_condition{condition="Ready",status="true"} == 0 and kube_node_spec_unschedulable == 0)
       > 1 and (count(kube_node_status_condition{condition="Ready",status="true"} == 0 and kube_node_spec_unschedulable == 0) /
-      count(kube_node_status_condition{condition="Ready",status="true"})) > 0.2
+      count(kube_node_status_condition{condition="Ready",status="true"} and kube_node_spec_unschedulable == 0)) > 0.2
     for: 1m
     labels:
       severity_level: "3"


### PR DESCRIPTION
## Description
Removed unschedulable nodes from K8SNodeNotReady alert

## Why do we need it, and what problem does it solve?
Alert K8SNodeNotReady was active while autoscaler removed the node from the cluster
Fix #2829

## What is the expected result?
If node is cordoned, alert K8SNodeNotReady ignores it.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: monitoring-kubernetes
type: chore
summary: removed unschedulable nodes from K8SNodeNotReady alert
impact: no impact expected
impact_level: low
```