### PR TITLE
[monitoring] fix discovery hook for monitoring applications module

### DIFF
--- a/ee/fe/modules/340-monitoring-applications/hooks/discovery.go
+++ b/ee/fe/modules/340-monitoring-applications/hooks/discovery.go
@@ -20,7 +20,7 @@ import (
 )
 
 func getAllowedApplications() (set.Set, error) {
-	res, err := filepath.Glob("../applications/*")
+	res, err := filepath.Glob("/deckhouse/modules/340-monitoring-applications/applications/*")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix error in discovery hook for monitoring-aplications module.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Discovery does not work properly.
```
monitoringApplications:
  enabledApplications: []
  internal:
    allowedApplications: []
    enabledApplicationsSummary: []
```

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
```
monitoringApplications:
  enabledApplications: []
  internal:
    allowedApplications:
    - consul
    - elasticsearch
    - etcd3
    - fluentd
    - grafana
    - memcached
    - minio
    - mongodb
    - nats
    - nginx
    - php-fpm
    - prometheus
    - rabbitmq
    - redis
    - sidekiq
    - trickster
    - uwsgi
    enabledApplicationsSummary:
    - prometheus
```

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring
type: fix
summary: Fix discovery hook for monitoring applications module.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
