### PR TITLE
Revert "[monitoring-kubernetes] removed unschedulable nodes from K8SNodeNotReady and K8SManyNodesNotReady alerts (#2942)"

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/kubelet.tpl
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/kubelet.tpl
@@ -1,8 +1,7 @@
 - name: coreos.kubelet
   rules:
   - alert: K8SNodeNotReady
-    expr: min(kube_node_status_condition{condition="Ready",status="true"}) BY (node) == 0 and
-      min(kube_node_spec_unschedulable == 0) by (node)
+    expr: min(kube_node_status_condition{condition="Ready",status="true"}) BY (node) == 0
     for: 10m
     labels:
       severity_level: "3"
@@ -12,9 +11,9 @@
         or has set itself to NotReady, for more than 10 minutes
       summary: Node status is NotReady
   - alert: K8SManyNodesNotReady
-    expr: count(kube_node_status_condition{condition="Ready",status="true"} == 0 and kube_node_spec_unschedulable == 0)
-      > 1 and (count(kube_node_status_condition{condition="Ready",status="true"} == 0 and kube_node_spec_unschedulable == 0) /
-      count(kube_node_status_condition{condition="Ready",status="true"} and kube_node_spec_unschedulable == 0)) > 0.2
+    expr: count(kube_node_status_condition{condition="Ready",status="true"} == 0)
+      > 1 and (count(kube_node_status_condition{condition="Ready",status="true"} ==
+      0) / count(kube_node_status_condition{condition="Ready",status="true"})) > 0.2
     for: 1m
     labels:
       severity_level: "3"


### PR DESCRIPTION
## Description
PR #2942 reverting.

## Why do we need it, and what problem does it solve?
It was accidentally merged (it was a draft but with ready-to-review status).

## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring-kubernetes
type: fix
summary: Reverting of "removed unschedulable nodes from K8SNodeNotReady alert"
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
