### PR TITLE
[admission-policy-engine] admission policy validation webhook include only tracked resources

### DIFF
--- a/candi/control-plane-kubeadm/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/config.yaml.tpl
@@ -3,7 +3,7 @@
     {{- $featureGates = list $featureGates "TTLAfterFinished=true" | join "," }}
 {{- end }}
 {{- if semverCompare ">= 1.21" .clusterConfiguration.kubernetesVersion }}
-    {{- $featureGates = list $featureGates "DaemonSetUpdateSurge=true" | join "," }}
+    {{- $featureGates = list $featureGates "DaemonSetUpdateSurge=true" "TopologyAwareHints=true" | join "," }}
 {{- end }}
 {{- if semverCompare "< 1.23" .clusterConfiguration.kubernetesVersion }}
     {{- $featureGates = list $featureGates "EphemeralContainers=true" | join "," }}

--- a/ee/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores.go
+++ b/ee/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	"k8s.io/client-go/restmapper"
 
 	v1 "github.com/deckhouse/deckhouse/ee/modules/030-cloud-provider-vsphere/hooks/internal/v1"
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
@@ -82,6 +83,16 @@ func doDiscover(input *go_hook.HookInput, dc dependency.Container) error {
 		Datacenter: output.Datacenter,
 		Zones:      output.Zones,
 	})
+
+	k, _ := dc.GetK8sClient()
+	aa, a := restmapper.GetAPIGroupResources(k.Discovery())
+		mr := restmapper.NewDiscoveryRESTMapper(aa)
+		mr.ResourcesFor()
+	restmapper.NewDeferredDiscoveryRESTMapper(k.DiscoveryV1beta1())
+	sg, _ := k.Discovery().ServerGroups()
+	sg.
+	sc, _ := k.Discovery().OpenAPISchema()
+	sc.
 
 	storageClasses := output.ZonedDataStores
 

--- a/ee/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores.go
+++ b/ee/modules/030-cloud-provider-vsphere/hooks/discover_zones_and_datastores.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
-	"k8s.io/client-go/restmapper"
 
 	v1 "github.com/deckhouse/deckhouse/ee/modules/030-cloud-provider-vsphere/hooks/internal/v1"
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
@@ -83,16 +82,6 @@ func doDiscover(input *go_hook.HookInput, dc dependency.Container) error {
 		Datacenter: output.Datacenter,
 		Zones:      output.Zones,
 	})
-
-	k, _ := dc.GetK8sClient()
-	aa, a := restmapper.GetAPIGroupResources(k.Discovery())
-		mr := restmapper.NewDiscoveryRESTMapper(aa)
-		mr.ResourcesFor()
-	restmapper.NewDeferredDiscoveryRESTMapper(k.DiscoveryV1beta1())
-	sg, _ := k.Discovery().ServerGroups()
-	sg.
-	sc, _ := k.Discovery().OpenAPISchema()
-	sc.
 
 	storageClasses := output.ZonedDataStores
 

--- a/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
+++ b/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package hooks
 
 import (

--- a/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
+++ b/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
@@ -93,7 +93,8 @@ func handleValidationKinds(input *go_hook.HookInput, dc dependency.Container) er
 					Kind:  kind,
 				})
 				if err != nil {
-					input.LogEntry.Warnf("Resource mapping failed. Group: %s, Kind: %s. Error: %s", apiGroup, kind, err)
+					// skip outdated resources, like extensions/Ingress
+					input.LogEntry.Warnf("Skip resource mapping. Group: %q, Kind: %q. Error: %q", apiGroup, kind, err)
 					continue
 				}
 

--- a/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
+++ b/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
@@ -4,37 +4,53 @@ import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
-			Name:       "constraints",
-			ApiVersion: "apps/v1",
-			Kind:       "Deployment",
+			Name:       "exporter-cm",
+			ApiVersion: "v1",
+			Kind:       "ConfigMap",
 			NamespaceSelector: &types.NamespaceSelector{
 				NameSelector: &types.NameSelector{
 					MatchNames: []string{"d8-admission-policy-engine"},
 				},
 			},
 			NameSelector: &types.NameSelector{
-				MatchNames: []string{"gatekeeper-controller-manager"},
+				MatchNames: []string{"constraint-exporter"},
 			},
-			FilterFunc: filterGatekeeperDeployment,
+			FilterFunc: filterExporterCM,
 		},
 	},
-}, dependency.WithExternalDependencies(xxxx))
+}, xxxx)
 
-func xxxx(input *go_hook.HookInput, dc dependency.Container) error {
-	k8, err := dc.GetK8sClient()
+func xxxx(input *go_hook.HookInput) error {
+	snap := input.Snapshots["exporter-cm"]
+	if len(snap) == 0 {
+		input.LogEntry.Info("no exporter cm found")
+		return nil
+	}
 
-	k8.Dynamic().Resource(v1.GroupVersionResource{
-		Group:    "constraints.gatekeeper.sh",
-		Version:  "v1beta1",
-		Resource: "",
-	}).List()
+	kinds := snap[0].(string)
+
+	input.LogEntry.Info("Find kinds", kinds)
+
+	input.Values.Set("admissionPolicyEngine.internal.trackedKinds", kinds)
+
+	return nil
+}
+
+func filterExporterCM(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var cm corev1.ConfigMap
+
+	err := sdk.FromUnstructured(obj, &cm)
+	if err != nil {
+		return nil, err
+	}
+
+	return cm.Data["kinds.yaml"], nil
 }

--- a/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
+++ b/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
@@ -37,7 +37,7 @@ func xxxx(input *go_hook.HookInput) error {
 
 	kinds := snap[0].(string)
 
-	input.LogEntry.Info("Find kinds", kinds)
+	input.LogEntry.Infof("Find kinds: %s", kinds)
 
 	input.Values.Set("admissionPolicyEngine.internal.trackedKinds", kinds)
 

--- a/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
+++ b/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
@@ -1,0 +1,34 @@
+package hooks
+
+import (
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "constraints",
+			ApiVersion: "apps/v1",
+			Kind:       "Deployment",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-admission-policy-engine"},
+				},
+			},
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"gatekeeper-controller-manager"},
+			},
+			FilterFunc: filterGatekeeperDeployment,
+		},
+	},
+}, dependency.WithExternalDependencies(xxxx))
+
+func xxxx(input *go_hook.HookInput, dc dependency.Container) error {
+	k8, err := dc.GetK8sClient()
+
+	k8.Dynamic().Resource().List()
+}

