### PR TITLE
[dhctl] Fix restart bootstrap cluster

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -26,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -174,12 +175,25 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *Config) erro
 			Name:     `ConfigMap "deckhouse"`,
 			Manifest: func() interface{} { return manifests.DeckhouseConfigMap(cfg.DeckhouseConfig) },
 			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().ConfigMaps("d8-system").Create(context.TODO(), manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})
-				return err
+				// check cm existing for prevent error
+				// deckhouse create manifests: create resource: admission webhook "validate-cm.deckhouse-config-webhook.deckhouse.io" denied the request:
+				// changing ConfigMap/deckhouse is not allowed for kubernetes-admin. Use ModuleConfig resources to configure Deckhouse.
+				// after restart bootstrap
+				cm := manifest.(*apiv1.ConfigMap)
+				_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
+					Get(context.TODO(), cm.GetName(), metav1.GetOptions{})
+				if err != nil {
+					if k8serror.IsNotFound(err) {
+						_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
+							Create(context.TODO(), manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})
+						return err
+					}
+					return err
+				}
+				return nil
 			},
 			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().ConfigMaps("d8-system").Update(context.TODO(), manifest.(*apiv1.ConfigMap), metav1.UpdateOptions{})
-				return err
+				return nil
 			},
 		},
 	}

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -182,15 +182,12 @@ func CreateDeckhouseManifests(kubeCl *client.KubernetesClient, cfg *Config) erro
 				cm := manifest.(*apiv1.ConfigMap)
 				_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
 					Get(context.TODO(), cm.GetName(), metav1.GetOptions{})
-				if err != nil {
-					if k8serror.IsNotFound(err) {
-						_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
-							Create(context.TODO(), manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})
-						return err
-					}
+				if err == nil || k8serror.IsNotFound(err) {
+					_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
+						Create(context.TODO(), manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})
 					return err
 				}
-				return nil
+				return err
 			},
 			UpdateFunc: func(manifest interface{}) error {
 				return nil


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Do not create/update `deckhouse` configmap if exists.

## Why do we need it, and what problem does it solve?
Prevent error:
```
deckhouse create manifests: create resource: admission webhook "[validate-cm.deckhouse-config-webhook.deckhouse.io](http://validate-cm.deckhouse-config-webhook.deckhouse.io/)" denied the request:     ↵
changing ConfigMap/deckhouse is not allowed for kubernetes-admin. Use ModuleConfig resources to configure Deckhouse.
```
during restart bootstrap cluster
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: fix
summary: Fix restart bootstrap cluster.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
