### PR TITLE
[istio] fix namespace discovery

### DIFF
--- a/ee/modules/110-istio/hooks/discovery_application_namespaces.go
+++ b/ee/modules/110-istio/hooks/discovery_application_namespaces.go
@@ -7,12 +7,12 @@ package hooks
 
 import (
 	"fmt"
-	v1 "k8s.io/api/core/v1"
 	"sort"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 

--- a/ee/modules/110-istio/hooks/discovery_application_namespaces_test.go
+++ b/ee/modules/110-istio/hooks/discovery_application_namespaces_test.go
@@ -79,7 +79,7 @@ spec: {}
 		})
 	})
 
-	Context("Application namespaces with labels and IstioOperator", func() {
+	FContext("Application namespaces with labels and IstioOperator", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(`
 ---
@@ -161,6 +161,16 @@ metadata:
   name: kube-ns9
   labels:
     istio-injection: enabled
+---
+# ns in terminatig phase
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-ns10
+  labels:
+    istio-injection: enabled
+status:
+  phase: Terminating
 `))
 			f.RunHook()
 		})

--- a/ee/modules/110-istio/hooks/discovery_application_namespaces_test.go
+++ b/ee/modules/110-istio/hooks/discovery_application_namespaces_test.go
@@ -162,15 +162,15 @@ metadata:
   labels:
     istio-injection: enabled
 ---
-# ns in terminatig phase
+# ns with deletionTimestamp
 apiVersion: v1
 kind: Namespace
 metadata:
   name: kube-ns10
+  annotations:
+    deletionTimestamp: "2020-10-22T21:30:34Z"
   labels:
     istio-injection: enabled
-status:
-  phase: Terminating
 `))
 			f.RunHook()
 		})

--- a/ee/modules/110-istio/hooks/discovery_application_namespaces_test.go
+++ b/ee/modules/110-istio/hooks/discovery_application_namespaces_test.go
@@ -79,7 +79,7 @@ spec: {}
 		})
 	})
 
-	FContext("Application namespaces with labels and IstioOperator", func() {
+	Context("Application namespaces with labels and IstioOperator", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(`
 ---


### PR DESCRIPTION
## Description
Ignore `Namespace` in terminating phase during istio driven `Namespace` discovery in `discovery_application_namespaces.go`

## Why do we need it, and what problem does it solve?
Closes https://github.com/deckhouse/deckhouse/issues/3052

## What is the expected result?
No errors in synchronization of the istio module during the existence of the istio driven namespace in termination state

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Exclude terminating application namespaces from discovery
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
