### PR TITLE
[extended-monitoring] Pass HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables into image-availability-exporter

### DIFF
--- a/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
+++ b/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
@@ -75,6 +75,8 @@ spec:
         {{- if .Values.extendedMonitoring.imageAvailability.skipRegistryCertVerification }}
         - --skip-registry-cert-verification={{ .Values.extendedMonitoring.imageAvailability.skipRegistryCertVerification }}
         {{- end }}
+        env:
+          {{- include "helm_lib_envs_for_proxy" . | nindent 10 }}
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}


### PR DESCRIPTION
Signed-off-by: Gleb Maiorov <gleb.maiorov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Pass HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables into image-availability-exporter.
Setting Deckhouse [proxy parameters](https://deckhouse.io/en/documentation/v1/deckhouse-configure-global.html#parameters-modules-proxy) required to actually pass said variables.

<details>
<summary>Changes were tested on local cluster.</summary>

* Before:
![before](https://user-images.githubusercontent.com/111346521/202156692-bc514e60-e1ae-4ff4-8926-39a5779325e1.png)

* After:
![after](https://user-images.githubusercontent.com/111346521/202164950-d39ad508-0d76-40f9-a49f-fd1ce2ff36f5.png)

</details>

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Currently image-availability-exporter is unaware of [proxy parameters](https://deckhouse.io/en/documentation/v1/deckhouse-configure-global.html#parameters-modules-proxy), which may lead to false alerts from `modules/340-extended-monitoring/monitoring/prometheus-rules/image-availability/image-checks.tpl` if proxy is used for registry access.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
httpProxy, httpsProxy and noProxy global configuration parameters are passed into `image-availability-exporter` container of the `image-availability-exporter` deployment as HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: extended-monitoring
type: chore
summary: Pass HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables into image-availability-exporter
impact_level: default
impact: Pod image-availability-exporter will be restarted if Deckhouse proxy parameters are set
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
