### PR TITLE
Add ability to control default list of ClusterIssuers

### DIFF
--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -108,3 +108,11 @@ properties:
     description: |
       Delete a secret with a certificate automatically if the corresponding Certificate resource was deleted from the cluster.
     x-examples: [true, false]
+
+  disableLetsencrypt:
+    type: boolean
+    default: true
+    description: |
+      Describes disabling letsencrypt and letsencryptstaging as reference from the cluster.
+    x-examples: [true]
+

--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -112,6 +112,6 @@ properties:
   disableLetsencrypt:
     type: boolean
     description: |
-      Feature to disable letsencrypt and letsencrypt-staging ClusterIssuer ojbects.
+      Disable `letsencrypt` and `letsencrypt-staging` ClusterIssuer objects (if set to `true`).
     x-examples: [true, false]
 

--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -111,8 +111,7 @@ properties:
 
   disableLetsencrypt:
     type: boolean
-    default: true
     description: |
-      Describes disabling letsencrypt and letsencryptstaging as reference from the cluster.
-    x-examples: [true]
+      Feature to disable letsencrypt and letsencrypt-staging ClusterIssuer ojbects.
+    x-examples: [true, false]
 

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -54,4 +54,4 @@ properties:
       Удалять секрет с сертификатом автоматически, если соответствующий ресурс Certificate удален из кластера.
   disableLetsencrypt:
     description: |
-      Не создавать объекты ClusterIssuer в кластере, если опция 'true'
+      Не создавать объекты ClusterIssuer в кластере (если 'true').

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -52,3 +52,6 @@ properties:
   cleanupOrphanSecrets:
     description: |
       Удалять секрет с сертификатом автоматически, если соответствующий ресурс Certificate удален из кластера.
+  disableLetsencrypt:
+    description: |
+      Не создавать объекты ClusterIssuer в кластере, если опция 'true'

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -54,4 +54,4 @@ properties:
       Удалять секрет с сертификатом автоматически, если соответствующий ресурс Certificate удален из кластера.
   disableLetsencrypt:
     description: |
-      Не создавать объекты ClusterIssuer в кластере (если 'true').
+      Не создавать ClusterIssuer `letsencrypt` и `letsencrypt-staging` в кластере (если 'true').

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -54,4 +54,4 @@ properties:
       Удалять секрет с сертификатом автоматически, если соответствующий ресурс Certificate удален из кластера.
   disableLetsencrypt:
     description: |
-      Не создавать ClusterIssuer `letsencrypt` и `letsencrypt-staging` в кластере (если 'true').
+      Не создавать ClusterIssuer `letsencrypt` и `letsencrypt-staging` в кластере (если `true`).

--- a/modules/101-cert-manager/template_tests/module_test.go
+++ b/modules/101-cert-manager/template_tests/module_test.go
@@ -413,5 +413,22 @@ podAntiAffinity:
 			}
 		})
 	})
-})
+	Context("<Control ClusterIssuer objects>", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValuesManagedHa)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("certManager", certManager)
+			f.ValuesSet("certManager.disableLetsencrypt", true)
+			f.HelmRender()
+		})
 
+		It("Check non-creation ClusterIssuer objects if disableLetsencrypt set to true", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			clusterIssuer := f.KubernetesGlobalResource("ClusterIssuer", "letsencrypt")
+			Expect(clusterIssuer.Exists()).To(BeFalse())
+			clusterIssuerStaging := f.KubernetesGlobalResource("ClusterIssuer", "letsencrypt-staging")
+			Expect(clusterIssuerStaging.Exists()).To(BeFalse())
+		})
+	})
+})

