### PR TITLE
[node-manager] add alert on master ng absent taint

### DIFF
--- a/modules/040-node-manager/hooks/handle_node_templates.go
+++ b/modules/040-node-manager/hooks/handle_node_templates.go
@@ -156,6 +156,8 @@ func nodeTemplatesHandler(input *go_hook.HookInput) error {
 	for _, nodeGroup := range nodeGroups {
 		ng := nodeGroup.(NodeSettings)
 		ngs[ng.Name] = ng
+
+		checkMasterNGTaints(input, ng, nodeGroups, nodes)
 	}
 
 	for _, nodeObj := range nodes {
@@ -361,6 +363,29 @@ func applyNodeTemplate(nodeObj *v1.Node, node, nodeGroup NodeSettings) error {
 	}
 
 	return nil
+}
+
+// "control-plane" taint could be absent only for single-node installations
+// it's not valid for the other cases
+func checkMasterNGTaints(input *go_hook.HookInput, ng NodeSettings, nodeGroups, nodes []go_hook.FilterResult) {
+	if ng.Name != "master" {
+		return
+	}
+
+	if len(nodeGroups) == 1 && len(nodes) == 1 {
+		return
+	}
+
+	controlPlaneTaintIsMissed := true
+	for _, taint := range ng.Taints {
+		if taint.Key == "node-role.kubernetes.io/control-plane" {
+			controlPlaneTaintIsMissed = false
+			break
+		}
+	}
+	if controlPlaneTaintIsMissed {
+		input.MetricsCollector.Set("d8_missed_taint_on_master_ng", 1, nil)
+	}
 }
 
 // ApplyTemplateMap return actual merged with template without excess keys.

--- a/modules/040-node-manager/hooks/handle_node_templates.go
+++ b/modules/040-node-manager/hooks/handle_node_templates.go
@@ -384,7 +384,7 @@ func checkMasterNGTaints(input *go_hook.HookInput, ng NodeSettings, nodeGroups, 
 		}
 	}
 	if controlPlaneTaintIsMissed {
-		input.MetricsCollector.Set("d8_nodegroup_controlplane_taint_missing", 1, nil)
+		input.MetricsCollector.Set("d8_nodegroup_taint_missing", 1, map[string]string{"name": ng.Name})
 	}
 }
 

--- a/modules/040-node-manager/hooks/handle_node_templates.go
+++ b/modules/040-node-manager/hooks/handle_node_templates.go
@@ -384,7 +384,7 @@ func checkMasterNGTaints(input *go_hook.HookInput, ng NodeSettings, nodeGroups, 
 		}
 	}
 	if controlPlaneTaintIsMissed {
-		input.MetricsCollector.Set("d8_missed_taint_on_master_ng", 1, nil)
+		input.MetricsCollector.Set("d8_nodegroup_controlplane_taint_missing", 1, nil)
 	}
 }
 

--- a/modules/040-node-manager/hooks/handle_node_templates_test.go
+++ b/modules/040-node-manager/hooks/handle_node_templates_test.go
@@ -895,7 +895,7 @@ spec:
 			f.RunHook()
 		})
 
-		It("Metric 'd8_nodegroup_controlplane_taint_missing' should appear", func() {
+		It("Metric 'd8_nodegroup_taint_missing' should appear", func() {
 			// collected metrics should have 'd8_nodegroup_taint_missing' metric
 			Expect(metricEqual(f.MetricsCollector.CollectedMetrics(), "d8_nodegroup_taint_missing", pointer.Float64(1))).To(BeTrue())
 		})
@@ -905,7 +905,7 @@ spec:
 func metricEqual(metrics []operation.MetricOperation, name string, value *float64) bool {
 	for _, metric := range metrics {
 		if metric.Name == name {
-			if value != nil && value == metric.Value {
+			if value != nil && *value == *metric.Value {
 				return true
 			} else if value == nil {
 				return true

--- a/modules/040-node-manager/hooks/handle_node_templates_test.go
+++ b/modules/040-node-manager/hooks/handle_node_templates_test.go
@@ -745,8 +745,8 @@ spec:
 			Expect(f).To(ExecuteSuccessfully())
 			taints := f.KubernetesGlobalResource("Node", "kube-master-0").Parse().Get("spec.taints")
 			Expect(taints.Array()).To(HaveLen(0))
-			// collected metrics should not have 'd8_nodegroup_controlplane_taint_missing' metric
-			Expect(metricEqual(f.MetricsCollector.CollectedMetrics(), "d8_nodegroup_controlplane_taint_missing", nil)).To(BeFalse())
+			// collected metrics should not have 'd8_nodegroup_taint_missing' metric
+			Expect(metricEqual(f.MetricsCollector.CollectedMetrics(), "d8_nodegroup_taint_missing", nil)).To(BeFalse())
 		})
 	})
 
@@ -843,8 +843,8 @@ spec:
 			taints := f.KubernetesGlobalResource("Node", "kube-master-0").Parse().Get("spec.taints")
 			Expect(taints.Array()).To(HaveLen(1))
 			Expect(taints.Array()[0].String()).To(Equal(`{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"}`))
-			// collected metrics should not have 'd8_nodegroup_controlplane_taint_missing' metric
-			Expect(metricEqual(f.MetricsCollector.CollectedMetrics(), "d8_nodegroup_controlplane_taint_missing", nil)).To(BeFalse())
+			// collected metrics should not have 'd8_nodegroup_taint_missing' metric
+			Expect(metricEqual(f.MetricsCollector.CollectedMetrics(), "d8_nodegroup_taint_missing", nil)).To(BeFalse())
 		})
 	})
 