--- a/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
+++ b/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
@@ -6,13 +6,18 @@ import (
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/restmapper"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
-			Name:       "exporter-cm",
+			Name:       "constraint-exporter-cm",
 			ApiVersion: "v1",
 			Kind:       "ConfigMap",
 			NamespaceSelector: &types.NamespaceSelector{
@@ -26,20 +31,72 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			FilterFunc: filterExporterCM,
 		},
 	},
-}, xxxx)
+}, dependency.WithExternalDependencies(handleValidationKinds))
 
-func xxxx(input *go_hook.HookInput) error {
-	snap := input.Snapshots["exporter-cm"]
+func handleValidationKinds(input *go_hook.HookInput, dc dependency.Container) error {
+	snap := input.Snapshots["constraint-exporter-cm"]
 	if len(snap) == 0 {
 		input.LogEntry.Info("no exporter cm found")
 		return nil
 	}
 
-	kinds := snap[0].(string)
+	kindsRaw := snap[0].(string)
 
-	input.LogEntry.Infof("Find kinds: %s", kinds)
+	var matchKinds []matchKind
 
-	input.Values.Set("admissionPolicyEngine.internal.trackedKinds", kinds)
+	err := yaml.Unmarshal([]byte(kindsRaw), &matchKinds)
+	if err != nil {
+		return err
+	}
+
+	res := make([]matchResoyrce, 0, len(matchKinds))
+
+	k8s, _ := dc.GetK8sClient()
+	apiRes, err := restmapper.GetAPIGroupResources(k8s.Discovery())
+
+	rmapper := restmapper.NewDiscoveryRESTMapper(apiRes)
+
+	for _, mk := range matchKinds {
+		groups := make([]string, 0, len(mk.APIGroups))
+		resources := make([]string, 0, len(mk.Kinds))
+
+		uniqGroups := make(map[string]struct{})
+		uniqResources := make(map[string]struct{})
+
+		for _, apiGroup := range mk.APIGroups {
+			for _, kind := range mk.Kinds {
+				rm, err := rmapper.RESTMapping(schema.GroupKind{
+					Group: apiGroup,
+					Kind:  kind,
+				})
+				if err != nil {
+					input.LogEntry.Warnf("Resource mapping failed. Group: %s, Kind: %s. Error: %s", apiGroup, kind, err)
+					continue
+				}
+
+				uniqGroups[rm.Resource.Group] = struct{}{}
+				uniqResources[rm.Resource.Resource] = struct{}{}
+			}
+		}
+
+		for k := range uniqGroups {
+			groups = append(groups, k)
+		}
+
+		for k := range uniqResources {
+			resources = append(resources, k)
+		}
+
+		res = append(res, matchResoyrce{
+			APIGroups: groups,
+			Resources: resources,
+		})
+	}
+
+	input.LogEntry.Infof("Find matchKinds: %s", matchKinds)
+	input.LogEntry.Infof("make resources: %s", res)
+
+	input.Values.Set("admissionPolicyEngine.internal.trackedResources", res)
 
 	return nil
 }
@@ -53,4 +110,14 @@ func filterExporterCM(obj *unstructured.Unstructured) (go_hook.FilterResult, err
 	}
 
 	return cm.Data["kinds.yaml"], nil
+}
+
+type matchKind struct {
+	APIGroups []string `json:"apiGroups"`
+	Kinds     []string `json:"kinds"`
+}
+
+type matchResoyrce struct {
+	APIGroups []string `json:"apiGroups"`
+	Resources []string `json:"resources"`
 }

