### PR TITLE
[upmeter,e2e] Smoke test with upmeter server, using per-probe public uptime

### DIFF
--- a/modules/500-upmeter/images/upmeter/Makefile
+++ b/modules/500-upmeter/images/upmeter/Makefile
@@ -1,8 +1,10 @@
 # https://github.com/golangci/golangci-lint
-GOLANGCI_LINT_VERSION=1.46.2
+GOLANGCI_LINT_VERSION=1.50.1
 # https://github.com/mvdan/gofumpt
-GOFUMPT_VERSION=0.3.1
-GOARCH=amd64
+GOFUMPT_VERSION=0.4.0
+
+ARCH_NAME := $(shell uname -m)
+OS_NAME := $(shell uname)
 UNAME=$(shell uname -s)
 
 GOFUMPT_BIN=/tmp/gofumpt-$(GOFUMPT_VERSION)
@@ -23,8 +25,8 @@ all: deps fmt build test
 
 deps:
 	go mod tidy
-	@test -f $(GOFUMPT_BIN)      || curl -sLo $(GOFUMPT_BIN) https://github.com/mvdan/gofumpt/releases/download/v$(GOFUMPT_VERSION)/gofumpt_v$(GOFUMPT_VERSION)_$(OS)_$(GOARCH)
-	@test -f $(GOLANGCILINT_BIN) || curl -sfL https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_LINT_VERSION)/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(OS)-$(GOARCH).tar.gz | tar -xzOf - golangci-lint-$(GOLANGCI_LINT_VERSION)-$(OS)-$(GOARCH)/golangci-lint > $(GOLANGCILINT_BIN)
+	@test -f $(GOFUMPT_BIN)      || curl -sLo $(GOFUMPT_BIN) https://github.com/mvdan/gofumpt/releases/download/v$(GOFUMPT_VERSION)/gofumpt_v$(GOFUMPT_VERSION)_$(OS)_$(ARCH_NAME)
+	@test -f $(GOLANGCILINT_BIN) || curl -sfL https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_LINT_VERSION)/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(OS)-$(ARCH_NAME).tar.gz | tar -xzOf - golangci-lint-$(GOLANGCI_LINT_VERSION)-$(OS)-$(ARCH_NAME)/golangci-lint > $(GOLANGCILINT_BIN)
 	@chmod +x $(GOLANGCILINT_BIN) $(GOFUMPT_BIN)
 
 lint:
@@ -34,7 +36,6 @@ fmt:
 	@# - gofumpt is not included in the .golangci.yaml because it conflicts with imports https://github.com/golangci/golangci-lint/issues/1490#issuecomment-778782810
 	@# - goimports is not turned on since it is used mostly by gofumpt internally
 	$(GOFUMPT_BIN) -l -w -extra .
-	gci -w -local d8.io/upmeter .
 	goimports -w -local d8.io/upmeter .
 	$(GOLANGCILINT_BIN) run ./... -c .golangci.yaml --fix
 
@@ -49,7 +50,7 @@ ci: deps lint
         || exit 1
 
 build:
-	GOOS="$(OS)" GOARCH="$(GOARCH)" go build -ldflags="-s -w" -o /tmp/upmeter ./cmd/upmeter/
+	GOOS="$(OS)" GOARCH="$(ARCH_NAME)" go build -ldflags="-s -w" -o /tmp/upmeter ./cmd/upmeter/
 
 build-docker:
 	docker build \

--- a/modules/500-upmeter/images/upmeter/pkg/db/context/context.go
+++ b/modules/500-upmeter/images/upmeter/pkg/db/context/context.go
@@ -93,7 +93,7 @@ func (c *DbContext) StmtRunner() StmtRunner {
 		return c.db
 	}
 
-	panic("Call StmtRunner from uninitialized DbContext")
+	panic("DB context is uninitialized")
 }
 
 // Start captures a connection from pool and returns a stoppable context.

