### PR TITLE
[monitoring-ping] Skip unschedulable nodes

### DIFF
--- a/modules/340-monitoring-ping/hooks/discover_targets.go
+++ b/modules/340-monitoring-ping/hooks/discover_targets.go
@@ -92,10 +92,11 @@ func discoverNodes(input *go_hook.HookInput) error {
 	combinedTargets := newTargets()
 
 	for _, address := range input.Snapshots["addresses"] {
-		if address != nil {
-			convertedAddress := address.(nodeTarget)
-			combinedTargets.Cluster = append(combinedTargets.Cluster, convertedAddress)
-		}
+        if address == nil {
+          continue
+        }  
+        convertedAddress := address.(nodeTarget)
+	    combinedTargets.Cluster = append(combinedTargets.Cluster, convertedAddress)
 	}
 
 	for _, target := range input.Values.Get(externalTargetsPath).Array() {

--- a/modules/340-monitoring-ping/hooks/discover_targets.go
+++ b/modules/340-monitoring-ping/hooks/discover_targets.go
@@ -56,6 +56,10 @@ func getAddress(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 		return nil, err
 	}
 
+	if node.Spec.Unschedulable {
+		return nil, nil
+	}
+
 	target := nodeTarget{Name: node.Name}
 	for _, address := range node.Status.Addresses {
 		if address.Type == v1.NodeInternalIP {

--- a/modules/340-monitoring-ping/hooks/discover_targets.go
+++ b/modules/340-monitoring-ping/hooks/discover_targets.go
@@ -92,11 +92,11 @@ func discoverNodes(input *go_hook.HookInput) error {
 	combinedTargets := newTargets()
 
 	for _, address := range input.Snapshots["addresses"] {
-        if address == nil {
-          continue
-        }  
-        convertedAddress := address.(nodeTarget)
-	    combinedTargets.Cluster = append(combinedTargets.Cluster, convertedAddress)
+		if address == nil {
+			continue
+		}
+		convertedAddress := address.(nodeTarget)
+		combinedTargets.Cluster = append(combinedTargets.Cluster, convertedAddress)
 	}
 
 	for _, target := range input.Values.Get(externalTargetsPath).Array() {

--- a/modules/340-monitoring-ping/hooks/discover_targets.go
+++ b/modules/340-monitoring-ping/hooks/discover_targets.go
@@ -43,8 +43,8 @@ type targets struct {
 }
 
 type nodeTargetFilterResult struct {
-	enabled bool
-	target  nodeTarget
+	Enabled bool
+	Target  nodeTarget
 }
 
 func newTargets() *targets {
@@ -61,7 +61,7 @@ func getAddress(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 		return nil, err
 	}
 
-	result := nodeTargetFilterResult{enabled: false}
+	result := nodeTargetFilterResult{Enabled: false}
 	if node.Spec.Unschedulable {
 		return result, nil
 	}
@@ -73,8 +73,8 @@ func getAddress(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 			break
 		}
 	}
-	result.enabled = true
-	result.target = target
+	result.Enabled = true
+	result.Target = target
 
 	return result, nil
 }
@@ -101,8 +101,8 @@ func discoverNodes(input *go_hook.HookInput) error {
 
 	for _, address := range input.Snapshots["addresses"] {
 		convertedAddress := address.(nodeTargetFilterResult)
-		if convertedAddress.enabled {
-			combinedTargets.Cluster = append(combinedTargets.Cluster, convertedAddress.target)
+		if convertedAddress.Enabled {
+			combinedTargets.Cluster = append(combinedTargets.Cluster, convertedAddress.Target)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Gleb Maiorov <gleb.maiorov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Skip unschedulabe nodes in `monitoring-ping`.

Changes were tested in local cluster.
After cordoning one of the workers corresponding metrics won't be captured anymore: 
![metric-example](https://user-images.githubusercontent.com/111346521/204576417-d435773d-b6ce-4ff5-86d7-2c11c6924ff0.png)

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Currently unschedulable nodes are still pinged in monitoring-ping module.
This causes false positive alerts when unschedulable node is no longer accessible, but isn't removed from k8s yet.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
`monitoring-ping` no longer tries to ping unschedulable nodes.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring-ping
type: chore
summary: Skip unschedulabe nodes in `monitoring-ping`
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
