### PR TITLE
[extended-monitoring] Fix alert typo

### DIFF
--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
@@ -120,7 +120,7 @@
         2. Analyze the DaemonSet's description: `kubectl -n {{ $labels.namespace }} describe ds {{ $labels.daemonset }}`
         3. If the `Number of Nodes Scheduled with Up-to-date Pods` parameter does not match
         `Current Number of Nodes Scheduled`, check the DaemonSet's updateStrategy:
-        `kubectl -n {{ $labels.namespace }} get ds {{ $labels.daemonset }}-o json | jq '.spec.updateStrategy'`
+        `kubectl -n {{ $labels.namespace }} get ds {{ $labels.daemonset }} -o json | jq '.spec.updateStrategy'`
         4. Note that if the OnDelete updateStrategy is set, the DaemonSet gets only updated when Pods are deleted.
 
   - alert: KubernetesStatefulSetReplicasUnavailable


### PR DESCRIPTION
Signed-off-by: Eugene Shevchenko <evgeny.shevchenko@flant.com>

## Description

Fixing the typo

## Why do we need it, and what problem does it solve?

Allows to copy and paste command example flawlessly

## What is the expected result?

The exprience is smoother

## Changelog entries

```changes
section: extended-monitoring
type: chore
summary: Fixed typo in alert templatessibly MULTI-LINE>, required if impact_level is high ↓
impact_level: low
```
