### PR TITLE
[site] Add redirects for documentation versions lower than 1.38

### DIFF
--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -19,6 +19,7 @@ metadata:
       proxy_set_header X-Original-URI         $request_uri;
       ssi on;
       ssi_silent_errors on;
+      rewrite ^(/en|/ru)?/documentation/v1\.3[0-7](\.[0-9]+)?(/.*)$ /documentation/v1.38$3 redirect;
       rewrite ^(/en|/ru)?(/documentation/v1\.[0-9]+)\.[0-9]+(/.*)$ $2$3 redirect;
       rewrite ^/ru/(.*) https://{{ $hostRu }}/$1 redirect;
       rewrite ^/en/(.*) https://{{ $hostEn }}/$1 redirect;


### PR DESCRIPTION
## Description
Add redirects for documentation versions lower than 1.38.

## Changelog entries
```changes
section: docs
type: chore
summary: Add redirects for documentation versions lower than 1.38.
impact_level: low
```
