### PR TITLE
[deckhouse-config] fix: do not list ModuleConfig if migration in progress

### DIFF
--- a/global-hooks/deckhouse-config/startup_sync.go
+++ b/global-hooks/deckhouse-config/startup_sync.go
@@ -86,7 +86,7 @@ func migrateOrSyncModuleConfigs(input *go_hook.HookInput, dc dependency.Containe
 		hasGeneratedCM = false
 	}
 	if hasGeneratedCM {
-		_, shouldMigrate := generatedCM.GetAnnotations()[d8config.MigrateToModuleConfigAnnotation]
+		_, shouldMigrate := generatedCM.GetAnnotations()[d8config.AnnoMigrationInProgress]
 		if shouldMigrate {
 			input.LogEntry.Infof("Migrate Configmap to ModuleConfig resources.")
 			return createInitialModuleConfigs(input, generatedCM.Data)
@@ -119,7 +119,7 @@ func migrateToGeneratedConfigMap(input *go_hook.HookInput, kubeClient k8s.Client
 	}
 
 	newCm := d8config.GeneratedConfigMap(data)
-	newCm.SetAnnotations(map[string]string{d8config.MigrateToModuleConfigAnnotation: "true"})
+	newCm.SetAnnotations(map[string]string{d8config.AnnoMigrationInProgress: "true"})
 
 	input.PatchCollector.Create(newCm, object_patch.UpdateIfExists())
 

--- a/global-hooks/deckhouse-config/startup_sync.go
+++ b/global-hooks/deckhouse-config/startup_sync.go
@@ -45,10 +45,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnStartup: &go_hook.OrderedConfig{Order: 1},
 }, dependency.WithExternalDependencies(migrateOrSyncModuleConfigs))
 
-const (
-	migrationAnnotation = "deckhouse.io/should-migrate-to-module-config-objects"
-)
-
 // migrateOrSyncModuleConfigs runs on deckhouse-controller startup
 // as early as possible and do two things:
 // - migrates deckhouse-controller from configuration via ConfigMap/deckhouse
@@ -90,7 +86,7 @@ func migrateOrSyncModuleConfigs(input *go_hook.HookInput, dc dependency.Containe
 		hasGeneratedCM = false
 	}
 	if hasGeneratedCM {
-		_, shouldMigrate := generatedCM.GetAnnotations()[migrationAnnotation]
+		_, shouldMigrate := generatedCM.GetAnnotations()[d8config.MigrateToModuleConfigAnnotation]
 		if shouldMigrate {
 			input.LogEntry.Infof("Migrate Configmap to ModuleConfig resources.")
 			return createInitialModuleConfigs(input, generatedCM.Data)
@@ -123,7 +119,7 @@ func migrateToGeneratedConfigMap(input *go_hook.HookInput, kubeClient k8s.Client
 	}
 
 	newCm := d8config.GeneratedConfigMap(data)
-	newCm.SetAnnotations(map[string]string{migrationAnnotation: "true"})
+	newCm.SetAnnotations(map[string]string{d8config.MigrateToModuleConfigAnnotation: "true"})
 
 	input.PatchCollector.Create(newCm, object_patch.UpdateIfExists())
 

--- a/global-hooks/deckhouse-config/startup_sync_test.go
+++ b/global-hooks/deckhouse-config/startup_sync_test.go
@@ -78,7 +78,7 @@ certManagerEnabled: "true"
 			generatedCM := f.KubernetesResource("ConfigMap", "d8-system", "deckhouse-generated-config-do-not-edit")
 			Expect(generatedCM.Exists()).Should(BeTrue())
 			// Note: use literal annotation to test accidental renaming
-			annotationJSON := fmt.Sprintf(`{"%s":"true"}`, "deckhouse.io/should-migrate-to-module-config-objects")
+			annotationJSON := fmt.Sprintf(`{"%s":"true"}`, "deckhouse.io/migration-in-progress")
 			Expect(generatedCM.Field("metadata.annotations").String()).Should(MatchJSON(annotationJSON))
 			Expect(generatedCM.Field("data.global").String()).Should(ContainSubstring("param1: val1"))
 			Expect(generatedCM.Field("data.deckhouse").Exists()).Should(BeTrue())
@@ -120,7 +120,7 @@ certManager: |
 certManagerEnabled: "false"
 unknownModule: |
   paramBool: true
-`, d8config.MigrateToModuleConfigAnnotation)
+`, d8config.AnnoMigrationInProgress)
 				f.KubeStateSet(cm)
 
 				f.BindingContexts.Set(f.GenerateOnStartupContext())
@@ -174,7 +174,7 @@ global: |
 deckhouse: |
   paramStr: 100
   paramNum: "100"
-`, d8config.MigrateToModuleConfigAnnotation)
+`, d8config.AnnoMigrationInProgress)
 				f.KubeStateSet(cm)
 
 				f.BindingContexts.Set(f.GenerateOnStartupContext())

--- a/global-hooks/deckhouse-config/startup_sync_test.go
+++ b/global-hooks/deckhouse-config/startup_sync_test.go
@@ -77,7 +77,8 @@ certManagerEnabled: "true"
 			// Note: use literal name to test accidental renaming.
 			generatedCM := f.KubernetesResource("ConfigMap", "d8-system", "deckhouse-generated-config-do-not-edit")
 			Expect(generatedCM.Exists()).Should(BeTrue())
