### PR TITLE
[monitoring-kubernetes] kube-state-metrics extended scrape_timeout

### DIFF
--- a/modules/340-monitoring-kubernetes/templates/kube-state-metrics/additional-scrape-config.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-state-metrics/additional-scrape-config.yaml
@@ -6,6 +6,7 @@
   metrics_path: '/main/metrics'
   scheme: https
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  scrape_timeout: {{ include "helm_lib_prometheus_target_scrape_timeout_seconds" (list . 20) }}
   tls_config:
     insecure_skip_verify: true
   static_configs:
@@ -25,6 +26,7 @@
   tls_config:
     insecure_skip_verify: true
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  scrape_timeout: {{ include "helm_lib_prometheus_target_scrape_timeout_seconds" (list . 20) }}
   static_configs:
   - targets: ['kube-state-metrics.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}.:8080']
   relabel_configs:


### PR DESCRIPTION
## Description
kube-state-metrics scrape timeout was extended.

I've decided to pick it as a patch to v1.40.2 for two reasons:
* there is possible unpleasant impact to Madison (hundreds of alerts like D8IstioActualVersionIsNotInstalled).
* there is a hand-fixed customer cluster under v1.36 🙄 .
* there are approved fixes in v1.40.2.

## Why do we need it, and what problem does it solve?
In some setups (Pods count > 3k), kube-state-metrics couldn't fit the standard timeout (10s).

## What is the expected result?
kube-state-metrics exports their metrics and prometheus scrapes them well.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring-kubernetes
type: fix
summary: kube-state-metrics scrape timeout was extended.
impact_level: low
```

