### PR TITLE
[ci] Run validations when milestone changes

### DIFF
--- a/.github/workflow_templates/validation.yml
+++ b/.github/workflow_templates/validation.yml
@@ -17,6 +17,9 @@ on:
      types:
       - opened
       - synchronize
+  issues:
+    types:
+      - "milestoned"
 
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
 concurrency:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -18,6 +18,9 @@ on:
      types:
       - opened
       - synchronize
+  issues:
+    types:
+      - "milestoned"
 
 # Cancel in-progress jobs for the same PR (pull_request_target event) or for the same branch (push event).
 concurrency:


### PR DESCRIPTION
Signed-off-by: Artem Kladov <artem.kladov@flant.com>

## Description
Run validations when milestone changes to reflect milstone changes in PR without manual restart of actions.

## Why do we need it, and what problem does it solve?
Milestone validation don't pass if you assign a milestone. You need to rerun the action manually to pass validation.

## What is the expected result?
Miletsone must pass after assigning a milestone to PR.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Run validations when milestone changes
impact_level: low
```
