### PR TITLE
[node-manager] fix openapi tests for node-manager after #2946

### DIFF
--- a/ee/modules/040-node-manager/openapi/openapi-case-tests.yaml
+++ b/ee/modules/040-node-manager/openapi/openapi-case-tests.yaml
@@ -1,38 +1,7 @@
-defaults:
-  internal: &internalDefault
-    clusterMasterAddresses: ["10.0.0.1:6443", "10.0.0.2:6443", "10.0.0.3:6443"]
-    kubernetesCA: myclusterca
-    bashibleApiServerCA: myapiserverca
-    bashibleApiServerCrt: myapiservercrt
-    bashibleApiServerKey: myapiserverprivkey
+# NOTE: values cases are in modules/040-node-manager/openapi directory.
 
 positive:
   configValues:
     - {}
     - allowedKubernetesVersions: ["1.21"]
     - allowedBundles: ["redos", "ubuntu-lts", "centos", "debian", "alteros", "astra"]
-  values:
-    - { internal: {} }
-    - internal:
-        <<: *internalDefault
-        standbyNodeGroups:
-          - name: worker
-            reserveCPU: 12m
-            reserveMemory: 30%
-        cloudProvider:
-          type: aws
-          machineClassKind: AWSInstanceClass
-          aws:
-            providerAccessKeyId: myprovaccesskeyid
-            providerSecretAccessKey: myprovsecretaccesskey
-            region: myregion
-            loadBalancerSecurityGroupID: mylbsecuritygroupid
-            keyName: mykeyname
-            instances:
-              iamProfileName: myiamprofilename
-            internal:
-              zoneToSubnetIdMap:
-                zonea: mysubnetida
-                zoneb: mysubnetidb
-            tags:
-              aaa: aaa

--- a/modules/040-node-manager/openapi/openapi-case-tests.yaml
+++ b/modules/040-node-manager/openapi/openapi-case-tests.yaml
@@ -36,3 +36,8 @@ positive:
                 zoneb: mysubnetidb
             tags:
               aaa: aaa
+
+negative:
+  configValues:
+    # NOTE: bundles from EE
+    - allowedBundles: [ "alteros", "astra" ]


### PR DESCRIPTION
## Description

- remove values cases from EE version
- add negative case in CE with EE bundles

## Why do we need it, and what problem does it solve?

Fix openapi tests after split in #2946

## What is the expected result?

OpenAPI tests works.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Fix OpenAPI tests after the split in #2946.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
