### PR TITLE
[tools] fix in registry migration script

### DIFF
--- a/tools/change-registry.sh
+++ b/tools/change-registry.sh
@@ -103,7 +103,7 @@ function parse_args() {
 
   domain_validator="^[a-z0-9][-a-z0-9\.]*[a-z]$"
   if ! [[ $REGISTRY_ADDRESS =~ $domain_validator ]]; then
-    >&2 echo "Domain must contains only symbols from [a-z0-9-.], first symbol must be letter or number, and last symbol must be letter: $REGISTRY_ADDRESS."
+    >&2 echo "Registry domain doesn't fit the regex "^[a-z0-9][-a-z0-9\.]*[a-z]$": $REGISTRY_ADDRESS."
     exit 1
   fi
 
@@ -114,7 +114,7 @@ function parse_args() {
 
   TOKEN="$(bb-rp-get-token)"
   if [[ "$TOKEN" == "" ]]; then
-    >&2 echo "Cannot get Bearer token from registry"
+    >&2 echo "Cannot get Bearer token from registry $REGISTRY_URL"
     exit 1
   fi
 

--- a/tools/change-registry.sh
+++ b/tools/change-registry.sh
@@ -101,6 +101,12 @@ function parse_args() {
     exit 1
   fi
 
+  domain_validator="^[a-z0-9][-a-z0-9\.]*[a-z]$"
+  if ! [[ $REGISTRY_ADDRESS =~ $domain_validator ]]; then
+    >&2 echo "Domain must contains only symbols from [a-z0-9-.], first symbol must be letter or number, and last symbol must be letter: $REGISTRY_ADDRESS."
+    exit 1
+  fi
+
   if [[ "$REGISTRY_CAFILE" != "" ]] && [[ ! -f "$REGISTRY_CAFILE" ]]; then
     >&2 echo "Cannot find ca file: $REGISTRY_CAFILE."
     exit 1
@@ -108,7 +114,7 @@ function parse_args() {
 
   TOKEN="$(bb-rp-get-token)"
   if [[ "$TOKEN" == "" ]]; then
-    echo "Cannot get Bearer token from registry"
+    >&2 echo "Cannot get Bearer token from registry"
     exit 1
   fi
 
@@ -139,8 +145,8 @@ if  [[ "$REGISTRY_CAFILE" != "" ]]; then
   REGISTRY_CAFILE="$(base64 -w0 < $REGISTRY_CAFILE)"
 fi
 
-#kubectl -n d8-system patch secret deckhouse-registry -p="{\"data\":{\".dockerconfigjson\": \"${DOCKERCONFIGJSON}\", \"address\": \"${REGISTRY_ADDRESS}\", \"path\": \"${REGISTRY_PATH}\", \"scheme\": \"${REGISTRY_SCHEME}\"}}"
-#if  [[ "$REGISTRY_CAFILE" != "" ]]; then
-#  REGISTRY_CAFILE="$(base64 -w0 < $REGISTRY_CAFILE)"
-#  kubectl -n d8-system patch secret deckhouse-registry -p="{\"data\":{\"ca\": \"${REGISTRY_CAFILE}\"}}"
-#fi
+kubectl -n d8-system patch secret deckhouse-registry -p="{\"data\":{\".dockerconfigjson\": \"${DOCKERCONFIGJSON}\", \"address\": \"${REGISTRY_ADDRESS}\", \"path\": \"${REGISTRY_PATH}\", \"scheme\": \"${REGISTRY_SCHEME}\"}}"
+if  [[ "$REGISTRY_CAFILE" != "" ]]; then
+  REGISTRY_CAFILE="$(base64 -w0 < $REGISTRY_CAFILE)"
+  kubectl -n d8-system patch secret deckhouse-registry -p="{\"data\":{\"ca\": \"${REGISTRY_CAFILE}\"}}"
+fi

--- a/tools/change-registry.sh
+++ b/tools/change-registry.sh
@@ -71,8 +71,14 @@ function parse_args() {
   REGISTRY_ADDRESS="$(cut -d "/" -f1 <<< "$TEMP_URL")"
   REGISTRY_PATH="${TEMP_URL#"$REGISTRY_ADDRESS"}"
   REGISTRY_SCHEME="$(sed "s/:\/\///" <<< "$REGISTRY_SCHEME")"
+
+  if [[ "$REGISTRY_PATH" == "" ]]; then
+    >&2 echo "Cannot parse path from registry url: $REGISTRY_URL. Registry url must have at least slash at the end. (for example, https://registry.example.com/ instead of https://registry.example.com)"
+    exit 1
+  fi
+
   if [[ "$REGISTRY_SCHEME" == "" ]]; then
-    >&2 echo "Cannot parse scheme from registry url: $URL. Scheme should be 'http' or 'https'."
+    >&2 echo "Cannot parse scheme from registry url: $REGISTRY_URL. Scheme should be 'http' or 'https'."
     exit 1
   fi
 


### PR DESCRIPTION
## Description
Added additional checks to the registry migration script. The script will exit with an error, in case of:
- There is no path in registry URL.
- Domain doesn't match RFC 1123 regex.
- It's impossible to get a Bearer token from the new registry.

## Why do we need it, and what problem does it solve?
In some cases, there can be problems after Deckhouse migration to other registry.

## What is the expected result?
Script will exit with error, in case of:
- There is no path in registry URL.
- Domain doesn't match RFC 1123 regex.
- It's impossible to get a Bearer token from the new registry.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: tools
type: fix
summary: Added additional checks to registry migration script.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
