### PR TITLE
[deckhouse-config] fix deckhouse-config webhook build

### DIFF
--- a/modules/003-deckhouse-config/images/deckhouse-config-webhook/werf.inc.yaml
+++ b/modules/003-deckhouse-config/images/deckhouse-config-webhook/werf.inc.yaml
@@ -1,7 +1,6 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ .Images.BASE_ALPINE }}
-#from: { { .BaseAlpine }}
 git:
   - add: /
     to: /deckhouse
@@ -18,6 +17,21 @@ git:
 {{ if eq .Env "FE" }}
       - ee/modules/*/openapi
       - ee/fe/modules/*/openapi
+{{ end }}
+stageDependencies:
+  install:
+    - modules/*/openapi
+    - global-hooks/openapi
+    # Include schemas from candi.
+    - candi/openapi/*
+    - candi/cloud-providers/*/openapi
+    # Include EE and FE modules.
+{{ if eq .Env "EE" }}
+    - ee/modules/*/openapi
+{{ end }}
+{{ if eq .Env "FE" }}
+    - ee/modules/*/openapi
+    - ee/fe/modules/*/openapi
 {{ end }}
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
@@ -36,19 +50,11 @@ docker:
 {{ $webhookRelPath := "modules/003-deckhouse-config/images/deckhouse-config-webhook" }}
 artifact: {{ .ModuleName }}/{{ .ImageName }}-artifact
 from: {{ .Images.BASE_GOLANG_16_ALPINE }}
-# from: { { .BaseGolang16Alpine }}
 shell:
-  beforeInstall:
-    #- apk add --no-cache git
   install:
     - cd {{ $webhookAbsPath }}
     - go mod download
   setup:
-    # Migrate ee/fe internal packages imports.
-#    - find /deckhouse/modules -type f -name '*.go' -exec sed -E -i 's|github.com/deckhouse/deckhouse/ee/modules|github.com/deckhouse/deckhouse/modules|g' {} +
-#    - find /deckhouse/modules -type f -name '*.go' -exec sed -E -i 's|github.com/deckhouse/deckhouse/ee/fe/modules|github.com/deckhouse/deckhouse/modules|g' {} +
-#    - find {{ $webhookAbsPath }} -type f -name '*.go' -exec sed -E -i 's|github.com/deckhouse/deckhouse/ee/modules|github.com/deckhouse/deckhouse/modules|g' {} +
-#    - find {{ $webhookAbsPath }} -type f -name '*.go' -exec sed -E -i 's|github.com/deckhouse/deckhouse/ee/fe/modules|github.com/deckhouse/deckhouse/modules|g' {} +
     - cd {{ $webhookAbsPath }}
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o deckhouse-config-webhook
     - mkdir /src

--- a/modules/003-deckhouse-config/images/deckhouse-config-webhook/werf.inc.yaml
+++ b/modules/003-deckhouse-config/images/deckhouse-config-webhook/werf.inc.yaml
@@ -18,20 +18,20 @@ git:
       - ee/modules/*/openapi
       - ee/fe/modules/*/openapi
 {{ end }}
-stageDependencies:
-  install:
-    - modules/*/openapi
-    - global-hooks/openapi
-    # Include schemas from candi.
-    - candi/openapi/*
-    - candi/cloud-providers/*/openapi
-    # Include EE and FE modules.
+    stageDependencies:
+      install:
+        - modules/*/openapi
+        - global-hooks/openapi
+        # Include schemas from candi.
+        - candi/openapi/*
+        - candi/cloud-providers/*/openapi
+        # Include EE and FE modules.
 {{ if eq .Env "EE" }}
-    - ee/modules/*/openapi
+        - ee/modules/*/openapi
 {{ end }}
 {{ if eq .Env "FE" }}
-    - ee/modules/*/openapi
-    - ee/fe/modules/*/openapi
+        - ee/modules/*/openapi
+        - ee/fe/modules/*/openapi
 {{ end }}
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact


### PR DESCRIPTION
## Description

Add stageDependencies to not fail on gitLatestPatch.

## Why do we need it, and what problem does it solve?

Fix build error:

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/1055474/203533122-69cd3a8e-67c2-469d-a53a-20a873f5d0b4.png">


## What is the expected result?

All PR builds are successful.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse-config
type: chore
summary: fix deckhouse-config webhook build
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