--- a/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
+++ b/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
@@ -83,7 +83,7 @@ func handleValidationKinds(input *go_hook.HookInput, dc dependency.Container) er
 	rmapper := restmapper.NewDiscoveryRESTMapper(apiRes)
 
 	for _, mk := range matchKinds {
-		uniqGroups := make(map[string]struct{})
+		uniqGroups := set.New()
 		uniqResources := make(map[string]struct{})
 
 		for _, apiGroup := range mk.APIGroups {

--- a/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
+++ b/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
@@ -1,10 +1,12 @@
 package hooks
 
 import (
-	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -30,5 +32,9 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 func xxxx(input *go_hook.HookInput, dc dependency.Container) error {
 	k8, err := dc.GetK8sClient()
 
-	k8.Dynamic().Resource().List()
+	k8.Dynamic().Resource(v1.GroupVersionResource{
+		Group:    "constraints.gatekeeper.sh",
+		Version:  "v1beta1",
+		Resource: "",
+	}).List()
 }

--- a/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
+++ b/modules/015-admission-policy-engine/hooks/detect_validation_resources.go
@@ -55,7 +55,7 @@ func handleValidationKinds(input *go_hook.HookInput, dc dependency.Container) er
 	}
 
 	resourcesRaw := snap[0].(string)
-	var res []matchResource
+	res := make([]matchResource, 0)
 
 	err := yaml.Unmarshal([]byte(resourcesRaw), &res)
 	if err != nil {

--- a/modules/015-admission-policy-engine/hooks/detect_validation_resources_test.go
+++ b/modules/015-admission-policy-engine/hooks/detect_validation_resources_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = FDescribe("Modules :: admission-policy-engine :: hooks :: detect_validation_resources", func() {
+	f := HookExecutionConfigInit(
+		`{"admissionPolicyEngine": {"internal": {"bootstrapped": true} } }`,
+		`{"admissionPolicyEngine":{}}`,
+	)
+	Context("CM exists", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(cm))
+			f.RunHook()
+		})
+		It("should generate resources", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trackedResources").Array()).NotTo(BeEmpty())
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trackedResources").String()).To(MatchJSON(`[{"apiGroups":[""],"resources":["pods"]}, {"apiGroups":["extensions","networking.k8s.io"],"resources":["ingresses"]}]`))
+		})
+	})
+
+})
+
+var cm = `
+apiVersion: v1
+data:
+  kinds.yaml: |
+    - apiGroups:
+      - ""
+      kinds:
+      - Pod
+    - apiGroups:
+      - extensions
+      - networking.k8s.io
+      kinds:
+      - Ingress
+kind: ConfigMap
+metadata:
+  annotations:
+    security.deckhouse.io/constraints-checksum: b73817c9948c3f7d823859980f0d8b1216f1f00222570bde38c9bd54b50cea87
+  creationTimestamp: "2022-11-11T19:00:16Z"
+  labels:
+    owner: constraint-exporter
+  name: constraint-exporter
+  namespace: d8-admission-policy-engine
+  resourceVersion: "116772759"
+  uid: db6044f5-9d18-449d-979d-b862598654ba
+`

--- a/modules/015-admission-policy-engine/hooks/detect_validation_resources_test.go
+++ b/modules/015-admission-policy-engine/hooks/detect_validation_resources_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: detect_validati
 			f.BindingContexts.Set(f.KubeStateSet(cm))
 			f.RunHook()
 		})
