### PR TITLE
[dhctl] minor edits of log messages

### DIFF
--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -240,7 +240,7 @@ func DefineBootstrapAbortCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 				terraStateLoader := terrastate.NewFileTerraStateLoader(stateCache, metaConfig)
 				destroyer = infrastructure.NewClusterInfra(terraStateLoader, stateCache)
 
-				logMsg := "Deckhouse not begin installed. Abort from cache"
+				logMsg := "Deckhouse installation was not started before. Abort from cache"
 				if app.ForceAbortFromCache {
 					logMsg = "Force aborting from cache"
 				}
@@ -271,7 +271,7 @@ func DefineBootstrapAbortCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
 				return err
 			}
 
-			log.InfoLn("Deckhouse was begin installed. Destroy cluster")
+			log.InfoLn("Deckhouse installation was started before. Destroy cluster")
 			return nil
 		})
 

--- a/dhctl/pkg/config/load.go
+++ b/dhctl/pkg/config/load.go
@@ -125,7 +125,7 @@ func (s *SchemaStore) ValidateWithIndex(index *SchemaIndex, doc *[]byte) error {
 
 	schema := s.getV1alpha1CompatibilitySchema(index)
 	if schema == nil {
-		return fmt.Errorf("Schema for %s does not found.", index.String())
+		return fmt.Errorf("Schema for %s wasn't found.", index.String())
 	}
 
 	isValid, err := openAPIValidate(doc, schema)

--- a/dhctl/pkg/kubernetes/client/lease-lock.go
+++ b/dhctl/pkg/kubernetes/client/lease-lock.go
@@ -289,7 +289,7 @@ func LockInfo(lease *coordinationv1.Lease) (string, *LockUserInfo) {
 	zeroUserInfo := LockUserInfo{
 		Name:       "unknown",
 		Host:       "unknown",
-		Additional: "Info does not set",
+		Additional: "Info is not set",
 	}
 	userInfo := zeroUserInfo
 	if lease != nil {

--- a/dhctl/pkg/log/process_test.go
+++ b/dhctl/pkg/log/process_test.go
@@ -30,14 +30,14 @@ func TestProcessStack(t *testing.T) {
 		Msg:       "process1",
 	})
 
-	require.Len(t, s.activeProcesses, 1, "process1 does not added to stack")
+	require.Len(t, s.activeProcesses, 1, "process1 is not added to stack")
 
 	s.push(&logProcessDescriptor{
 		StartedAt: time.Now(),
 		Msg:       "process2",
 	})
 
-	require.Len(t, s.activeProcesses, 2, "process2 does not added to stack")
+	require.Len(t, s.activeProcesses, 2, "process2 is not added to stack")
 
 	assertPop := func(t *testing.T, len int, process string) {
 		p := s.pop()

--- a/dhctl/pkg/operations/bootstrap.go
+++ b/dhctl/pkg/operations/bootstrap.go
@@ -60,7 +60,7 @@ func BootstrapMaster(sshClient *ssh.Client, bundleName, nodeIP string, metaConfi
 			err := log.Process("default", bootstrapScript, func() error {
 				if _, err := os.Stat(scriptPath); err != nil {
 					if os.IsNotExist(err) {
-						log.InfoF("Script %s doesn't found\n", scriptPath)
+						log.InfoF("Script %s wasn't found\n", scriptPath)
 						return nil
 					}
 					return fmt.Errorf("script path: %v", err)

--- a/dhctl/pkg/template/engine.go
+++ b/dhctl/pkg/template/engine.go
@@ -39,7 +39,7 @@ func (e Engine) Render(tmpl []byte) (out *bytes.Buffer, err error) {
 func (e Engine) initFunMap(t *template.Template) {
 	funcMap := FuncMap()
 
-	// include function doesn't required in candi templates
+	// include function isn't required in candi templates
 	funcMap["include"] = func(name string, data interface{}) (string, error) {
 		return "NotImplemented", nil
 	}


### PR DESCRIPTION
## Description
Minor edits of log messages in dhctl.

## Why do we need it, and what problem does it solve?
Some messages of dhctl confuse.

## What is the expected result?
—

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: fix
summary: Minor edits of log messages in dhctl.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
