### PR TITLE
[site] Fix the menu of versions on the site

### DIFF
--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -19,6 +19,7 @@ metadata:
       proxy_set_header X-Original-URI         $request_uri;
       ssi on;
       ssi_silent_errors on;
+      rewrite ^(/en|/ru)?(/documentation/v1\.[0-9]+)\.[0-9]+(/.*)$ $2$3 redirect;
       rewrite ^/ru/(.*) https://{{ $hostRu }}/$1 redirect;
       rewrite ^/en/(.*) https://{{ $hostEn }}/$1 redirect;
       {{- include "rewrites" . | nindent 6 }}

--- a/docs/site/_includes/channel-menu.html
+++ b/docs/site/_includes/channel-menu.html
@@ -12,7 +12,7 @@
 <div class="submenu-container">
     <ul class="submenu">
     {{- range (slice .VersionItems 1) }}
-      {{- $majMinVersion := regexReplaceAll "(v[0-9]+\\.[0-9]+).+" .Version "$1" }}
+      {{- $majMinVersion := regexReplaceAll "(v[0-9]+\\.[0-9]+)\\..+" .Version "$1" }}
       {{- if not (and (eq .Version "latest") (eq $majMinVersion $prevVersion)) }}
             <li class="submenu-item">
                 <a data-proofer-ignore class="submenu-item-link" href="/documentation/{{ .VersionURL }}/{{ $CurrentPageURLRelative }}">

--- a/docs/site/werf-debug.yaml
+++ b/docs/site/werf-debug.yaml
@@ -77,7 +77,7 @@ ansible:
         chdir: /go/src/app
 git:
   - url: https://github.com/flant/web-router.git
-    tag: v1.0.14-rc.1
+    tag: v1.0.14
     add: /
     to: /go/src/app
     stageDependencies:

--- a/docs/site/werf.yaml
+++ b/docs/site/werf.yaml
@@ -87,7 +87,7 @@ ansible:
         chdir: /go/src/app
 git:
   - url: https://github.com/flant/web-router.git
-    tag: v1.0.14-rc.1
+    tag: v1.0.14
     add: /
     to: /go/src/app
     stageDependencies:


### PR DESCRIPTION
## Description
- Fix the menu of versions on the site.
- Add redirects for documentation from a patch version to a Maj.Min version.
- Use a stable web-router tag.

## Changelog entries
```changes
section: docs
type: fix
summary: Fix the menu of versions on the site.
impact_level: low
```
