### PR TITLE
[testing] avoid using werf inside the docker

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -14,6 +14,7 @@ steps:
 
   - name: Run go generate
     run: |
+      {!{/* TODO replace with 'make generate' when make become available on runners */}!}
       (cd tools && go generate)
       (cd modules/500-upmeter/hooks/smokemini/internal/snapshot && go generate)
 

--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -5,12 +5,16 @@ steps:
   {!{ tmpl.Exec "started_at_output"            . | strings.Indent 2 }!}
   {!{ tmpl.Exec "checkout_step"                . | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}
+  {!{ tmpl.Exec "werf_install_step"            . | strings.Indent 2 }!}
 
   - name: Run go generate
     run: |
       TESTS_IMAGE_NAME={!{ printf "%s%s" (datasource "image_versions").REGISTRY_PATH (datasource "image_versions").BASE_GOLANG_18_BUSTER | quote }!}
-      docker run -v $(pwd):/deckhouse --tmpfs /deckhouse/.git/worktrees -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse ${TESTS_IMAGE_NAME} sh -c "trap 'chown -R $(id -u):$(id -g) /deckhouse' EXIT; make generate"
-      docker run -v $(pwd):/deckhouse --tmpfs /deckhouse/.git/worktrees -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse/modules/500-upmeter/hooks/smokemini/internal/snapshot ${TESTS_IMAGE_NAME} go generate .
+      RENDERED_WERF_CONFIG="$(mktemp)"
+      CI_COMMIT_REF_NAME= CI_COMMIT_TAG= WERF_ENV=FE werf config render --dev --log-quiet > "$RENDERED_WERF_CONFIG"
+      docker run -v $(pwd):/deckhouse -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse -v "$RENDERED_WERF_CONFIG:/tmp/rendered-werf.yaml" ${TESTS_IMAGE_NAME} make generate RENDERED_WERF_CONFIG=/tmp/rendered-werf.yaml
+      rm -f "$RENDERED_WERF_CONFIG"
+      docker run -v $(pwd):/deckhouse -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse/modules/500-upmeter/hooks/smokemini/internal/snapshot ${TESTS_IMAGE_NAME} go generate .
 
   - name: Check generated code
     run: |

--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -7,14 +7,15 @@ steps:
   {!{ tmpl.Exec "login_readonly_registry_step" . | strings.Indent 2 }!}
   {!{ tmpl.Exec "werf_install_step"            . | strings.Indent 2 }!}
 
+  - name: Set up Go 1.16
+    uses: actions/setup-go@v3
+    with:
+      go-version: 1.16
+
   - name: Run go generate
     run: |
-      TESTS_IMAGE_NAME={!{ printf "%s%s" (datasource "image_versions").REGISTRY_PATH (datasource "image_versions").BASE_GOLANG_18_BUSTER | quote }!}
-      RENDERED_WERF_CONFIG="$(mktemp)"
-      CI_COMMIT_REF_NAME= CI_COMMIT_TAG= WERF_ENV=FE werf config render --dev --log-quiet > "$RENDERED_WERF_CONFIG"
-      docker run -v $(pwd):/deckhouse -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse -v "$RENDERED_WERF_CONFIG:/tmp/rendered-werf.yaml" ${TESTS_IMAGE_NAME} make generate RENDERED_WERF_CONFIG=/tmp/rendered-werf.yaml
-      rm -f "$RENDERED_WERF_CONFIG"
-      docker run -v $(pwd):/deckhouse -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse/modules/500-upmeter/hooks/smokemini/internal/snapshot ${TESTS_IMAGE_NAME} go generate .
+      (cd tools && go generate)
+      (cd modules/500-upmeter/hooks/smokemini/internal/snapshot && go generate)
 
   - name: Check generated code
     run: |

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -397,11 +397,21 @@ jobs:
           logout: false
       # </template: login_readonly_registry_step>
 
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
       - name: Run go generate
         run: |
           TESTS_IMAGE_NAME="registry.deckhouse.io/base_images/golang:1.18.5-buster@sha256:eb4b3bd59da4604b0ab27d3837e39dacfba4a48cdd289419a3c49993c0eadba4"
-          docker run -v $(pwd):/deckhouse --tmpfs /deckhouse/.git/worktrees -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse ${TESTS_IMAGE_NAME} sh -c "trap 'chown -R $(id -u):$(id -g) /deckhouse' EXIT; make generate"
-          docker run -v $(pwd):/deckhouse --tmpfs /deckhouse/.git/worktrees -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse/modules/500-upmeter/hooks/smokemini/internal/snapshot ${TESTS_IMAGE_NAME} go generate .
+          RENDERED_WERF_CONFIG="$(mktemp)"
+          CI_COMMIT_REF_NAME= CI_COMMIT_TAG= WERF_ENV=FE werf config render --dev --log-quiet > "$RENDERED_WERF_CONFIG"
+          docker run -v $(pwd):/deckhouse -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse -v "$RENDERED_WERF_CONFIG:/tmp/rendered-werf.yaml" ${TESTS_IMAGE_NAME} make generate RENDERED_WERF_CONFIG=/tmp/rendered-werf.yaml
+          rm -f "$RENDERED_WERF_CONFIG"
+          docker run -v $(pwd):/deckhouse -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse/modules/500-upmeter/hooks/smokemini/internal/snapshot ${TESTS_IMAGE_NAME} go generate .
 
       - name: Check generated code
         run: |

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -404,14 +404,15 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.16
+
       - name: Run go generate
         run: |
-          TESTS_IMAGE_NAME="registry.deckhouse.io/base_images/golang:1.18.5-buster@sha256:eb4b3bd59da4604b0ab27d3837e39dacfba4a48cdd289419a3c49993c0eadba4"
-          RENDERED_WERF_CONFIG="$(mktemp)"
-          CI_COMMIT_REF_NAME= CI_COMMIT_TAG= WERF_ENV=FE werf config render --dev --log-quiet > "$RENDERED_WERF_CONFIG"
-          docker run -v $(pwd):/deckhouse -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse -v "$RENDERED_WERF_CONFIG:/tmp/rendered-werf.yaml" ${TESTS_IMAGE_NAME} make generate RENDERED_WERF_CONFIG=/tmp/rendered-werf.yaml
-          rm -f "$RENDERED_WERF_CONFIG"
-          docker run -v $(pwd):/deckhouse -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse/modules/500-upmeter/hooks/smokemini/internal/snapshot ${TESTS_IMAGE_NAME} go generate .
+          (cd tools && go generate)
+          (cd modules/500-upmeter/hooks/smokemini/internal/snapshot && go generate)
 
       - name: Check generated code
         run: |

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -143,11 +143,21 @@ jobs:
           logout: false
       # </template: login_readonly_registry_step>
 
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
       - name: Run go generate
         run: |
           TESTS_IMAGE_NAME="registry.deckhouse.io/base_images/golang:1.18.5-buster@sha256:eb4b3bd59da4604b0ab27d3837e39dacfba4a48cdd289419a3c49993c0eadba4"
-          docker run -v $(pwd):/deckhouse --tmpfs /deckhouse/.git/worktrees -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse ${TESTS_IMAGE_NAME} sh -c "trap 'chown -R $(id -u):$(id -g) /deckhouse' EXIT; make generate"
-          docker run -v $(pwd):/deckhouse --tmpfs /deckhouse/.git/worktrees -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse/modules/500-upmeter/hooks/smokemini/internal/snapshot ${TESTS_IMAGE_NAME} go generate .
+          RENDERED_WERF_CONFIG="$(mktemp)"
+          CI_COMMIT_REF_NAME= CI_COMMIT_TAG= WERF_ENV=FE werf config render --dev --log-quiet > "$RENDERED_WERF_CONFIG"
+          docker run -v $(pwd):/deckhouse -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse -v "$RENDERED_WERF_CONFIG:/tmp/rendered-werf.yaml" ${TESTS_IMAGE_NAME} make generate RENDERED_WERF_CONFIG=/tmp/rendered-werf.yaml
+          rm -f "$RENDERED_WERF_CONFIG"
+          docker run -v $(pwd):/deckhouse -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse/modules/500-upmeter/hooks/smokemini/internal/snapshot ${TESTS_IMAGE_NAME} go generate .
 
       - name: Check generated code
         run: |

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -150,14 +150,15 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.16
+
       - name: Run go generate
         run: |
-          TESTS_IMAGE_NAME="registry.deckhouse.io/base_images/golang:1.18.5-buster@sha256:eb4b3bd59da4604b0ab27d3837e39dacfba4a48cdd289419a3c49993c0eadba4"
-          RENDERED_WERF_CONFIG="$(mktemp)"
-          CI_COMMIT_REF_NAME= CI_COMMIT_TAG= WERF_ENV=FE werf config render --dev --log-quiet > "$RENDERED_WERF_CONFIG"
-          docker run -v $(pwd):/deckhouse -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse -v "$RENDERED_WERF_CONFIG:/tmp/rendered-werf.yaml" ${TESTS_IMAGE_NAME} make generate RENDERED_WERF_CONFIG=/tmp/rendered-werf.yaml
-          rm -f "$RENDERED_WERF_CONFIG"
-          docker run -v $(pwd):/deckhouse -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse/modules/500-upmeter/hooks/smokemini/internal/snapshot ${TESTS_IMAGE_NAME} go generate .
+          (cd tools && go generate)
+          (cd modules/500-upmeter/hooks/smokemini/internal/snapshot && go generate)
 
       - name: Check generated code
         run: |

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -199,14 +199,15 @@ jobs:
           channel: ${{env.WERF_CHANNEL}}
       # </template: werf_install_step>
 
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.16
+
       - name: Run go generate
         run: |
-          TESTS_IMAGE_NAME="registry.deckhouse.io/base_images/golang:1.18.5-buster@sha256:eb4b3bd59da4604b0ab27d3837e39dacfba4a48cdd289419a3c49993c0eadba4"
-          RENDERED_WERF_CONFIG="$(mktemp)"
-          CI_COMMIT_REF_NAME= CI_COMMIT_TAG= WERF_ENV=FE werf config render --dev --log-quiet > "$RENDERED_WERF_CONFIG"
-          docker run -v $(pwd):/deckhouse -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse -v "$RENDERED_WERF_CONFIG:/tmp/rendered-werf.yaml" ${TESTS_IMAGE_NAME} make generate RENDERED_WERF_CONFIG=/tmp/rendered-werf.yaml
-          rm -f "$RENDERED_WERF_CONFIG"
-          docker run -v $(pwd):/deckhouse -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse/modules/500-upmeter/hooks/smokemini/internal/snapshot ${TESTS_IMAGE_NAME} go generate .
+          (cd tools && go generate)
+          (cd modules/500-upmeter/hooks/smokemini/internal/snapshot && go generate)
 
       - name: Check generated code
         run: |

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -192,11 +192,21 @@ jobs:
           logout: false
       # </template: login_readonly_registry_step>
 
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v1.2
+        with:
+          channel: ${{env.WERF_CHANNEL}}
+      # </template: werf_install_step>
+
       - name: Run go generate
         run: |
           TESTS_IMAGE_NAME="registry.deckhouse.io/base_images/golang:1.18.5-buster@sha256:eb4b3bd59da4604b0ab27d3837e39dacfba4a48cdd289419a3c49993c0eadba4"
-          docker run -v $(pwd):/deckhouse --tmpfs /deckhouse/.git/worktrees -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse ${TESTS_IMAGE_NAME} sh -c "trap 'chown -R $(id -u):$(id -g) /deckhouse' EXIT; make generate"
-          docker run -v $(pwd):/deckhouse --tmpfs /deckhouse/.git/worktrees -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse/modules/500-upmeter/hooks/smokemini/internal/snapshot ${TESTS_IMAGE_NAME} go generate .
+          RENDERED_WERF_CONFIG="$(mktemp)"
+          CI_COMMIT_REF_NAME= CI_COMMIT_TAG= WERF_ENV=FE werf config render --dev --log-quiet > "$RENDERED_WERF_CONFIG"
+          docker run -v $(pwd):/deckhouse -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse -v "$RENDERED_WERF_CONFIG:/tmp/rendered-werf.yaml" ${TESTS_IMAGE_NAME} make generate RENDERED_WERF_CONFIG=/tmp/rendered-werf.yaml
+          rm -f "$RENDERED_WERF_CONFIG"
+          docker run -v $(pwd):/deckhouse -v ~/go-pkg-cache:/go/pkg -v ~/deckhouse-bin-cache:/deckhouse/bin -w /deckhouse/modules/500-upmeter/hooks/smokemini/internal/snapshot ${TESTS_IMAGE_NAME} go generate .
 
       - name: Check generated code
         run: |

--- a/tools/images_tags/main.go
+++ b/tools/images_tags/main.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"go/format"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -73,27 +72,15 @@ func main() {
 
 	tags := make(map[string]map[string]string)
 
-	var out []byte
-	var err error
-
-	renderedWerfConfig := os.Getenv("RENDERED_WERF_CONFIG")
-	if renderedWerfConfig != "" {
-		// Rendered werf config specified, use it without calling werf
-		out, err = ioutil.ReadFile(renderedWerfConfig)
-		if err != nil {
-			panic(err)
-		}
-	} else {
-		// Run werf config render to get config file from which we calculate images names
-		cmd := exec.Command("werf", "config", "render", "--dev", "--log-quiet")
-		cmd.Env = os.Environ()
-		cmd.Env = append(cmd.Env, "CI_COMMIT_REF_NAME=", "CI_COMMIT_TAG=", "WERF_ENV=FE")
-		cmd.Dir = path.Join("..")
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			fmt.Println(string(out))
-			panic(err)
-		}
+	// Run werf config render to get config file from which  we calculate images names
+	cmd := exec.Command("werf", "config", "render", "--dev", "--log-quiet")
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "CI_COMMIT_REF_NAME=", "CI_COMMIT_TAG=", "WERF_ENV=FE")
+	cmd.Dir = path.Join("..")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println(string(out))
+		panic(err)
 	}
 
 	// Parse werf config and take images tags from it


### PR DESCRIPTION
## Description

Using werf insude the docker container brings additional problems:
- Werf creates new git objects with wrong permissions, which must be fixed every time after running docker
- Werf wants to control git worktrees, which are persistent and can be broken insude/outside container

## Why do we need it, and what problem does it solve?

It seems the [previous fix](https://github.com/deckhouse/deckhouse/pull/2848) does not working properly
This is another attempt to fix it.

## What is the expected result?

No more werf inside the docker, let it on a host only

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: testing
type: fix
summary: avoid using werf inside the docker
impact: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
