### PR TITLE
Fix AMI in Get Started guide

### DIFF
--- a/candi/cloud-providers/aws/docs/LAYOUTS.md
+++ b/candi/cloud-providers/aws/docs/LAYOUTS.md
@@ -28,8 +28,9 @@ masterNodeGroup:
   instanceClass:
     # type of the instance
     instanceType: m5.xlarge
-    # Amazon Machine Image id
-    ami: ami-03818140b4ac9ae2b
+    # Amazon Machine Image ID
+    # AMI Catalog in the AWS console: EC2 -> AMI Catalog
+    ami: ami-0caef02b518350c8b
     # master node VM disk size
     diskSizeGb: 30
     # master node VM disk type to use
@@ -42,7 +43,7 @@ nodeGroups:
     replicas: 2
     instanceClass:
       instanceType: t2.medium
-      ami: ami-03818140b4ac9ae2b
+      ami: ami-0caef02b518350c8b
     additionalTags:
       backup: me
 vpcNetworkCIDR: "10.241.0.0/16"
@@ -78,7 +79,7 @@ withNAT:
     zone: eu-central-1a
     instanceClass:
       instanceType: m5.large
-      ami: ami-09a4a23815cdb5e06
+      ami: ami-0caef02b518350c8b
       diskType: gp3
 masterNodeGroup:
   # Number of master nodes.
@@ -87,8 +88,9 @@ masterNodeGroup:
   instanceClass:
     # type of the instance
     instanceType: m5.xlarge
-    # Amazon Machine Image id
-    ami: ami-03818140b4ac9ae2b
+    # Amazon Machine Image ID
+    # AMI Catalog in the AWS console: EC2 -> AMI Catalog
+    ami: ami-0caef02b518350c8b
     # master node VM disk size
     diskSizeGb: 30
     # master node VM disk type to use
@@ -101,7 +103,7 @@ nodeGroups:
     replicas: 2
     instanceClass:
       instanceType: t2.medium
-      ami: ami-03818140b4ac9ae2b
+      ami: ami-0caef02b518350c8b
     additionalTags:
       backup: me
 vpcNetworkCIDR: "10.241.0.0/16"

--- a/candi/cloud-providers/aws/docs/LAYOUTS_RU.md
+++ b/candi/cloud-providers/aws/docs/LAYOUTS_RU.md
@@ -30,8 +30,9 @@ masterNodeGroup:
   instanceClass:
     # тип используемого инстанса
     instanceType: m5.xlarge
-    # id образа виртуальной машины в Amazon
-    ami: ami-03818140b4ac9ae2b
+    # ID образа виртуальной машины в Amazon
+    # каталог AMI в консоли AWS: EC2 -> AMI Catalog
+    ami: ami-0caef02b518350c8b
     # размер диска для виртуальной машины master-узла
     diskSizeGb: 30
     # используемый тип диска для виртуальной машины master-узла
@@ -44,7 +45,7 @@ nodeGroups:
     replicas: 2
     instanceClass:
       instanceType: t2.medium
-      ami: ami-03818140b4ac9ae2b
+      ami: ami-0caef02b518350c8b
     additionalTags:
       backup: me
 vpcNetworkCIDR: "10.241.0.0/16"
@@ -80,7 +81,7 @@ withNAT:
     zone: eu-central-1a
     instanceClass:
       instanceType: m5.large
-      ami: ami-09a4a23815cdb5e06
+      ami: ami-0caef02b518350c8b
       diskType: gp3
 masterNodeGroup:
   # Количество master-узлов.
@@ -89,8 +90,9 @@ masterNodeGroup:
   instanceClass:
     # тип используемого инстанса
     instanceType: m5.xlarge
-    # id образа виртуальной машины в Amazon
-    ami: ami-03818140b4ac9ae2b
+    # ID образа виртуальной машины в Amazon
+    # каталог AMI в консоли AWS: EC2 -> AMI Catalog
+    ami: ami-0caef02b518350c8b
     # размер диска для виртуальной машины master-узла
     diskSizeGb: 30
     # используемый тип диска для виртуальной машины master-узла
