### PR TITLE
[candi] various bashible fixes and improvements

### DIFF
--- a/candi/bashible/bashbooster/50_deckhouse_registrypackages.sh
+++ b/candi/bashible/bashbooster/50_deckhouse_registrypackages.sh
@@ -41,8 +41,11 @@ bb-rp-is-installed?() {
   fi
 
   AUTH_HEADER="$(curl --retry 3 -sSLi "${SCHEME}://${REGISTRY_ADDRESS}/v2/" | grep -i "www-authenticate")"
-  AUTH_REALM="$(awk -F "," '{split($1,s,"\""); print s[2]}' <<< "${AUTH_HEADER}")"
-  AUTH_SERVICE="$(awk -F "," '{split($2,s,"\""); print s[2]}' <<< "${AUTH_HEADER}" | sed "s/ /+/g")"
+  AUTH_REALM="$(grep -oE 'Bearer realm="http[s]{0,1}://[a-z0-9\.\-\/:]+"' <<< ${AUTH_HEADER} | cut -d '"' -f2)"
+  AUTH_SERVICE="$(grep -oE 'service="[[:print:]]+"' <<< "${AUTH_HEADER}" | cut -d '"' -f2)"
+  if [ -z ${AUTH_REALM} ]; then
+    bb-exit 1 "cannot parse registry auth header ${AUTH_HEADER}"
+  fi
   # shellcheck disable=SC2086
   # Remove leading / from REGISTRY_PATH due to scope format -> scope=repository:deckhouse/fe:pull
   curl --retry 3 -fsSL ${AUTH} "${AUTH_REALM}?service=${AUTH_SERVICE}&scope=repository:${REGISTRY_PATH#/}:pull" | jq -r '.token'

