### PR TITLE
[deckhouse] remove approved status from printer columns

### DIFF
--- a/modules/002-deckhouse/crds/deckhouse-release.yaml
+++ b/modules/002-deckhouse/crds/deckhouse-release.yaml
@@ -81,14 +81,10 @@ spec:
                 approved:
                   type: boolean
                   description: |
-                    The status of the release's readiness for deployment. Always true for automatic updates (`update.mode: Auto`).
+                    The status of the release's readiness for deployment. Makes sense only for Manual updates (`update.mode: Manual`).
       subresources:
         status: {}
       additionalPrinterColumns:
-        - name: approved
-          jsonPath: .status.approved
-          type: boolean
-          description: 'Is the release approved for deployment.'
         - name: phase
           jsonPath: .status.phase
           type: string

--- a/modules/002-deckhouse/crds/deckhouse-release.yaml
+++ b/modules/002-deckhouse/crds/deckhouse-release.yaml
@@ -81,7 +81,7 @@ spec:
                 approved:
                   type: boolean
                   description: |
-                    The status of the release's readiness for deployment. Makes sense only for Manual updates (`update.mode: Manual`).
+                    The status of the release's readiness for deployment. It makes sense only for Manual updates (`update.mode: Manual`).
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/modules/002-deckhouse/crds/doc-ru-deckhouse-release.yaml
+++ b/modules/002-deckhouse/crds/doc-ru-deckhouse-release.yaml
@@ -35,14 +35,10 @@ spec:
                   description: Время изменения статуса релиза
                 approved:
                   description: |
-                    Статус готовности релиза к обновлению. Всегда true для Автоматического обновления (`update.mode: Auto`).
+                    Статус готовности релиза к обновлению. Используется только для режима обновления Manual (`update.mode: Manual`).
       subresources:
         status: {}
       additionalPrinterColumns:
-        - name: approved
-          jsonPath: .status.approved
-          type: boolean
-          description: 'Готов ли релиз к установке.'
         - name: phase
           jsonPath: .status.phase
           type: string


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Remove .status.approved printer field

## Why do we need it, and what problem does it solve?
It doesn't make sense for a user but only confuses him. We left this flag for internal logic (state) but hide it from the output

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse
type: fix
summary: Removed the `Approved` column from the status columns.
```
