### PR TITLE
[docs] Clarify using the ClusterConfiguration and the <provider>ClusterConfiguration parameters

### DIFF
--- a/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
@@ -25,6 +25,8 @@ apiVersions:
         required: [replicas, instanceClass]
         description: |
           Parameters of the master's NodeGroup.
+
+          > Caution! After changing the parameters of the section, you need to run `dhctl converge` for the changes to take effect.
         properties:
           replicas:
             type: integer

--- a/candi/cloud-providers/aws/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/doc-ru-cluster_configuration.yaml
@@ -8,7 +8,10 @@ apiVersions:
 
           Учетная запись должна иметь доступ ко всем VPC в списке. Также вы можете настроить соединение [вручную](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html), если доступа нет.
       masterNodeGroup:
-        description: Спецификация для описания NodeGroup master-узлов.
+        description: |
+          Спецификация для описания NodeGroup master-узлов.
+
+          > Внимание! После изменения параметров секции `masterNodeGroup` необходимо выполнить команду `dhctl converge`, чтобы изменения вступили в силу.
         properties:
           replicas:
             description: Сколько master-узлов создавать.

--- a/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
@@ -93,6 +93,8 @@ apiVersions:
       masterNodeGroup:
         description: |
           The definition of the master's NodeGroup.
+
+          > Caution! After changing the parameters of the section, you need to run `dhctl converge` for the changes to take effect.
         required: [replicas, instanceClass]
         properties:
           replicas:

--- a/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
@@ -46,6 +46,8 @@ apiVersions:
       masterNodeGroup:
         description: |
           Спецификация для описания NodeGroup master-узлов.
+
+          > Внимание! После изменения параметров секции `masterNodeGroup` необходимо выполнить команду `dhctl converge`, чтобы изменения вступили в силу.
         properties:
           replicas:
             description: |

--- a/candi/cloud-providers/gcp/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/gcp/openapi/cluster_configuration.yaml
@@ -50,7 +50,10 @@ apiVersions:
       masterNodeGroup:
         type: object
         required: [replicas, instanceClass]
-        description: Parameters of the master's NodeGroup.
+        description: |
+          Parameters of the master's NodeGroup.
+
+          > Caution! After changing the parameters of the section, you need to run `dhctl converge` for the changes to take effect.
         properties:
           replicas:
             type: integer