--- a/candi/bashible/bashbooster/50_deckhouse_registrypackages.sh
+++ b/candi/bashible/bashbooster/50_deckhouse_registrypackages.sh
@@ -44,7 +44,7 @@ bb-rp-is-installed?() {
   AUTH_REALM="$(grep -oE 'Bearer realm="http[s]{0,1}://[a-z0-9\.\:\/\-]+"' <<< ${AUTH_HEADER} | cut -d '"' -f2)"
   AUTH_SERVICE="$(grep -oE 'service="[[:print:]]+"' <<< "${AUTH_HEADER}" | cut -d '"' -f2 | sed 's/ /+/g')"
   if [ -z ${AUTH_REALM} ]; then
-    bb-exit 1 "cannot parse registry auth header ${AUTH_HEADER}"
+    bb-exit 1 "couldn't find bearer realm parameter, consider enabling bearer token auth in your registry, returned header: ${AUTH_HEADER}"
   fi
   # shellcheck disable=SC2086
   # Remove leading / from REGISTRY_PATH due to scope format -> scope=repository:deckhouse/fe:pull

--- a/candi/bashible/bashbooster/50_deckhouse_registrypackages.sh
+++ b/candi/bashible/bashbooster/50_deckhouse_registrypackages.sh
@@ -41,8 +41,8 @@ bb-rp-is-installed?() {
   fi
 
   AUTH_HEADER="$(curl --retry 3 -sSLi "${SCHEME}://${REGISTRY_ADDRESS}/v2/" | grep -i "www-authenticate")"
-  AUTH_REALM="$(grep -oE 'Bearer realm="http[s]{0,1}://[a-z0-9\.\-\/:]+"' <<< ${AUTH_HEADER} | cut -d '"' -f2)"
-  AUTH_SERVICE="$(grep -oE 'service="[[:print:]]+"' <<< "${AUTH_HEADER}" | cut -d '"' -f2)"
+  AUTH_REALM="$(grep -oE 'Bearer realm="http[s]{0,1}://[a-z0-9\.\:\/\-]+"' <<< ${AUTH_HEADER} | cut -d '"' -f2)"
+  AUTH_SERVICE="$(grep -oE 'service="[[:print:]]+"' <<< "${AUTH_HEADER}" | cut -d '"' -f2 | sed 's/ /+/g')"
   if [ -z ${AUTH_REALM} ]; then
     bb-exit 1 "cannot parse registry auth header ${AUTH_HEADER}"
   fi

--- a/candi/bashible/bundles/centos/all/000_install_ca_certificates.sh.tpl
+++ b/candi/bashible/bundles/centos/all/000_install_ca_certificates.sh.tpl
@@ -20,11 +20,18 @@ fi
 
 {{- if .registry.ca }}
 bb-event-on 'registry-ca-changed' '_update_ca_certificates'
-function _update_ca_certificates() {
+_update_ca_certificates() {
+  bb-flag-set containerd-need-restart
   update-ca-trust
 }
 
 bb-sync-file /etc/pki/ca-trust/source/anchors/registry-ca.crt - registry-ca-changed << "EOF"
 {{ .registry.ca }}
 EOF
+{{- else }}
+if [-f /etc/pki/ca-trust/source/anchors/registry-ca.crt ]; then
+  rm -f /etc/pki/ca-trust/source/anchors/registry-ca.crt
+  _update_ca_certificates
+fi
 {{- end }}
+

--- a/candi/bashible/bundles/centos/all/000_install_ca_certificates.sh.tpl
+++ b/candi/bashible/bundles/centos/all/000_install_ca_certificates.sh.tpl
@@ -29,7 +29,7 @@ bb-sync-file /etc/pki/ca-trust/source/anchors/registry-ca.crt - registry-ca-chan
 {{ .registry.ca }}
 EOF
 {{- else }}
-if [-f /etc/pki/ca-trust/source/anchors/registry-ca.crt ]; then
+if [ -f /etc/pki/ca-trust/source/anchors/registry-ca.crt ]; then
   rm -f /etc/pki/ca-trust/source/anchors/registry-ca.crt
   _update_ca_certificates
 fi

--- a/candi/bashible/bundles/centos/bootstrap.sh.tpl
+++ b/candi/bashible/bundles/centos/bootstrap.sh.tpl
@@ -1,4 +1,4 @@
-{{- /*
+x{{- /*
 # Copyright 2021 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -78,8 +78,12 @@ bb-rp-get-token() {
   fi
 
   AUTH_HEADER="$(curl --retry 3 -k -sSLi "${SCHEME}://${REGISTRY_ADDRESS}/v2/" | grep -i "www-authenticate")"
-  AUTH_REALM="$(awk -F "," '{split($1,s,"\""); print s[2]}' <<< "${AUTH_HEADER}")"
-  AUTH_SERVICE="$(awk -F "," '{split($2,s,"\""); print s[2]}' <<< "${AUTH_HEADER}" | sed "s/ /+/g")"
+  AUTH_REALM="$(grep -oE 'Bearer realm="http[s]{0,1}://[a-z0-9\.\-\/:]+"' <<< ${AUTH_HEADER} | cut -d '"' -f2)"
+  AUTH_SERVICE="$(grep -oE 'service="[[:print:]]+"' <<< "${AUTH_HEADER}" | cut -d '"' -f2)"
+  if [ -z ${AUTH_REALM} ]; then
+    >&2 echo "cannot parse registry auth header ${AUTH_HEADER}"
+    return 1
+  fi
 {{- /*
   # Remove leading / from REGISTRY_PATH due to scope format -> scope=repository:deckhouse/fe:pull
 */}}

--- a/candi/bashible/bundles/centos/bootstrap.sh.tpl
+++ b/candi/bashible/bundles/centos/bootstrap.sh.tpl
@@ -81,7 +81,7 @@ bb-rp-get-token() {
   AUTH_REALM="$(grep -oE 'Bearer realm="http[s]{0,1}://[a-z0-9\.\:\/\-]+"' <<< ${AUTH_HEADER} | cut -d '"' -f2)"
   AUTH_SERVICE="$(grep -oE 'service="[[:print:]]+"' <<< "${AUTH_HEADER}" | cut -d '"' -f2 | sed 's/ /+/g')"
   if [ -z ${AUTH_REALM} ]; then
-    >&2 echo "cannot parse registry auth header ${AUTH_HEADER}"
+    >&2 echo "couldn't find bearer realm parameter, consider enabling bearer token auth in your registry, returned header: ${AUTH_HEADER}"
     return 1
   fi
 {{- /*

--- a/candi/bashible/bundles/centos/bootstrap.sh.tpl
+++ b/candi/bashible/bundles/centos/bootstrap.sh.tpl
@@ -78,8 +78,8 @@ bb-rp-get-token() {
   fi
 
   AUTH_HEADER="$(curl --retry 3 -k -sSLi "${SCHEME}://${REGISTRY_ADDRESS}/v2/" | grep -i "www-authenticate")"
-  AUTH_REALM="$(grep -oE 'Bearer realm="http[s]{0,1}://[a-z0-9\.\-\/:]+"' <<< ${AUTH_HEADER} | cut -d '"' -f2)"
-  AUTH_SERVICE="$(grep -oE 'service="[[:print:]]+"' <<< "${AUTH_HEADER}" | cut -d '"' -f2)"
+  AUTH_REALM="$(grep -oE 'Bearer realm="http[s]{0,1}://[a-z0-9\.\:\/\-]+"' <<< ${AUTH_HEADER} | cut -d '"' -f2)"
+  AUTH_SERVICE="$(grep -oE 'service="[[:print:]]+"' <<< "${AUTH_HEADER}" | cut -d '"' -f2 | sed 's/ /+/g')"
   if [ -z ${AUTH_REALM} ]; then
     >&2 echo "cannot parse registry auth header ${AUTH_HEADER}"
     return 1

--- a/candi/bashible/bundles/centos/bootstrap.sh.tpl
+++ b/candi/bashible/bundles/centos/bootstrap.sh.tpl
@@ -1,4 +1,4 @@
-x{{- /*
+{{- /*
 # Copyright 2021 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/candi/bashible/bundles/debian/all/000_install_ca_certificates.sh.tpl
+++ b/candi/bashible/bundles/debian/all/000_install_ca_certificates.sh.tpl
@@ -32,7 +32,7 @@ bb-sync-file /usr/local/share/ca-certificates/registry-ca.crt - registry-ca-chan
 {{ .registry.ca }}
 EOF
 {{- else }}
-if [-f /usr/local/share/ca-certificates/registry-ca.crt ]; then
+if [ -f /usr/local/share/ca-certificates/registry-ca.crt ]; then
   rm -f /usr/local/share/ca-certificates/registry-ca.crt
   _update_ca_certificates
 fi

--- a/candi/bashible/bundles/debian/all/000_install_ca_certificates.sh.tpl
+++ b/candi/bashible/bundles/debian/all/000_install_ca_certificates.sh.tpl
@@ -23,11 +23,17 @@ fi
 
 {{- if .registry.ca }}
 bb-event-on 'registry-ca-changed' '_update_ca_certificates'
-function _update_ca_certificates() {
+_update_ca_certificates() {
+  bb-flag-set containerd-need-restart
   update-ca-certificates
 }
 
 bb-sync-file /usr/local/share/ca-certificates/registry-ca.crt - registry-ca-changed << "EOF"
 {{ .registry.ca }}
 EOF
+{{- else }}
+if [-f /usr/local/share/ca-certificates/registry-ca.crt ]; then
+  rm -f /usr/local/share/ca-certificates/registry-ca.crt
+  _update_ca_certificates
+fi
 {{- end }}

--- a/candi/bashible/bundles/ubuntu-lts/all/000_install_ca_certificates.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/all/000_install_ca_certificates.sh.tpl
@@ -34,7 +34,7 @@ bb-sync-file /usr/local/share/ca-certificates/registry-ca.crt - registry-ca-chan
 {{ .registry.ca }}
 EOF
 {{- else }}
-if [-f /usr/local/share/ca-certificates/registry-ca.crt ]; then
+if [ -f /usr/local/share/ca-certificates/registry-ca.crt ]; then
   rm -f /usr/local/share/ca-certificates/registry-ca.crt
   _update_ca_certificates
 fi

--- a/candi/bashible/bundles/ubuntu-lts/all/000_install_ca_certificates.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/all/000_install_ca_certificates.sh.tpl
@@ -25,11 +25,17 @@ fi
 
 {{- if .registry.ca }}
 bb-event-on 'registry-ca-changed' '_update_ca_certificates'
-function _update_ca_certificates() {
+_update_ca_certificates() {
+  bb-flag-set containerd-need-restart
   update-ca-certificates
 }
 
 bb-sync-file /usr/local/share/ca-certificates/registry-ca.crt - registry-ca-changed << "EOF"
 {{ .registry.ca }}
 EOF
+{{- else }}
+if [-f /usr/local/share/ca-certificates/registry-ca.crt ]; then
+  rm -f /usr/local/share/ca-certificates/registry-ca.crt
+  _update_ca_certificates
+fi
 {{- end }}

--- a/candi/bashible/common-steps/all/001_set_system_proxy.sh.tpl
+++ b/candi/bashible/common-steps/all/001_set_system_proxy.sh.tpl
@@ -1,4 +1,4 @@
-# Copyright 2021 Flant JSC
+# Copyright 2022 Flant JSC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/candi/bashible/common-steps/all/001_set_system_proxy.sh.tpl
+++ b/candi/bashible/common-steps/all/001_set_system_proxy.sh.tpl
@@ -36,7 +36,7 @@ mkdir -p /etc/systemd/system.conf.d/
 
 bb-sync-file /etc/systemd/system.conf.d/proxy-default-environment.conf - << EOF
 [Manager]
-DefaultEnvironment="HTTP_PROXY=${HTTP_PROXY:-}" "HTTPS_PROXY=${HTTPS_PROXY:-}" "NO_PROXY=${NO_PROXY:-}"
+DefaultEnvironment="HTTP_PROXY=${HTTP_PROXY:-}" "http_proxy=${HTTP_PROXY:-}" "HTTPS_PROXY=${HTTPS_PROXY:-}" "https_proxy=${HTTPS_PROXY:-}" "NO_PROXY=${NO_PROXY:-}" "no_proxy=${NO_PROXY:-}"
 EOF
 {{- else }}
 if [ -f /etc/systemd/system.conf.d/proxy-default-environment.conf ]; then

--- a/candi/bashible/common-steps/all/001_set_system_proxy.sh.tpl
+++ b/candi/bashible/common-steps/all/001_set_system_proxy.sh.tpl
@@ -23,7 +23,7 @@ HTTPS_PROXY={{ .modulesProxy.httpsProxy | quote }}
 
   {{- $noProxy := list "169.254.169.254" .normal.clusterDomain .normal.podSubnetCIDR .normal.serviceSubnetCIDR }}
   {{- if .modulesProxy.noProxy }}
-    {{- $noProxy = concat $noProxy $context.Values.global.modules.proxy.noProxy }}
+    {{- $noProxy = concat $noProxy modulesProxy.noProxy }}
 NO_PROXY={{ $noProxy | join "," | quote }}
   {{- end }}
 

--- a/candi/bashible/common-steps/all/001_set_system_proxy.sh.tpl
+++ b/candi/bashible/common-steps/all/001_set_system_proxy.sh.tpl
@@ -23,7 +23,7 @@ HTTPS_PROXY={{ .modulesProxy.httpsProxy | quote }}
 
   {{- $noProxy := list "169.254.169.254" .normal.clusterDomain .normal.podSubnetCIDR .normal.serviceSubnetCIDR }}
   {{- if .modulesProxy.noProxy }}
-    {{- $noProxy = concat $noProxy modulesProxy.noProxy }}
+    {{- $noProxy = concat $noProxy .modulesProxy.noProxy }}
 NO_PROXY={{ $noProxy | join "," | quote }}
   {{- end }}
 

--- a/candi/bashible/common-steps/all/001_set_system_proxy.tpl
+++ b/candi/bashible/common-steps/all/001_set_system_proxy.tpl
@@ -1,0 +1,42 @@
+# Copyright 2021 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .modulesProxy }}
+  {{- if .modulesProxy.httpProxy }}
+HTTP_PROXY={{ .modulesProxy.httpProxy | quote }}
+  {{- end }}
+
+  {{- if .modulesProxy.httpsProxy }}
+HTTPS_PROXY={{ .modulesProxy.httpsProxy | quote }}
+  {{- end }}
+
+  {{- $noProxy := list "169.254.169.254" .normal.clusterDomain .normal.podSubnetCIDR .normal.serviceSubnetCIDR }}
+  {{- if .modulesProxy.noProxy }}
+    {{- $noProxy = concat $noProxy $context.Values.global.modules.proxy.noProxy }}
+NO_PROXY={{ $noProxy | join "," | quote }}
+  {{- end }}
+
+bb-event-on 'bb-sync-file-changed' '_on_proxy_default_environment_changed'
+_on_proxy_default_environment_changed() {
+  systemctl daemon-reload
+  bb-flag-set containerd-need-restart
+}
+
+mkdir -p /etc/systemd/system.conf.d/
+
+bb-sync-file /etc/systemd/system.conf.d/proxy-default-environment.conf - << EOF
+[Manager]
+DefaultEnvironment="HTTP_PROXY=${HTTP_PROXY:-}" "HTTPS_PROXY=${HTTPS_PROXY:-}" "NO_PROXY=${NO_PROXY:-}"
+EOF
+{{- end }}

--- a/candi/bashible/common-steps/node-group/050_configure_and_start_containerd.sh.tpl
+++ b/candi/bashible/common-steps/node-group/050_configure_and_start_containerd.sh.tpl
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 {{- if eq .cri "Containerd" }}
+if bb-flag? containerd-need-restart; then
+  bb-log-warning "'containerd-need-restart' flag was set. Containerd should be restarted!"
+  _on_containerd_config_changed
+fi
+
 bb-event-on 'bb-sync-file-changed' '_on_containerd_config_changed'
 _on_containerd_config_changed() {
   {{ if ne .runType "ImageBuilding" -}}

--- a/candi/bashible/common-steps/node-group/050_configure_and_start_containerd.sh.tpl
+++ b/candi/bashible/common-steps/node-group/050_configure_and_start_containerd.sh.tpl
@@ -13,17 +13,18 @@
 # limitations under the License.
 
 {{- if eq .cri "Containerd" }}
+_on_containerd_config_changed() {
+  {{ if ne .runType "ImageBuilding" -}}
+  systemctl restart containerd.service
+  {{- end }}
+}
+
 if bb-flag? containerd-need-restart; then
   bb-log-warning "'containerd-need-restart' flag was set. Containerd should be restarted!"
   _on_containerd_config_changed
 fi
 
 bb-event-on 'bb-sync-file-changed' '_on_containerd_config_changed'
-_on_containerd_config_changed() {
-  {{ if ne .runType "ImageBuilding" -}}
-  systemctl restart containerd.service
-  {{- end }}
-}
 
   {{- $max_concurrent_downloads := 3 }}
   {{- if hasKey .nodeGroup.cri "containerd" }}

--- a/ee/candi/bashible/bundles/alteros/all/000_install_ca_certificates.sh.tpl
+++ b/ee/candi/bashible/bundles/alteros/all/000_install_ca_certificates.sh.tpl
@@ -9,11 +9,17 @@ fi
 
 {{- if .registry.ca }}
 bb-event-on 'registry-ca-changed' '_update_ca_certificates'
-function _update_ca_certificates() {
+_update_ca_certificates() {
+  bb-flag-set containerd-need-restart
   update-ca-trust
 }
 
 bb-sync-file /etc/pki/ca-trust/source/anchors/registry-ca.crt - registry-ca-changed << "EOF"
 {{ .registry.ca }}
 EOF
+{{- else }}
+if [ -f /etc/pki/ca-trust/source/anchors/registry-ca.crt ]; then
+  rm -f /etc/pki/ca-trust/source/anchors/registry-ca.crt
+  _update_ca_certificates
+fi
 {{- end }}

--- a/ee/candi/bashible/bundles/astra/all/000_install_ca_certificates.sh.tpl
+++ b/ee/candi/bashible/bundles/astra/all/000_install_ca_certificates.sh.tpl
@@ -1,6 +1,5 @@
 # Copyright 2022 Flant JSC
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE.
-
 # Avoid problems with expired ca-certificates
 bb-apt-install --force ca-certificates
 
@@ -12,11 +11,17 @@ fi
 
 {{- if .registry.ca }}
 bb-event-on 'registry-ca-changed' '_update_ca_certificates'
-function _update_ca_certificates() {
+_update_ca_certificates() {
+  bb-flag-set containerd-need-restart
   update-ca-certificates
 }
 
 bb-sync-file /usr/local/share/ca-certificates/registry-ca.crt - registry-ca-changed << "EOF"
 {{ .registry.ca }}
 EOF
+{{- else }}
+if [ -f /usr/local/share/ca-certificates/registry-ca.crt ]; then
+  rm -f /usr/local/share/ca-certificates/registry-ca.crt
+  _update_ca_certificates
+fi
 {{- end }}

--- a/ee/candi/bashible/bundles/redos/all/000_install_ca_certificates.sh.tpl
+++ b/ee/candi/bashible/bundles/redos/all/000_install_ca_certificates.sh.tpl
@@ -9,11 +9,17 @@ fi
 
 {{- if .registry.ca }}
 bb-event-on 'registry-ca-changed' '_update_ca_certificates'
-function _update_ca_certificates() {
+_update_ca_certificates() {
+  bb-flag-set containerd-need-restart
   update-ca-trust
 }
 
 bb-sync-file /etc/pki/ca-trust/source/anchors/registry-ca.crt - registry-ca-changed << "EOF"
 {{ .registry.ca }}
 EOF
+{{- else }}
+if [ -f /etc/pki/ca-trust/source/anchors/registry-ca.crt ]; then
+  rm -f /etc/pki/ca-trust/source/anchors/registry-ca.crt
+  _update_ca_certificates
+fi
 {{- end }}

--- a/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
@@ -146,8 +146,6 @@ func (cb *ContextBuilder) Build() (BashibleContextData, map[string][]byte, map[s
 			ClusterDNSAddress:  cb.clusterInputData.ClusterDNSAddress,
 			ApiserverEndpoints: cb.clusterInputData.APIServerEndpoints,
 			KubernetesCA:       cb.clusterInputData.KubernetesCA,
-			PodSubnetCIDR:      cb.clusterInputData.PodSubnetCIDR,
-			ServiceSubnetCIDR:  cb.clusterInputData.ServiceSubnetCIDR,
 		},
 		Registry:      cb.registryData,
 		Images:        cb.imagesTags,
@@ -485,8 +483,6 @@ type normal struct {
 	ClusterDNSAddress  string   `json:"clusterDNSAddress" yaml:"clusterDNSAddress"`
 	ApiserverEndpoints []string `json:"apiserverEndpoints" yaml:"apiserverEndpoints"`
 	KubernetesCA       string   `json:"kubernetesCA" yaml:"kubernetesCA"`
-	PodSubnetCIDR      string   `json:"podSubnetCIDR" yaml:"podSubnetCIDR"`
-	ServiceSubnetCIDR  string   `json:"serviceSubnetCIDR" yaml:"serviceSubnetCIDR"`
 }
 
 type registry struct {
@@ -517,8 +513,6 @@ type dockerCfg struct {
 
 type inputData struct {
 	ClusterDomain             string      `json:"clusterDomain" yaml:"clusterDomain"`
-	PodSubnetCIDR             string      `json:"podSubnetCIDR" yaml:"podSubnetCIDR"`
-	ServiceSubnetCIDR         string      `json:"serviceSubnetCIDR" yaml:"serviceSubnetCIDR"`
 	ClusterDNSAddress         string      `json:"clusterDNSAddress" yaml:"clusterDNSAddress"`
 	CloudProvider             interface{} `json:"cloudProvider,omitempty" yaml:"cloudProvider,omitempty"`
 	PackagesProxy             interface{} `json:"packagesProxy,omitempty" yaml:"packagesProxy,omitempty"`

--- a/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/template/context_builder.go
@@ -146,10 +146,13 @@ func (cb *ContextBuilder) Build() (BashibleContextData, map[string][]byte, map[s
 			ClusterDNSAddress:  cb.clusterInputData.ClusterDNSAddress,
 			ApiserverEndpoints: cb.clusterInputData.APIServerEndpoints,
 			KubernetesCA:       cb.clusterInputData.KubernetesCA,
+			PodSubnetCIDR:      cb.clusterInputData.PodSubnetCIDR,
+			ServiceSubnetCIDR:  cb.clusterInputData.ServiceSubnetCIDR,
 		},
 		Registry:      cb.registryData,
 		Images:        cb.imagesTags,
 		PackagesProxy: cb.clusterInputData.PackagesProxy,
+		ModulesProxy:  cb.clusterInputData.ModulesProxy,
 	}
 
 	for _, bundle := range cb.clusterInputData.AllowedBundles {
@@ -449,6 +452,8 @@ type tplContextCommon struct {
 	Registry registry                     `json:"registry" yaml:"registry"`
 
 	PackagesProxy interface{} `json:"packagesProxy,omitempty" yaml:"packagesProxy,omitempty"`
+
+	ModulesProxy interface{} `json:"modulesProxy,omitempty" yaml:"modulesProxy,omitempty"`
 }
 
 type bundleNGContext struct {
@@ -480,6 +485,8 @@ type normal struct {
 	ClusterDNSAddress  string   `json:"clusterDNSAddress" yaml:"clusterDNSAddress"`
 	ApiserverEndpoints []string `json:"apiserverEndpoints" yaml:"apiserverEndpoints"`
 	KubernetesCA       string   `json:"kubernetesCA" yaml:"kubernetesCA"`
+	PodSubnetCIDR      string   `json:"podSubnetCIDR" yaml:"podSubnetCIDR"`
+	ServiceSubnetCIDR  string   `json:"serviceSubnetCIDR" yaml:"serviceSubnetCIDR"`
 }
 
 type registry struct {
@@ -510,9 +517,12 @@ type dockerCfg struct {
 
 type inputData struct {
 	ClusterDomain             string      `json:"clusterDomain" yaml:"clusterDomain"`
+	PodSubnetCIDR             string      `json:"podSubnetCIDR" yaml:"podSubnetCIDR"`
+	ServiceSubnetCIDR         string      `json:"serviceSubnetCIDR" yaml:"serviceSubnetCIDR"`
 	ClusterDNSAddress         string      `json:"clusterDNSAddress" yaml:"clusterDNSAddress"`
 	CloudProvider             interface{} `json:"cloudProvider,omitempty" yaml:"cloudProvider,omitempty"`
 	PackagesProxy             interface{} `json:"packagesProxy,omitempty" yaml:"packagesProxy,omitempty"`
+	ModulesProxy              interface{} `json:"modulesProxy,omitempty" yaml:"modulesProxy,omitempty"`
 	APIServerEndpoints        []string    `json:"apiserverEndpoints" yaml:"apiserverEndpoints"`
 	KubernetesCA              string      `json:"kubernetesCA" yaml:"kubernetesCA"`
 	AllowedBundles            []string    `json:"allowedBundles" yaml:"allowedBundles"`

--- a/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
@@ -123,8 +123,6 @@ spec:
 {{- define "bashible_input_data" }}
     clusterDomain: {{ $.Values.global.discovery.clusterDomain | toYaml }}
     clusterDNSAddress: {{ $.Values.global.discovery.clusterDNSAddress | toYaml }}
-    podSubnetCIDR: {{ $.Values.global.discovery.podSubnet | toYaml }}
-    serviceSubnetCIDR: {{ $.Values.global.discovery.serviceSubnet | toYaml }}
 
     {{- if hasKey $.Values.nodeManager.internal "cloudProvider" }}
     cloudProvider:
@@ -136,7 +134,17 @@ spec:
     {{- end }}
   {{- if hasKey $.Values.global.modules "proxy" }}
     modulesProxy:
-      {{- $.Values.global.modules.proxy | toYaml | nindent 6 }}
+    {{- if hasKey $.Values.global.modules.proxy "httpProxy" }}
+      httpProxy: {{ $.Values.global.modules.proxy.httpProxy | quote }}
+    {{- end }}
+    {{- if hasKey $.Values.global.modules.proxy "httpsProxy" }}
+      httpsProxy: {{ $.Values.global.modules.proxy.httpsProxy | quote }}
+    {{- end }}
+    {{- $noProxy := list "169.254.169.254" $.Values.global.clusterConfiguration.clusterDomain $.Values.global.clusterConfiguration.podSubnetCIDR $.Values.global.clusterConfiguration.serviceSubnetCIDR }}
+    {{- if hasKey $.Values.global.modules.proxy "noProxy" }}
+      {{- $noProxy = concat $noProxy $.Values.global.modules.proxy.noProxy }}
+      noProxy: {{ $noProxy | join "," | quote }}
+    {{- end }}
   {{- end }}
     apiserverEndpoints:
       {{- $.Values.nodeManager.internal.clusterMasterAddresses | toYaml | nindent 6 }}

--- a/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
@@ -123,6 +123,9 @@ spec:
 {{- define "bashible_input_data" }}
     clusterDomain: {{ $.Values.global.discovery.clusterDomain | toYaml }}
     clusterDNSAddress: {{ $.Values.global.discovery.clusterDNSAddress | toYaml }}
+    podSubnetCIDR: {{ $.Values.global.discovery.podSubnet | toYaml }}
+    serviceSubnetCIDR: {{ $.Values.global.discovery.serviceSubnet | toYaml }}
+
     {{- if hasKey $.Values.nodeManager.internal "cloudProvider" }}
     cloudProvider:
       {{- $.Values.nodeManager.internal.cloudProvider | toYaml | nindent 6 }}
@@ -131,6 +134,10 @@ spec:
     packagesProxy:
       {{- $.Values.global.clusterConfiguration.packagesProxy | toYaml | nindent 6 }}
     {{- end }}
+  {{- if hasKey $.Values.global.modules "proxy" }}
+    modulesProxy:
+      {{- $.Values.global.modules.proxy | toYaml | nindent 6 }}
+  {{- end }}
     apiserverEndpoints:
       {{- $.Values.nodeManager.internal.clusterMasterAddresses | toYaml | nindent 6 }}
     {{- if $.Values.nodeManager.internal.kubernetesCA }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
1. Added fail with error if docker registry cannot support bearer token auth.
2. Added bashible unit to setup system-wide proxy from deckhouse config (for closed environments).
3. Fixed registry custom ca certificate step.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
1. If docker registry cannot suport bearer token auth, bashible fails with curl error, which is not informative.
2. global proxy is needed for containerd in closed environments to pull images from registry.
3. When registry ca certificate changes, we need to restart containerd. 
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: chore
summary: |
  Added fail with error if docker registry cannot support bearer token auth.
  Added bashible unit to setup system-wide proxy from deckhouse config (for closed environments).
  Fixed registry custom ca certificate step.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
