### PR TITLE
[extended-monitoring] Restart if metrics were last collected more than 15 minutes

### DIFF
--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from concurrent.futures.thread import ThreadPoolExecutor
+from datetime import datetime, timedelta
 from itertools import chain
 from threading import Thread
 from time import sleep
@@ -272,12 +273,14 @@ def _get_metrics():
 class GetHandler(BaseHTTPRequestHandler):
     _response = ""
     _populated = False
+    _last_observe = datetime.now()
 
     @classmethod
     def get_metrics(cls):
         # setting string variable is atomic in Python
         cls._response, quantity = _get_metrics()
         logging.info('Metrics are collected successfully. Batches quantity: {}'.format(quantity))
+        cls._last_observe = datetime.now()
 
     @classmethod
     def loop_get_metrics(cls):
@@ -301,8 +304,10 @@ class GetHandler(BaseHTTPRequestHandler):
             return
 
         if self.path == "/healthz":
-            self.send_response(200)
+            # Fail if metrics were last collected more than 15 minutes ago
+            self.send_response(200 if self.__class__._last_observe > (datetime.now() - timedelta(minutes=15)) else 400)
             self.end_headers()
+            logging.info('Last observed time: {}'.format(self.__class__._last_observe.strftime("%m/%d/%Y, %H:%M:%S")))
             return
 
         if self.path == "/metrics":

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
@@ -305,7 +305,7 @@ class GetHandler(BaseHTTPRequestHandler):
 
         if self.path == "/healthz":
             # Fail if metrics were last collected more than 15 minutes ago
-            self.send_response(200 if self.__class__._last_observe > (datetime.now() - timedelta(minutes=15)) else 400)
+            self.send_response(200 if self.__class__._last_observe > (datetime.now() - timedelta(minutes=15)) else 500)
             self.end_headers()
             logging.info('Last observed time: {}'.format(self.__class__._last_observe.strftime("%m/%d/%Y, %H:%M:%S")))
             return

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/extended-monitoring.py
@@ -305,7 +305,8 @@ class GetHandler(BaseHTTPRequestHandler):
 
         if self.path == "/healthz":
             # Fail if metrics were last collected more than 15 minutes ago
-            self.send_response(200 if self.__class__._last_observe > (datetime.now() - timedelta(minutes=15)) else 500)
+            fresh_enough = self.__class__._last_observe > (datetime.now() - timedelta(minutes=15))
+            self.send_response(200 if fresh_enough else 500)
             self.end_headers()
             logging.info('Last observed time: {}'.format(self.__class__._last_observe.strftime("%m/%d/%Y, %H:%M:%S")))
             return


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
Sometimes extended monitoring exporter can stop sending metrics because of Kubernetes API server connection loss of something.  This PR adds the check that new metrics are collected. Otherwise, kubelet will restart the pod because of the failed liveness probe.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: extended-monitroing
type: fix
summary: Restart if metrics were last collected more than 15 minutes
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
