### PR TITLE
[testing] fix openapi cases test

### DIFF
--- a/ee/modules/450-network-gateway/openapi/openapi-case-tests.yaml
+++ b/ee/modules/450-network-gateway/openapi/openapi-case-tests.yaml
@@ -10,7 +10,11 @@ positive:
         search:
           - office.example.com
   values:
-    - internal:
+    - nodeSelector:
+        type: network-gateway
+      subnet: "192.168.43.0/24"
+      publicAddress: "10.220.243.240"
+      internal:
         effectiveStorageClass: 'test'
 negative:
   configValues:

--- a/modules/002-deckhouse/openapi/openapi-case-tests.yaml
+++ b/modules/002-deckhouse/openapi/openapi-case-tests.yaml
@@ -20,11 +20,12 @@ negative:
   configValues:
   - logLevel: FooBar
     bundle: Default
-  - update:
-      mode: Manual
-      windows:
-        - from: '8:00'
-          to: '13:00'
+# TODO oneOf is deleted in values.yaml, this case is positive now.
+#  - update:
+#      mode: Manual
+#      windows:
+#        - from: '8:00'
+#          to: '13:00'
   values:
   - internal:
       currentReleaseImageName: registry.deckhouse.io/deckhouse/ce/dev??sha256:e9e41b1abc067bd59f1cdf2d7c44cb80911b733d3d711209abd291c9458e51c4

--- a/modules/301-prometheus-metrics-adapter/openapi/openapi-case-tests.yaml
+++ b/modules/301-prometheus-metrics-adapter/openapi/openapi-case-tests.yaml
@@ -78,8 +78,10 @@ negative:
 
   # Cases with absent keys required for Helm.
   helmValues:
-  # No requried fields.
+  # No required fields.
+  # TODO: empty adapterCert is added as a workaround. Remove after cleaning 'default:{}' in values.yaml.
   - internal:
+      adapterCert: {}
       customMetrics:
         daemonset: { }
         deployment: { }

--- a/testing/openapi_cases/openapi_cases_test.go
+++ b/testing/openapi_cases/openapi_cases_test.go
@@ -59,7 +59,9 @@ var _ = Describe("OpenAPI case tests", func() {
 	}
 	Expect(err).NotTo(HaveOccurred(), "All openapi test cases should be parsed")
 
-	for _, testCases := range allTestCases {
+	for _, item := range allTestCases {
+		// Need copy for proper carrying in test function.
+		testCases := item
 		It(fmt.Sprintf("Openapi test cases should pass in %s", testCases.dir), func() {
 			ExecuteTestCases(testCases)
 		})


### PR DESCRIPTION
## Description

- copy iterator variable for proper carrying
- fix some non-working tests

## Why do we need it, and what problem does it solve?

Commit e66033a2 brings regression: only global OpenAPI schema was tested.

## What is the expected result?

- OpenAPI cases test should fail on invalid values for modules.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: testing
type: fix
summary: fix openapi cases tests
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
