### PR TITLE
Automatically allocate 100% free space while creating lvmthin pool

### DIFF
--- a/modules/041-linstor/docs/CONFIGURATION.md
+++ b/modules/041-linstor/docs/CONFIGURATION.md
@@ -69,7 +69,7 @@ LINSTOR in Deckhouse can be configured by assigning special tag `linstor-<pool_n
 
      ```shell
      vgcreate data_project /dev/nvme0n1 /dev/nvme1n1
-     lvcreate -L 1.8T -T data_project/thindata --add-tag linstor-thindata
+     lvcreate -l 100%FREE -T data_project/thindata --add-tag linstor-thindata
      ```
 
      > Note, that the group itself should not have this tag configured.

--- a/modules/041-linstor/docs/CONFIGURATION_RU.md
+++ b/modules/041-linstor/docs/CONFIGURATION_RU.md
@@ -69,7 +69,7 @@ stringData:
 
      ```shell
      vgcreate data_project /dev/nvme0n1 /dev/nvme1n1
-     lvcreate -L 1.8T -T data_project/thindata --add-tag linstor-thindata
+     lvcreate -l 100%FREE -T data_project/thindata --add-tag linstor-thindata
      ```
 
      > Обратите внимание, что сама группа томов не обязана содержать какой-либо тег.


### PR DESCRIPTION
## Description
Automatically allocate 100% free space while creating lvmthin pool

## Why do we need it, and what problem does it solve?

Don't force user to think about space allocation

## What is the expected result?

Docs updated

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [X] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: linstor
type: chore
summary: document how to automatically allocate 100% free space while creating lvmthin pool
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
