### PR TITLE
[monitoring] Add node group filter to Nodes dashboard

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/nodes.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/kubernetes-cluster/nodes/nodes.json
@@ -32,6 +32,7 @@
   "panels": [
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds_prometheus"
       },
       "fieldConfig": {
@@ -388,7 +389,7 @@
       "pluginVersion": "8.5.2",
       "targets": [
         {
-          "expr": "kube_node_info{node=~\"$node\"}",
+          "expr": "kube_node_info{node=~\"$node\"} * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -396,7 +397,7 @@
           "refId": "A"
         },
         {
-          "expr": "count by (node) (node_cpu_seconds_total{node=~\"$node\", mode=\"idle\"})",
+          "expr": "count by (node) (node_cpu_seconds_total{node=~\"$node\", mode=\"idle\"}) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -404,7 +405,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum by (node) (avg_over_time(node_load1{node=~\"$node\"}[$__range]))",
+          "expr": "sum by (node) (avg_over_time(node_load1{node=~\"$node\"}[$__range])) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -412,7 +413,7 @@
           "refId": "C"
         },
         {
-          "expr": "100 - (avg by (node) (rate(node_cpu_seconds_total{node=~\"$node\", mode=\"idle\"}[$__interval_sx4])) * 100 )",
+          "expr": "100 - (avg by (node) (rate(node_cpu_seconds_total{node=~\"$node\", mode=\"idle\"}[$__interval_sx4])) * 100 * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"}))",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -420,7 +421,7 @@
           "refId": "F"
         },
         {
-          "expr": "sum by (node) (avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__range]))",
+          "expr": "sum by (node) (avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__range])) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -428,7 +429,7 @@
           "refId": "G"
         },
         {
-          "expr": "sum by (node) \n  (\n    avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__range])\n    -\n    avg_over_time(node_memory_MemFree_bytes{node=~\"$node\"}[$__range])\n    -\n    avg_over_time(node_memory_Buffers_bytes{node=~\"$node\"}[$__range])\n    -\n    avg_over_time(node_memory_Cached_bytes{node=~\"$node\"}[$__range])\n  )",
+          "expr": "sum by (node) \n  (\n    avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__range])\n    -\n    avg_over_time(node_memory_MemFree_bytes{node=~\"$node\"}[$__range])\n    -\n    avg_over_time(node_memory_Buffers_bytes{node=~\"$node\"}[$__range])\n    -\n    avg_over_time(node_memory_Cached_bytes{node=~\"$node\"}[$__range])\n  ) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -436,7 +437,7 @@
           "refId": "H"
         },
         {
-          "expr": "sum by (node) (avg_over_time(node_memory_Cached_bytes{node=~\"$node\"}[$__range]) + avg_over_time(node_memory_Buffers_bytes{node=~\"$node\"}[$__range]))",
+          "expr": "sum by (node) (avg_over_time(node_memory_Cached_bytes{node=~\"$node\"}[$__range]) + avg_over_time(node_memory_Buffers_bytes{node=~\"$node\"}[$__range])) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -444,7 +445,7 @@
           "refId": "J"
         },
         {
-          "expr": "sum by (node) (rate(node_network_receive_bytes_total{node=~\"$node\", device!~\"lo\"}[$__range]))",
+          "expr": "sum by (node) (rate(node_network_receive_bytes_total{node=~\"$node\", device!~\"lo\"}[$__range])) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -452,7 +453,7 @@
           "refId": "K"
         },
         {
-          "expr": "sum by (node) (rate(node_network_transmit_bytes_total{node=~\"$node\", device!~\"lo\"}[$__range]))",
+          "expr": "sum by (node) (rate(node_network_transmit_bytes_total{node=~\"$node\", device!~\"lo\"}[$__range])) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -460,7 +461,7 @@
           "refId": "L"
         },
         {
-          "expr": "sum by (node) (rate(node_disk_read_bytes_total{node=~\"$node\"}[$__range]))",
+          "expr": "sum by (node) (rate(node_disk_read_bytes_total{node=~\"$node\"}[$__range])) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -468,7 +469,7 @@
           "refId": "M"
         },
         {
-          "expr": "sum by (node) (rate(node_disk_written_bytes_total{node=~\"$node\"}[$__range]))",
+          "expr": "sum by (node) (rate(node_disk_written_bytes_total{node=~\"$node\"}[$__range])) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -569,10 +570,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "P0D6E4079E36703EB"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "count(kube_node_info)",
+          "expr": "count(kube_node_info * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"}))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -619,7 +620,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P0D6E4079E36703EB"
+        "uid": "$ds_prometheus"
       },
       "gridPos": {
         "h": 1,
@@ -638,6 +639,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds_prometheus"
       },
       "editable": true,
