### PR TITLE
[dhctl] Fix struct_vs_unmarshal test

### DIFF
--- a/dhctl/pkg/kubernetes/actions/manifests/manifests_test.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests_test.go
@@ -84,6 +84,7 @@ func Test_struct_vs_unmarshal(t *testing.T) {
 		LogLevel:         "debug",
 		Bundle:           "default",
 		IsSecureRegistry: true,
+		DeployTime:       time.Now(),
 	}
 
 	depl1 := DeckhouseDeployment(params)


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Fix struct_vs_unmarshal test

## Why do we need it, and what problem does it solve?
Test was unstable and was not passed. [Example](https://github.com/deckhouse/deckhouse/actions/runs/3523321321/jobs/5907568953)

## What is the expected result?
Test always should pass

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: fix
summary: Fix struct_vs_unmarshal test
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