--- a/modules/500-upmeter/images/upmeter/pkg/db/context/pool.go
+++ b/modules/500-upmeter/images/upmeter/pkg/db/context/pool.go
@@ -33,17 +33,21 @@ const (
 // First, we use busy_timeout+MaxOpenConns(1) as a common workaround.
 //
 // Next, custom pool helps to stick queries and transactions to connections.
-//   (See https://turriate.com/articles/making-sqlite-faster-in-go)
+//
+//	(See https://turriate.com/articles/making-sqlite-faster-in-go)
 //
 // And finally, set _txlock=immediate to start transactions in write mode.
-//   (See https://www.sqlite.org/lang_transaction.html)
+//
+//	(See https://www.sqlite.org/lang_transaction.html)
 //
 // busy_time and MaxOpenConns help eliminate errors "database is locked"
-//      See     https://github.com/mattn/go-sqlite3/issues/274
-//              https://github.com/mattn/go-sqlite3#faq
+//
+//	See     https://github.com/mattn/go-sqlite3/issues/274
+//	        https://github.com/mattn/go-sqlite3#faq
 //
 // Can I use this in multiple routines concurrently?
-//      Yes for readonly. But, No for writable. See #50, #51, #209, #274.
+//
+//	Yes for readonly. But, No for writable. See #50, #51, #209, #274.
 func DefaultConnectionOptions() map[string]string {
 	return map[string]string{
 		"_busy_timeout": "9999999",

--- a/modules/500-upmeter/images/upmeter/pkg/db/dao/episode5m.go
+++ b/modules/500-upmeter/images/upmeter/pkg/db/dao/episode5m.go
@@ -202,7 +202,7 @@ func (d *EpisodeDao5m) ListEpisodeSumsForRanges(rng ranges.StepRange, ref check.
 
 		rows, err := d.DbCtx.StmtRunner().Query(query, queryArgs...)
 		if err != nil {
-			return nil, fmt.Errorf("select for TimeslotRange: %v", err)
+			return nil, err
 		}
 		defer rows.Close()
 
@@ -234,7 +234,7 @@ func (d *EpisodeDao5m) ListEpisodeSumsForRanges(rng ranges.StepRange, ref check.
 					&entity.Episode.ProbeRef.Probe)
 			}
 			if err != nil {
-				return nil, fmt.Errorf("row to Episode5m: %v", err)
+				return nil, fmt.Errorf("row to entity episode: %v", err)
 			}
 			entity.Episode.TimeSlot = time.Unix(stepRange.From, 0)
 			res = append(res, entity.Episode)

--- a/modules/500-upmeter/images/upmeter/pkg/db/dao/exporting.go
+++ b/modules/500-upmeter/images/upmeter/pkg/db/dao/exporting.go
@@ -266,7 +266,7 @@ func getEarliestExportEpisodes(ctx *dbcontext.DbContext, syncID string, originsC
 // - the table contains fulfilled origin counts for the syncID
 // - there are expired (more than 24h ago) episodes.
 //
-//  Otherwise, this function returns ErrNotFound.
+//	Otherwise, this function returns ErrNotFound.
 //
 // Consider unfulfilled episodes to be fulfilled even if they are found with earlier timeslots that the desired
 // origins_count have reached. By the limitation of timeseries storages, we can only export the earliest episodes.
@@ -274,33 +274,30 @@ func getEarliestExportEpisodes(ctx *dbcontext.DbContext, syncID string, originsC
 // of thee slot range is the mark that earlier episodes will never be fulfilled. Thus it is better to send them
 // than to skip them.
 //
-//
 // Case #1, we have unfulfilled episodes earlier than a fulfilled one
 //
-//     N = origins count
-//     D = desired origins count
+//	 N = origins count
+//	 D = desired origins count
 //
-//          Fresh episode fulfilled by the Dth agent, making N=D
-//                         ↓
-//      N<D   N<D   N<D   N=D   N<D   N<D   ...
-//    |-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|--> time (slots)
-//       ↑
-//      Send this anyway, because
-//              - there is no hope it will ever reach D
-//              - timeseries storage accept only newer samples related to existing ones
-//
+//	      Fresh episode fulfilled by the Dth agent, making N=D
+//	                     ↓
+//	  N<D   N<D   N<D   N=D   N<D   N<D   ...
+//	|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|--> time (slots)
+//	   ↑
+//	  Send this anyway, because
+//	          - there is no hope it will ever reach D
+//	          - timeseries storage accept only newer samples related to existing ones
 //
 // Case #2, all episodes are unfulfilled, and we have 24h-old among them
 //
-//       24h ago
-//          ↓
-//      N<D ↓ N<D   N<D   N<D   N<D   N<D   ...
-//    |-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|--> time (slots)
-//       ↑
-//      Send this anyway, because
-//              - it will never reach D, because upmeter server skips episodes that are older than 24h
-//              - again, timeseries storage accept only newer samples related to existing ones
-//
+//	   24h ago
+//	      ↓
+//	  N<D ↓ N<D   N<D   N<D   N<D   N<D   ...
+//	|-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|--> time (slots)
+//	   ↑
+//	  Send this anyway, because
+//	          - it will never reach D, because upmeter server skips episodes that are older than 24h
+//	          - again, timeseries storage accept only newer samples related to existing ones
 func getEarliestTimeSlot(ctx *dbcontext.DbContext, syncID string, originsCount int) (int64, error) {
 	commonSlot, err := getEarliestCommonTimeSlot(ctx, syncID)
 	if err != nil {

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/dex.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/dex.go
@@ -56,7 +56,7 @@ func (v dexAPIVerifier) Request() *http.Request {
 }
 
 /*
-	Expected JSON
+Expected JSON
 
 	{
 	  "keys": [

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/prometheus.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/prometheus.go
@@ -58,7 +58,7 @@ func (v prometheusAPIVerifier) Request() *http.Request {
 }
 
 /*
-	Expected JSON
+Expected JSON
 
 	{
 	  "status": "success",
@@ -118,22 +118,21 @@ func (v *metricPresenceVerifier) Request() *http.Request {
 }
 
 /*
-{
-  "status": "success",
-  "data": {
-    "resultType": "vector",
-    "result": [                 <- array must not be empty
-      {
-        "metric": {},
-        "value": [
-          1614179019.102,
-          "24"                  <- string number must not be zero
-        ]
-      }
-    ]
-  }
-}
-
+	{
+	  "status": "success",
+	  "data": {
+	    "resultType": "vector",
+	    "result": [                 <- array must not be empty
+	      {
+	        "metric": {},
+	        "value": [
+	          1614179019.102,
+	          "24"                  <- string number must not be zero
+	        ]
+	      }
+	    ]
+	  }
+	}
 */
 func (v *metricPresenceVerifier) Verify(body []byte) check.Error {
 	resultPath := "data.result"

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/prometheus_metrics_adapter.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/prometheus_metrics_adapter.go
@@ -58,25 +58,25 @@ func (v metricsAdapterAPIVerifier) Request() *http.Request {
 /*
 Expecting this with non-zero value
 
-{
-  "kind": "MetricValueList",
-  "apiVersion": "custom.metrics.k8s.io/v1beta1",
-  "metadata": {
-    "selfLink": "/apis/custom.metrics.k8s.io/v1beta1/namespaces/d8-upmeter/metrics/memory_1m"
-  },
-  "items": [
-    {
-      "describedObject": {
-        "kind": "Namespace",
-        "name": "d8-upmeter",
-        "apiVersion": "/v1"
-      },
-      "metricName": "memory_1m",
-      "timestamp": "2021-02-16T08:05:18Z",
-      "value": "73252864"                               <- we check this
-    }
-  ]
-}
+	{
+	  "kind": "MetricValueList",
+	  "apiVersion": "custom.metrics.k8s.io/v1beta1",
+	  "metadata": {
+	    "selfLink": "/apis/custom.metrics.k8s.io/v1beta1/namespaces/d8-upmeter/metrics/memory_1m"
+	  },
+	  "items": [
+	    {
+	      "describedObject": {
+	        "kind": "Namespace",
+	        "name": "d8-upmeter",
+	        "apiVersion": "/v1"
+	      },
+	      "metricName": "memory_1m",
+	      "timestamp": "2021-02-16T08:05:18Z",
+	      "value": "73252864"                               <- we check this
+	    }
+	  ]
+	}
 */
 func (v metricsAdapterAPIVerifier) Verify(body []byte) check.Error {
 	value := gjson.Get(string(body), "items.0.value")

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/episode_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/episode_test.go
@@ -290,8 +290,3 @@ func episodes(ref *check.ProbeRef, slots []time.Time) []*check.Episode {
 	}
 	return eps
 }
-
-func episode(ref *check.ProbeRef, slotUnix int64) *check.Episode {
-	ep := check.NewEpisode(*ref, time.Unix(slotUnix, 0), 30*time.Second, check.Stats{})
-	return &ep
-}

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/parse_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/parse_test.go
@@ -28,7 +28,7 @@ func Test_parseStepRange(t *testing.T) {
 	g := NewWithT(t)
 
 	cases := []struct {
-		args [3]string
+		args [3]string // from, to, step
 		want ranges.StepRange
 	}{
 		{
@@ -40,6 +40,11 @@ func Test_parseStepRange(t *testing.T) {
 			// duration notation in step
 			args: [...]string{"1617061615", "1617083215", "30m"},
 			want: ranges.StepRange{From: 1617061615, To: 1617083215, Step: 1800},
+		},
+		{
+			// seconds notation for small step
+			args: [...]string{"1617061600", "1617083230", "30"},
+			want: ranges.StepRange{From: 1617061600, To: 1617083230, Step: 30},
 		},
 	}
 

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
@@ -167,7 +167,7 @@ func (h *PublicStatusHandler) calcStatuses(
 
 		groupSummary, err := flattenSummary(groupRef, resp.Statuses)
 		if err != nil {
-			log.Errorf("generating summary %s: %v", group, err)
+			log.Errorf("generating summary for group %s: %v", group, err)
 			return nil, err
 		}
 
@@ -192,7 +192,7 @@ func (h *PublicStatusHandler) calcStatuses(
 
 			probeSummary, err := flattenSummary(probeRef, resp.Statuses)
 			if err != nil {
-				log.Errorf("generating summary %s: %v", group, err)
+				log.Errorf("generating summary for probe %s/%s: %v", group, groupRef.Probe, err)
 				return nil, err
 			}
 
@@ -252,11 +252,11 @@ var ErrNoData = fmt.Errorf("no data")
 func pickSummaryByLastComleteEpisode(ref check.ProbeRef, statuses map[string]map[string][]entity.EpisodeSummary, slotSize time.Duration) ([]entity.EpisodeSummary, error) {
 	summary, err := pickSummary(ref, statuses)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting summary for slot size %s: %w", slotSize, err)
 	}
 	lastFulfilled, found := shrinkToFulfilled(summary, slotSize)
 	if !found {
-		return nil, ErrNoData
+		return nil, fmt.Errorf("shrinking data to last complete episode: %w", ErrNoData)
 	}
 	return []entity.EpisodeSummary{lastFulfilled}, nil
 }

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
@@ -161,7 +161,7 @@ func (h *PublicStatusHandler) calcStatuses(
 			muteDowntimeTypes: muteTypes,
 		}
 
-		groupSummary, err := h.getProbeSummary(lister, h.DowntimeMonitor, filter, pickSummary)
+		groupSummary, err := h.getProbeSummary(lister, filter, pickSummary)
 		if err != nil {
 			return nil, fmt.Errorf("getting summary for group %s: %v", group, err)
 		}
@@ -180,7 +180,7 @@ func (h *PublicStatusHandler) calcStatuses(
 				muteDowntimeTypes: muteTypes,
 			}
 
-			probeSummary, err := h.getProbeSummary(lister, h.DowntimeMonitor, filter, pickSummary)
+			probeSummary, err := h.getProbeSummary(lister, filter, pickSummary)
 			if err != nil {
 				return nil, fmt.Errorf("getting summary for probe %s/%s: %v", group, groupRef.Probe, err)
 			}
@@ -209,14 +209,12 @@ func (h *PublicStatusHandler) calcStatuses(
 
 func (h *PublicStatusHandler) getProbeSummary(
 	lister entity.RangeEpisodeLister,
-	monitor *downtime.Monitor,
 	filter *statusFilter,
-	pickSummary summaryPicker) ([]entity.EpisodeSummary, error) {
-
+	pickSummary summaryPicker,
+) ([]entity.EpisodeSummary, error) {
 	resp, err := getStatusSummary(lister, h.DowntimeMonitor, filter)
 	if err != nil {
-		log.Errorf("fetching summary: %w", err)
-		return nil, err
+		return nil, fmt.Errorf("fetching summary: %w", err)
 	}
 
 	gpSummary, err := pickSummary(filter.probeRef, resp.Statuses)

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
@@ -146,6 +146,8 @@ func (h *PublicStatusHandler) calcStatuses(
 		"InfrastructureAccident",
 	}
 
+	slotSize := time.Duration(rng.Step) * time.Second
+
 	groups := h.ProbeLister.Groups()
 	groupStatuses := make([]GroupStatus, 0, len(groups))
 	for _, group := range groups {
@@ -192,13 +194,13 @@ func (h *PublicStatusHandler) calcStatuses(
 			probeAvails = append(probeAvails, ProbeAvailability{
 				Probe:        probeRef.Probe,
 				Availability: av,
-				Status:       calculateStatus(probeSummary),
+				Status:       calculateStatus(probeSummary, slotSize),
 			})
 		}
 
 		gs := GroupStatus{
 			Group:  group,
-			Status: calculateStatus(groupSummary),
+			Status: calculateStatus(groupSummary, slotSize),
 			Probes: probeAvails,
 		}
 		groupStatuses = append(groupStatuses, gs)
@@ -313,9 +315,7 @@ func shrinkToFulfilled(summary []entity.EpisodeSummary, slotSize time.Duration) 
 //   - Operational is when we observe only uptime
 //   - Outage is when we observe only downtime
 //   - Degraded is when we observe mixed uptime and downtime
-func calculateStatus(sums []entity.EpisodeSummary) PublicStatus {
-	slotSize := 5 * time.Minute
-
+func calculateStatus(sums []entity.EpisodeSummary, slotSize time.Duration) PublicStatus {
 	// for the peek case
 	if len(sums) == 1 {
 		switch {

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
@@ -284,12 +284,11 @@ func pickGroupProbeSummary(ref check.ProbeRef, statuses map[string]map[string][]
 		return nil, fmt.Errorf("%w (empty row) for probe '%s/%s'", ErrNoData, g, p)
 	}
 
-	if len(episodeSummaries) == 1 {
-		return episodeSummaries, nil
-	}
-
 	// Summary column in the end is implied, ignore summary column in the end
 	n := len(episodeSummaries) - 1
+	if n == 1 {
+		return episodeSummaries, nil
+	}
 	if n != 3 {
 		return nil, fmt.Errorf("unexpected count %d!=3 for probe '%s/%s'", n, g, p)
 	}

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
@@ -280,7 +280,16 @@ func pickGroupProbeSummary(ref check.ProbeRef, statuses map[string]map[string][]
 	}
 
 	episodeSummaries := statuses[g][p]
-	n := len(episodeSummaries) - 1 // ignore summary column in the end
+	if len(episodeSummaries) == 0 {
+		return nil, fmt.Errorf("%w (empty row) for probe '%s/%s'", ErrNoData, g, p)
+	}
+
+	if len(episodeSummaries) == 1 {
+		return episodeSummaries, nil
+	}
+
+	// Summary column in the end is implied, ignore summary column in the end
+	n := len(episodeSummaries) - 1
 	if n != 3 {
 		return nil, fmt.Errorf("unexpected count %d!=3 for probe '%s/%s'", n, g, p)
 	}

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/public_status.go
@@ -114,12 +114,12 @@ func (h *PublicStatusHandler) getGroupStatusList(peek bool) ([]GroupStatus, erro
 	now := time.Now()
 
 	if peek {
-		slotSize := 30 * time.Second
 		// Observe only last fulfilled 30 seconds for the speed of availability calculation
 		return h.calcStatuses(
 			new30SecondsStepRange(now),
 			dao.NewEpisodeDao30s(daoCtx),
 			func(ref check.ProbeRef, statuses map[string]map[string][]entity.EpisodeSummary) ([]entity.EpisodeSummary, error) {
+				slotSize := 30 * time.Second
 				return pickGroupProbeSummaryByLastCompleteEpisode(ref, statuses, slotSize)
 			},
 		)

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/public_status_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/public_status_test.go
@@ -157,7 +157,7 @@ func Test_calculateStatus(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := calculateStatus(tt.args.summary); got != tt.want {
+			if got := calculateStatus(tt.args.summary, 5*time.Minute); got != tt.want {
 				t.Errorf("calculateStatus() = %v, want %v", got, tt.want)
 			}
 		})

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/public_status_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/public_status_test.go
@@ -25,7 +25,7 @@ import (
 
 func Test_currentRange(t *testing.T) {
 	ts := time.Unix(1803468883, 90)
-	rng := threeStepRange(ts)
+	rng := new15MinuteStepRange(ts)
 
 	n := (rng.To - rng.From) / rng.Step
 	if n != 3 {

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/public_status_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/public_status_test.go
@@ -25,7 +25,7 @@ import (
 
 func Test_currentRange(t *testing.T) {
 	ts := time.Unix(1803468883, 90)
-	rng := new15MinuteStepRange(ts)
+	rng := new15MinutesStepRange(ts)
 
 	n := (rng.To - rng.From) / rng.Step
 	if n != 3 {

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/status.go
@@ -138,11 +138,10 @@ func getStatus(dbctx *dbcontext.DbContext, monitor *downtime.Monitor, filter *st
 	}
 
 	resp := &StatusResponse{
-		Statuses: statuses,
-		Step:     rng.Step,
-		From:     rng.From,
-		To:       rng.To,
-		// Episodes:  episodes, // To much data, only for debug.
+		Statuses:  statuses,
+		Step:      rng.Step,
+		From:      rng.From,
+		To:        rng.To,
 		Incidents: incidents,
 	}
 

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/status.go
@@ -132,32 +132,6 @@ func parseFilter(r *http.Request) (*statusFilter, error) {
 	return parsed, nil
 }
 
-// func getStatus(dbctx *dbcontext.DbContext, monitor *downtime.Monitor, filter *statusFilter) (*StatusResponse, error) {
-// 	incidents, err := fetchIncidents(monitor, filter.muteDowntimeTypes, filter.probeRef.Group, filter.stepRange)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	daoCtx := dbctx.Start()
-// 	defer daoCtx.Stop()
-// 	dao5m := dao.NewEpisodeDao5m(daoCtx)
-
-// 	statuses, err := entity.GetStatuses(dao5m, filter.probeRef, filter.stepRange, incidents)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	resp := &StatusResponse{
-// 		Statuses:  statuses,
-// 		Step:      filter.stepRange.Step,
-// 		From:      filter.stepRange.From,
-// 		To:        filter.stepRange.To,
-// 		Incidents: incidents,
-// 	}
-
-// 	return resp, nil
-// }
-
 func getStatusSummary(lister entity.RangeEpisodeLister, monitor *downtime.Monitor, filter *statusFilter) (*StatusResponse, error) {
 	incidents, err := fetchIncidents(monitor, filter.muteDowntimeTypes, filter.probeRef.Group, filter.stepRange)
 	if err != nil {

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/status.go
@@ -25,6 +25,7 @@ import (
 
 	"d8.io/upmeter/pkg/check"
 	dbcontext "d8.io/upmeter/pkg/db/context"
+	"d8.io/upmeter/pkg/db/dao"
 	"d8.io/upmeter/pkg/monitor/downtime"
 	"d8.io/upmeter/pkg/server/entity"
 	"d8.io/upmeter/pkg/server/ranges"
@@ -60,7 +61,14 @@ func (h *StatusRangeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// force default filtering
+	// Adjust range to 5m slots.
+	rng := ranges.New5MinStepRange(filter.stepRange.From, filter.stepRange.To, filter.stepRange.Step)
+	log.Infof("[from to step] input [%d %d %d] adjusted to [%d, %d, %d]",
+		filter.stepRange.From, filter.stepRange.To, filter.stepRange.Step,
+		rng.From, rng.To, rng.Step)
+	filter.stepRange = rng
+
+	// Force default filtering.
 	if len(filter.muteDowntimeTypes) == 0 {
 		filter.muteDowntimeTypes = []string{
 			"Maintenance",
@@ -69,7 +77,11 @@ func (h *StatusRangeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	resp, err := getStatus(h.DbCtx, h.DowntimeMonitor, filter)
+	// Query the DB
+	daoCtx := h.DbCtx.Start()
+	defer daoCtx.Stop()
+
+	resp, err := getStatus(dao.NewEpisodeDao5m(daoCtx), h.DowntimeMonitor, filter)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, err.Error(), http.StatusInternalServerError)
@@ -120,28 +132,48 @@ func parseFilter(r *http.Request) (*statusFilter, error) {
 	return parsed, nil
 }
 
-func getStatus(dbctx *dbcontext.DbContext, monitor *downtime.Monitor, filter *statusFilter) (*StatusResponse, error) {
-	// Adjust range to step slots.
-	rng := ranges.NewStepRange(filter.stepRange.From, filter.stepRange.To, filter.stepRange.Step)
-	log.Infof("[from to step] input [%d %d %d] adjusted to [%d, %d, %d]",
-		filter.stepRange.From, filter.stepRange.To, filter.stepRange.Step,
-		rng.From, rng.To, rng.Step)
+// func getStatus(dbctx *dbcontext.DbContext, monitor *downtime.Monitor, filter *statusFilter) (*StatusResponse, error) {
+// 	incidents, err := fetchIncidents(monitor, filter.muteDowntimeTypes, filter.probeRef.Group, filter.stepRange)
+// 	if err != nil {
+// 		return nil, err
+// 	}
 
-	incidents, err := fetchIncidents(monitor, filter.muteDowntimeTypes, filter.probeRef.Group, rng)
+// 	daoCtx := dbctx.Start()
+// 	defer daoCtx.Stop()
+// 	dao5m := dao.NewEpisodeDao5m(daoCtx)
+
+// 	statuses, err := entity.GetStatuses(dao5m, filter.probeRef, filter.stepRange, incidents)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	resp := &StatusResponse{
+// 		Statuses:  statuses,
+// 		Step:      filter.stepRange.Step,
+// 		From:      filter.stepRange.From,
+// 		To:        filter.stepRange.To,
+// 		Incidents: incidents,
+// 	}
+
+// 	return resp, nil
+// }
+
+func getStatus(lister entity.RangeEpisodeLister, monitor *downtime.Monitor, filter *statusFilter) (*StatusResponse, error) {
+	incidents, err := fetchIncidents(monitor, filter.muteDowntimeTypes, filter.probeRef.Group, filter.stepRange)
 	if err != nil {
 		return nil, err
 	}
 
-	statuses, err := entity.Statuses(dbctx, filter.probeRef, rng, incidents)
+	statuses, err := entity.GetStatuses(lister, filter.probeRef, filter.stepRange, incidents)
 	if err != nil {
 		return nil, err
 	}
 
 	resp := &StatusResponse{
 		Statuses:  statuses,
-		Step:      rng.Step,
-		From:      rng.From,
-		To:        rng.To,
+		Step:      filter.stepRange.Step,
+		From:      filter.stepRange.From,
+		To:        filter.stepRange.To,
 		Incidents: incidents,
 	}
 

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/status.go
@@ -81,7 +81,7 @@ func (h *StatusRangeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	daoCtx := h.DbCtx.Start()
 	defer daoCtx.Stop()
 
-	resp, err := getStatus(dao.NewEpisodeDao5m(daoCtx), h.DowntimeMonitor, filter)
+	resp, err := getStatusSummary(dao.NewEpisodeDao5m(daoCtx), h.DowntimeMonitor, filter)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, err.Error(), http.StatusInternalServerError)
@@ -158,7 +158,7 @@ func parseFilter(r *http.Request) (*statusFilter, error) {
 // 	return resp, nil
 // }
 
-func getStatus(lister entity.RangeEpisodeLister, monitor *downtime.Monitor, filter *statusFilter) (*StatusResponse, error) {
+func getStatusSummary(lister entity.RangeEpisodeLister, monitor *downtime.Monitor, filter *statusFilter) (*StatusResponse, error) {
 	incidents, err := fetchIncidents(monitor, filter.muteDowntimeTypes, filter.probeRef.Group, filter.stepRange)
 	if err != nil {
 		return nil, err

--- a/modules/500-upmeter/images/upmeter/pkg/server/api/status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/api/status.go
@@ -164,7 +164,7 @@ func getStatus(lister entity.RangeEpisodeLister, monitor *downtime.Monitor, filt
 		return nil, err
 	}
 
-	statuses, err := entity.GetStatuses(lister, filter.probeRef, filter.stepRange, incidents)
+	statuses, err := entity.GetSummary(lister, filter.probeRef, filter.stepRange, incidents)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/500-upmeter/images/upmeter/pkg/server/entity/episode_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/entity/episode_test.go
@@ -158,7 +158,7 @@ func Test_Update5mEpisode_Saves(t *testing.T) {
 
 	from := initial30s.TimeSlot.Truncate(5 * time.Minute)
 	to := from.Add(5 * time.Minute)
-	timerange := ranges.NewStepRange(from.Unix(), to.Unix(), 300)
+	timerange := ranges.New5MinStepRange(from.Unix(), to.Unix(), 300)
 	entities, err := dao.ListEpisodeSumsForRanges(timerange, initial30s.ProbeRef)
 	if err != nil {
 		t.Errorf("cannot get 5m episodes: %v", err)

--- a/modules/500-upmeter/images/upmeter/pkg/server/entity/status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/entity/status.go
@@ -17,6 +17,7 @@ limitations under the License.
 package entity
 
 import (
+	"fmt"
 	"sort"
 	"time"
 
@@ -96,7 +97,7 @@ type RangeEpisodeLister interface {
 func GetSummary(lister RangeEpisodeLister, ref check.ProbeRef, rng ranges.StepRange, incidents []check.DowntimeIncident) (map[string]map[string][]EpisodeSummary, error) {
 	episodes, err := lister.ListEpisodeSumsForRanges(rng, ref)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("listing episodes for range %s: %w", rng, err)
 	}
 
 	statuses := calculateStatuses(episodes, incidents, rng.Subranges, ref)

--- a/modules/500-upmeter/images/upmeter/pkg/server/entity/status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/entity/status.go
@@ -99,7 +99,8 @@ func Statuses(dbctx *dbcontext.DbContext, ref check.ProbeRef, rng ranges.StepRan
 	return statuses, nil
 }
 
-/**
+/*
+*
 calculateStatuses returns arrays of EpisodeSummary objects for each group and probe.
 Each EpisodeSummary object is combined from Episodes for a step range.
 
@@ -109,16 +110,17 @@ Returned structure is map[group][probe][dataByTime]
 
 Example output:
 aGroup:
-  aProbe:
-  - timeslot: 0
-    up: 300
-    down: 0
-  - timeslot: 300
-    up: 300
-    down: 0
-  - timeslot: 900
-    up: 300
-    down: 0
+
+	aProbe:
+	- timeslot: 0
+	  up: 300
+	  down: 0
+	- timeslot: 300
+	  up: 300
+	  down: 0
+	- timeslot: 900
+	  up: 300
+	  down: 0
 */
 func calculateStatuses(episodes []check.Episode, incidents []check.DowntimeIncident, stepRanges []ranges.Range, ref check.ProbeRef) map[string]map[string][]EpisodeSummary {
 	// Combine multiple episodes into one for the same probe and timeslot. Basically, we deduce

--- a/modules/500-upmeter/images/upmeter/pkg/server/entity/status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/entity/status.go
@@ -70,6 +70,11 @@ func (s *EpisodeSummary) Avail() time.Duration {
 	return s.Up + s.Down + s.Unknown
 }
 
+func (s *EpisodeSummary) Complete() bool {
+	// muted and downtimes cannot affect this
+	return s.Up+s.Down+s.Unknown+s.NoData == 5*time.Minute
+}
+
 // ByTimeSlot implements sort.Interface based on the TimeSlot field.
 type ByTimeSlot []EpisodeSummary
 

--- a/modules/500-upmeter/images/upmeter/pkg/server/entity/status.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/entity/status.go
@@ -222,22 +222,22 @@ func calcMuteDuration(inc check.DowntimeIncident, rng ranges.Range, group string
 }
 
 // updateMute applies muting to a EpisodeSummary based on intervals described by incidents.
-func updateMute(statuses map[string]map[string]map[int64]*EpisodeSummary, incidents []check.DowntimeIncident, stepRanges []ranges.Range) {
-	if len(incidents) == 0 || len(stepRanges) == 0 {
+func updateMute(statuses map[string]map[string]map[int64]*EpisodeSummary, incidents []check.DowntimeIncident, rangeList []ranges.Range) {
+	if len(incidents) == 0 || len(rangeList) == 0 {
 		return
 	}
 
 	for group := range statuses {
-		for _, stepRange := range stepRanges {
+		for _, rng := range rangeList {
 			var (
-				step             = stepRange.Dur()
+				step             = rng.Dur()
 				muted            time.Duration
 				relatedDowntimes []check.DowntimeIncident
 			)
 
 			// calculate maximum known mute duration
 			for _, incident := range incidents {
-				m := calcMuteDuration(incident, stepRange, group)
+				m := calcMuteDuration(incident, rng, group)
 				if m == 0 {
 					continue
 				}
@@ -247,7 +247,7 @@ func updateMute(statuses map[string]map[string]map[int64]*EpisodeSummary, incide
 
 			// Apply `muted` to all probes in group.
 			for probeName := range statuses[group] {
-				status := statuses[group][probeName][stepRange.From]
+				status := statuses[group][probeName][rng.From]
 
 				status.Downtimes = relatedDowntimes
 

--- a/modules/500-upmeter/images/upmeter/pkg/server/entity/status_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/entity/status_test.go
@@ -57,7 +57,7 @@ func Test_CalculateStatuses_success_only(t *testing.T) {
 	}
 
 	t.Run("simple case with minimal step", func(t *testing.T) {
-		s := calculateStatuses(episodes, nil, ranges.NewStepRange(0, 900, 300).Subranges, probeRef)
+		s := calculateStatuses(episodes, nil, ranges.New5MinStepRange(0, 900, 300).Subranges, probeRef)
 
 		// Len should be 4: 3 episodes + one total episode for a period.
 		assertTree(g, s, probeRef, 3+1, "simple case with minimal step")
@@ -68,7 +68,7 @@ func Test_CalculateStatuses_success_only(t *testing.T) {
 	})
 
 	t.Run("mmm", func(t *testing.T) {
-		s := calculateStatuses(episodes, nil, ranges.NewStepRange(0, 1200, 300).Subranges, probeRef)
+		s := calculateStatuses(episodes, nil, ranges.New5MinStepRange(0, 1200, 300).Subranges, probeRef)
 
 		assertTree(g, s, probeRef, 4+1, "testGroup/testProbe len 4")
 		assertTimers(g, s[group][probe][0], counters{up: 300})
@@ -79,7 +79,7 @@ func Test_CalculateStatuses_success_only(t *testing.T) {
 	})
 
 	t.Run("2x step", func(t *testing.T) {
-		s := calculateStatuses(episodes, nil, ranges.NewStepRange(0, 1200, 600).Subranges, probeRef)
+		s := calculateStatuses(episodes, nil, ranges.New5MinStepRange(0, 1200, 600).Subranges, probeRef)
 
 		assertTree(g, s, probeRef, 2+1, "testGroup/testProbe len 2")
 		assertTimers(g, s[group][probe][0], counters{up: 600})

--- a/modules/500-upmeter/images/upmeter/pkg/server/ranges/steprange.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/ranges/steprange.go
@@ -36,11 +36,22 @@ func (r Range) Diff() time.Duration {
 	return time.Duration(r.To-r.From) * time.Second
 }
 
-// NewStepRange aligns range borders and calculates subranges.
+// New5MinStepRange returns SteRange aligned to 5 minute step.
+func New5MinStepRange(from, to, step int64) StepRange {
+	step = alignStep(step, 300)
+	return NewStepRange(from, to, step)
+}
+
+// New30SecStepRange returns SteRange aligned to 30 seconds step.
+func New30SecStepRange(from, to, step int64) StepRange {
+	step = alignStep(step, 30)
+	return NewStepRange(from, to, step)
+}
+
+// New5MinStepRange aligns range borders and calculates subranges.
 func NewStepRange(from, to, step int64) StepRange {
+	to = alignEdgeForward(to, step)
 	count := (to - from) / step
-	step = alignStep(step)
-	to = alignEdge(to, step)
 	from = to - step*count
 
 	res := StepRange{
@@ -70,17 +81,13 @@ func NewStepRange(from, to, step int64) StepRange {
 	return res
 }
 
-// alignStep makes sure that the step is a multiple of 300.
-func alignStep(step int64) int64 {
-	var (
-		minStep     = int64(300)
-		alignedStep = step - step%minStep
-	)
-	return maxInt64(minStep, alignedStep)
+// alignStep makes sure that the step is a multiple of min.
+func alignStep(step, min int64) int64 {
+	return maxInt64(min, step-step%min)
 }
 
-// alignStep makes sure the
-func alignEdge(to, step int64) int64 {
+// alignEdgeForward makes sure the edge is a multiple of step, rounded to bigger side.
+func alignEdgeForward(to, step int64) int64 {
 	if to%step == 0 {
 		return to
 	}

--- a/modules/500-upmeter/images/upmeter/pkg/server/ranges/steprange.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/ranges/steprange.go
@@ -37,7 +37,7 @@ type Range struct {
 	To   int64
 }
 
-func (r Range) Diff() time.Duration {
+func (r Range) Dur() time.Duration {
 	return time.Duration(r.To-r.From) * time.Second
 }
 

--- a/modules/500-upmeter/images/upmeter/pkg/server/ranges/steprange.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/ranges/steprange.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ranges
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -25,6 +26,10 @@ type StepRange struct {
 	To        int64
 	Step      int64
 	Subranges []Range
+}
+
+func (r StepRange) String() string {
+	return fmt.Sprintf("StepRange{From: %d, To: %d, Step: %d, Subranges: (N=%d)}", r.From, r.To, r.Step, len(r.Subranges))
 }
 
 type Range struct {

--- a/modules/500-upmeter/images/upmeter/pkg/server/ranges/steprange_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/ranges/steprange_test.go
@@ -115,7 +115,7 @@ func Test_CalculateAdjustedStepRanges(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NewStepRange(tt.args.from, tt.args.to, tt.args.step).Subranges
+			got := New5MinStepRange(tt.args.from, tt.args.to, tt.args.step).Subranges
 
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("CalculateAdjustedStepRanges() = %v, want %v", got, tt.want)
@@ -149,7 +149,7 @@ func TestAlignStep(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := alignStep(tt.arg); got != tt.want {
+			if got := alignStep(tt.arg, 300); got != tt.want {
 				t.Errorf("alignStep() = %v, want %v", got, tt.want)
 			}
 		})
@@ -221,7 +221,7 @@ func TestAlignEdge(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := alignEdge(tt.args.to, tt.args.step); got != tt.want {
+			if got := alignEdgeForward(tt.args.to, tt.args.step); got != tt.want {
 				t.Errorf("alignEdge() = %v, want %v", got, tt.want)
 			}
 		})
@@ -234,8 +234,8 @@ func Test_readjusting(t *testing.T) {
 		to := from + rand.Int63n(30000)
 		step := 1 + rand.Int63n(30000)
 
-		rng1 := NewStepRange(from, to, step)
-		rng2 := NewStepRange(rng1.From, rng1.To, rng1.Step)
+		rng1 := New5MinStepRange(from, to, step)
+		rng2 := New5MinStepRange(rng1.From, rng1.To, rng1.Step)
 
 		if !reflect.DeepEqual(rng1, rng2) {
 			t.Errorf("step ranges must be equal: initial=%v, secondary=%v", rng1, rng2)

--- a/modules/500-upmeter/images/upmeter/pkg/server/ranges/steprange_test.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/ranges/steprange_test.go
@@ -98,6 +98,18 @@ func Test_CalculateAdjustedStepRanges(t *testing.T) {
 				{From: 1603670400, To: 1603756800},
 				{From: 1603756800, To: 1603843200},
 			},
+		}, {
+			name: "30s aligned range is foced to 5m",
+			args: args{from: 1603784700, to: 1603784730, step: 30},
+			want: []Range{
+				{From: 1603784700, To: 1603785000},
+			},
+		}, {
+			name: "30s not aligned range is foced to 5m",
+			args: args{from: 1603784693, to: 1603784732, step: 30},
+			want: []Range{
+				{From: 1603784700, To: 1603785000},
+			},
 		},
 	}
 

--- a/modules/500-upmeter/images/upmeter/pkg/server/server.go
+++ b/modules/500-upmeter/images/upmeter/pkg/server/server.go
@@ -176,7 +176,7 @@ func cleanOld30sEpisodes(ctx context.Context, dbCtx *dbcontext.DbContext) {
 func initHttpServer(dbCtx *dbcontext.DbContext, downtimeMonitor *downtime.Monitor, controller *remotewrite.Controller, probeLister registry.ProbeLister, addr string) *http.Server {
 	mux := http.NewServeMux()
 
-	// Setup API handlers
+	// API handlers
 	mux.Handle("/api/probe", &api.ProbeListHandler{DbCtx: dbCtx, ProbeLister: probeLister})
 	mux.Handle("/api/status/range", &api.StatusRangeHandler{DbCtx: dbCtx, DowntimeMonitor: downtimeMonitor})
 	mux.Handle("/public/api/status", &api.PublicStatusHandler{DbCtx: dbCtx, DowntimeMonitor: downtimeMonitor, ProbeLister: probeLister})

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -98,6 +98,9 @@ SWITCH_TO_IMAGE_TAG=
 # ssh command with common args.
 ssh_command="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=quiet"
 
+# On Centos7/RedHat bootstrap puts jq to /usr/local/bin/jq
+export PATH="/usr/local/bin:$PATH"
+
 # Path to private SSH key to connect to cluster after bootstrap
 ssh_private_key_path=
 # User for SSH connect.

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -543,7 +543,7 @@ trap pause-the-test EXIT
 # UPMETER AVAILABILITY SETUP
 #
 ### Get the IP of upmeter server
-for ((i=0; i<15; i++)); do
+for ((i=0; i<40; i++)); do
   upmeter_addr=$(kubectl -n d8-upmeter get ep upmeter -o json | jq -re '.subsets[].addresses[0] | .ip') && break
   >&2 echo "Attempt to get Endpoints for upmeter #$i failed. Sleeping 30 seconds..."
   sleep 30

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -603,6 +603,9 @@ for ((i=0; i<15; i++)); do
     ' <<<"$avail_json")"
 
   ### Print the list of probe statuses
+  echo '='
+  echo '====================== AVAILABILITY, STATUS, PROBE '======================
+  #     0.626  failure  monitoring-and-autoscaling/prometheus-metrics-adapter
   echo "$(jq -r '.[] | [((.availability * 1000 | round) / 1000), .status, .probe] | @tsv' <<<"$avail_report")" | column -t
 
   ### Gather the overall availability status: "ok" or "failure"

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -572,7 +572,7 @@ for ((i=0; i<$attempts; i++)); do
                 | .probes[]
                 | {
                   probe: ($group + "/" + .probe),
-                  status: (if .availability > 0.99 then "ok" else "pending" end),
+                  status: (if .availability > 0.99 then "up" else "pending" end),
                   availability: .availability
                 }
               ]
@@ -581,7 +581,7 @@ for ((i=0; i<$attempts; i++)); do
           ' <<<"$avail_json")"
 
         # Printing the table of probe statuses
-        echo ''
+        echo '*'
         echo '====================== AVAILABILITY, STATUS, PROBE ======================'
         # E.g.:  0.626  failure  monitoring-and-autoscaling/prometheus-metrics-adapter
         echo "$(jq -re '.[] | [((.availability*1000|round) / 1000), .status, .probe] | @tsv' <<<"$avail_report")" | column -t
@@ -601,7 +601,7 @@ for ((i=0; i<$attempts; i++)); do
   fi
 
     cat <<EOF
-Availability check: $([ "$availability" == "ok" ] && echo "success" || echo "failure")
+Availability check: $([ "$availability" == "ok" ] && echo "success" || echo "pending")
 EOF
 
   if [[ -n "$ingress_inlet" ]]; then

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -528,6 +528,20 @@ export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 export LANG=C
 set -Eeuo pipefail
 
+function pause-the-test() {
+  while true; do
+    if ! { kubectl get configmap pause-the-test -o json | jq -re '.metadata.name == "pause-the-test"' >/dev/null ; }; then
+      break
+    fi
+
+    >&2 echo 'Waiting until "kubectl delete cm pause-the-test" before destroying cluster'
+
+    sleep 30
+  done
+}
+
+trap pause-the-test EXIT
+
 #
 # UPMETER AVAILABILITY SETUP
 #

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -562,7 +562,7 @@ for ((i=0; i<$attempts; i++)); do
       # -e flag does not work as expected. See
       # https://github.com/stedolan/jq/pull/1697#issuecomment-1242588319
       #
-      if avail_json="$(curl -k -s -S -m5 -H "Authorization: Bearer $upmeter_auth_token" "https://${upmeter_addr}:8443/public/api/status?peek=1" | echo null | jq -ce)" 2>/dev/null; then
+      if avail_json="$(curl -k -s -S -m5 -H "Authorization: Bearer $upmeter_auth_token" "https://${upmeter_addr}:8443/public/api/status?peek=1" || echo null | jq -ce)" 2>/dev/null; then
         # Transforming the data to a flat array of the following structure  [{ "probe": "{group}/{probe}", "status": "ok/pending" }]
         avail_report="$(jq -re '
           [

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -602,7 +602,7 @@ for ((i=0; i<20; i++)); do
 
   ### Print the list of probe statuses
   echo '='
-  echo '====================== AVAILABILITY, STATUS, PROBE '======================
+  echo '====================== AVAILABILITY, STATUS, PROBE ======================'
   #     0.626  failure  monitoring-and-autoscaling/prometheus-metrics-adapter
   echo "$(jq -r '.[] | [((.availability * 1000 | round) / 1000), .status, .probe] | @tsv' <<<"$avail_report")" | column -t
 

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -545,7 +545,8 @@ else
   ingress=""
 fi
 
-availability = ""
+availability=""
+
 # With sleep timeout of 30s, we have 25 minutes period in total to catch the 100% availability from upmeter
 for ((i=0; i<50; i++)); do
   # Sleeping at the start for readability. First iterations do not succeed anyway.

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -574,7 +574,7 @@ else
 fi
 
 # With sleep timeout of 30s, we have 20 minutes period in total to catch the 100% availability from upmeter
-for ((i=0; i<20; i++)); do
+for ((i=0; i<40; i++)); do
   ### Get availability data based on last 30 seconds of probe measurements, note 'peek=1' query param
   avail_json="$(curl -k -s -H "Authorization: Bearer $upmeter_auth_token" "https://${upmeter_addr}:8443/public/api/status?peek=1")"
   if [[ -z "$avail_json" ]]; then

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -98,9 +98,6 @@ SWITCH_TO_IMAGE_TAG=
 # ssh command with common args.
 ssh_command="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=quiet"
 
-# On Centos7/RedHat bootstrap puts jq to /usr/local/bin/jq
-# export PATH="/usr/local/bin:$PATH"
-
 # Path to private SSH key to connect to cluster after bootstrap
 ssh_private_key_path=
 # User for SSH connect.
@@ -547,9 +544,6 @@ trap pause-the-test EXIT
 #
 ### Get the IP of upmeter server
 for ((i=0; i<15; i++)); do
-  echo $PATH || true            ## DELETE ME
-  ls /usr/local/bin/jq || true  ## DELETE ME
-  which jq || true              ## DELETE ME
   upmeter_addr=$(kubectl -n d8-upmeter get ep upmeter -o json | jq -re '.subsets[].addresses[0] | .ip') && break
   >&2 echo "Attempt to get Endpoints for upmeter #$i failed. Sleeping 30 seconds..."
   sleep 30

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -574,9 +574,9 @@ else
 fi
 
 # With sleep timeout of 30s, we have 20 minutes period in total to catch the 100% availability from upmeter
-for ((i=0; i<40; i++)); do
-  ### Get availability data based on last 10 minutes
-  avail_json="$(curl -k -s -H "Authorization: Bearer $upmeter_auth_token" "https://${upmeter_addr}:8443/public/api/status")"
+for ((i=0; i<20; i++)); do
+  ### Get availability data based on last 30 seconds of probe measurements, note 'peek=1' query param
+  avail_json="$(curl -k -s -H "Authorization: Bearer $upmeter_auth_token" "https://${upmeter_addr}:8443/public/api/status?peek=1")"
   if [[ -z "$avail_json" ]]; then
     >&2 echo "Attempt to get availability data #$i failed. Sleeping 30 seconds..."
     sleep 30

--- a/testing/cloud_layouts/script.sh
+++ b/testing/cloud_layouts/script.sh
@@ -548,7 +548,7 @@ fi
 availability=""
 attempts=50
 # With sleep timeout of 30s, we have 25 minutes period in total to catch the 100% availability from upmeter
-for ((i=0; i<$attempts; i++)); do
+for i in $(seq $attempts); do
   # Sleeping at the start for readability. First iterations do not succeed anyway.
   sleep 30
 
@@ -572,7 +572,7 @@ for ((i=0; i<$attempts; i++)); do
                 | .probes[]
                 | {
                   probe: ($group + "/" + .probe),
-                  status: (if .availability > 0.99 then "up" else "pending" end),
+                  status: (if .availability > 0.99   then "up"   else "pending"   end),
                   availability: .availability
                 }
               ]


### PR DESCRIPTION
## Description

In public status route on the server, we add uptime value per probe.

## Why do we need it, and what problem does it solve?

It can help us track the availablility of more cluster components in e2e tests than smoke-mini can
provide.

## What is the expected result?

e2e tests request the uptime information from upmeter server and fail is the uptime is not satisfactory.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: upmeter
type: feature
summary: Added probe uptime in public status API to use in e2e tests
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
