### PR TITLE
[node-manager] Fix ng expander cm

### DIFF
--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -80,6 +80,15 @@ mcmEmergencyBrake: false
 
 const nodeManagerAWS = `
 internal:
+  clusterAutoscalerPriorities:
+    "50":
+    - ^xxx-staging-[0-9a-zA-Z]+$
+    "70":
+    - ^xxx-staging-spot-m5a-2xlarge-[0-9a-zA-Z]+$
+    "90":
+    - ^xxx-staging-spot-[0-9a-zA-Z]+$
+    - ^xxx-staging-spot-m5a.8xlarge-[0-9a-zA-Z]+$
+    - ^xxx-staging-spot-c5.16xlarge-[0-9a-zA-Z]+$
   machineDeployments: {}
   instancePrefix: myprefix
   clusterMasterAddresses: ["10.0.0.1:6443", "10.0.0.2:6443", "10.0.0.3:6443"]
@@ -549,6 +558,17 @@ var _ = Describe("Module :: node-manager :: helm template ::", func() {
 					Expect(f.RenderError).ShouldNot(HaveOccurred())
 
 					rule := f.KubernetesResource("PrometheusRule", "d8-cloud-instance-manager", "node-manager-cluster-autoscaler")
+					cm := f.KubernetesResource("ConfigMap", "d8-cloud-instance-manager", "cluster-autoscaler-priority-expander")
+					Expect(cm.Field("data.priorities").String()).To(MatchYAML(`
+50:
+  - ^xxx-staging-[0-9a-zA-Z]+$
+70:
+  - ^xxx-staging-spot-m5a-2xlarge-[0-9a-zA-Z]+$
+90:
+  - ^xxx-staging-spot-[0-9a-zA-Z]+$
+  - ^xxx-staging-spot-m5a.8xlarge-[0-9a-zA-Z]+$
+  - ^xxx-staging-spot-c5.16xlarge-[0-9a-zA-Z]+$
+`))
 
 					assertSpecDotGroupsArray(rule, false)
 				})

--- a/modules/040-node-manager/templates/cluster-autoscaler/expander-cm.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/expander-cm.yaml
@@ -10,7 +10,7 @@ data:
     {{- if hasKey $.Values.nodeManager.internal "clusterAutoscalerPriorities" }}
     {{- range $k, $v := $.Values.nodeManager.internal.clusterAutoscalerPriorities }}
     {{ $k | atoi }}:
-{{ $v | toYaml | indent 6 }}
+      {{- $v | toYaml | nindent 6 }}
     {{- end }}
     {{- else }}
     {}

--- a/modules/040-node-manager/templates/cluster-autoscaler/expander-cm.yaml
+++ b/modules/040-node-manager/templates/cluster-autoscaler/expander-cm.yaml
@@ -10,7 +10,7 @@ data:
     {{- if hasKey $.Values.nodeManager.internal "clusterAutoscalerPriorities" }}
     {{- range $k, $v := $.Values.nodeManager.internal.clusterAutoscalerPriorities }}
     {{ $k | atoi }}:
-      {{ $v | toYaml }}
+{{ $v | toYaml | indent 6 }}
     {{- end }}
     {{- else }}
     {}


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Fix generating expander configmap for cluster-autoscaler if Deckhouse has a few node groups with the same priority

## Why do we need it, and what problem does it solve?
Same priority on a few node groups generates wrong yaml:
```
apiVersion: v1
data:
  priorities: |-
    50:
      - ^xxx-staging-[0-9a-zA-Z]+$
    70:
      - ^xxx-staging-spot-m5a-2xlarge-[0-9a-zA-Z]+$
    90:
      - ^xxx-staging-spot-[0-9a-zA-Z]+$
- ^xxx-staging-spot-m5a.8xlarge-[0-9a-zA-Z]+$
- ^xxx-staging-spot-c5.16xlarge-[0-9a-zA-Z]+$
kind: ConfigMap
metadata:
  labels:
    app: cluster-autoscaler
    heritage: deckhouse
    module: node-manager
    workload-resource-policy.deckhouse.io: master
  name: cluster-autoscaler-priority-expander
  namespace: d8-cloud-instance-manager
```

## What is the expected result?
After this fix cm will look like:
```
apiVersion: v1
data:
  priorities: |-
    50:
      - ^xxx-staging-[0-9a-zA-Z]+$
    70:
      - ^xxx-staging-spot-m5a-2xlarge-[0-9a-zA-Z]+$
    90:
      - ^xxx-staging-spot-[0-9a-zA-Z]+$
      - ^xxx-staging-spot-m5a.8xlarge-[0-9a-zA-Z]+$
      - ^xxx-staging-spot-c5.16xlarge-[0-9a-zA-Z]+$
kind: ConfigMap
metadata:
  labels:
    app: cluster-autoscaler
    heritage: deckhouse
    module: node-manager
    workload-resource-policy.deckhouse.io: master
  name: cluster-autoscaler-priority-expander
  namespace: d8-cloud-instance-manager
```


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Fix `cluster-autoscaler` configMap generation when a few node groups have the same priority.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
