### PR TITLE
[flant-integration] Filter master nodes based on "node.deckhouse.io/group" and consider "node-role.kubernetes.io/master" taint for dedicated master

### DIFF
--- a/ee/modules/600-flant-integration/hooks/pricing/envs_from_nodes.go
+++ b/ee/modules/600-flant-integration/hooks/pricing/envs_from_nodes.go
@@ -51,12 +51,13 @@ func ApplyPricingNodeFilter(obj *unstructured.Unstructured) (go_hook.FilterResul
 		n.Type = t
 	}
 
-	if _, ok := node.ObjectMeta.Labels["node-role.kubernetes.io/control-plane"]; !ok {
+	if nodeGroup, ok := node.ObjectMeta.Labels["node.deckhouse.io/group"]; !ok || nodeGroup != "master" {
 		return n, err
 	}
 
 	for _, taint := range node.Spec.Taints {
-		if taint.Key == "node-role.kubernetes.io/control-plane" {
+		if taint.Key == "node-role.kubernetes.io/control-plane" ||
+			taint.Key == "node-role.kubernetes.io/master" {
 			n.MasterNodeInfo.IsDedicated = true
 			break
 		}

--- a/ee/modules/600-flant-integration/hooks/pricing/envs_from_nodes.go
+++ b/ee/modules/600-flant-integration/hooks/pricing/envs_from_nodes.go
@@ -52,7 +52,7 @@ func ApplyPricingNodeFilter(obj *unstructured.Unstructured) (go_hook.FilterResul
 	}
 
 	if nodeGroup, ok := node.ObjectMeta.Labels["node.deckhouse.io/group"]; !ok || nodeGroup != "master" {
-		return n, err
+		return n, nil
 	}
 
 	for _, taint := range node.Spec.Taints {


### PR DESCRIPTION
Signed-off-by: Gleb Maiorov <gleb.maiorov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Filter master nodes based on `node.deckhouse.io/group` in pricing and consider both `node-role.kubernetes.io/master` and `node-role.kubernetes.io/control-plane` taints for dedicated master.

<details>
<summary>

This PR was tested manually on dev-cluster with `node-role.kubernetes.io/control-plane` taint replaced with `node-role.kubernetes.io/master` in `master` NodeGroup.

</summary>

* Corresponding metric on main:
![metrics_before](https://user-images.githubusercontent.com/111346521/203531501-cf94912f-fa6f-4d56-ae37-6204b607c4ec.png)

* Corresponding metric on this PR:
![metrics_after](https://user-images.githubusercontent.com/111346521/203535835-01f59cbd-f88c-4159-b9ff-241e2ca3f9b5.png)

</details>

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The Kubernetes project is [moving away](https://github.com/kubernetes/kubeadm/issues/2200) from wording that is considered offensive, so `node-role.kubernetes.io/master` label/taint being replaced with `node-role.kubernetes.io/control-plane`.

Relying on `node.deckhouse.io/group` label instead of `node-role.kubernetes.io/control-plane` is useful in case of additional changes in K8s label wording because it defined inside Deckhouse.

Unfortunately, there are no Deckhouse-defined taints for master nodes, and they seems unlikely to be implemented due to the need of tolerating such taints and syncing them with K8s-defined labels.
So, both `node-role.kubernetes.io/master` (which is planned for removal in K8s 1.25) and `node-role.kubernetes.io/control-plane` (which wouldn't exist in 1.19 clusters) taints need to be considered when determining whether master node is dedicated.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

* `node.deckhouse.io/group` label is used to filter master nodes in pricing instead of `node-role.kubernetes.io/control-plane`
* both `node-role.kubernetes.io/master` and `node-role.kubernetes.io/control-plane` are considered when determining whether master node is dedicated

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: flant-integration
type: chore
summary: Filter master nodes based on `node.deckhouse.io/group` in pricing and consider both `node-role.kubernetes.io/master` and `node-role.kubernetes.io/control-plane` taints for dedicated master
impact: `pricing` pods will restart in `d8-flant-integration` namespace
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
