### PR TITLE
[docs] Fix ModuleConfig APIVersion in the documentation

### DIFF
--- a/docs/documentation/_includes/module-enable-snippet.liquid
+++ b/docs/documentation/_includes/module-enable-snippet.liquid
@@ -1,5 +1,5 @@
 ```yaml
-apiVersion: deckhouse.io/v1
+apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
 metadata:
   name: {{ include.moduleName }}


### PR DESCRIPTION
## Description
Change the incorrect `deckhouse.io/v1` ModuleConfig version to the correct `deckhouse.io/v1alpha1`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix
summary: Fix ModuleConfig APIVersion in the documentation.
impact_level: low
```
