### PR TITLE
[node-manager] Fix script name generation in the bashible-apiserver

### DIFF
--- a/modules/040-node-manager/images/bashible-apiserver/pkg/template/node_group_configuration.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/template/node_group_configuration.go
@@ -17,6 +17,8 @@ limitations under the License.
 package template
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -35,6 +37,11 @@ type NodeGroupConfiguration struct {
 	// Populated by the system.
 
 	Status NodeGroupConfigurationStatus `json:"status,omitempty"`
+}
+
+// GenerateScriptName generates name for a bash script like xxx_some_name.sh, We have to specify integer part with 3 digits
+func (ng NodeGroupConfiguration) GenerateScriptName() string {
+	return fmt.Sprintf("%03d_%s", ng.Spec.Weight, ng.Name)
 }
 
 type NodeGroupConfigurationSpec struct {

--- a/modules/040-node-manager/images/bashible-apiserver/pkg/template/steps_storage.go
+++ b/modules/040-node-manager/images/bashible-apiserver/pkg/template/steps_storage.go
@@ -252,7 +252,7 @@ func (s *StepsStorage) readTemplates(baseDir string, templates map[string][]byte
 }
 
 func (s *StepsStorage) AddNodeGroupConfiguration(nc *NodeGroupConfiguration) {
-	name := fmt.Sprintf("%03d_%s", nc.Spec.Weight, nc.Name)
+	name := nc.GenerateScriptName()
 	klog.Infof("Adding NodeGroupConfiguration %s to context", name)
 	ngBundlePairs := generateNgBundlePairs(nc.Spec.NodeGroups, nc.Spec.Bundles)
 
@@ -274,7 +274,7 @@ func (s *StepsStorage) AddNodeGroupConfiguration(nc *NodeGroupConfiguration) {
 }
 
 func (s *StepsStorage) RemoveNodeGroupConfiguration(nc *NodeGroupConfiguration) {
-	name := fmt.Sprintf("%d_%s", nc.Spec.Weight, nc.Name)
+	name := nc.GenerateScriptName()
 	klog.Infof("Removing NodeGroupConfiguration %s from context", name)
 	ngBundlePairs := generateNgBundlePairs(nc.Spec.NodeGroups, nc.Spec.Bundles)
 


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Fix script name generation

## Why do we need it, and what problem does it solve?
Names for adding and removing scripts are different. And we can't remove a script with a double digits name

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Fix script name generation and the bashible-apiserver
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