@@ -103,7 +105,7 @@ nodeGroups:
     replicas: 2
     instanceClass:
       instanceType: t2.medium
-      ami: ami-03818140b4ac9ae2b
+      ami: ami-0caef02b518350c8b
     additionalTags:
       backup: me
 vpcNetworkCIDR: "10.241.0.0/16"

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.standard.ce.inc
@@ -105,7 +105,7 @@ masterNodeGroup:
     # [<ru>] id образа виртуальной машины в Amazon
     # [<en>] you might consider changing this
     # [<ru>] возможно, захотите изменить
-    ami: ami-0fee04b212b7499e2
+    ami: ami-097a2df4ac947655f
 # [<en>] address space of the AWS cloud
 # [<ru>] адресное пространство облака внутри AWS
 vpcNetworkCIDR: "10.241.0.0/16"

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.standard.ce.inc
@@ -101,11 +101,17 @@ masterNodeGroup:
     # [<en>] you might consider changing this
     # [<ru>] возможно, захотите изменить
     instanceType: c5.large
-    # [<en>] Amazon Machine Image id
-    # [<ru>] id образа виртуальной машины в Amazon
-    # [<en>] you might consider changing this
-    # [<ru>] возможно, захотите изменить
-    ami: ami-097a2df4ac947655f
+    # [<en>] Amazon Machine Image ID
+    # [<en>] The example uses the Ubuntu Server 22.04 image for the eu-central-1 region.
+    # [<en>] Change the AMI ID if you use a different region (the 'provider.region' parameter).
+    # [<en>] AMI Catalog in the AWS console: EC2 -> AMI Catalog.
+    # [<ru>] ID образа виртуальной машины в Amazon.
+    # [<ru>] В примере используется образ Ubuntu Server 22.04 для региона eu-central-1.
+    # [<ru>] Измените AMI ID, если используете другой регион в параметре 'provider.region'.
+    # [<ru>] Каталог AMI в консоли AWS: EC2 -> AMI Catalog.
+    # [<en>] You might consider changing this.
+    # [<ru>] Возможно, захотите изменить.
+    ami: ami-0caef02b518350c8b
 # [<en>] address space of the AWS cloud
 # [<ru>] адресное пространство облака внутри AWS
 vpcNetworkCIDR: "10.241.0.0/16"

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.standard.ee.inc
@@ -107,11 +107,17 @@ masterNodeGroup:
     # [<en>] you might consider changing this
     # [<ru>] возможно, захотите изменить
     instanceType: c5.large
-    # [<en>] Amazon Machine Image id
-    # [<ru>] id образа виртуальной машины в Amazon
-    # [<en>] you might consider changing this
-    # [<ru>] возможно, захотите изменить
-    ami: ami-097a2df4ac947655f
+    # [<en>] Amazon Machine Image ID
+    # [<en>] The example uses the Ubuntu Server 22.04 image for the eu-central-1 region.
+    # [<en>] Change the AMI ID if you use a different region (the 'provider.region' parameter).
+    # [<en>] AMI Catalog in the AWS console: EC2 -> AMI Catalog.
+    # [<ru>] ID образа виртуальной машины в Amazon.
+    # [<ru>] В примере используется образ Ubuntu Server 22.04 для региона eu-central-1.
+    # [<ru>] Измените AMI ID, если используете другой регион в параметре 'provider.region'.
+    # [<ru>] Каталог AMI в консоли AWS: EC2 -> AMI Catalog.
+    # [<en>] You might consider changing this.
+    # [<ru>] Возможно, захотите изменить.
+    ami: ami-0caef02b518350c8b
 # [<en>] address space of the AWS cloud
 # [<ru>] адресное пространство облака внутри AWS
 vpcNetworkCIDR: "10.241.0.0/16"

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.standard.ee.inc
@@ -111,7 +111,7 @@ masterNodeGroup:
     # [<ru>] id образа виртуальной машины в Amazon
     # [<en>] you might consider changing this
     # [<ru>] возможно, захотите изменить
