### PR TITLE
[monitoring-kubernetes] excluded unschedulable nodes from K8SNodeNotReady and K8SManyNodesNotReady alerts

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/kubelet.tpl
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/kubelet.tpl
@@ -1,7 +1,8 @@
 - name: coreos.kubelet
   rules:
   - alert: K8SNodeNotReady
-    expr: min(kube_node_status_condition{condition="Ready",status="true"}) BY (node) == 0
+    expr: min(kube_node_status_condition{condition="Ready",status="true"}) BY (node) == 0 and
+          min(kube_node_spec_unschedulable == 0) by (node)
     for: 10m
     labels:
       severity_level: "3"
@@ -11,9 +12,9 @@
         or has set itself to NotReady, for more than 10 minutes
       summary: Node status is NotReady
   - alert: K8SManyNodesNotReady
-    expr: count(kube_node_status_condition{condition="Ready",status="true"} == 0)
-      > 1 and (count(kube_node_status_condition{condition="Ready",status="true"} ==
-      0) / count(kube_node_status_condition{condition="Ready",status="true"})) > 0.2
+    expr: count(kube_node_status_condition{condition="Ready",status="true"} == 0 and on (node) kube_node_spec_unschedulable == 0) > 1
+      and (count(kube_node_status_condition{condition="Ready",status="true"} == 0 and on (node) kube_node_spec_unschedulable == 0) /
+      count(kube_node_status_condition{condition="Ready",status="true"} and on (node) kube_node_spec_unschedulable == 0)) > 0.2
     for: 1m
     labels:
       severity_level: "3"


### PR DESCRIPTION
## Description
Excluded unschedulable nodes from K8SNodeNotReady and K8SManyNodesNotReady alerts.

## Why do we need it, and what problem does it solve?
When a node is about to be removed by cluster-autoscaler, alerts can start firing despite the node is cordoned.
Fix #2829

## What is the expected result?
Alerts K8SNodeNotReady and K8SManyNodesNotReady ignore cordoned nodes.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: monitoring-kubernetes
type: chore
summary: Excluded unschedulable nodes from K8SNodeNotReady and K8SManyNodesNotReady alerts.
impact_level: low
```