-		It("should generate resources", func() {
+		It("should have generated resources", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("admissionPolicyEngine.internal.trackedResources").Array()).NotTo(BeEmpty())
 			Expect(f.ValuesGet("admissionPolicyEngine.internal.trackedResources").String()).To(MatchJSON(`[{"apiGroups":[""],"resources":["pods"]}, {"apiGroups":["extensions","networking.k8s.io"],"resources":["ingresses"]}]`))
@@ -45,25 +45,22 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: detect_validati
 var cm = `
 apiVersion: v1
 data:
-  validate-kinds.yaml: |
+  validate-resources.yaml: |
     - apiGroups:
       - ""
-      kinds:
-      - Pod
+      resources:
+      - pods
     - apiGroups:
       - extensions
       - networking.k8s.io
-      kinds:
-      - Ingress
+      resources:
+      - ingresses
 kind: ConfigMap
 metadata:
   annotations:
     security.deckhouse.io/constraints-checksum: b73817c9948c3f7d823859980f0d8b1216f1f00222570bde38c9bd54b50cea87
-  creationTimestamp: "2022-11-11T19:00:16Z"
   labels:
     owner: constraint-exporter
   name: constraint-exporter
   namespace: d8-admission-policy-engine
-  resourceVersion: "116772759"
-  uid: db6044f5-9d18-449d-979d-b862598654ba
 `

--- a/modules/015-admission-policy-engine/hooks/detect_validation_resources_test.go
+++ b/modules/015-admission-policy-engine/hooks/detect_validation_resources_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = FDescribe("Modules :: admission-policy-engine :: hooks :: detect_validation_resources", func() {
+var _ = Describe("Modules :: admission-policy-engine :: hooks :: detect_validation_resources", func() {
 	f := HookExecutionConfigInit(
 		`{"admissionPolicyEngine": {"internal": {"bootstrapped": true} } }`,
 		`{"admissionPolicyEngine":{}}`,
@@ -45,7 +45,7 @@ var _ = FDescribe("Modules :: admission-policy-engine :: hooks :: detect_validat
 var cm = `
 apiVersion: v1
 data:
-  kinds.yaml: |
+  validate-kinds.yaml: |
     - apiGroups:
       - ""
       kinds:

--- a/modules/015-admission-policy-engine/hooks/detect_validation_resources_test.go
+++ b/modules/015-admission-policy-engine/hooks/detect_validation_resources_test.go
@@ -40,6 +40,18 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: detect_validati
 		})
 	})
 
+	Context("Empty CM", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(emptyCM))
+			f.RunHook()
+		})
+		It("should have empty array", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trackedResources").Array()).To(BeEmpty())
+			Expect(f.ValuesGet("admissionPolicyEngine.internal.trackedResources").String()).To(MatchJSON(`[]`))
+		})
+	})
+
 })
 
 var cm = `
@@ -59,6 +71,16 @@ kind: ConfigMap
 metadata:
   annotations:
     security.deckhouse.io/constraints-checksum: b73817c9948c3f7d823859980f0d8b1216f1f00222570bde38c9bd54b50cea87
+  labels:
+    owner: constraint-exporter
+  name: constraint-exporter
+  namespace: d8-admission-policy-engine
+`
+
+var emptyCM = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
   labels:
     owner: constraint-exporter
   name: constraint-exporter

--- a/modules/015-admission-policy-engine/images/constraint-exporter/go.mod
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/prometheus/client_golang v1.13.0
+	github.com/stretchr/testify v1.7.0
 	k8s.io/apimachinery v0.25.0
 	k8s.io/client-go v0.25.0
 	k8s.io/klog/v2 v2.70.1
@@ -34,6 +35,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect

--- a/modules/015-admission-policy-engine/images/constraint-exporter/go.sum
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/go.sum
@@ -252,6 +252,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/modules/015-admission-policy-engine/images/constraint-exporter/main.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/main.go
@@ -43,8 +43,8 @@ var (
 		"Path under which to expose metrics")
 	interval = flag.Duration("server.interval", 30*time.Second,
 		"Kubernetes API server polling interval")
-	trackKinds       = flag.Bool("track-match-kinds", true, "TODO")
-	trackKindsCMName = flag.String("match-kinds-configmap", "constraint-exporter",
+	trackValidationKinds = flag.Bool("track-validation-match-kinds", true, "Tracked kinds for validation webhook")
+	trackKindsCMName     = flag.String("match-kinds-configmap", "constraint-exporter",
 		"ConfigMap for export tracking resource kinds")
 
 	ticker *time.Ticker
@@ -139,11 +139,11 @@ func main() {
 
 	ns := os.Getenv("POD_NAMESPACE")
 	if len(ns) == 0 {
-		klog.Fatal("Pod namespace not set")
+		klog.Fatal("Pod namespace is not set")
 	}
 
 	exporter := NewExporter()
-	if *trackKinds {
+	if *trackValidationKinds {
 		err := exporter.initKindTracker(ns, *trackKindsCMName)
 		if err != nil {
 			klog.Fatal(err)

--- a/modules/015-admission-policy-engine/images/constraint-exporter/main.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/main.go
@@ -80,7 +80,7 @@ func NewExporter() *Exporter {
 
 func (e *Exporter) initKindTracker(cmNS, cmName string) error {
 	kt := kinds.NewKindTracker(e.client, cmNS, cmName)
-	err := kt.FindPreviousHash()
+	err := kt.FindInitialChecksum()
 	if err != nil {
 		return err
 	}

--- a/modules/015-admission-policy-engine/images/constraint-exporter/pkg/gatekeeper/constraints.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/pkg/gatekeeper/constraints.go
@@ -18,6 +18,7 @@ package gatekeeper
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
@@ -57,7 +58,17 @@ type Constraint struct {
 
 // ConstraintSpec collect general information about the overall constraints applied to the cluster
 type ConstraintSpec struct {
-	EnforcementAction string `json:"enforcementAction"`
+	EnforcementAction string          `json:"enforcementAction"`
+	Match             ConstraintMatch `json:"match"`
+}
+
+type ConstraintMatch struct {
+	Kinds []MatchKind `json:"kinds"`
+}
+
+type MatchKind struct {
+	APIGroups []string `json:"apiGroups"`
+	Kinds     []string `json:"kinds"`
 }
 
 const (
@@ -66,26 +77,7 @@ const (
 	constraintsGroupVersion = "v1beta1"
 )
 
-func createKubeClient() (*kubernetes.Clientset, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	return clientset, nil
-}
-
-func createKubeClientGroupVersion() (controllerClient.Client, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
-
+func createKubeClientGroupVersion(config *rest.Config) (controllerClient.Client, error) {
 	client, err := controllerClient.New(config, controllerClient.Options{})
 	if err != nil {
 		return nil, err
@@ -95,13 +87,8 @@ func createKubeClientGroupVersion() (controllerClient.Client, error) {
 }
 
 // GetConstraints returns a list of all OPA constraints
-func GetConstraints() ([]Constraint, error) {
-	client, err := createKubeClient()
-	if err != nil {
-		return nil, err
-	}
-
-	cClient, err := createKubeClientGroupVersion()
+func GetConstraints(config *rest.Config, client *kubernetes.Clientset) ([]Constraint, error) {
+	cClient, err := createKubeClientGroupVersion(config)
 	if err != nil {
 		return nil, err
 	}
@@ -138,10 +125,6 @@ func GetConstraints() ([]Constraint, error) {
 
 		if len(actual.Items) > 0 {
 			for _, item := range actual.Items {
-				// kind := item.GetKind()
-				// name := item.GetName()
-				// namespace := item.GetNamespace()
-				// klog.Infof("Kind:%s, Name:%s, Namespace:%s \n", kind, name, namespace)
 				var constraint Constraint
 
 				err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.UnstructuredContent(), &constraint)
@@ -150,11 +133,14 @@ func GetConstraints() ([]Constraint, error) {
 					continue
 				}
 
-				constraints = append(constraints, Constraint{
-					Meta:   ConstraintMeta{Kind: item.GetKind(), Name: item.GetName()},
-					Status: ConstraintStatus{TotalViolations: constraint.Status.TotalViolations, Violations: constraint.Status.Violations},
-					Spec:   ConstraintSpec{EnforcementAction: constraint.Spec.EnforcementAction},
-				})
+				fmt.Println("Meta", constraint.Meta)
+
+				constraint.Meta.Kind = item.GetKind()
+				constraint.Meta.Name = item.GetName()
+
+				fmt.Printf("CONST: %+v\n", constraint)
+
+				constraints = append(constraints, constraint)
 			}
 		}
 

--- a/modules/015-admission-policy-engine/images/constraint-exporter/pkg/gatekeeper/constraints.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/pkg/gatekeeper/constraints.go
@@ -18,7 +18,6 @@ package gatekeeper
 
 import (
 	"context"
-	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
@@ -135,8 +134,6 @@ func GetConstraints(config *rest.Config, client *kubernetes.Clientset) ([]Constr
 
 				constraint.Meta.Kind = item.GetKind()
 				constraint.Meta.Name = item.GetName()
-
-				fmt.Printf("CONST: %+v\n", constraint)
 
 				constraints = append(constraints, constraint)
 			}

--- a/modules/015-admission-policy-engine/images/constraint-exporter/pkg/gatekeeper/constraints.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/pkg/gatekeeper/constraints.go
@@ -19,13 +19,12 @@ package gatekeeper
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog/v2"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/modules/015-admission-policy-engine/images/constraint-exporter/pkg/gatekeeper/constraints.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/pkg/gatekeeper/constraints.go
@@ -133,8 +133,6 @@ func GetConstraints(config *rest.Config, client *kubernetes.Clientset) ([]Constr
 					continue
 				}
 
-				fmt.Println("Meta", constraint.Meta)
-
 				constraint.Meta.Kind = item.GetKind()
 				constraint.Meta.Name = item.GetName()
 

--- a/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds.go
@@ -68,11 +68,11 @@ func (kt *KindTracker) UpdateKinds(constraints []gatekeeper.Constraint) {
 		return
 	}
 
-	fmt.Println("CHECKSUM", checksum, kt.latestChecksum)
-
 	if checksum == kt.latestChecksum {
 		return
 	}
+
+	klog.Info("Checksum is not equal. Updating")
 
 	cm, err := kt.client.CoreV1().ConfigMaps(kt.cmNamespace).Get(context.TODO(), kt.cmName, v1.GetOptions{})
 	if err != nil {
@@ -109,7 +109,7 @@ func (kt *KindTracker) UpdateKinds(constraints []gatekeeper.Constraint) {
 	kt.latestChecksum = checksum
 }
 
-func (kt *KindTracker) FindPreviousHash() error {
+func (kt *KindTracker) FindInitialChecksum() error {
 	cm, err := kt.client.CoreV1().ConfigMaps(kt.cmNamespace).Get(context.TODO(), kt.cmName, v1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds.go
@@ -8,13 +8,38 @@ import (
 	"strings"
 
 	"github.com/flant/constraint_exporter/pkg/gatekeeper"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 )
 
-func deduplicateKinds(constraints []gatekeeper.Constraint) map[string]gatekeeper.MatchKind {
+const (
+	checksumAnnotation = "security.deckhouse.io/constraints-checksum"
+)
+
+type KindTracker struct {
+	client      *kubernetes.Clientset
+	cmNamespace string
+	cmName      string
+
+	latestChecksum string
+}
+
+func NewKindTracker(client *kubernetes.Clientset, cmNS, cmName string) *KindTracker {
+	return &KindTracker{
+		client:      client,
+		cmNamespace: cmNS,
+		cmName:      cmName,
+	}
+}
+
+func deduplicateKinds(constraints []gatekeeper.Constraint) (map[string]gatekeeper.MatchKind /*kinds checksum*/, string) {
 	// deduplicate
-	m := make(map[string]gatekeeper.MatchKind)
+	m := make(map[string]gatekeeper.MatchKind, 0)
+	hasher := sha256.New()
 
 	for _, con := range constraints {
 		for _, k := range con.Spec.Match.Kinds {
@@ -22,34 +47,105 @@ func deduplicateKinds(constraints []gatekeeper.Constraint) map[string]gatekeeper
 			sort.Strings(k.Kinds)
 			key := fmt.Sprintf("%s:%s", strings.Join(k.APIGroups, ","), strings.Join(k.Kinds, ","))
 
-			m[key] = k
+			if _, ok := m[key]; !ok {
+				m[key] = k
+				hasher.Write([]byte(key))
+			}
 		}
 	}
 
-	return m
+	return m, fmt.Sprintf("%x", hasher.Sum(nil))
 }
 
-func UpdateCM(client *kubernetes.Clientset, constraints []gatekeeper.Constraint, ns, cmName string) {
+func (kt *KindTracker) UpdateKinds(constraints []gatekeeper.Constraint) {
 	if len(constraints) == 0 {
 		return
 	}
 
-	deduplicated := deduplicateKinds(constraints)
+	deduplicated, checksum := deduplicateKinds(constraints)
 
 	if len(deduplicated) == 0 {
 		return
 	}
 
-	hasher := sha256.New()
+	fmt.Println("CHECKSUM", checksum, kt.latestChecksum)
 
-	for key := range deduplicated {
-		hasher.Write([]byte(key))
+	if checksum == kt.latestChecksum {
+		return
 	}
 
-	hashsum := fmt.Sprintf("%x", hasher.Sum(nil))
-
-	cm, err := client.CoreV1().ConfigMaps(ns).Get(context.TODO(), cmName, v1.GetOptions{})
+	cm, err := kt.client.CoreV1().ConfigMaps(kt.cmNamespace).Get(context.TODO(), kt.cmName, v1.GetOptions{})
 	if err != nil {
-
+		if errors.IsNotFound(err) {
+			err = kt.createCM()
+			if err != nil {
+				klog.Errorf("Create kinds cm failed: %s", err)
+				return
+			}
+		} else {
+			klog.Errorf("Get kinds cm failed: %s", err)
+			return
+		}
 	}
+
+	kinds := make([]gatekeeper.MatchKind, 0, len(deduplicated))
+	for _, k := range deduplicated {
+		kinds = append(kinds, k)
+	}
+
+	data, _ := yaml.Marshal(kinds)
+
+	cm.Annotations[checksumAnnotation] = checksum
+	cm.Data = map[string]string{"kinds.yaml": string(data)}
+
+	_, err = kt.client.CoreV1().ConfigMaps(kt.cmNamespace).Update(context.TODO(), cm, v1.UpdateOptions{})
+	if err != nil {
+		klog.Errorf("Update kinds failed: %s", err)
+	}
+	kt.latestChecksum = checksum
+}
+
+func (kt *KindTracker) FindPreviousHash() error {
+	cm, err := kt.client.CoreV1().ConfigMaps(kt.cmNamespace).Get(context.TODO(), kt.cmName, v1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			klog.Info("Kinds configmap not found. Creating.")
+			err = kt.createCM()
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	v, ok := cm.Annotations[checksumAnnotation]
+	if !ok {
+		return nil
+	}
+
+	kt.latestChecksum = v
+	return nil
+}
+
+func (kt *KindTracker) createCM() error {
+	cm := &corev1.ConfigMap{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      kt.cmName,
+			Namespace: kt.cmNamespace,
+			Labels: map[string]string{
+				"owner": "constraint-exporter",
+			},
+			Annotations: nil,
+		},
+		Data: nil,
+	}
+
+	_, err := kt.client.CoreV1().ConfigMaps(kt.cmNamespace).Create(context.TODO(), cm, v1.CreateOptions{})
+
+	return err
 }

--- a/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kinds
 
 import (

--- a/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds.go
@@ -1,0 +1,55 @@
+package kinds
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/flant/constraint_exporter/pkg/gatekeeper"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func deduplicateKinds(constraints []gatekeeper.Constraint) map[string]gatekeeper.MatchKind {
+	// deduplicate
+	m := make(map[string]gatekeeper.MatchKind)
+
+	for _, con := range constraints {
+		for _, k := range con.Spec.Match.Kinds {
+			sort.Strings(k.APIGroups)
+			sort.Strings(k.Kinds)
+			key := fmt.Sprintf("%s:%s", strings.Join(k.APIGroups, ","), strings.Join(k.Kinds, ","))
+
+			m[key] = k
+		}
+	}
+
+	return m
+}
+
+func UpdateCM(client *kubernetes.Clientset, constraints []gatekeeper.Constraint, ns, cmName string) {
+	if len(constraints) == 0 {
+		return
+	}
+
+	deduplicated := deduplicateKinds(constraints)
+
+	if len(deduplicated) == 0 {
+		return
+	}
+
+	hasher := sha256.New()
+
+	for key := range deduplicated {
+		hasher.Write([]byte(key))
+	}
+
+	hashsum := fmt.Sprintf("%x", hasher.Sum(nil))
+
+	cm, err := client.CoreV1().ConfigMaps(ns).Get(context.TODO(), cmName, v1.GetOptions{})
+	if err != nil {
+
+	}
+}

--- a/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/flant/constraint_exporter/pkg/gatekeeper"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds.go
@@ -95,6 +95,10 @@ func (kt *KindTracker) UpdateKinds(constraints []gatekeeper.Constraint) {
 
 	data, _ := yaml.Marshal(kinds)
 
+	if len(cm.Annotations) == 0 {
+		cm.Annotations = make(map[string]string, 0)
+	}
+
 	cm.Annotations[checksumAnnotation] = checksum
 	cm.Data = map[string]string{"kinds.yaml": string(data)}
 

--- a/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds_test.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kinds
 
 import (

--- a/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds_test.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds_test.go
@@ -38,7 +38,7 @@ func TestDeduplicate(t *testing.T) {
 		},
 	}}}
 
-	res := deduplicateKinds([]gatekeeper.Constraint{con, con2})
+	res, _ := deduplicateKinds([]gatekeeper.Constraint{con, con2})
 
 	assert.Len(t, res, 2)
 	assert.Equal(t, res[":Pod"], gatekeeper.MatchKind{APIGroups: []string{""}, Kinds: []string{"Pod"}})

--- a/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds_test.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds_test.go
@@ -1,0 +1,46 @@
+package kinds
+
+import (
+	"testing"
+
+	"github.com/flant/constraint_exporter/pkg/gatekeeper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeduplicate(t *testing.T) {
+	con := gatekeeper.Constraint{Spec: gatekeeper.ConstraintSpec{Match: gatekeeper.ConstraintMatch{
+		Kinds: []gatekeeper.MatchKind{
+			{
+				APIGroups: []string{""},
+				Kinds:     []string{"Pod"},
+			},
+			{
+				APIGroups: []string{""},
+				Kinds:     []string{"Pod"},
+			},
+			{
+				APIGroups: []string{"networking.k8s.io", "extensions"},
+				Kinds:     []string{"Ingress"},
+			},
+		},
+	}}}
+
+	con2 := gatekeeper.Constraint{Spec: gatekeeper.ConstraintSpec{Match: gatekeeper.ConstraintMatch{
+		Kinds: []gatekeeper.MatchKind{
+			{
+				APIGroups: []string{""},
+				Kinds:     []string{"Pod"},
+			},
+			{
+				APIGroups: []string{"extensions", "networking.k8s.io"},
+				Kinds:     []string{"Ingress"},
+			},
+		},
+	}}}
+
+	res := deduplicateKinds([]gatekeeper.Constraint{con, con2})
+
+	assert.Len(t, res, 2)
+	assert.Equal(t, res[":Pod"], gatekeeper.MatchKind{APIGroups: []string{""}, Kinds: []string{"Pod"}})
+	assert.Equal(t, res["extensions,networking.k8s.io:Ingress"], gatekeeper.MatchKind{APIGroups: []string{"extensions", "networking.k8s.io"}, Kinds: []string{"Ingress"}})
+}

--- a/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds_test.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/pkg/kinds/kinds_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/flant/constraint_exporter/pkg/gatekeeper"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/modules/015-admission-policy-engine/openapi/values.yaml
+++ b/modules/015-admission-policy-engine/openapi/values.yaml
@@ -22,17 +22,7 @@ properties:
           ca:
             type: string
             x-examples: ["YjY0ZW5jX3N0cmluZwo="]
-      watchedValidationResources:
-        type: array
-        description: "apiGroup + kind pairs for validation webhook"
-        x-examples:
-          - ":Pods"
-          - "networking.k8s.io:Ingress"
-        items:
-          type: string
       trackedKinds:
-        type: array
-        items:
-          type: object
-          properties:
-            additionalProperties: true
+        type: object
+        properties:
+          additionalProperties: true

--- a/modules/015-admission-policy-engine/openapi/values.yaml
+++ b/modules/015-admission-policy-engine/openapi/values.yaml
@@ -22,3 +22,11 @@ properties:
           ca:
             type: string
             x-examples: ["YjY0ZW5jX3N0cmluZwo="]
+      watchedValidationResources:
+        type: array
+        description: "apiGroup + kind pairs for validation webhook"
+        x-examples:
+          - ":Pods"
+          - "networking.k8s.io:Ingress"
+        items:
+          type: string

--- a/modules/015-admission-policy-engine/openapi/values.yaml
+++ b/modules/015-admission-policy-engine/openapi/values.yaml
@@ -24,5 +24,4 @@ properties:
             x-examples: ["YjY0ZW5jX3N0cmluZwo="]
       trackedKinds:
         type: object
-        properties:
-          additionalProperties: true
+        additionalProperties: true

--- a/modules/015-admission-policy-engine/openapi/values.yaml
+++ b/modules/015-admission-policy-engine/openapi/values.yaml
@@ -22,6 +22,16 @@ properties:
           ca:
             type: string
             x-examples: ["YjY0ZW5jX3N0cmluZwo="]
-      trackedKinds:
-        type: object
-        additionalProperties: true
+      trackedResources:
+        type: array
+        items:
+          type: object
+          properties:
+            apiGroups:
+              type: array
+              items:
+                type: string
+            resources:
+              type: array
+              items:
+                type: string

--- a/modules/015-admission-policy-engine/openapi/values.yaml
+++ b/modules/015-admission-policy-engine/openapi/values.yaml
@@ -30,3 +30,9 @@ properties:
           - "networking.k8s.io:Ingress"
         items:
           type: string
+      trackedKinds:
+        type: array
+        items:
+          type: object
+          properties:
+            additionalProperties: true

--- a/modules/015-admission-policy-engine/openapi/values.yaml
+++ b/modules/015-admission-policy-engine/openapi/values.yaml
@@ -24,6 +24,7 @@ properties:
             x-examples: ["YjY0ZW5jX3N0cmluZwo="]
       trackedResources:
         type: array
+        default: []
         items:
           type: object
           properties:

--- a/modules/015-admission-policy-engine/template_tests/module_test.go
+++ b/modules/015-admission-policy-engine/template_tests/module_test.go
@@ -54,13 +54,12 @@ modules:
 )
 
 var _ = Describe("Module :: admissionPolicyEngine :: helm template ::", func() {
-	f := SetupHelmConfig(`{admissionPolicyEngine: {podSecurityStandards: {}, internal: {webhook: {ca: YjY0ZW5jX3N0cmluZwo=, crt: YjY0ZW5jX3N0cmluZwo=, key: YjY0ZW5jX3N0cmluZwo=}}}}`)
+	f := SetupHelmConfig(`{admissionPolicyEngine: {podSecurityStandards: {}, internal: {trackedResources: [{"apiGroups":[""],"resources":["pods"]},{"apiGroups":["extensions","networking.k8s.io"],"resources":["ingresses"]}], webhook: {ca: YjY0ZW5jX3N0cmluZwo=, crt: YjY0ZW5jX3N0cmluZwo=, key: YjY0ZW5jX3N0cmluZwo=}}}}`)
 
 	Context("Cluster with deckhouse on master node", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			// f.ValuesSetFromYaml("deckhouse", moduleValuesForMasterNode)
 			f.HelmRender()
 		})
 
@@ -70,8 +69,10 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template ::", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 			sa := f.KubernetesResource("ServiceAccount", nsName, "admission-policy-engine")
 			dp := f.KubernetesResource("Deployment", nsName, "gatekeeper-controller-manager")
+			vw := f.KubernetesGlobalResource("ValidatingWebhookConfiguration", "d8-admission-policy-engine-config")
 			Expect(sa.Exists()).To(BeTrue())
 			Expect(dp.Exists()).To(BeTrue())
+			Expect(vw.Exists()).To(BeTrue())
 		})
 	})
 })

--- a/modules/015-admission-policy-engine/template_tests/policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/policies_test.go
@@ -41,6 +41,7 @@ admissionPolicyEngine:
       ca: YjY0ZW5jX3N0cmluZwo=
       crt: YjY0ZW5jX3N0cmluZwo=
       key: YjY0ZW5jX3N0cmluZwo=
+    trackedResources: []
   podSecurityStandards:
     policies:
       hostPorts:

--- a/modules/015-admission-policy-engine/templates/audit-deployment.yaml
+++ b/modules/015-admission-policy-engine/templates/audit-deployment.yaml
@@ -70,7 +70,7 @@ spec:
         - --constraint-violations-limit=20
         - --audit-from-cache=false
         - --audit-chunk-size=500
-        - --audit-match-kind-only=false
+        - --audit-match-kind-only=true
         - --emit-audit-events=false
         - --operation=audit
         - --operation=status

--- a/modules/015-admission-policy-engine/templates/audit-deployment.yaml
+++ b/modules/015-admission-policy-engine/templates/audit-deployment.yaml
@@ -131,6 +131,11 @@ spec:
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "constraintExporter") }}
         imagePullPolicy: 'IfNotPresent'
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}

--- a/modules/015-admission-policy-engine/templates/rbac-for-us.yaml
+++ b/modules/015-admission-policy-engine/templates/rbac-for-us.yaml
@@ -32,6 +32,15 @@ rules:
       - patch
       - update
       - watch
+{{/*  For contraint exporter*/}}
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - create
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/modules/015-admission-policy-engine/templates/rbac-for-us.yaml
+++ b/modules/015-admission-policy-engine/templates/rbac-for-us.yaml
@@ -32,7 +32,7 @@ rules:
       - patch
       - update
       - watch
-{{/*  For contraint exporter*/}}
+{{/*  For constraint exporter*/}}
   - apiGroups:
       - ""
     resources:

--- a/modules/015-admission-policy-engine/templates/service.yaml
+++ b/modules/015-admission-policy-engine/templates/service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: gatekeeper-webhook-service
   namespace: d8-admission-policy-engine
+  annotations:
+    service.kubernetes.io/topology-aware-hints: "auto"
   {{- include "helm_lib_module_labels" (list . (dict "app" "gatekeeper" "control-plane" "controller-manager" "gatekeeper.sh/system" "yes")) | nindent 2 }}
 spec:
   ports:

--- a/modules/015-admission-policy-engine/templates/validatingwebhookconfiguration.yaml
+++ b/modules/015-admission-policy-engine/templates/validatingwebhookconfiguration.yaml
@@ -1,3 +1,4 @@
+{{- if gt (len .Values.admissionPolicyEngine.internal.trackedResources) 0 }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -25,32 +26,17 @@ webhooks:
         - deckhouse
   objectSelector: {}
   rules:
+  {{- range $trackResource := .Values.admissionPolicyEngine.internal.trackedResources }}
   - apiGroups:
-    - '*'
+      {{- $trackResource.apiGroups | toYaml | nindent 6 }}
     apiVersions:
     - '*'
     operations:
     - CREATE
     - UPDATE
     resources:
-    - '*'
-    # Explicitly list all known subresources except "status" (to avoid destabilizing the cluster and increasing load on gatekeeper).
-    # You can find a rough list of subresources by doing a case-sensitive search in the Kubernetes codebase for 'Subresource("'
-    - 'pods/ephemeralcontainers'
-    - 'pods/exec'
-    - 'pods/log'
-    - 'pods/eviction'
-    - 'pods/portforward'
-    - 'pods/proxy'
-    - 'pods/attach'
-    - 'pods/binding'
-    - 'deployments/scale'
-    - 'replicasets/scale'
-    - 'statefulsets/scale'
-    - 'replicationcontrollers/scale'
-    - 'services/proxy'
-    - 'nodes/proxy'
-    # For constraints that mitigate CVE-2020-8554
-    - 'services/status'
+      {{- $trackResource.resources | toYaml | nindent 6 }}
+  {{- end }}
   sideEffects: None
   timeoutSeconds: 3
+{{- end }}

--- a/modules/021-kube-proxy/templates/configmap.yaml
+++ b/modules/021-kube-proxy/templates/configmap.yaml
@@ -9,6 +9,7 @@ config.conf: |
     EndpointSliceTerminatingCondition: true
     ProxyTerminatingEndpoints: true
     DaemonSetUpdateSurge: true
+    TopologyAwareHints: true
   {{- end }}
   nodePortAddresses: ["__node_address__"]
   clientConnection:


### PR DESCRIPTION
## Description
Get resources from tracked constraints to watch only them in the validation webhook

## Why do we need it, and what problem does it solve?
By default validation webhook is too open. It validates all type of the resources. We can calculate only desired resources and follow them. Deckhouse will automatically filter unsupported resources (like `extensions/Ingress` for the 1.24 k8s).
Also enable [Topology Aware Hints](https://kubernetes.io/docs/concepts/services-networking/topology-aware-hints/) for webhook service to save traffic in the multi-zone clusters

## What is the expected result?
We have the next match in the constraint:
```
spec:
  enforcementAction: deny
  match:
    kinds:
    - apiGroups:
      - ""
      kinds:
      - Pod
```

then validation webhook will have:
```
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
    name: d8-admission-policy-engine-config
webhooks:
  ...
  rules:
  - apiGroups:
    - ""
    apiVersions:
    - '*'
    operations:
    - CREATE
    - UPDATE
    resources:
    - pods
    scope: '*'
```

if we add a constraint with:
```
spec:
  match:
    kinds:
      - apiGroups: ["extensions", "networking.k8s.io"]
        kinds: ["Ingress"]
```

validation webhook will have:
```
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
    name: d8-admission-policy-engine-config
webhooks:
  ...
  rules:
  - apiGroups:
    - ""
    apiVersions:
    - '*'
    operations:
    - CREATE
    - UPDATE
    resources:
    - pods
    scope: '*'
  - apiGroups:
    - networking.k8s.io
    apiVersions:
    - '*'
    operations:
    - CREATE
    - UPDATE
    resources:
    - ingresses
    scope: '*'
```

---
EndpointSlice after enabling topology aware looks like:
```
addressType: IPv4
apiVersion: discovery.k8s.io/v1
endpoints:
- addresses:
  - 10.111.2.15
  conditions:
    ready: true
    serving: true
    terminating: false
  hints:
    forZones:
    - name: eu-central-1b
  nodeName: xxx
  targetRef:
    kind: Pod
    name: gatekeeper-controller-manager-556649ff9d-mccwl
    namespace: d8-admission-policy-engine
  zone: eu-central-1b
- addresses:
  - 10.111.1.13
  conditions:
    ready: true
    serving: true
    terminating: false
  hints:
    forZones:
    - name: eu-central-1a
  nodeName: yyy
  targetRef:
    kind: Pod
    name: gatekeeper-controller-manager-556649ff9d-hcvk9
    namespace: d8-admission-policy-engine
  zone: eu-central-1a
kind: EndpointSlice
metadata:
  ...
ports:
- name: https-webhook-server
  port: 8443
  protocol: TCP
```

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: admission-policy-engine
type: fix
summary: Watch only desired (constrainted) resources by validation webhook
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
