### PR TITLE
[flant-integration] Added regex to parse os image for rocky, alteros, redos, alma and astra linux

### DIFF
--- a/ee/modules/600-flant-integration/images/flant-pricing/hooks/prometheus_metrics.sh
+++ b/ee/modules/600-flant-integration/images/flant-pricing/hooks/prometheus_metrics.sh
@@ -326,6 +326,9 @@ function node_os_image_metrics() {
                 "(?:(debian).*(9|10|11))",
                 "(?:(ubuntu).*(16.04|18.04|20.04|22.04))",
                 "(?:(rocky).*(8|9))",
+                "(?:(almalinux).*(7|8|7.*|8.*))",
+                "(?:(redos).*(7|7.*))",
+                "(?:(alteros).*(7|7.*))",
                 "(?:(astra))"
               ] | join("|")
             ).captures // [{string: "unknown"}] |

--- a/ee/modules/600-flant-integration/images/flant-pricing/hooks/prometheus_metrics.sh
+++ b/ee/modules/600-flant-integration/images/flant-pricing/hooks/prometheus_metrics.sh
@@ -326,9 +326,9 @@ function node_os_image_metrics() {
                 "(?:(debian).*(9|10|11))",
                 "(?:(ubuntu).*(16.04|18.04|20.04|22.04))",
                 "(?:(rocky).*(8|9))",
-                "(?:(almalinux).*(7|8|7.*|8.*))",
-                "(?:(redos).*(7|7.*))",
-                "(?:(alteros).*(7|7.*))",
+                "(?:(almalinux).*(7|8))",
+                "(?:(redos).*(7))",
+                "(?:(alteros).*(7))",
                 "(?:(astra))"
               ] | join("|")
             ).captures // [{string: "unknown"}] |

--- a/ee/modules/600-flant-integration/images/flant-pricing/hooks/prometheus_metrics.sh
+++ b/ee/modules/600-flant-integration/images/flant-pricing/hooks/prometheus_metrics.sh
@@ -324,7 +324,9 @@ function node_os_image_metrics() {
                 "(?:(r)ed (h)at (e)nterprise (l)inux.*(7|8))",
                 "(?:(centos).*(7|8))",
                 "(?:(debian).*(9|10|11))",
-                "(?:(ubuntu).*(16.04|18.04|20.04|22.04))"
+                "(?:(ubuntu).*(16.04|18.04|20.04|22.04))",
+                "(?:(rocky).*(8|9))",
+                "(?:(astra))"
               ] | join("|")
             ).captures // [{string: "unknown"}] |
             .[] | select(.string) | .string


### PR DESCRIPTION
## Description
Changes in flant-integration for Rocky, RedOS, AlterOS, Alma and Astra Linux support

## Why do we need it, and what problem does it solve?
We need correct parsing of OS image param in flant-integration module for correct OS name discover from client nodes.

## What is the expected result?
Correct data about nodes with Rocky, RedOS, AlterOS, Alma and Astra Linux

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: flant-integration
type: chore
summary: Changes in flant-integration for Rocky, RedOS, AlterOS, Alma and Astra Linux support
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
