### PR TITLE
[deckhouse-config] fix CE build of the deckhouse-config-webhook

### DIFF
--- a/modules/003-deckhouse-config/images/deckhouse-config-webhook/register.go
+++ b/modules/003-deckhouse-config/images/deckhouse-config-webhook/register.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// TODO(future) put this to make?
+
+//go:generate go run ../../../../tools/settings_conversions/main.go -output register-settings-conversions.go

--- a/modules/003-deckhouse-config/images/deckhouse-config-webhook/werf.inc.yaml
+++ b/modules/003-deckhouse-config/images/deckhouse-config-webhook/werf.inc.yaml
@@ -89,6 +89,7 @@ git:
     - dhctl/go.mod
     - dhctl/go.sum
     - go_lib
+    - tools
     - go.mod
     - go.sum
     - modules/*/settings-conversion/**/*.go

--- a/modules/003-deckhouse-config/images/deckhouse-config-webhook/werf.inc.yaml
+++ b/modules/003-deckhouse-config/images/deckhouse-config-webhook/werf.inc.yaml
@@ -55,20 +55,14 @@ shell:
     - cd {{ $webhookAbsPath }}
     - go mod download
   setup:
-    # Migrate ee/fe internal packages imports
-    - find /deckhouse/modules/* -type f -name '*.go' -exec sed -E -i 's|github.com/deckhouse/deckhouse/ee/modules|github.com/deckhouse/deckhouse/modules|g' {} +
-    - find /deckhouse/modules/* -type f -name '*.go' -exec sed -E -i 's|github.com/deckhouse/deckhouse/ee/fe/modules|github.com/deckhouse/deckhouse/modules|g' {} +
     - cd {{ $webhookAbsPath }}
     # Re-generate conversion imports for particular edition (CE/EE/FE).
     # TODO(future) Create special register file in tools to generate only conversion imports for the webhook, and use go generate here.
     - cp register-settings-conversions.go register-settings-conversions.go~
     - go run ../../../../tools/settings_conversions/main.go -output register-settings-conversions.go
-    - diff -u register-settings-conversions.go~ register-settings-conversions.go || true
+    - echo "Excluded conversions:" && (diff -u register-settings-conversions.go~ register-settings-conversions.go | grep '^-' || true)
     # Build webhook binary.
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /deckhouse-config-webhook
-    # Some debug output.
-    - ls -la /deckhouse
-    - go version /deckhouse-config-webhook
 
 git:
 - add: /{{ $webhookRelPath }}

--- a/modules/003-deckhouse-config/images/deckhouse-config-webhook/werf.inc.yaml
+++ b/modules/003-deckhouse-config/images/deckhouse-config-webhook/werf.inc.yaml
@@ -35,7 +35,7 @@ git:
 {{ end }}
 import:
   - artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-    add: /src/deckhouse-config-webhook
+    add: /deckhouse-config-webhook
     to: /deckhouse-config-webhook
     before: setup
 shell:
@@ -55,12 +55,20 @@ shell:
     - cd {{ $webhookAbsPath }}
     - go mod download
   setup:
+    # Migrate ee/fe internal packages imports
+    - find /deckhouse/modules/* -type f -name '*.go' -exec sed -E -i 's|github.com/deckhouse/deckhouse/ee/modules|github.com/deckhouse/deckhouse/modules|g' {} +
+    - find /deckhouse/modules/* -type f -name '*.go' -exec sed -E -i 's|github.com/deckhouse/deckhouse/ee/fe/modules|github.com/deckhouse/deckhouse/modules|g' {} +
     - cd {{ $webhookAbsPath }}
-    - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o deckhouse-config-webhook
-    - mkdir /src
-    - mv deckhouse-config-webhook /src
+    # Re-generate conversion imports for particular edition (CE/EE/FE).
+    # TODO(future) Create special register file in tools to generate only conversion imports for the webhook, and use go generate here.
+    - cp register-settings-conversions.go register-settings-conversions.go~
+    - go run ../../../../tools/settings_conversions/main.go -output register-settings-conversions.go
+    - diff -u register-settings-conversions.go~ register-settings-conversions.go
+    # Build webhook binary.
+    - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /deckhouse-config-webhook
+    # Some debug output.
     - ls -la /deckhouse
-    - go version /src/deckhouse-config-webhook
+    - go version /deckhouse-config-webhook
 
 git:
 - add: /{{ $webhookRelPath }}
@@ -101,6 +109,7 @@ git:
       - go.sum
     setup:
       - go_lib/**/*.go
+      - tools/**/*.go
       - modules/*/settings-conversion/**/*.go
 {{ if eq .Env "EE" }}
       - ee/modules/*/settings-conversion/**/*.go

--- a/modules/003-deckhouse-config/images/deckhouse-config-webhook/werf.inc.yaml
+++ b/modules/003-deckhouse-config/images/deckhouse-config-webhook/werf.inc.yaml
@@ -63,7 +63,7 @@ shell:
     # TODO(future) Create special register file in tools to generate only conversion imports for the webhook, and use go generate here.
     - cp register-settings-conversions.go register-settings-conversions.go~
     - go run ../../../../tools/settings_conversions/main.go -output register-settings-conversions.go
-    - diff -u register-settings-conversions.go~ register-settings-conversions.go
+    - diff -u register-settings-conversions.go~ register-settings-conversions.go || true
     # Build webhook binary.
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /deckhouse-config-webhook
     # Some debug output.


### PR DESCRIPTION
## Description

Fix werf.inc.yaml to work with CE sources:

- add go run to re-generate conversion imports
- cleanup: put binary to /

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

CE build fails https://github.com/deckhouse/deckhouse/actions/runs/3580644295/jobs/6022949324
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

Release build  justworks.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse-config
type: fix
summary: Fix the CE revision build of the `deckhouse-config-webhook`.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