@@ -684,7 +686,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "100 - (avg by (node) (rate(node_cpu_seconds_total{node=~\"$node\", mode=\"idle\"}[$__interval_sx4])) * 100 )",
+          "expr": "100 - (avg by (node) (rate(node_cpu_seconds_total{node=~\"$node\", mode=\"idle\"}[$__interval_sx4]) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})) * 100 )",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -734,6 +736,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds_prometheus"
       },
       "editable": true,
@@ -780,7 +783,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum by (node) (avg_over_time(node_load1{node=~\"$node\"}[$__interval_sx3]))",
+          "expr": "sum by (node) (avg_over_time(node_load1{node=~\"$node\"}[$__interval_sx3]) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"}))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ node }}",
@@ -827,6 +830,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds_prometheus"
       },
       "description": "This graph shows the load as a percentage of the number of cores on the node",
@@ -874,7 +878,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum by (node) (avg_over_time(node_load1{node=~\"$node\"}[$__interval_sx3])) / count by (node) (node_cpu_seconds_total{node=~\"$node\", mode=\"idle\"}) * 100",
+          "expr": "(sum by (node) (avg_over_time(node_load1{node=~\"$node\"}[$__interval_sx3])) / count by (node) (node_cpu_seconds_total{node=~\"$node\", mode=\"idle\"}) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ node }}",
@@ -918,7 +922,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "P0D6E4079E36703EB"
+        "uid": "$ds_prometheus"
       },
       "gridPos": {
         "h": 1,
@@ -935,6 +939,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": {
+            "type": "prometheus",
             "uid": "$ds_prometheus"
           },
           "editable": true,
@@ -977,7 +982,7 @@
           "steppedLine": true,
           "targets": [
             {
-              "expr": "sum by (mode) (rate(node_cpu_seconds_total{node=~\"$node\"}[$__interval_sx4])) * 100",
+              "expr": "(sum by (mode) (rate(node_cpu_seconds_total{node=~\"$node\"}[$__interval_sx4]))\n* on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})) * 100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -1026,7 +1031,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P0D6E4079E36703EB"
+        "uid": "$ds_prometheus"
       },
       "gridPos": {
         "h": 1,
@@ -1045,6 +1050,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds_prometheus"
       },
       "editable": true,
@@ -1093,7 +1099,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum by (node) \n  (\n    avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_MemFree_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Buffers_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Cached_bytes{node=~\"$node\"}[$__interval_sx3])\n  )",
+          "expr": "sum by (node) \n  (\n    avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_MemFree_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Buffers_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Cached_bytes{node=~\"$node\"}[$__interval_sx3])\n  ) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1143,6 +1149,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds_prometheus"
       },
       "editable": true,
@@ -1191,7 +1198,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum by (node) \n  (\n    avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_MemFree_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Buffers_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Cached_bytes{node=~\"$node\"}[$__interval_sx3])\n  )\n/\nsum by (node) (avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__interval_sx3]))\n* 100",
+          "expr": "(sum by (node) \n  (\n    avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_MemFree_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Buffers_bytes{node=~\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Cached_bytes{node=~\"$node\"}[$__interval_sx3])\n  )\n/\nsum by (node) (avg_over_time(node_memory_MemTotal_bytes{node=~\"$node\"}[$__interval_sx3]))\n* on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})) * 100",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -1202,7 +1209,7 @@
           "step": 10
         },
         {
-          "expr": "sum by (node) (avg_over_time(node_load1{node=~\"$node\"}[$__interval_sx3])) / count by (node) (node_cpu_seconds_total{node=~\"$node\", mode=\"idle\"}) * 100",
+          "expr": "(sum by (node) (avg_over_time(node_load1{node=~\"$node\"}[$__interval_sx3])) / count by (node) (node_cpu_seconds_total{node=~\"$node\", mode=\"idle\"})\n* on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})) * 100",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 1,
@@ -1245,7 +1252,7 @@
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
-        "uid": "P0D6E4079E36703EB"
+        "uid": "$ds_prometheus"
       },
       "gridPos": {
         "h": 1,
@@ -1262,6 +1269,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": {
+            "type": "prometheus",
             "uid": "$ds_prometheus"
           },
           "editable": true,
@@ -1312,21 +1320,21 @@
           "steppedLine": true,
           "targets": [
             {
-              "expr": "sum by (node) (avg_over_time(node_memory_MemTotal_bytes{node=\"$node\"}[$__interval_sx3]))",
+              "expr": "sum by (node) (avg_over_time(node_memory_MemTotal_bytes{node=\"$node\"}[$__interval_sx3])) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Total",
               "refId": "A"
             },
             {
-              "expr": "sum by (node) (avg_over_time(node_memory_MemFree_bytes{node=\"$node\"}[$__interval_sx3]))",
+              "expr": "sum by (node) (avg_over_time(node_memory_MemFree_bytes{node=\"$node\"}[$__interval_sx3])) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Free",
               "refId": "B"
             },
             {
-              "expr": "sum by (node) \n  (\n    avg_over_time(node_memory_MemTotal_bytes{node=\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_MemFree_bytes{node=\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Buffers_bytes{node=\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Cached_bytes{node=\"$node\"}[$__interval_sx3])\n  )",
+              "expr": "sum by (node) \n  (\n    avg_over_time(node_memory_MemTotal_bytes{node=\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_MemFree_bytes{node=\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Buffers_bytes{node=\"$node\"}[$__interval_sx3])\n    -\n    avg_over_time(node_memory_Cached_bytes{node=\"$node\"}[$__interval_sx3])\n  ) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -1337,14 +1345,14 @@
               "step": 10
             },
             {
-              "expr": "sum by (node) (avg_over_time(node_memory_Cached_bytes{node=\"$node\"}[$__interval_sx3]))",
+              "expr": "sum by (node) (avg_over_time(node_memory_Cached_bytes{node=\"$node\"}[$__interval_sx3])) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Cached",
               "refId": "D"
             },
             {
-              "expr": "sum by (node) (avg_over_time(node_memory_Buffers_bytes{node=\"$node\"}[$__interval_sx3]))",
+              "expr": "sum by (node) (avg_over_time(node_memory_Buffers_bytes{node=\"$node\"}[$__interval_sx3])) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "Buffered",
@@ -1390,7 +1398,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "P0D6E4079E36703EB"
+        "uid": "$ds_prometheus"
       },
       "gridPos": {
         "h": 1,
@@ -1409,6 +1417,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds_prometheus"
       },
       "editable": true,
@@ -1468,7 +1477,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum by (node) (rate(node_disk_read_bytes_total{node=~\"$node\"}[$__interval_sx4]))",
+          "expr": "sum by (node) (rate(node_disk_read_bytes_total{node=~\"$node\"}[$__interval_sx4])) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1516,6 +1525,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds_prometheus"
       },
       "editable": true,
@@ -1575,7 +1585,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum by (node) (rate(node_disk_written_bytes_total{node=~\"$node\"}[$__interval_sx4]))",
+          "expr": "sum by (node) (rate(node_disk_written_bytes_total{node=~\"$node\"}[$__interval_sx4])) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1583,14 +1593,6 @@
           "refId": "A",
           "step": 20,
           "target": ""
-        },
-        {
-          "expr": "",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "refId": "B",
-          "step": 20
         }
       ],
       "thresholds": [],
@@ -1628,7 +1630,7 @@
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
-        "uid": "P0D6E4079E36703EB"
+        "uid": "$ds_prometheus"
       },
       "gridPos": {
         "h": 1,
@@ -1648,6 +1650,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds_prometheus"
       },
       "editable": true,
@@ -1699,7 +1702,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum by (node) (rate(node_network_receive_bytes_total{node=~\"$node\",device!~\"lo\"}[$__interval_sx4]))",
+          "expr": "sum by (node) (rate(node_network_receive_bytes_total{node=~\"$node\",device!~\"lo\"}[$__interval_sx4])) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1750,6 +1753,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
+        "type": "prometheus",
         "uid": "$ds_prometheus"
       },
       "editable": true,
@@ -1801,7 +1805,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum by (node) (rate(node_network_transmit_bytes_total{node=~\"$node\",device!~\"lo\"}[$__interval_sx4]))",
+          "expr": "sum by (node) (rate(node_network_transmit_bytes_total{node=~\"$node\",device!~\"lo\"}[$__interval_sx4])) * on (node) group_left(node_group) sum by(node) (node_group_node_status{node_group=~\"$node_group\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -1886,18 +1890,50 @@
         "definition": "",
         "hide": 0,
         "includeAll": true,
-        "label": "Node",
+        "label": "Node Group",
         "multi": true,
-        "name": "node",
+        "name": "node_group",
         "options": [],
         "query": {
-          "query": "label_values(up{job=\"node-exporter\"}, node)",
+          "query": "label_values(node_group_info, name)",
           "refId": "main-node-Variable-Query"
         },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_prometheus"
+        },
+        "definition": "label_values(node_group_node_status{node_group=~\"$node_group\"}, node)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Node",
+        "multi": true,
+        "name": "node",
+        "options": [],
+        "query": {
+          "query": "label_values(node_group_node_status{node_group=~\"$node_group\"}, node)",
+          "refId": "main-node-Variable-Query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
         "tagValuesQuery": "",
         "tagsQuery": "",
         "type": "query",


### PR DESCRIPTION
Signed-off-by: Vasily Maryutenkov <vasily.maryutenkov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added `Node Group` filter to `Kubernetes Cluster / Nodes` Grafana dashboard

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Allows to view nodes charts in the context of node groups

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

`Kubernetes Cluster / Nodes` Grafana dashboard should work properly

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
