### PR TITLE
[cloud-provider-yandex] fix: test fails on unmarshaling YAML with duplicated keys

### DIFF
--- a/modules/030-cloud-provider-yandex/hooks/yandex_cluster_configuration_test.go
+++ b/modules/030-cloud-provider-yandex/hooks/yandex_cluster_configuration_test.go
@@ -86,7 +86,6 @@ masterNodeGroup:
     memory: 4096
     platform: standard-v2
   replicas: 1
-nodeNetworkCIDR: 10.231.0.0/22
 provider:
   cloudID: test
   folderID: test
@@ -94,7 +93,6 @@ provider:
     {
       "id": "test"
     }
-sshPublicKey: ssh-rsa test
 withNATInstance:
   internalSubnetID: test
   natInstanceExternalAddress: 84.201.160.148


### PR DESCRIPTION
## Description

Remove duplicated keys from YAML in test.

## Why do we need it, and what problem does it solve?

All PRs have failed tests because of this test. It seems we've updated yaml library or something like that.

<details><summary>Log example</summary>
<pre>
Modules :: cloud-provider-yandex :: hooks :: yandex_cluster_configuration :: /deckhouse/modules/030-cloud-provider-yandex/hooks/yandex_cluster_configuration_test.go:29
  Provider data is successfully discovered
  /deckhouse/modules/030-cloud-provider-yandex/hooks/yandex_cluster_configuration_test.go:162
    All values should be gathered from discovered data [It]
    /deckhouse/modules/030-cloud-provider-yandex/hooks/yandex_cluster_configuration_test.go:168

    Expected '
    apiVersion: deckhouse.io/v1
    existingNetworkID: enpma5uvcfbkuac1i1jb
    kind: YandexClusterConfiguration
    layout: WithNATInstance
    masterNodeGroup:
      instanceClass:
        cores: 2
        imageID: test
        memory: 4096
        platform: standard-v2
      replicas: 1
    nodeNetworkCIDR: 10.231.0.0/22
    provider:
      cloudID: test
      folderID: test
      serviceAccountJSON: |-
        {
          "id": "test"
        }
    sshPublicKey: ssh-rsa test
    withNATInstance:
      internalSubnetID: test
      natInstanceExternalAddress: 84.201.160.148
      exporterAPIKey: ""
    nodeNetworkCIDR: 84.201.160.148/31
    sshPublicKey: ssh-rsa AAAAAbbbb
    ' should be valid YAML, but it is not.
    Underlying error:yaml: unmarshal errors:
      line 26: mapping key "nodeNetworkCIDR" already defined at line 13
      line 27: mapping key "sshPublicKey" already defined at line 21

    /deckhouse/modules/030-cloud-provider-yandex/hooks/yandex_cluster_configuration_test.go:183
</pre>
</details>

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

All tests for cloud-provider-yandex module should not fail.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-yandex
type: chore
summary: Remove duplicated keys from YAML in test.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
