### PR TITLE
[monitoring-kubernetes-control-plane] control-plane-proxy change listen port

### DIFF
--- a/modules/340-monitoring-kubernetes-control-plane/templates/control-plane-proxy/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes-control-plane/templates/control-plane-proxy/daemonset.yaml
@@ -56,19 +56,19 @@ spec:
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
         args:
-          - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8181"
+          - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8008"
           - "--client-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
           - "--v=2"
           - "--logtostderr=true"
           - "--stale-cache-interval=1h30m"
           - "--livez-path=/livez"
         ports:
-        - containerPort: 8181
+        - containerPort: 8008
           name: https-metrics
         livenessProbe:
           httpGet:
             path: /livez
-            port: 8181
+            port: 8008
             scheme: HTTPS
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS

--- a/modules/340-monitoring-kubernetes-control-plane/templates/control-plane-proxy/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes-control-plane/templates/control-plane-proxy/daemonset.yaml
@@ -56,19 +56,19 @@ spec:
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
         args:
-          - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8080"
+          - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8181"
           - "--client-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
           - "--v=2"
           - "--logtostderr=true"
           - "--stale-cache-interval=1h30m"
           - "--livez-path=/livez"
         ports:
-        - containerPort: 8080
+        - containerPort: 8181
           name: https-metrics
         livenessProbe:
           httpGet:
             path: /livez
-            port: 8080
+            port: 8181
             scheme: HTTPS
         env:
         - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS


### PR DESCRIPTION
Signed-off-by: Vitaliy Snurnitsin <vitaliy.snurnitsin@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Changed listen port because it is already used by ingress-nginx module.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
There is a conflict when ingress-nginx and control-plane-proxy are running on the same nodes.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring-kubernetes-control-plane
type: fix
summary: Port to listen changed to 8008 because it is already used by the ingress-nginx module.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
