### PR TITLE
[log-shipper] Add telemetry

### DIFF
--- a/modules/460-log-shipper/hooks/internal/composer/composer.go
+++ b/modules/460-log-shipper/hooks/internal/composer/composer.go
@@ -19,6 +19,7 @@ package composer
 import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 
+	"github.com/deckhouse/deckhouse/go_lib/telemetry"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/apis/v1alpha1"
 	"github.com/deckhouse/deckhouse/modules/460-log-shipper/hooks/internal/vector/destination"
@@ -44,19 +45,30 @@ func FromInput(input *go_hook.HookInput) *Composer {
 	for _, d := range destSnap {
 		dest := d.(v1alpha1.ClusterLogDestination)
 		res.Dest = append(res.Dest, dest)
+		customResourceMetric(input, "ClusterLogDestination", dest.Name, dest.Namespace)
 	}
 
 	for _, s := range sourceSnap {
 		src := s.(v1alpha1.ClusterLoggingConfig)
 		res.Source = append(res.Source, src)
+		customResourceMetric(input, "ClusterLoggingConfig", src.Name, src.Namespace)
 	}
 
 	for _, ns := range namespacedSourceSnap {
 		src := ns.(v1alpha1.PodLoggingConfig)
 		res.Source = append(res.Source, v1alpha1.NamespacedToCluster(src))
+		customResourceMetric(input, "PodLoggingConfig", src.Name, src.Namespace)
 	}
 
 	return res
+}
+
+func customResourceMetric(input *go_hook.HookInput, kind, name, namespace string) {
+	input.MetricsCollector.Set(telemetry.WrapName("log_shipper_custom_resource"), 1, map[string]string{
+		"kind":         kind,
+		"cr_name":      name,
+		"cr_namespace": namespace,
+	})
 }
 
 func (c *Composer) Do() ([]byte, error) {


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Collect data of log-shipper custom resources.

## Why do we need it, and what problem does it solve?
To be aware of various cluster configurations and the number of clusters where the module is really used by applications.

## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: log-shipper
type: chore
summary: Add telemetry.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