-    ami: ami-0fee04b212b7499e2
+    ami: ami-097a2df4ac947655f
 # [<en>] address space of the AWS cloud
 # [<ru>] адресное пространство облака внутри AWS
 vpcNetworkCIDR: "10.241.0.0/16"

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.with_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.with_nat.ce.inc
@@ -90,11 +90,17 @@ withNAT:
       # [<en>] you might consider changing this
       # [<ru>] возможно, захотите изменить
       instanceType: m5.large
-      # [<en>] Amazon Machine Image id
-      # [<ru>] id образа виртуальной машины в Amazon
-      # [<en>] you might consider changing this
-      # [<ru>] возможно, захотите изменить
-      ami: ami-09a4a23815cdb5e06
+      # [<en>] Amazon Machine Image ID
+      # [<en>] The example uses the Ubuntu Server 22.04 image for the eu-central-1 region.
+      # [<en>] Change the AMI ID if you use a different region (the 'provider.region' parameter).
+      # [<en>] AMI Catalog in the AWS console: EC2 -> AMI Catalog.
+      # [<ru>] ID образа виртуальной машины в Amazon.
+      # [<ru>] В примере используется образ Ubuntu Server 22.04 для региона eu-central-1.
+      # [<ru>] Измените AMI ID, если используете другой регион в параметре 'provider.region'.
+      # [<ru>] Каталог AMI в консоли AWS: EC2 -> AMI Catalog.
+      # [<en>] You might consider changing this.
+      # [<ru>] Возможно, захотите изменить.
+      ami: ami-0caef02b518350c8b
       # [<en>] Disk type
       # [<ru>] Тип диска
       diskType: gp3
@@ -124,11 +130,17 @@ masterNodeGroup:
     # [<en>] you might consider changing this
     # [<ru>] возможно, захотите изменить
     instanceType: c5.large
-    # [<en>] Amazon Machine Image id
-    # [<ru>] id образа виртуальной машины в Amazon
-    # [<en>] you might consider changing this
-    # [<ru>] возможно, захотите изменить
-    ami: ami-097a2df4ac947655f
+    # [<en>] Amazon Machine Image ID
+    # [<en>] The example uses the Ubuntu Server 22.04 image for the eu-central-1 region.
+    # [<en>] Change the AMI ID if you use a different region (the 'provider.region' parameter).
+    # [<en>] AMI Catalog in the AWS console: EC2 -> AMI Catalog.
+    # [<ru>] ID образа виртуальной машины в Amazon.
+    # [<ru>] В примере используется образ Ubuntu Server 22.04 для региона eu-central-1.
+    # [<ru>] Измените AMI ID, если используете другой регион в параметре 'provider.region'.
+    # [<ru>] Каталог AMI в консоли AWS: EC2 -> AMI Catalog.
+    # [<en>] You might consider changing this.
+    # [<ru>] Возможно, захотите изменить.
+    ami: ami-0caef02b518350c8b
 # [<en>] address space of the AWS cloud
 # [<ru>] адресное пространство облака внутри AWS
 vpcNetworkCIDR: "10.241.0.0/16"

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.with_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.with_nat.ce.inc
@@ -128,7 +128,7 @@ masterNodeGroup:
     # [<ru>] id образа виртуальной машины в Amazon
     # [<en>] you might consider changing this
     # [<ru>] возможно, захотите изменить
-    ami: ami-0fee04b212b7499e2
+    ami: ami-097a2df4ac947655f
 # [<en>] address space of the AWS cloud
 # [<ru>] адресное пространство облака внутри AWS
 vpcNetworkCIDR: "10.241.0.0/16"

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.with_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.with_nat.ee.inc
@@ -96,11 +96,17 @@ withNAT:
       # [<en>] you might consider changing this
       # [<ru>] возможно, захотите изменить
       instanceType: m5.large
