### PR TITLE
[deckhouse-controller] libjq is not needed for Go hooks, remove it

### DIFF
--- a/deckhouse-controller/go-build.sh
+++ b/deckhouse-controller/go-build.sh
@@ -20,18 +20,10 @@ deckhouseVer="dev"
 shellOpVer=$(go list -m all | grep shell-operator | cut -d' ' -f 2-)
 addonOpVer=$(go list -m all | grep addon-operator | cut -d' ' -f 2-)
 
-jqRoot=$1
-if [ "x${jqRoot}" = "x" ]; then
-  >&2 echo "A path to libjq static libraries should be specified!"
-  exit 1
-fi
-
 # Can be removed when Go 1.16 will be in use.
 export GO111MODULE=on
 
-CGO_ENABLED=1 \
-    CGO_CFLAGS="-I${jqRoot}/include" \
-    CGO_LDFLAGS="-L${jqRoot}/lib" \
+CGO_ENABLED=0 \
     GOOS=linux \
     go build \
      -ldflags="-s -w -X 'main.DeckhouseVersion=$deckhouseVer' -X 'main.AddonOperatorVersion=$addonOpVer' -X 'main.ShellOperatorVersion=$shellOpVer'" \

--- a/deckhouse-controller/go-build.sh
+++ b/deckhouse-controller/go-build.sh
@@ -23,8 +23,7 @@ addonOpVer=$(go list -m all | grep addon-operator | cut -d' ' -f 2-)
 # Can be removed when Go 1.16 will be in use.
 export GO111MODULE=on
 
-CGO_ENABLED=0 \
-    GOOS=linux \
+GOOS=linux \
     go build \
      -ldflags="-s -w -X 'main.DeckhouseVersion=$deckhouseVer' -X 'main.AddonOperatorVersion=$addonOpVer' -X 'main.ShellOperatorVersion=$shellOpVer'" \
      -o ./deckhouse-controller \

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/flant/addon-operator v1.0.7-0.20221108074825-ba5d9983d012 // branch: main
 	github.com/flant/kube-client v0.0.6
-	github.com/flant/shell-operator v1.0.13-0.20221018121846-032ccd06522c // branch: main
+	github.com/flant/shell-operator v1.0.13-0.20221128074459-7222dec2222f // branch: feat_build_tag_to_enable_libjq_go
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/spec v0.19.8

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a/go.mod h1:+SYqi5w
 github.com/flant/logboek v0.3.4 h1://0FHwS7hoLHTz7H+JlLheKlu298edC+qV61ca9OJBQ=
 github.com/flant/logboek v0.3.4/go.mod h1:/vKAVARjAIs2OlxxDRn7SvltNVcWMb1Ifo23kCDJZco=
 github.com/flant/shell-operator v1.0.12/go.mod h1:jX93Qs9VqikWb6PCj0mZHS++DeLx4I3yfuTr5KzvBso=
-github.com/flant/shell-operator v1.0.13-0.20221018121846-032ccd06522c h1:6nc/DYDzA74Xcc0qctoJbuEJ+1e3uNgEOqH2Dp/ynus=
-github.com/flant/shell-operator v1.0.13-0.20221018121846-032ccd06522c/go.mod h1:jX93Qs9VqikWb6PCj0mZHS++DeLx4I3yfuTr5KzvBso=
+github.com/flant/shell-operator v1.0.13-0.20221128074459-7222dec2222f h1:MTjpIB2iIbAA69cbcCYK/npL6Nnv+DpjkJi98w0ajCE=
+github.com/flant/shell-operator v1.0.13-0.20221128074459-7222dec2222f/go.mod h1:jX93Qs9VqikWb6PCj0mZHS++DeLx4I3yfuTr5KzvBso=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/werf.yaml
+++ b/werf.yaml
@@ -317,10 +317,6 @@ import:
   add: /out/deckhouse-controller
   to: /usr/bin/deckhouse-controller
   after: setup
-- artifact: libjq
-  add: /libjq
-  to: /libjq
-  after: setup
 - artifact: jq
   add: /usr/bin/jq
   to: /usr/bin/jq
@@ -364,8 +360,6 @@ docker:
     DECKHOUSE_POD: tests
     MODULES_DIR: /deckhouse/modules
     GLOBAL_HOOKS_DIR: /deckhouse/global-hooks
-    CGO_CFLAGS: "-I/libjq/include"
-    CGO_LDFLAGS: "-L/libjq/lib"
 ---
 artifact: deckhouse-controller
 fromImage: base-for-go
@@ -403,11 +397,6 @@ git:
       - modules/**/*.go
 {{ .Files.Get (printf "tools/build_includes/modules-with-dependencies-%s.yaml" .Env) }}
 {{ .Files.Get (printf "tools/build_includes/candi-%s.yaml" .Env) }}
-import:
-- artifact: libjq
-  add: /libjq
-  to: /libjq
-  before: setup
 mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg
@@ -427,7 +416,7 @@ shell:
   # into separate phases.
   - go mod download
   - cd /deckhouse/deckhouse-controller
-  - ./go-build.sh /libjq
+  - ./go-build.sh
   - mv deckhouse-controller /out
 
 ---
@@ -497,26 +486,6 @@ ansible:
       make LDFLAGS=-all-static
       make prefix=/usr install
 
----
-artifact: libjq
-from: {{ .Images.BASE_ALPINE }}
-fromCacheVersion: "20210527"
-git:
-- url: https://github.com/flant/libjq-go
-  tag: v1.6.2
-  add: /
-  to: /src
-  stageDependencies:
-    install:
-      - "scripts/**"
-    setup:
-      - "modules/**"
-ansible:
-  install:
-  - shell: /src/scripts/install-libjq-dependencies-alpine.sh
-  - raw: rm -rf /var/cache/apk/*
-  setup:
-  - shell: /src/scripts/build-libjq-static.sh /src /libjq
 ---
 image: dev/install
 from: {{ .Images.BASE_ALPINE }}


### PR DESCRIPTION
## Description

Remove libjq-go from build.

Supporting PR: https://github.com/flant/shell-operator/pull/440

## Why do we need it, and what problem does it solve?

libjq is not needed for Go hooks.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse-controller
type: chore
summary: Remove libjq-go from build
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
