### PR TITLE
Increasing failureThreshold of startupProbes for main and longterm prometheus objects

### DIFF
--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -57,9 +57,9 @@ spec:
   - name: deckhouse-registry
   listenLocal: true
   containers:
-    - name: prometheus
-      startupProbe:
-        failureThreshold: 300
+  - name: prometheus
+    startupProbe:
+      failureThreshold: 300
   - name: kube-rbac-proxy
     {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 4 }}
     image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -57,6 +57,9 @@ spec:
   - name: deckhouse-registry
   listenLocal: true
   containers:
+    - name: prometheus
+      startupProbe:
+        failureThreshold: 300
   - name: kube-rbac-proxy
     {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 4 }}
     image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
@@ -93,18 +96,6 @@ spec:
   {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
         {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 8 }}
   {{- end }}
-    startupProbe:
-      exec:
-        command:
-        - sh
-        - -c
-        - if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/ready;
-          elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready;
-          else exit 1; fi
-      failureThreshold: 300
-      periodSeconds: 15
-      successThreshold: 1
-      timeoutSeconds: 3
   - name: config-reloader
     resources:
       requests:
@@ -112,18 +103,6 @@ spec:
   {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
         {{- include "longterm_config_reloader_resources" . | nindent 8 }}
   {{- end }}
-    startupProbe:
-      exec:
-        command:
-        - sh
-        - -c
-        - if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/ready;
-          elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready;
-          else exit 1; fi
-      failureThreshold: 300
-      periodSeconds: 15
-      successThreshold: 1
-      timeoutSeconds: 3
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -93,6 +93,11 @@ spec:
   {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
         {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 8 }}
   {{- end }}
+    startupProbe:
+      failureThreshold: 300
+      periodSeconds: 15
+      successThreshold: 1
+      timeoutSeconds: 3
   - name: config-reloader
     resources:
       requests:
@@ -100,6 +105,11 @@ spec:
   {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
         {{- include "longterm_config_reloader_resources" . | nindent 8 }}
   {{- end }}
+    startupProbe:
+      failureThreshold: 300
+      periodSeconds: 15
+      successThreshold: 1
+      timeoutSeconds: 3
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -99,8 +99,8 @@ spec:
         - sh
         - -c
         - if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/ready;
-        elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready;
-        else exit 1; fi
+          elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready;
+          else exit 1; fi
       failureThreshold: 300
       periodSeconds: 15
       successThreshold: 1
@@ -118,8 +118,8 @@ spec:
         - sh
         - -c
         - if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/ready;
-        elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready;
-        else exit 1; fi
+          elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready;
+          else exit 1; fi
       failureThreshold: 300
       periodSeconds: 15
       successThreshold: 1

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -95,9 +95,6 @@ spec:
   {{- end }}
     startupProbe:
       failureThreshold: 300
-      periodSeconds: 15
-      successThreshold: 1
-      timeoutSeconds: 3
   - name: config-reloader
     resources:
       requests:
@@ -107,9 +104,6 @@ spec:
   {{- end }}
     startupProbe:
       failureThreshold: 300
-      periodSeconds: 15
-      successThreshold: 1
-      timeoutSeconds: 3
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/longterm/prometheus.yaml
@@ -94,7 +94,17 @@ spec:
         {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 8 }}
   {{- end }}
     startupProbe:
+      exec:
+        command:
+        - sh
+        - -c
+        - if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/ready;
+        elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready;
+        else exit 1; fi
       failureThreshold: 300
+      periodSeconds: 15
+      successThreshold: 1
+      timeoutSeconds: 3
   - name: config-reloader
     resources:
       requests:
@@ -103,7 +113,17 @@ spec:
         {{- include "longterm_config_reloader_resources" . | nindent 8 }}
   {{- end }}
     startupProbe:
+      exec:
+        command:
+        - sh
+        - -c
+        - if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/ready;
+        elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready;
+        else exit 1; fi
       failureThreshold: 300
+      periodSeconds: 15
+      successThreshold: 1
+      timeoutSeconds: 3
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -59,6 +59,9 @@ spec:
   - name: deckhouse-registry
   listenLocal: true
   containers:
+  - name: prometheus
+    startupProbe:
+      failureThreshold: 300
   - name: kube-rbac-proxy
     {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 4 }}
     image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
