### PR TITLE
[bashible] Show bash debug output for failed sources steps when bootstrap cluster.

### DIFF
--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -239,7 +239,8 @@ function main() {
     echo === Step: $step
     echo ===
     attempt=0
-    until /bin/bash -eEo pipefail -c "export TERM=xterm-256color; unset CDPATH; cd $BOOTSTRAP_DIR; source /var/lib/bashible/bashbooster.sh; source $step"
+    sx=""
+    until /bin/bash -"$sx"eEo pipefail -c "export TERM=xterm-256color; unset CDPATH; cd $BOOTSTRAP_DIR; source /var/lib/bashible/bashbooster.sh; source $step"
     do
       attempt=$(( attempt + 1 ))
       if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then
@@ -251,6 +252,9 @@ function main() {
       echo ===
       echo === Step: $step
       echo ===
+      {{- if eq .runType "ClusterBootstrap" }}
+      if [ "$attempt" -gt 2 ];then sx=x;fi
+      {{- end }}
     done
   done
 

--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -253,7 +253,9 @@ function main() {
       echo === Step: $step
       echo ===
       {{- if eq .runType "ClusterBootstrap" }}
-      if [ "$attempt" -gt 2 ];then sx=x;fi
+      if [ "$attempt" -gt 2 ]; then
+        sx=x
+      fi
       {{- end }}
     done
   done


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Add `-x` parameter for bash source step command if step fail 3 times.

## Why do we need it, and what problem does it solve?
Close #2158

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: bashible
type: feature
summary: Show bash debug output for failed sources steps when bootstrap cluster.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
