### PR TITLE
[docs] Add Rocky Linux to the list of supported OS

### DIFF
--- a/docs/documentation/_data/supported_versions.yml
+++ b/docs/documentation/_data/supported_versions.yml
@@ -11,6 +11,9 @@ osDistributions:
   astra:
     name: Astra Linux Special Edition
     url: https://astralinux.ru/products/astra-linux-special-edition/
+  rocky:
+    name: Rocky Linux
+    url: https://rockylinux.org/download
   alteros:
     name: AlterOS
     url: https://alter-os.ru/

--- a/docs/documentation/_data/version_map_addition.yml
+++ b/docs/documentation/_data/version_map_addition.yml
@@ -6,6 +6,9 @@
     '1.7':
       ru_support: 'true'
       en_support: 'false'
+  rocky:
+    '8':
+    '9':
   '_redos':
     '7.3':
       ru_support: 'true'


### PR DESCRIPTION
## Description
Add Rocky Linux 8 and 9 to the list of supported OS.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add Rocky Linux 8 and 9 to the list of supported OS.
impact_level: low
```