@@ -95,18 +98,6 @@ spec:
 {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
         {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 8 }}
 {{- end }}
-    startupProbe:
-      exec:
-        command:
-        - sh
-        - -c
-        - if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/ready;
-          elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready;
-          else exit 1; fi
-      failureThreshold: 300
-      periodSeconds: 15
-      successThreshold: 1
-      timeoutSeconds: 3
   - name: config-reloader
     resources:
       requests:
@@ -114,18 +105,6 @@ spec:
 {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
         {{- include "config_reloader_resources" . | nindent 8 }}
 {{- end }}
-    startupProbe:
-      exec:
-        command:
-        - sh
-        - -c
-        - if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/ready;
-          elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready;
-          else exit 1; fi
-      failureThreshold: 300
-      periodSeconds: 15
-      successThreshold: 1
-      timeoutSeconds: 3
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -96,7 +96,17 @@ spec:
         {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 8 }}
 {{- end }}
     startupProbe:
+      exec:
+        command:
+        - sh
+        - -c
+        - if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/ready;
+        elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready;
+        else exit 1; fi
       failureThreshold: 300
+      periodSeconds: 15
+      successThreshold: 1
+      timeoutSeconds: 3
   - name: config-reloader
     resources:
       requests:
@@ -105,7 +115,17 @@ spec:
         {{- include "config_reloader_resources" . | nindent 8 }}
 {{- end }}
     startupProbe:
+      exec:
+        command:
+        - sh
+        - -c
+        - if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/ready;
+        elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready;
+        else exit 1; fi
       failureThreshold: 300
+      periodSeconds: 15
+      successThreshold: 1
+      timeoutSeconds: 3
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -97,9 +97,6 @@ spec:
 {{- end }}
     startupProbe:
       failureThreshold: 300
-      periodSeconds: 15
-      successThreshold: 1
-      timeoutSeconds: 3
   - name: config-reloader
     resources:
       requests:
@@ -109,9 +106,6 @@ spec:
 {{- end }}
     startupProbe:
       failureThreshold: 300
-      periodSeconds: 15
-      successThreshold: 1
-      timeoutSeconds: 3
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -101,8 +101,8 @@ spec:
         - sh
         - -c
         - if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/ready;
-        elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready;
-        else exit 1; fi
+          elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready;
+          else exit 1; fi
       failureThreshold: 300
       periodSeconds: 15
       successThreshold: 1
@@ -120,8 +120,8 @@ spec:
         - sh
         - -c
         - if [ -x "$(command -v curl)" ]; then exec curl http://localhost:9090/-/ready;
-        elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready;
-        else exit 1; fi
+          elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null http://localhost:9090/-/ready;
+          else exit 1; fi
       failureThreshold: 300
       periodSeconds: 15
       successThreshold: 1

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -95,6 +95,11 @@ spec:
 {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
         {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 8 }}
 {{- end }}
+    startupProbe:
+      failureThreshold: 300
+      periodSeconds: 15
+      successThreshold: 1
+      timeoutSeconds: 3
   - name: config-reloader
     resources:
       requests:
@@ -102,6 +107,11 @@ spec:
 {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler-crd") }}
         {{- include "config_reloader_resources" . | nindent 8 }}
 {{- end }}
+    startupProbe:
+      failureThreshold: 300
+      periodSeconds: 15
+      successThreshold: 1
+      timeoutSeconds: 3
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Description
Increasing failureThreshold of startupProbes for main and longterm prometheus objects.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
It is fix, relates to poor performance of used resources.
It refers to this issue: #2884 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
The prometheus objects as main and longterm would have the following for startupProbe:
**failureThreshold: 300**
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: fix
summary: Setting up failureThreshold of startupProbes for main and longterm prometheus objects from 60 to 300.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
