### PR TITLE
[cloud-provider-openstack] Added patch for old OpenStack versions support

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/images/cinder-csi-plugin/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/cinder-csi-plugin/werf.inc.yaml
@@ -34,9 +34,14 @@ shell:
   - apt update
   - apt install git mercurial rsync patch -y
   install:
-  - mkdir /src
-  - wget https://github.com/kubernetes/cloud-provider-openstack/archive/{{ $value.csi.openstack }}.tar.gz -O - | tar -xz --strip-components=1 -C /src/ && \
+  - git clone https://github.com/kubernetes/cloud-provider-openstack.git /src
   - cd /src
+  - git checkout tags/{{ $value.csi.openstack }}
+  - git config --global user.email "builder@deckhouse.io"
+    {{- if or (semverCompare "1.23" $version) (semverCompare "1.24" $version) }}
+  - git cherry-pick 03db687b95ea168e0de9609a7eaad43243f88944
+    {{- end }}
+  - export VERSION={{ $value.csi.openstack }}
   - make cinder-csi-plugin
   {{- end }}
 {{- end }}

--- a/ee/modules/030-cloud-provider-openstack/openapi/config-values.yaml
+++ b/ee/modules/030-cloud-provider-openstack/openapi/config-values.yaml
@@ -67,6 +67,11 @@ properties:
       - ["some-bgp-network"]
     items:
       type: string
+  ignoreVolumeMicroversion:
+    type: boolean
+    description: |
+      Setting for backwards compatibility. Enable if the cloud OpenStack version is less than 3.34 and you get error "Version 3.34 is not supported by the API. Minimum is 3.0 and maximum is 3.x" when ordering a PV. This will disable volumes online resize, but will restore ability to order new PVs. (original PR https://github.com/kubernetes/cloud-provider-openstack/pull/1986/)
+    default: false
   podNetworkMode:
     type: string
     description: |

--- a/ee/modules/030-cloud-provider-openstack/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/030-cloud-provider-openstack/openapi/doc-ru-config-values.yaml
@@ -43,6 +43,10 @@ properties:
       Имена дополнительных сетей, которые могут быть подключены к виртуальной машине и использованы в `cloud-controller-manager` для проставления `ExternalIP` в `.status.addresses` в Node API объект.
 
       Если в кластере есть инстансы, для которых будут использоваться External Networks, отличные от указанных в схеме размещения, то их следует передавать в параметре `additionalExternalNetworkNames`.
+  ignoreVolumeMicroversion:
+    type: boolean
+    description: |
+      Настройка для обратной совместимости. Включите, если версия OpenStack в облаке меньше 3.34, и вы получаете ошибку "Version 3.34 is not supported by the API. Minimum is 3.0 and maximum is 3.x" при заказе PV. Это отключит изменения размеров томов "на лету", но вернет возможность заказа новых PV. (оригинальный PR https://github.com/kubernetes/cloud-provider-openstack/pull/1986/)
   podNetworkMode:
     description: |
       Способ организации трафика в той сети, которая используется для коммуникации между Pod'ами (обычно это internal сеть, но бывают исключения):

--- a/ee/modules/030-cloud-provider-openstack/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-openstack/openapi/values.yaml
@@ -35,6 +35,9 @@ properties:
             type: string
           region:
             type: string
+      ignoreVolumeMicroversion:
+        type: boolean
+        default: false
       internalNetworkNames:
         type: array
         default: []

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/secret.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/secret.yaml
@@ -43,6 +43,9 @@ floating-network-id = {{ .Values.cloudProviderOpenstack.internal.loadBalancer.fl
 enable-ingress-hostname = true
   {{- end }}
 [BlockStorage]
+  {{- if or (semverCompare "1.23" .Values.global.discovery.kubernetesVersion) (semverCompare "1.24" .Values.global.discovery.kubernetesVersion) }}
+ignore-volume-microversion = {{ .Values.cloudProviderOpenstack.internal.ignoreVolumeMicroversion }}
+  {{- end }}
 rescan-on-resize = true
 {{- end }}
 ---


### PR DESCRIPTION
## Description
Backported fix for OpenStack with version older than 3.34, in some clouds (like VK cloud) persistent volume provisioning didn't worked.

## Why do we need it, and what problem does it solve?
Fix #3129 

## What is the expected result?
Provisioning works in OpenStack with API versions lower then 3.34.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-openstack
type: fix
summary: Backported fix for OpenStack with version older than 3.34, for compatibility with some clouds (e.g. VK cloud).
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