--- a/candi/cloud-providers/gcp/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/gcp/openapi/doc-ru-cluster_configuration.yaml
@@ -26,7 +26,10 @@ apiVersions:
 
           Сервис-аккаунт должен иметь доступ ко всем перечисленным VPC. Если доступа нет, то пиринг необходимо [настраивать вручную](https://cloud.google.com/vpc/docs/using-vpc-peering#gcloud).
       masterNodeGroup:
-        description: Спецификация для описания NodeGroup master-узлов.
+        description: |
+          Спецификация для описания NodeGroup master-узлов.
+
+          > Внимание! После изменения параметров секции `masterNodeGroup` необходимо выполнить команду `dhctl converge`, чтобы изменения вступили в силу.
         properties:
           replicas:
             description: Сколько master-узлов создавать.

--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -37,6 +37,8 @@ apiVersions:
         type: object
         description: |
           The definition of the master's NodeGroup.
+
+          > Caution! After changing the parameters of the section, you need to run `dhctl converge` for the changes to take effect.
         additionalProperties: false
         required: [replicas, instanceClass]
         properties:

--- a/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
@@ -8,6 +8,8 @@ apiVersions:
       masterNodeGroup:
         description: |
           Спецификация для описания NodeGroup master-узлов.
+
+          > Внимание! После изменения параметров секции `masterNodeGroup` необходимо выполнить команду `dhctl converge`, чтобы изменения вступили в силу.
         properties:
           replicas:
             description: |

--- a/candi/openapi/cluster_configuration.yaml
+++ b/candi/openapi/cluster_configuration.yaml
@@ -76,7 +76,10 @@ apiVersions:
         description: Address space of the cluster's Pods.
       podSubnetNodeCIDRPrefix:
         type: string
-        description: The prefix of Pod network on a node.
+        description: |
+          The prefix of Pod network on a node.
+
+          > Caution! Don't change the parameter in a working cluster.
         default: "24"
       serviceSubnetCIDR:
         type: string

--- a/candi/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/openapi/doc-ru-cluster_configuration.yaml
@@ -37,6 +37,8 @@ apiVersions:
       podSubnetNodeCIDRPrefix:
         description: |
           Префикс сети Pod'ов на узле.
+
+          > Внимание! Не меняйте параметр в уже развернутом кластере.
       serviceSubnetCIDR:
         description: |
           Адресное пространство для service'ов кластера.

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -251,14 +251,7 @@ To switch the Deckhouse cluster to using a third-party registry, follow these st
 
 ## How do I change the configuration of a cluster?
 
-The general cluster parameters are stored in the `ClusterConfiguration` structure. It contains parameters such as:
-
-- cluster domain: `clusterDomain`;
-- CRI used in the cluster: `defaultCRI`;
-- Kubernetes control plane version: `kubernetesVersion`;
-- cluster type (Static, Cloud): `clusterType`;
-- address space of the cluster's Pods: `podSubnetCIDR`;
-- address space of the cluster's services: `serviceSubnetCIDR` etc.
+The general cluster parameters are stored in the [ClusterConfiguration](installing/configuration.html#clusterconfiguration) structure. It contains parameters such as:
 
 To change the general cluster parameters, run the command:
 
@@ -266,9 +259,11 @@ To change the general cluster parameters, run the command:
 kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit cluster-configuration
 ```
 
+After saving the changes, Deckhouse will bring the cluster configuration to the state according to the changed configuration. Depending on the size of the cluster, this may take some time.
+
 ## How do I change the configuration of a cloud provider in a cluster?
 
-Cloud provider setting of a cloud of hybrid cluster are stored in the `<PROVIDER_NAME>ClusterConfiguration` structure, where `<PROVIDER_NAME>` — name/code of the cloud provider. E.g., for an OpenStack provider, the structure will be called `OpenStackClusterConfiguration`.
+Cloud provider setting of a cloud of hybrid cluster are stored in the `<PROVIDER_NAME>ClusterConfiguration` structure, where `<PROVIDER_NAME>` — name/code of the cloud provider. E.g., for an OpenStack provider, the structure will be called [OpenStackClusterConfiguration]({% if site.mode == 'local' and site.d8Revision == 'CE' %}{{ site.urls[page.lang] }}/documentation/v1/{% endif %}modules/030-cloud-provider-openstack/cluster_configuration.html).
 
 Regardless of the cloud provider used, its settings can be changed using the command:
 
@@ -278,7 +273,7 @@ kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit prov
 
 ## How do I change the configuration of a static cluster?
 
-Settings of a static cluster are stored in the `StaticClusterConfiguration` structure.
+Settings of a static cluster are stored in the [StaticClusterConfiguration](installing/configuration.html#staticclusterconfiguration) structure.
 
 To change the settings of a static cluster, run the command:
 
@@ -288,7 +283,7 @@ kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit stat
 
 ## How do I upgrade the Kubernetes version in a cluster?
 
-To upgrade the Kubernetes version in a cluster change the `kubernetesVersion` parameter in the `ClusterConfiguration` structure by making the following steps:
+To upgrade the Kubernetes version in a cluster change the [kubernetesVersion](installing/configuration.html#parameters-kubernetesversion) parameter in the [ClusterConfiguration](installing/configuration.html#clusterconfiguration) structure by making the following steps:
 1. Run the command:
 
    ```shell
@@ -296,4 +291,5 @@ To upgrade the Kubernetes version in a cluster change the `kubernetesVersion` pa
    ```
 
 1. Change the `kubernetesVersion` field.
-1. Save the changes.
+1. Save the changes. Cluster nodes will start updating sequentially.
+1. Wait for the update to finish. You can track the progress of the update using the `kubectl get no` command. The update is completed when the new version appears in the command's output for each cluster node in the `VERSION` column.

--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -251,7 +251,7 @@ To switch the Deckhouse cluster to using a third-party registry, follow these st
 
 ## How do I change the configuration of a cluster?
 
-The general cluster parameters are stored in the [ClusterConfiguration](installing/configuration.html#clusterconfiguration) structure. It contains parameters such as:
+The general cluster parameters are stored in the [ClusterConfiguration](installing/configuration.html#clusterconfiguration) structure.
 
 To change the general cluster parameters, run the command:
 

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -255,14 +255,7 @@ chmod 700 d8-push.sh
 
 ## Как изменить конфигурацию кластера
 
-Общие параметры кластера хранятся в структуре `ClusterConfiguration`. Она содержит такие параметры, как:
-
-- домен кластера: `clusterDomain`;
-- используемый CRI: `defaultCRI`;
-- используемая версия control plane Kubernetes: `kubernetesVersion`;
-- тип кластера (Static, Cloud): `clusterType`;
-- сеть Pod’ов кластера: `podSubnetCIDR`;
-- сеть для service’ов кластера: `serviceSubnetCIDR` и др.
+Общие параметры кластера хранятся в структуре [ClusterConfiguration](installing/configuration.html#clusterconfiguration).
 
 Чтобы изменить общие параметры кластера, выполните команду:
 
@@ -270,9 +263,11 @@ chmod 700 d8-push.sh
 kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit cluster-configuration
 ```
 
+После сохранения изменений Deckhouse приведет конфигурацию кластера к измененному состоянию. В зависимости от размеров кластера это может занять какое-то время.
+
 ## Как изменить конфигурацию облачного провайдера в кластере?
 
-Настройки используемого облачного провайдера в облачном или гибридном кластере хранятся в структуре `<PROVIDER_NAME>ClusterConfiguration`, где `<PROVIDER_NAME>` — название/код провайдера. Например, для провайдера OpenStack структура будет называться `OpenStackClusterConfiguration`.
+Настройки используемого облачного провайдера в облачном или гибридном кластере хранятся в структуре `<PROVIDER_NAME>ClusterConfiguration`, где `<PROVIDER_NAME>` — название/код провайдера. Например, для провайдера OpenStack структура будет называться [OpenStackClusterConfiguration]({% if site.mode == 'local' and site.d8Revision == 'CE' %}{{ site.urls[page.lang] }}/documentation/v1/{% endif %}modules/030-cloud-provider-openstack/cluster_configuration.html).
 
 Независимо от используемого облачного провайдера, его настройки можно изменить с помощью команды:
 
@@ -282,7 +277,7 @@ kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit prov
 
 ## Как изменить конфигурацию статического кластера?
 
-Настройки статического кластера хранятся в структуре `StaticClusterConfiguration`.
+Настройки статического кластера хранятся в структуре [StaticClusterConfiguration](installing/configuration.html#staticclusterconfiguration).
 
 Чтобы изменить параметры статического кластера, выполните команду:
 
@@ -292,7 +287,7 @@ kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit stat
 
 ## Как обновить версию Kubernetes в кластере?
 
-Чтобы обновить версию Kubernetes в кластере, измените параметр `kubernetesVersion` в структуре `ClusterConfiguration` выполнив следующие шаги:
+Чтобы обновить версию Kubernetes в кластере, измените параметр [kubernetesVersion](installing/configuration.html#parameters-kubernetesversion) в структуре [ClusterConfiguration](installing/configuration.html#clusterconfiguration) выполнив следующие шаги:
 1. Выполните команду:
 
    ```shell
@@ -300,4 +295,5 @@ kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit stat
    ```
 
 1. Измените параметр `kubernetesVersion`.
-1. Сохраните изменения.
+1. Сохраните изменения. Узлы кластера начнут последовательно обновляться.
+1. Дождитесь окончания обновления.  Отслеживать ход обновления можно с помощью команды `kubectl get no`. Обновление можно считать завершенным, когда в выводе команды у каждого узла кластера в колонке `VERSION` появится обновленная версия.

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -45,6 +45,8 @@ apiVersions:
       masterNodeGroup:
         description: |
           The definition of the master's NodeGroup.
+
+          > Caution! After changing the parameters of the section, you need to run `dhctl converge` for the changes to take effect.
         x-doc-required: true
         additionalProperties: false
         required: [replicas, instanceClass, volumeTypeMap]

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -22,6 +22,8 @@ apiVersions:
       masterNodeGroup:
         description: |
           Спецификация для описания NodeGroup master-узлов.
+
+          > Внимание! После изменения параметров секции `masterNodeGroup` необходимо выполнить команду `dhctl converge`, чтобы изменения вступили в силу.
         properties:
           replicas:
             description: |

--- a/ee/candi/cloud-providers/vsphere/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vsphere/openapi/cluster_configuration.yaml
@@ -24,6 +24,8 @@ apiVersions:
         required: [replicas, instanceClass]
         description: |
           The definition of the master's NodeGroup.
+
+          > Caution! After changing the parameters of the section, you need to run `dhctl converge` for the changes to take effect.
         properties:
           replicas:
             type: integer

--- a/ee/candi/cloud-providers/vsphere/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vsphere/openapi/doc-ru-cluster_configuration.yaml
@@ -12,6 +12,8 @@ apiVersions:
         masterNodeGroup:
           description: |
             Спецификация для описания NodeGroup master-узлов.
+
+            > Внимание! После изменения параметров секции `masterNodeGroup` необходимо выполнить команду `dhctl converge`, чтобы изменения вступили в силу.
           properties:
             replicas:
               description: |


### PR DESCRIPTION
## Description
Clarify using the ClusterConfiguration and the <provider>ClusterConfiguration parameters.

Close: #2957

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: doc
type: fix
summary: Clarify using the ClusterConfiguration and the <provider>ClusterConfiguration parameters.
impact_level: low
```

