### PR TITLE
[testing] re-render github workflows (fix)

### DIFF
--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -411,6 +411,7 @@ jobs:
 
       - name: Run go generate
         run: |
+
           (cd tools && go generate)
           (cd modules/500-upmeter/hooks/smokemini/internal/snapshot && go generate)
 

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -157,6 +157,7 @@ jobs:
 
       - name: Run go generate
         run: |
+
           (cd tools && go generate)
           (cd modules/500-upmeter/hooks/smokemini/internal/snapshot && go generate)
 

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -206,6 +206,7 @@ jobs:
 
       - name: Run go generate
         run: |
+
           (cd tools && go generate)
           (cd modules/500-upmeter/hooks/smokemini/internal/snapshot && go generate)
 


### PR DESCRIPTION
## Description

run render-workflows.sh (fix for https://github.com/deckhouse/deckhouse/pull/2984)

## Why do we need it, and what problem does it solve?

fix regression when https://github.com/deckhouse/deckhouse/pull/2984 was merged without rendering github workflows

## What is the expected result?

No more werf inside the docker, let it on a host only

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: testing
type: fix
summary: run render-workflows.sh (fix for 2984)
impact: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