-      # [<en>] Amazon Machine Image id
-      # [<ru>] id образа виртуальной машины в Amazon
-      # [<en>] you might consider changing this
-      # [<ru>] возможно, захотите изменить
-      ami: ami-09a4a23815cdb5e06
+      # [<en>] Amazon Machine Image ID
+      # [<en>] The example uses the Ubuntu Server 22.04 image for the eu-central-1 region.
+      # [<en>] Change the AMI ID if you use a different region (the 'provider.region' parameter).
+      # [<en>] AMI Catalog in the AWS console: EC2 -> AMI Catalog.
+      # [<ru>] ID образа виртуальной машины в Amazon.
+      # [<ru>] В примере используется образ Ubuntu Server 22.04 для региона eu-central-1.
+      # [<ru>] Измените AMI ID, если используете другой регион в параметре 'provider.region'.
+      # [<ru>] Каталог AMI в консоли AWS: EC2 -> AMI Catalog.
+      # [<en>] You might consider changing this.
+      # [<ru>] Возможно, захотите изменить.
+      ami: ami-0caef02b518350c8b
       # [<en>] Disk type
       # [<ru>] Тип диска
       diskType: gp3
@@ -130,11 +136,17 @@ masterNodeGroup:
     # [<en>] you might consider changing this
     # [<ru>] возможно, захотите изменить
     instanceType: c5.large
-    # [<en>] Amazon Machine Image id
-    # [<ru>] id образа виртуальной машины в Amazon
-    # [<en>] you might consider changing this
-    # [<ru>] возможно, захотите изменить
-    ami: ami-097a2df4ac947655f
+    # [<en>] Amazon Machine Image ID
+    # [<en>] The example uses the Ubuntu Server 22.04 image for the eu-central-1 region.
+    # [<en>] Change the AMI ID if you use a different region (the 'provider.region' parameter).
+    # [<en>] AMI Catalog in the AWS console: EC2 -> AMI Catalog.
+    # [<ru>] ID образа виртуальной машины в Amazon.
+    # [<ru>] В примере используется образ Ubuntu Server 22.04 для региона eu-central-1.
+    # [<ru>] Измените AMI ID, если используете другой регион в параметре 'provider.region'.
+    # [<ru>] Каталог AMI в консоли AWS: EC2 -> AMI Catalog.
+    # [<en>] You might consider changing this.
+    # [<ru>] Возможно, захотите изменить.
+    ami: ami-0caef02b518350c8b
 # [<en>] address space of the AWS cloud
 # [<ru>] адресное пространство облака внутри AWS
 vpcNetworkCIDR: "10.241.0.0/16"

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.with_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.with_nat.ee.inc
@@ -134,7 +134,7 @@ masterNodeGroup:
     # [<ru>] id образа виртуальной машины в Amazon
     # [<en>] you might consider changing this
     # [<ru>] возможно, захотите изменить
-    ami: ami-0fee04b212b7499e2
+    ami: ami-097a2df4ac947655f
 # [<en>] address space of the AWS cloud
 # [<ru>] адресное пространство облака внутри AWS
 vpcNetworkCIDR: "10.241.0.0/16"

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
@@ -105,7 +105,7 @@ masterNodeGroup:
     # [<ru>] id образа виртуальной машины в Amazon
     # [<en>] you might consider changing this
     # [<ru>] возможно, захотите изменить
-    ami: ami-0fee04b212b7499e2
+    ami: ami-097a2df4ac947655f
 # [<en>] address space of the AWS cloud
 # [<ru>] адресное пространство облака внутри AWS
 vpcNetworkCIDR: "10.241.0.0/16"

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ce.inc
@@ -101,11 +101,17 @@ masterNodeGroup:
     # [<en>] you might consider changing this
     # [<ru>] возможно, захотите изменить
     instanceType: c5.large
