### PR TITLE
[istio] fix D8IstioActualVersionIsNotInstalled

### DIFF
--- a/ee/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
+++ b/ee/modules/110-istio/monitoring/prometheus-rules/dataplane.yaml
@@ -15,18 +15,21 @@
       plk_protocol_version: "1"
       summary: control-plane version for Pod with already injected sidecar isn't installed
     expr: |
-      max by (dataplane_pod, namespace, revision, desired_revision, version, desired_version)
       (
-        d8_istio_dataplane_metadata{revision!="absent"}
-        unless on (revision)
+        max by (dataplane_pod, namespace, revision, desired_revision, version, desired_version)
         (
-          istio_build{component="pilot"}
-          * on (pod,namespace) group_left(revision)
+          d8_istio_dataplane_metadata{revision!="absent"}
+          unless on (revision)
+          (
+            istio_build{component="pilot"}
+            * on (pod,namespace) group_left(revision)
             (
               label_replace(kube_pod_labels, "revision", "$1", "label_istio_io_rev", "(.+)")
             )
+          )
         )
-      )
+      # labels kube-state-metrics should exist
+      ) and on() count(up{job="kube-state-metrics", scrape_endpoint="main"}==1)!=0
     for: 5m
     labels:
       severity_level: "4"


### PR DESCRIPTION
## Description
fixed istio control-plane alert `D8IstioActualVersionIsNotInstalled`

## Why do we need it, and what problem does it solve?
The absence of metrics from kube-state-metrics led to false alerts

## What is the expected result?
Alert works fine

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: fixed istio control-plane alert `D8IstioActualVersionIsNotInstalled`
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
