### PR TITLE
[extended-monitoring] Typos in CertificateSecretExpiredSoon

### DIFF
--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificate.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/certificates/certificate.yaml
@@ -20,7 +20,7 @@
         - If the certificate is manually managed, upload a newer one.
         - If certificate is managed by cert-manager, try inspecting certificate resource, the recommended course of action:
           1. Retrieve certificate name from the secret: `cert=$(kubectl get secret -n {{$labels.namespace}} {{$labels.name}} -o 'jsonpath={.metadata.annotations.cert-manager\.io/certificate-name}')`
-          2. View the status of the Certificate and try to figure out why it is not updated: `kubectl describe cert -m {{$labels.namespace}} "$cert"`
+          2. View the status of the Certificate and try to figure out why it is not updated: `kubectl describe cert -n {{$labels.namespace}} "$cert"`
 
   - alert: CertificateSecretExpired
     expr: |


### PR DESCRIPTION
Signed-off-by: Maksim Nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
Fixes https://github.com/deckhouse/deckhouse/issues/2904

## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: extended-monitoring
type: fix
summary: Fix a typo in CertificateSecretExpiredSoon alert's description
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
