### PR TITLE
[node-local-dns] disable node-local-dns for cilium installations on nodes with kernel < 5.7

### DIFF
--- a/ee/modules/350-node-local-dns/templates/daemonset.yaml
+++ b/ee/modules/350-node-local-dns/templates/daemonset.yaml
@@ -62,6 +62,10 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
 {{- end }}
       serviceAccountName: d8-node-local-dns
+{{- if (.Values.global.enabledModules | has "cni-cilium") }}
+      initContainers:
+      {{- include "helm_lib_module_init_container_check_linux_kernel" (tuple . ">= 5.7") | nindent 6 }}
+{{- end }}
       containers:
       - name: coredns
         {{- include "helm_lib_module_container_security_context_capabilities_drop_all_and_add" (list . (list "NET_BIND_SERVICE" "NET_ADMIN" "NET_RAW")) | nindent 8 }}

--- a/ee/modules/350-node-local-dns/templates/daemonset.yaml
+++ b/ee/modules/350-node-local-dns/templates/daemonset.yaml
@@ -49,6 +49,13 @@ spec:
   selector:
     matchLabels:
       app: node-local-dns
+{{- if (.Values.global.enabledModules | has "cni-cilium") }}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
+      maxSurge: 100%
+{{- end }}
   template:
     metadata:
       labels:
@@ -63,11 +70,6 @@ spec:
 {{- end }}
       serviceAccountName: d8-node-local-dns
 {{- if (.Values.global.enabledModules | has "cni-cilium") }}
-      updateStrategy:
-        type: RollingUpdate
-        rollingUpdate:
-          maxUnavailable: 100%
-          maxSurge: 100%
       initContainers:
       {{- include "helm_lib_module_init_container_check_linux_kernel" (tuple . ">= 5.7") | nindent 6 }}
 {{- end }}

--- a/ee/modules/350-node-local-dns/templates/daemonset.yaml
+++ b/ee/modules/350-node-local-dns/templates/daemonset.yaml
@@ -49,13 +49,6 @@ spec:
   selector:
     matchLabels:
       app: node-local-dns
-{{- if (.Values.global.enabledModules | has "cni-cilium") }}
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 100%
-      maxSurge: 100%
-{{- end }}
   template:
     metadata:
       labels:

--- a/ee/modules/350-node-local-dns/templates/daemonset.yaml
+++ b/ee/modules/350-node-local-dns/templates/daemonset.yaml
@@ -63,6 +63,11 @@ spec:
 {{- end }}
       serviceAccountName: d8-node-local-dns
 {{- if (.Values.global.enabledModules | has "cni-cilium") }}
+      updateStrategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 100%
+          maxSurge: 100%
       initContainers:
       {{- include "helm_lib_module_init_container_check_linux_kernel" (tuple . ">= 5.7") | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Disable node-local-dns for cilium installations on nodes with kernel < 5.7 due to problems with ebpf-socket and resolved endpoints.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-local-dns
type: fix
summary: Disable `node-local-dns` for cilium installations on nodes with kernel < 5.7 due to problems with `ebpf-socket` and resolved endpoints.
impact: The node-local-dns module stops working for cilium installations on nodes with kernels < 5.7.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