-    # [<en>] Amazon Machine Image id
-    # [<ru>] id образа виртуальной машины в Amazon
-    # [<en>] you might consider changing this
-    # [<ru>] возможно, захотите изменить
-    ami: ami-097a2df4ac947655f
+    # [<en>] Amazon Machine Image ID
+    # [<en>] The example uses the Ubuntu Server 22.04 image for the eu-central-1 region.
+    # [<en>] Change the AMI ID if you use a different region (the 'provider.region' parameter).
+    # [<en>] AMI Catalog in the AWS console: EC2 -> AMI Catalog.
+    # [<ru>] ID образа виртуальной машины в Amazon.
+    # [<ru>] В примере используется образ Ubuntu Server 22.04 для региона eu-central-1.
+    # [<ru>] Измените AMI ID, если используете другой регион в параметре 'provider.region'.
+    # [<ru>] Каталог AMI в консоли AWS: EC2 -> AMI Catalog.
+    # [<en>] You might consider changing this.
+    # [<ru>] Возможно, захотите изменить.
+    ami: ami-0caef02b518350c8b
 # [<en>] address space of the AWS cloud
 # [<ru>] адресное пространство облака внутри AWS
 vpcNetworkCIDR: "10.241.0.0/16"

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ee.inc
@@ -107,11 +107,17 @@ masterNodeGroup:
     # [<en>] you might consider changing this
     # [<ru>] возможно, захотите изменить
     instanceType: c5.large
-    # [<en>] Amazon Machine Image id
-    # [<ru>] id образа виртуальной машины в Amazon
-    # [<en>] you might consider changing this
-    # [<ru>] возможно, захотите изменить
-    ami: ami-097a2df4ac947655f
+    # [<en>] Amazon Machine Image ID
+    # [<en>] The example uses the Ubuntu Server 22.04 image for the eu-central-1 region.
+    # [<en>] Change the AMI ID if you use a different region (the 'provider.region' parameter).
+    # [<en>] AMI Catalog in the AWS console: EC2 -> AMI Catalog.
+    # [<ru>] ID образа виртуальной машины в Amazon.
+    # [<ru>] В примере используется образ Ubuntu Server 22.04 для региона eu-central-1.
+    # [<ru>] Измените AMI ID, если используете другой регион в параметре 'provider.region'.
+    # [<ru>] Каталог AMI в консоли AWS: EC2 -> AMI Catalog.
+    # [<en>] You might consider changing this.
+    # [<ru>] Возможно, захотите изменить.
+    ami: ami-0caef02b518350c8b
 # [<en>] address space of the AWS cloud
 # [<ru>] адресное пространство облака внутри AWS
 vpcNetworkCIDR: "10.241.0.0/16"

--- a/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ee.inc
+++ b/docs/site/_includes/getting_started/aws/partials/config.yml.without_nat.ee.inc
@@ -111,7 +111,7 @@ masterNodeGroup:
     # [<ru>] id образа виртуальной машины в Amazon
     # [<en>] you might consider changing this
     # [<ru>] возможно, захотите изменить
-    ami: ami-0fee04b212b7499e2
+    ami: ami-097a2df4ac947655f
 # [<en>] address space of the AWS cloud
 # [<ru>] адресное пространство облака внутри AWS
 vpcNetworkCIDR: "10.241.0.0/16"

--- a/docs/site/js/getting-started.js
+++ b/docs/site/js/getting-started.js
@@ -18,11 +18,11 @@ $(document).ready(function () {
 
 function config_highlight() {
   let matchMustChange = '!CHANGE_';
-  let matchMightChangeEN = "# you might consider changing this";
-  let matchMightChangeRU = "# возможно, захотите изменить";
+  let matchMightChangeEN = /# [Yy]ou might consider changing this\.?/;
+  let matchMightChangeRU = /# [Вв]озможно, захотите изменить\.?/;
 
   $('code span.c1').filter(function () {
-    return (this.innerText === matchMightChangeEN) || (this.innerText === matchMightChangeRU);
+    return (matchMightChangeEN.test(this.innerText)) || (matchMightChangeRU.test(this.innerText));
   }).each(function (index) {
     try {
       if ($(this).next().next().next() && $(this).next().next().next().text() === '-') {


### PR DESCRIPTION
## Description

AWS AMI in the Getting Started was updated to Ubuntu Server 22.04 LTS.

Clarified description in the AWS config files in the Getting Started.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: Updated AWS AMI in the Getting Started to Ubuntu Server 22.04 LTS.
impact_level: low
```
