### PR TITLE
[e2e tests, azure] Fix zone discovery and matching

### DIFF
--- a/modules/500-upmeter/hooks/dynamic_probe/hook.go
+++ b/modules/500-upmeter/hooks/dynamic_probe/hook.go
@@ -169,17 +169,18 @@ func filterCloudProviderAvailabilityZonesFromSecret(obj *unstructured.Unstructur
 		return nil, err
 	}
 
-	region, ok := secret.Data["region"]
-	if !ok {
-		return loc, nil
-	}
 	provider, ok := secret.Data["type"]
 	if !ok {
 		return loc, nil
 	}
 	if string(provider) == "azure" {
+		region, ok := secret.Data["region"]
+		if !ok {
+			return loc, fmt.Errorf("azure cloud provider secret must contain region")
+		}
+
 		// Azure zones are in format "region-zone", and we have to track the knowledge of the zone
-		// prefix
+		// prefix since nodegroups don't carry the region information themselves.
 		loc.zonePrefix = string(region)
 		for i, zone := range loc.zones {
 			loc.zones[i] = fmt.Sprintf("%s-%s", region, zone)

--- a/modules/500-upmeter/hooks/dynamic_probe/hook.go
+++ b/modules/500-upmeter/hooks/dynamic_probe/hook.go
@@ -97,12 +97,12 @@ func collectDynamicNames(input *go_hook.HookInput) error {
 	// prefix, e.g. "west-1" will be just "1" in Azure.
 	data := emptyNames().
 		WithIngressControllers(ingressNames...).
-		WithZonePrefix(loc.zonePrefix)
+		WithZonePrefix(loc.ZonePrefix)
 
 	// We can track ephemeral node groups if only we have zones present in cloud provider secret.
-	if len(loc.zones) > 0 {
+	if len(loc.Zones) > 0 {
 		data = data.
-			WithZones(loc.zones...).
+			WithZones(loc.Zones...).
 			WithNodeGroups(nodeGroupNames...)
 	}
 
@@ -141,8 +141,8 @@ func filterNamesFromConfigmap(obj *unstructured.Unstructured) (go_hook.FilterRes
 // cloudLocations contains zones (with prefixes) and reqion prefix itself for NodeGroup fetcher in
 // Upmeter Agent.
 type cloudLocations struct {
-	zones      []string
-	zonePrefix string
+	Zones      []string
+	ZonePrefix string
 }
 
 func parseCloudLocations(filtered []go_hook.FilterResult) cloudLocations {
@@ -150,7 +150,7 @@ func parseCloudLocations(filtered []go_hook.FilterResult) cloudLocations {
 		return cloudLocations{}
 	}
 	loc := filtered[0].(cloudLocations)                  // let it panic
-	loc.zones = set.New(loc.zones...).Delete("").Slice() // unique and non-empty
+	loc.Zones = set.New(loc.Zones...).Delete("").Slice() // unique and non-empty
 	return loc
 }
 
@@ -168,7 +168,7 @@ func filterCloudProviderAvailabilityZonesFromSecret(obj *unstructured.Unstructur
 		// zone absence is fine for static clusters
 		return loc, nil
 	}
-	if err := yaml.Unmarshal(zoneData, &loc.zones); err != nil {
+	if err := yaml.Unmarshal(zoneData, &loc.Zones); err != nil {
 		return nil, err
 	}
 
@@ -184,9 +184,9 @@ func filterCloudProviderAvailabilityZonesFromSecret(obj *unstructured.Unstructur
 
 		// Azure zones are in format "region-zone", and we have to track the knowledge of the zone
 		// prefix since nodegroups don't carry the region information themselves.
-		loc.zonePrefix = string(region)
-		for i, zone := range loc.zones {
-			loc.zones[i] = fmt.Sprintf("%s-%s", region, zone)
+		loc.ZonePrefix = string(region)
+		for i, zone := range loc.Zones {
+			loc.Zones[i] = fmt.Sprintf("%s-%s", region, zone)
 		}
 	}
 

--- a/modules/500-upmeter/hooks/dynamic_probe/hook.go
+++ b/modules/500-upmeter/hooks/dynamic_probe/hook.go
@@ -94,9 +94,11 @@ func collectDynamicNames(input *go_hook.HookInput) error {
 	)
 
 	// Populate values
-	data := emptyNames().WithIngressControllers(ingressNames...)
+	data := emptyNames().
+		WithIngressControllers(ingressNames...).
+		WithZonePrefix(loc.zonePrefix)
 
-	// We cannot track any ephemeral node group if no zones present in cloud provider secret.
+	// We can track ephemeral node groups if only we have zones present in cloud provider secret.
 	if len(loc.zones) > 0 {
 		data = data.
 			WithZones(loc.zones...).

--- a/modules/500-upmeter/hooks/dynamic_probe/hook.go
+++ b/modules/500-upmeter/hooks/dynamic_probe/hook.go
@@ -93,7 +93,8 @@ func collectDynamicNames(input *go_hook.HookInput) error {
 		loc            = parseCloudLocations(input.Snapshots["cloud_provider_secret"])
 	)
 
-	// Populate values
+	// Populate values. `zonePrefix` is for cloud zones that are passed around without region
+	// prefix, e.g. "west-1" will be just "1" in Azure.
 	data := emptyNames().
 		WithIngressControllers(ingressNames...).
 		WithZonePrefix(loc.zonePrefix)
@@ -137,6 +138,8 @@ func filterNamesFromConfigmap(obj *unstructured.Unstructured) (go_hook.FilterRes
 	return names, nil
 }
 
+// cloudLocations contains zones (with prefixes) and reqion prefix itself for NodeGroup fetcher in
+// Upmeter Agent.
 type cloudLocations struct {
 	zones      []string
 	zonePrefix string

--- a/modules/500-upmeter/hooks/dynamic_probe/hook.go
+++ b/modules/500-upmeter/hooks/dynamic_probe/hook.go
@@ -17,6 +17,8 @@ limitations under the License.
 package dynamic_probe
 
 import (
+	"fmt"
+
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
@@ -150,7 +152,7 @@ func filterCloudProviderAvailabilityZonesFromSecret(obj *unstructured.Unstructur
 		return nil, err
 	}
 
-	regionData, ok := secret.Data["region"]
+	region, ok := secret.Data["region"]
 	if !ok {
 		return []string{}, nil
 	}
@@ -161,7 +163,8 @@ func filterCloudProviderAvailabilityZonesFromSecret(obj *unstructured.Unstructur
 	if string(providerData) == "azure" {
 		// Azure zones are in format "region-zone"
 		for i, zone := range zones {
-			zones[i] = string(regionData) + "-" + zone
+			zones[i] = fmt.Sprintf("%s-%s", region, zone)
+
 		}
 	}
 

--- a/modules/500-upmeter/hooks/dynamic_probe/names.go
+++ b/modules/500-upmeter/hooks/dynamic_probe/names.go
@@ -22,6 +22,7 @@ type names struct {
 	IngressControllerNames       []string `json:"ingressControllerNames"`
 	CloudEphemeralNodeGroupNames []string `json:"cloudEphemeralNodeGroupNames"`
 	Zones                        []string `json:"zones"`
+	ZonePrefix                   string   `json:"zonePrefix"`
 }
 
 // emptyNames fills fields with non-nil values
@@ -40,6 +41,11 @@ func (n *names) WithIngressControllers(ingNames ...string) *names {
 
 func (n *names) WithZones(zones ...string) *names {
 	n.Zones = zones
+	return n
+}
+
+func (n *names) WithZonePrefix(p string) *names {
+	n.ZonePrefix = p
 	return n
 }
 

--- a/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
+++ b/modules/500-upmeter/images/upmeter/cmd/upmeter/parse_args.go
@@ -127,6 +127,10 @@ func parseAgentArgs(cmd *kingpin.CmdClause, config *agent.Config) {
 	cmd.Flag("dynamic-probe-known-zone", "A known zone for node group").
 		StringsVar(&config.DynamicProbes.Zones)
 
+	// Zone prefix that can be used in some cloud providers
+	cmd.Flag("dynamic-probe-known-zoneprefix", "A known zone prefix for current cloud provider").
+		StringVar(&config.DynamicProbes.ZonePrefix)
+
 	// User-Agent
 	// TODO generate from CI?
 	cmd.Flag("user-agent", "User Agent for HTTP client").

--- a/modules/500-upmeter/images/upmeter/pkg/agent/agent.go
+++ b/modules/500-upmeter/images/upmeter/pkg/agent/agent.go
@@ -60,6 +60,7 @@ type DynamicProbesConfig struct {
 	IngressControllers []string
 	NodeGroups         []string
 	Zones              []string
+	ZonePrefix         string
 }
 
 func NewConfig() *Config {
@@ -91,6 +92,7 @@ func (a *Agent) Start(ctx context.Context) error {
 		IngressNginxControllers: a.config.DynamicProbes.IngressControllers,
 		NodeGroups:              a.config.DynamicProbes.NodeGroups,
 		Zones:                   a.config.DynamicProbes.Zones,
+		ZonePrefix:              a.config.DynamicProbes.ZonePrefix,
 	}
 
 	nodeMon := node.NewMonitor(kubeAccess.Kubernetes(), log.NewEntry(a.logger))

--- a/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_nodegroup.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/checker/k8s_nodegroup.go
@@ -18,7 +18,6 @@ package checker
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -213,17 +212,9 @@ func (f *nodeGroupFetcher) fetchAzureRegion() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	azureValues, ok := cloudProviderSettings.Data["azure"]
+	region, ok := cloudProviderSettings.Data["region"]
 	if !ok {
-		return "", fmt.Errorf("azure cloud provider settings not found")
-	}
-	var azureSettings map[string]string
-	if err := json.Unmarshal(azureValues, &azureSettings); err != nil {
-		return "", fmt.Errorf("failed to unmarshal azure cloud provider settings: %v", err)
-	}
-	region, ok := azureSettings["location"]
-	if !ok {
-		return "", fmt.Errorf("azure cloud provider settings does not contain location")
+		return "", fmt.Errorf("azure cloud provider does not contain region")
 	}
 	f.azureRegion = string(region)
 	return f.azureRegion, nil

--- a/modules/500-upmeter/images/upmeter/pkg/probe/group_nodegroups.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/group_nodegroups.go
@@ -27,7 +27,7 @@ import (
 	"d8.io/upmeter/pkg/probe/checker"
 )
 
-func initNodeGroups(access kubernetes.Access, nodeLister node.Lister, preflight checker.Doer, nodeGroupNames, knownZones []string) []runnerConfig {
+func initNodeGroups(access kubernetes.Access, nodeLister node.Lister, preflight checker.Doer, nodeGroupNames, knownZones []string, zonePrefix string) []runnerConfig {
 	const (
 		groupNodeGroups     = "nodegroups"
 		controlPlaneTimeout = 5 * time.Second
@@ -38,7 +38,7 @@ func initNodeGroups(access kubernetes.Access, nodeLister node.Lister, preflight 
 
 	for _, ngName := range nodeGroupNames {
 		configs = append(configs,
-			nodeGroupChecker(access, nodeLister, groupNodeGroups, controlPlanePinger, controlPlaneTimeout, ngName, knownZones),
+			nodeGroupChecker(access, nodeLister, groupNodeGroups, controlPlanePinger, controlPlaneTimeout, ngName, knownZones, zonePrefix),
 		)
 	}
 	return configs
@@ -52,6 +52,7 @@ func nodeGroupChecker(
 	controlPlaneTimeout time.Duration,
 	ngName string,
 	zones []string,
+	zonePrefix string,
 ) runnerConfig {
 	ngLister := &nodeGroupLister{
 		name:     ngName,
@@ -72,6 +73,7 @@ func nodeGroupChecker(
 
 			Name:       ngName,
 			KnownZones: zones,
+			ZonePrefix: zonePrefix,
 		},
 	}
 }

--- a/modules/500-upmeter/images/upmeter/pkg/probe/load.go
+++ b/modules/500-upmeter/images/upmeter/pkg/probe/load.go
@@ -67,6 +67,7 @@ type DynamicConfig struct {
 	IngressNginxControllers []string
 	NodeGroups              []string
 	Zones                   []string
+	ZonePrefix              string
 }
 
 func (l *Loader) Load() []*check.Runner {
@@ -146,7 +147,7 @@ func (l *Loader) collectConfigs() []runnerConfig {
 	l.configs = append(l.configs, initLoadBalancing(l.access, l.preflight)...)
 	l.configs = append(l.configs, initDeckhouse(l.access, l.preflight, l.logger)...)
 	l.configs = append(l.configs, initNginx(l.access, l.preflight, l.dynamic.IngressNginxControllers)...)
-	l.configs = append(l.configs, initNodeGroups(l.access, l.nodeLister, l.preflight, l.dynamic.NodeGroups, l.dynamic.Zones)...)
+	l.configs = append(l.configs, initNodeGroups(l.access, l.nodeLister, l.preflight, l.dynamic.NodeGroups, l.dynamic.Zones, l.dynamic.ZonePrefix)...)
 
 	return l.configs
 }

--- a/modules/500-upmeter/openapi/values.yaml
+++ b/modules/500-upmeter/openapi/values.yaml
@@ -88,6 +88,9 @@ properties:
             default: []
             items:
               type: string
+          zonePrefix:
+            type: string
+            default: ""
       auth:
         type: object
         default: {}

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -103,6 +103,7 @@ spec:
               {{- range $zone := .Values.upmeter.internal.dynamicProbes.zones }}
             - --dynamic-probe-known-zone={{ $zone }}
               {{- end }}
+            - --dynamic-probe-known-zoneprefix={{ .Values.upmeter.internal.dynamicProbes.zonePrefix}}
             {{- end }}
           volumeMounts:
           - mountPath: /db


### PR DESCRIPTION
## Description

Fix nodegroup probe for clusters in Azure Cloud

## Why do we need it, and what problem does it solve?

In Azure, we have mismatch between VM zones ("1", "2", "3") used in upmeter zone discovery. But nodes have topology.kubernetes.io/zone label in the form '$region-1', '$region-2', etc. We have to add a workaround for that.

In future, deckhouse-wise zone notation can be chosen separately from what Azure tooling accepts on input. 

## What is the expected result?

e2e tests in Azure pass

## Checklist
- [x] e2e tests passed.

## Changelog entries


```changes
section: upmeter
type: fix
summary: Fixed nodegroup probe for clusters in Azure by fixing zone name discovery.
```
