### PR TITLE
[DX] Fix code generation when /deckhouse is symlinked

### DIFF
--- a/deckhouse-controller/register/main.go
+++ b/deckhouse-controller/register/main.go
@@ -50,6 +50,13 @@ func cwd() string {
 		dir = filepath.Dir(dir)
 	}
 
+	// If deckhouse repo directory is symlinked (e.g. to /deckhouse), resolve the real path.
+	// Otherwise, filepath.Walk will ignore all subdirectories.
+	dir, err = filepath.EvalSymlinks(dir)
+	if err != nil {
+		panic(err)
+	}
+
 	return dir
 }
 

--- a/testing/helm/init.go
+++ b/testing/helm/init.go
@@ -76,6 +76,9 @@ func SetupHelmConfig(values string) *Config {
 	}
 
 	modulePath := filepath.Dir(wd)
+	for filepath.Base(filepath.Dir(modulePath)) != "modules" && filepath.Dir(modulePath) != "/" {
+		modulePath = filepath.Dir(modulePath)
+	}
 
 	moduleName, err := library.GetModuleNameByPath(modulePath)
 	if err != nil {

--- a/tools/build.go
+++ b/tools/build.go
@@ -210,6 +210,14 @@ func cwd() string {
 	for i := 0; i < 2; i++ { // ../
 		dir = filepath.Dir(dir)
 	}
+
+	// If deckhouse repo directory is symlinked (e.g. to /deckhouse), resolve the real path.
+	// Otherwise, filepath.Walk will ignore all subdirectories.
+	dir, err = filepath.EvalSymlinks(dir)
+	if err != nil {
+		panic(err)
+	}
+
 	return dir
 }
 

--- a/tools/register/main.go
+++ b/tools/register/main.go
@@ -52,6 +52,13 @@ func cwd() string {
 		dir = filepath.Dir(dir)
 	}
 
+	// If deckhouse repo directory is symlinked (e.g. to /deckhouse), resolve the real path.
+	// Otherwise, filepath.Walk will ignore all subdirectories.
+	dir, err = filepath.EvalSymlinks(dir)
+	if err != nil {
+		panic(err)
+	}
+
 	return dir
 }
 


### PR DESCRIPTION
## Description

Code generation should work when deckhouse repo root is symlinked at /deckhouse. This PR attempts
for fix go's `filepath.Walk` for this case.

## Why do we need it, and what problem does it solve?

Enhances DX for those who use /deckhouse symnlink for development

## What is the expected result?

The code generation tha depends on modules should work, e.g. statically generated serviceaccount
list in audit policy.

## Changelog entries

```changes
section: tools
type: chore
summary: Fixed the generation of go files in /deckhouse
```