-			annotationJSON := fmt.Sprintf(`{"%s":"true"}`, migrationAnnotation)
+			// Note: use literal annotation to test accidental renaming
+			annotationJSON := fmt.Sprintf(`{"%s":"true"}`, "deckhouse.io/should-migrate-to-module-config-objects")
 			Expect(generatedCM.Field("metadata.annotations").String()).Should(MatchJSON(annotationJSON))
 			Expect(generatedCM.Field("data.global").String()).Should(ContainSubstring("param1: val1"))
 			Expect(generatedCM.Field("data.deckhouse").Exists()).Should(BeTrue())
@@ -119,7 +120,7 @@ certManager: |
 certManagerEnabled: "false"
 unknownModule: |
   paramBool: true
-`, migrationAnnotation)
+`, d8config.MigrateToModuleConfigAnnotation)
 				f.KubeStateSet(cm)
 
 				f.BindingContexts.Set(f.GenerateOnStartupContext())
@@ -173,7 +174,7 @@ global: |
 deckhouse: |
   paramStr: 100
   paramNum: "100"
-`, migrationAnnotation)
+`, d8config.MigrateToModuleConfigAnnotation)
 				f.KubeStateSet(cm)
 
 				f.BindingContexts.Set(f.GenerateOnStartupContext())

--- a/go_lib/deckhouse-config/initial_config_loader.go
+++ b/go_lib/deckhouse-config/initial_config_loader.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	MigrateToModuleConfigAnnotation = "deckhouse.io/should-migrate-to-module-config-objects"
+	AnnoMigrationInProgress = "deckhouse.io/migration-in-progress"
 )
 
 // InitialConfigLoader runs conversions on module sections in the ConfigMap
@@ -97,7 +97,7 @@ func (l *InitialConfigLoader) GetInitialKubeConfig(cmName string) (*kcm.KubeConf
 	// as-is if migration to ModuleConfig resources is still in progress (annotation is present).
 	migrationInProgress := false
 	if len(cm.GetAnnotations()) > 0 {
-		_, migrationInProgress = cm.GetAnnotations()[MigrateToModuleConfigAnnotation]
+		_, migrationInProgress = cm.GetAnnotations()[AnnoMigrationInProgress]
 	}
 
 	if cmName == GeneratedConfigMapName && !migrationInProgress {

--- a/go_lib/deckhouse-config/initial_config_loader.go
+++ b/go_lib/deckhouse-config/initial_config_loader.go
@@ -34,6 +34,10 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/set"
 )
 
+const (
+	MigrateToModuleConfigAnnotation = "deckhouse.io/should-migrate-to-module-config-objects"
+)
+
 // InitialConfigLoader runs conversions on module sections in the ConfigMap
 // or for settings in all ModuleConfig resources to make a KubeConfig
 // with values conform to the latest OpenAPI schemas.
@@ -89,8 +93,14 @@ func (l *InitialConfigLoader) GetInitialKubeConfig(cmName string) (*kcm.KubeConf
 
 	// Check if the Deckhouse is using ModuleConfig resources and load config from ModuleConfig resources.
 	// It is not possible to load settings from the ConfigMap/deckhouse-generated-do-no-edit, because it
-	// has no versions but it is useful as a source of possible names.
-	if cmName == GeneratedConfigMapName {
+	// has no versions but it is useful as a source of possible names. Though use ConfigMap/deckhouse-generated-do-no-edit
+	// as-is if migration to ModuleConfig resources is still in progress (annotation is present).
+	migrationInProgress := false
+	if len(cm.GetAnnotations()) > 0 {
+		_, migrationInProgress = cm.GetAnnotations()[MigrateToModuleConfigAnnotation]
+	}
+
+	if cmName == GeneratedConfigMapName && !migrationInProgress {
 		cfgList, err := GetAllConfigs(l.KubeClient)
 		if err != nil {
 			return nil, fmt.Errorf("load initial config from ModuleConfig resources: %v", err)
@@ -98,7 +108,8 @@ func (l *InitialConfigLoader) GetInitialKubeConfig(cmName string) (*kcm.KubeConf
 		return l.ModuleConfigListToInitialConfig(cfgList, possibleNames)
 	}
 
-	// Deckhouse doesn't use ModuleConfig resources, use ConfigMap/deckhouse content.
+	// Deckhouse doesn't use ModuleConfig resources, use data from ConfigMap/deckhouse or from ConfigMap/deckhouse-generated-config-do-not-edit.
+	// Assume data were not migrated and have version 0.
 	return l.LegacyConfigMapToInitialConfig(cm.Data)
 }
 


### PR DESCRIPTION

## Description
- Fix initial config loader to skip listing ModuleConfig resources if the ConfigMap/deckhouse-generated... has migration annotation.
- Fix "deckhouse readiness" false-positive in e2e script when Pod is in Terminating phase but is still is ready.

## Why do we need it, and what problem does it solve?

e2e test fails when switch releases from 1.40 to 1.41: deckhouse-controller somehow starts with empty configuration despite  existing configuration in ConfigMap/deckhouse-generated-config-do-not-edit.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

'Switching e2e' tests not fail.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse-config
type: fix
summary: Ignore listing ModuleConfig at start when migration in progress.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