--- a/modules/101-cert-manager/template_tests/module_test.go
+++ b/modules/101-cert-manager/template_tests/module_test.go
@@ -18,6 +18,11 @@ package template_tests
 
 import (
 	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
 )
 
 func Test(t *testing.T) {

--- a/modules/101-cert-manager/template_tests/module_test.go
+++ b/modules/101-cert-manager/template_tests/module_test.go
@@ -18,11 +18,6 @@ package template_tests
 
 import (
 	"testing"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
-	. "github.com/deckhouse/deckhouse/testing/helm"
 )
 
 func Test(t *testing.T) {
@@ -403,6 +398,10 @@ podAntiAffinity:
 
 			clusterIssuer := f.KubernetesResource("ClusterIssuer", "d8-cert-manager", "clouddns")
 			Expect(clusterIssuer.Exists()).To(BeTrue())
+
+			if certManager.Field("disableLetsencrypt").Bool() == "true" {
+				Expect(clusterIssuer.Exists()).To(BeFalse())
+			}
 			if clusterIssuer.Field("apiVersion").String() == "cert-manager.io/v1" {
 				Expect(clusterIssuer.Field("spec.acme.solvers.0.dns01.cloudDNS.project").String()).To(Equal("project-209317"))
 				Expect(clusterIssuer.Field("spec.acme.solvers.0.dns01.cloudDNS.serviceAccountSecretRef.name").String()).To(Equal("clouddns"))
@@ -415,3 +414,4 @@ podAntiAffinity:
 		})
 	})
 })
+

--- a/modules/101-cert-manager/template_tests/module_test.go
+++ b/modules/101-cert-manager/template_tests/module_test.go
@@ -399,9 +399,6 @@ podAntiAffinity:
 			clusterIssuer := f.KubernetesResource("ClusterIssuer", "d8-cert-manager", "clouddns")
 			Expect(clusterIssuer.Exists()).To(BeTrue())
 
-			if certManager.Field("disableLetsencrypt").Bool() == "true" {
-				Expect(clusterIssuer.Exists()).To(BeFalse())
-			}
 			if clusterIssuer.Field("apiVersion").String() == "cert-manager.io/v1" {
 				Expect(clusterIssuer.Field("spec.acme.solvers.0.dns01.cloudDNS.project").String()).To(Equal("project-209317"))
 				Expect(clusterIssuer.Field("spec.acme.solvers.0.dns01.cloudDNS.serviceAccountSecretRef.name").String()).To(Equal("clouddns"))
@@ -413,7 +410,7 @@ podAntiAffinity:
 			}
 		})
 	})
-	Context("<Control ClusterIssuer objects>", func() {
+	Context("<DisableLetsencrypt>", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValuesManagedHa)
 			f.ValuesSet("global.modulesImages", GetModulesImages())

--- a/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt-staging.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt-staging.yaml
@@ -1,3 +1,4 @@
+{{- if not (hasKey .Values.certManager "disableLetsencrypt:") }}
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -34,3 +35,5 @@ spec:
                 - key: "dedicated.deckhouse.io"
                   operator: "Equal"
                   value: "cert-manager"
+{{- end }}
+

--- a/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt-staging.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt-staging.yaml
@@ -1,4 +1,4 @@
-{{- if not (hasKey .Values.certManager "disableLetsencrypt:") }}
+{{- if not .Values.certManager.disableLetsencrypt }}
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer

--- a/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt.yaml
@@ -1,3 +1,4 @@
+{{- if not (hasKey .Values.certManager "disableLetsencrypt:") }}
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -34,3 +35,5 @@ spec:
                 - key: "dedicated.deckhouse.io"
                   operator: "Equal"
                   value: "cert-manager"
+{{- end }}
+

--- a/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/clusterissuer-letsencrypt.yaml
@@ -1,4 +1,4 @@
-{{- if not (hasKey .Values.certManager "disableLetsencrypt:") }}
+{{- if not .Values.certManager.disableLetsencrypt }}
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer


### PR DESCRIPTION
## Description
Implementation of the feature to control ClusterIssuers objects in case of its disabling.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
It is feauture request, required by client, to avoid the ClusterIssuer objects creation due to unsage of letsencrypt of cert-manager.
It refers to this issue: #2711
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
In case of specifying 'false' or non-specified - the backward compatibility will be used, so nothing would be changed.
In case of specifying 'true' - there wouldn't be any creation regarding to ClusterIssuer objects at all.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cert-manager
type: feature
summary: Ability to disable the `letsencrypt` ClusterIssuers creation in case of needs.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
