### PR TITLE
[deckhouse-config] update version for configs with empty spec.settings

### DIFF
--- a/go_lib/deckhouse-config/status.go
+++ b/go_lib/deckhouse-config/status.go
@@ -62,7 +62,7 @@ func (s *StatusReporter) ForConfig(cfg *d8cfg_v1alpha1.ModuleConfig, bundleName 
 		// Use latest version if spec.version is empty.
 		version = strconv.Itoa(chain.LatestVersion())
 	}
-	if cfg.Spec.Version > 0 && len(cfg.Spec.Settings) > 0 {
+	if cfg.Spec.Version > 0 {
 		version = strconv.Itoa(cfg.Spec.Version)
 		if !chain.IsKnownVersion(cfg.Spec.Version) {
 			versionWarning = fmt.Sprintf("Error: invalid spec.version, use version %d", chain.LatestVersion())

--- a/modules/003-deckhouse-config/hooks/update_status.go
+++ b/modules/003-deckhouse-config/hooks/update_status.go
@@ -123,6 +123,7 @@ func updateModuleConfigStatuses(input *go_hook.HookInput) error {
 		moduleStatus := d8config.Service().StatusReporter().ForConfig(cfg, bundleName)
 		statusPatch := makeStatusPatch(cfg, moduleStatus)
 		if statusPatch != nil {
+			// TODO Switch to debug level in 1.42 release.
 			input.LogEntry.Infof(
 				"Patch /status for moduleconfig/%s: state '%s' to '%s', version '%s' to %s', status '%s' to '%s'",
 				cfg.GetName(),

--- a/modules/003-deckhouse-config/hooks/update_status.go
+++ b/modules/003-deckhouse-config/hooks/update_status.go
@@ -123,7 +123,13 @@ func updateModuleConfigStatuses(input *go_hook.HookInput) error {
 		moduleStatus := d8config.Service().StatusReporter().ForConfig(cfg, bundleName)
 		statusPatch := makeStatusPatch(cfg, moduleStatus)
 		if statusPatch != nil {
-			input.LogEntry.Infof("Patch /status for %s: change (state=%s, status=%s) to state=%s, status=%s", cfg.GetName(), cfg.Status.State, cfg.Status.Status, statusPatch.State, statusPatch.Status)
+			input.LogEntry.Infof(
+				"Patch /status for moduleconfig/%s: state '%s' to '%s', version '%s' to %s', status '%s' to '%s'",
+				cfg.GetName(),
+				cfg.Status.State, statusPatch.State,
+				cfg.Status.Version, statusPatch.Version,
+				cfg.Status.Status, statusPatch.Status,
+			)
 			input.PatchCollector.MergePatch(statusPatch, "deckhouse.io/v1alpha1", "ModuleConfig", "", cfg.GetName(), object_patch.WithSubresource("/status"))
 		}
 	}


### PR DESCRIPTION
## Description

Update version for configs with empty spec.settings.

## Why do we need it, and what problem does it solve?

Should display version for empty settings:

```
spec:
  enabled: false
  settings: {}
  version: 1
```

```
NAME                       STATE      VERSION   STATUS   AGE
log-shipper                Enabled    1                  73m
node-local-dns             Disabled                      39m
prometheus                 Enabled    2                  73m
```

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse-config
type: fix
summary: Update version for configs with empty spec.settings.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