@@ -896,8 +896,8 @@ spec:
 		})
 
 		It("Metric 'd8_nodegroup_controlplane_taint_missing' should appear", func() {
-			// collected metrics should have 'd8_nodegroup_controlplane_taint_missing' metric
-			Expect(metricEqual(f.MetricsCollector.CollectedMetrics(), "d8_nodegroup_controlplane_taint_missing", pointer.Float64(1))).To(BeTrue())
+			// collected metrics should have 'd8_nodegroup_taint_missing' metric
+			Expect(metricEqual(f.MetricsCollector.CollectedMetrics(), "d8_nodegroup_taint_missing", pointer.Float64(1))).To(BeTrue())
 		})
 	})
 })

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
@@ -81,7 +81,7 @@
 
   - alert: NodeGroupMasterTaintIsAbsent
     expr: |
-      max (d8_missed_taint_on_master_ng) > 0
+      max (d8_nodegroup_controlplane_taint_missing) > 0
     for: 20m
     labels:
       severity_level: "4"

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
@@ -78,3 +78,25 @@
       description: |
         Possibly, autoscaler has provisioned too many Nodes. Take a look at the state of the Machine in the cluster.
 {{- template "todo_list" }}
+
+  - alert: NodeGroupMasterTaintIsAbsent
+    expr: |
+      max (d8_missed_taint_on_master_ng) > 0
+    for: 20m
+    labels:
+      severity_level: "4"
+      tier: cluster
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      summary: The 'master' node group does not contain desired taint.
+      description: |
+        `master` node group has no `node-role.kubernetes.io/control-plane` taint. Probably, your control-plane nodes are missconfigured
+        and are able to run not only control-plane Pods. Please, add:
+        ```yaml
+          nodeTemplate:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/control-plane
+        ```
+        to the `master` node group spec.
+        `key: node-role.kubernetes.io/master` taint was deprecated and will not worker in the kubernetes 1.24+.

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
@@ -81,7 +81,7 @@
 
   - alert: NodeGroupMasterTaintIsAbsent
     expr: |
-      max (d8_nodegroup_controlplane_taint_missing) > 0
+      max (d8_nodegroup_taint_missing{name="master"}) > 0
     for: 20m
     labels:
       severity_level: "4"

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
@@ -99,4 +99,4 @@
               key: node-role.kubernetes.io/control-plane
         ```
         to the `master` node group spec.
-        `key: node-role.kubernetes.io/master` taint was deprecated and will not worker in the kubernetes 1.24+.
+        `key: node-role.kubernetes.io/master` taint was deprecated and will have no effect in Kubernetes 1.24+.

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
@@ -91,7 +91,7 @@
       plk_markup_format: "markdown"
       summary: The 'master' node group does not contain desired taint.
       description: |
-        `master` node group has no `node-role.kubernetes.io/control-plane` taint. Probably, your control-plane nodes are missconfigured
+        `master` node group has no `node-role.kubernetes.io/control-plane` taint. Probably control-plane nodes are misconfigured
         and are able to run not only control-plane Pods. Please, add:
         ```yaml
           nodeTemplate:


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Add an alert about missing taints

## Why do we need it, and what problem does it solve?
Some old-created node groups are missing desired control-plane taint and it could lead to the problems in 1.24+ k8s clusters

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: feature 
summary: Add an alert about missing control-plane taints on the `master` node group
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
