### PR TITLE
[deckhouse-config] fix: apply defaults before spec.settings validation

### DIFF
--- a/global-hooks/deckhouse-config/startup_sync.go
+++ b/global-hooks/deckhouse-config/startup_sync.go
@@ -19,6 +19,8 @@ package hooks
 import (
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -241,11 +243,14 @@ func syncModuleConfigs(input *go_hook.HookInput, generatedCM *v1.ConfigMap, allC
 	}
 
 	// Log deleted sections in source CM.
+	fields := make([]string, 0)
 	for name := range generatedCM.Data {
 		if _, has := cmData[name]; !has {
-			input.LogEntry.Warnf("ModuleConfig/%s was deleted. Section '%s' will be deleted from cm/%s.", name, name, regeneratedCM.Name)
+			fields = append(fields, name)
 		}
 	}
+	sort.Strings(fields)
+	input.LogEntry.Warnf("Remove fields [%s] from cm/%s", strings.Join(fields, ", "), regeneratedCM.Name)
 
 	return nil
 }

--- a/global-hooks/deckhouse-config/startup_sync.go
+++ b/global-hooks/deckhouse-config/startup_sync.go
@@ -232,7 +232,7 @@ func syncModuleConfigs(input *go_hook.HookInput, generatedCM *v1.ConfigMap, allC
 		return err
 	}
 	regeneratedCM := d8config.GeneratedConfigMap(cmData)
-	input.LogEntry.Infof("Re-create Config/%s on sync", regeneratedCM.Name)
+	input.LogEntry.Infof("Re-creating Config/%s on sync", regeneratedCM.Name)
 	input.PatchCollector.Create(regeneratedCM, object_patch.UpdateIfExists())
 
 	// Return if source cm was empty.

--- a/global-hooks/deckhouse-config/testdata/test-startup-sync/global-hooks/openapi/config-values.yaml
+++ b/global-hooks/deckhouse-config/testdata/test-startup-sync/global-hooks/openapi/config-values.yaml
@@ -9,3 +9,6 @@ properties:
     type: number
   paramBool:
     type: boolean
+  paramDef:
+    type: string
+    default: "azaza"

--- a/global-hooks/deckhouse-config/testdata/test-startup-sync/modules/001-cert-manager/openapi/config-values.yaml
+++ b/global-hooks/deckhouse-config/testdata/test-startup-sync/modules/001-cert-manager/openapi/config-values.yaml
@@ -2,6 +2,7 @@
 type: object
 default: {}
 additionalProperties: false
+required: [paramBool]
 properties:
   paramStr:
     type: string
@@ -9,3 +10,7 @@ properties:
     type: number
   paramBool:
     type: boolean
+  # Add default value to test instantiation of default values in the Validate method.
+  paramDef:
+    type: string
+    default: "defaultValue"

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.9.0
-	github.com/flant/addon-operator v1.0.7-0.20221108074825-ba5d9983d012 // branch: main
+	github.com/flant/addon-operator v1.0.7-0.20221201175530-b6848e4a965e // branch: main
 	github.com/flant/kube-client v0.0.6
 	github.com/flant/shell-operator v1.0.13-0.20221128074459-7222dec2222f // branch: feat_build_tag_to_enable_libjq_go
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwo
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/flant/addon-operator v1.0.7-0.20221108074825-ba5d9983d012 h1:patMND+YAyOGZCVlWIcky1k9QhDvABVNkdTpQJeOhgw=
-github.com/flant/addon-operator v1.0.7-0.20221108074825-ba5d9983d012/go.mod h1:YPJrwtDVvsA5fIFbNqoSfyWaomoWahALVKqo39GTlnU=
+github.com/flant/addon-operator v1.0.7-0.20221201175530-b6848e4a965e h1:rdbVYXqs5Eu9SnFWAZOhur5ggoPU+TRTiBSbsx4+fPU=
+github.com/flant/addon-operator v1.0.7-0.20221201175530-b6848e4a965e/go.mod h1:YPJrwtDVvsA5fIFbNqoSfyWaomoWahALVKqo39GTlnU=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v0.0.6 h1:cHFMf7xGtJOgg+KBuPcA+7q+M7IJRSgf2pHVStv2aj0=

--- a/go_lib/deckhouse-config/initial_config_loader.go
+++ b/go_lib/deckhouse-config/initial_config_loader.go
@@ -52,22 +52,28 @@ func NewInitialConfigLoader(kubeClient client.Client) *InitialConfigLoader {
 	}
 }
 
+// GetInitialKubeConfig runs conversions on settings to feed valid 'KubeConfig'
+// to the AddonOperator. Otherwise, Deckhouse will stuck trying to validate old settings
+// with new OpenAPI schemas.
+//
+// There are 2 cases:
+// 1. cm/deckhouse is in use or cm/deckhouse-generated-do-no-edit was just copied (it has annotation).
+//   There are no ModuleConfig resources, so module sections are treated as settings with version 0.
+// 2. cm/deckhouse-generated-do-no-edit has no annotation.
+//   ConfigMap has no versions, so ModuleConfig resources are used to create initial config.
+//   Also, there is no ModuleManager instance, only module names from the ConfigMap are used.
 func (l *InitialConfigLoader) GetInitialKubeConfig(cmName string) (*kcm.KubeConfig, error) {
 	if cmName != DeckhouseConfigMapName && cmName != GeneratedConfigMapName {
 		return nil, fmt.Errorf("load initial config: unknown ConfigMap/%s", cmName)
 	}
 
-	// Init Kubernetes client if it was not specified. Mute logger to prevent non-formatted message.
-	lvl := log.GetLevel()
-	log.SetLevel(log.FatalLevel)
+	// Init Kubernetes client if it was not specified.
 	err := l.initKubeClient()
-	log.SetLevel(lvl)
 	if err != nil {
 		return nil, fmt.Errorf("init default Kubernetes client: %v", err)
 	}
 
-	// Prepare possible names from the ConfigMap.
-	// Also, return nil if the ConfigMap is not exists or contains no settings — it'll be handled by the global hook.
+	// Get ConfigMap. Return nil if the ConfigMap is not exists or contains no settings — it'll be handled by the global hook.
 	cm, err := GetConfigMap(l.KubeClient, DeckhouseNS, cmName)
 	if err != nil {
 		if k8errors.IsNotFound(err) {
@@ -76,8 +82,16 @@ func (l *InitialConfigLoader) GetInitialKubeConfig(cmName string) (*kcm.KubeConf
 		return nil, fmt.Errorf("load cm/%s: %v", cmName, err)
 	}
 
-	// Assume sections with values are possible names.
-	// Return nil if there are no sections with values in the ConfigMap — it'll be handled by the global hook.
+	// Check if the ConfigMap/deckhouse-generated-config-do-not-edit is just a copy of ConfigMap/deckhouse.
+	migrationInProgress := false
+	if len(cm.GetAnnotations()) > 0 {
+		_, migrationInProgress = cm.GetAnnotations()[AnnoMigrationInProgress]
+	}
+
+	if cmName == DeckhouseConfigMapName || migrationInProgress {
+		return l.LegacyConfigMapToInitialConfig(cm.Data)
+	}
+
 	possibleNames := set.New()
 	hasValues := false
 	for k := range cm.Data {
@@ -87,36 +101,32 @@ func (l *InitialConfigLoader) GetInitialKubeConfig(cmName string) (*kcm.KubeConf
 		}
 		possibleNames.Add(utils.ModuleNameFromValuesKey(valuesKey))
 	}
+
+	// No conversions needed if there are no settings in the ConfigMap.
+	// KubeConfigManager will be absolutely happy about this situation.
 	if !hasValues {
 		return nil, nil
 	}
 
-	// Check if the Deckhouse is using ModuleConfig resources and load config from ModuleConfig resources.
-	// It is not possible to load settings from the ConfigMap/deckhouse-generated-do-no-edit, because it
-	// has no versions but it is useful as a source of possible names. Though use ConfigMap/deckhouse-generated-do-no-edit
-	// as-is if migration to ModuleConfig resources is still in progress (annotation is present).
-	migrationInProgress := false
-	if len(cm.GetAnnotations()) > 0 {
-		_, migrationInProgress = cm.GetAnnotations()[AnnoMigrationInProgress]
+	// Create initial config from ModuleConfig resources using module names from the ConfigMap.
+	cfgList, err := GetAllConfigs(l.KubeClient)
+	if err != nil {
+		return nil, fmt.Errorf("load initial config from ModuleConfig resources: %v", err)
 	}
-
-	if cmName == GeneratedConfigMapName && !migrationInProgress {
-		cfgList, err := GetAllConfigs(l.KubeClient)
-		if err != nil {
-			return nil, fmt.Errorf("load initial config from ModuleConfig resources: %v", err)
-		}
-		return l.ModuleConfigListToInitialConfig(cfgList, possibleNames)
-	}
-
-	// Deckhouse doesn't use ModuleConfig resources, use data from ConfigMap/deckhouse or from ConfigMap/deckhouse-generated-config-do-not-edit.
-	// Assume data were not migrated and have version 0.
-	return l.LegacyConfigMapToInitialConfig(cm.Data)
+	return l.ModuleConfigListToInitialConfig(cfgList, possibleNames)
 }
 
 func (l *InitialConfigLoader) initKubeClient() error {
 	if l.KubeClient != nil {
 		return nil
 	}
+
+	// Mute logger to prevent non-formatted message.
+	lvl := log.GetLevel()
+	log.SetLevel(log.FatalLevel)
+	defer func() {
+		log.SetLevel(lvl)
+	}()
 
 	kubeClient := shell_operator.DefaultMainKubeClient(nil, nil)
 	err := kubeClient.Init()
@@ -180,10 +190,10 @@ func (l *InitialConfigLoader) ModuleConfigListToInitialConfig(allConfigs []*d8cf
 	return kcm.ParseConfigMapData(data)
 }
 
-// LegacyConfigMapToInitialConfig runs registered conversion for each module section in cmData.
-// It assumes settings have version 0 (cm/deckhouse case).
+// LegacyConfigMapToInitialConfig runs registered conversion for each 'module section'
+// in the ConfigMap data. It assumes settings have version 0 (cm/deckhouse case).
 func (l *InitialConfigLoader) LegacyConfigMapToInitialConfig(cmData map[string]string) (*kcm.KubeConfig, error) {
-	// Use ConfigMap parser from addon-operator.
+	// Parse data as KubeConfigManager will do.
 	kubeCfg, err := kcm.ParseConfigMapData(cmData)
 	if err != nil {
 		return nil, fmt.Errorf("parse ConfigMap data: %v", err)

--- a/go_lib/deckhouse-config/initial_config_loader.go
+++ b/go_lib/deckhouse-config/initial_config_loader.go
@@ -73,7 +73,8 @@ func (l *InitialConfigLoader) GetInitialKubeConfig(cmName string) (*kcm.KubeConf
 		return nil, fmt.Errorf("init default Kubernetes client: %v", err)
 	}
 
-	// Get ConfigMap. Return nil if the ConfigMap is not exists or contains no settings — it'll be handled by the global hook.
+	// Get ConfigMap. Return nil if the ConfigMap is not exists or contains no settings.
+	// This situation will be handled later by the 'startup_sync.go' global hook.
 	cm, err := GetConfigMap(l.KubeClient, DeckhouseNS, cmName)
 	if err != nil {
 		if k8errors.IsNotFound(err) {

--- a/go_lib/deckhouse-config/status.go
+++ b/go_lib/deckhouse-config/status.go
@@ -54,23 +54,26 @@ func (s *StatusReporter) ForConfig(cfg *d8cfg_v1alpha1.ModuleConfig, bundleName 
 		}
 	}
 
-	// Show conversion or validation error for ignored ModuleConfig resources.
-	// Put error first.
-	// TODO(future): add cache for these errors.
-	res := Service().ConfigValidator().Validate(cfg)
-	if res.HasError() {
-		invalidMsg := fmt.Sprintf("Ignored: %s", res.Error)
-		return Status{
-			State:   "N/A",
-			Version: "",
-			Status:  invalidMsg,
+	chain := conversion.Registry().Chain(cfg.GetName())
+
+	// Run conversions and validate versioned settings to warn about invalid spec.settings.
+	// TODO(future): add cache for these errors, for example in internal values.
+	if chain.IsKnownVersion(cfg.Spec.Version) && hasVersionedSettings(cfg) {
+		res := Service().ConfigValidator().Validate(cfg)
+		if res.HasError() {
+			invalidMsg := fmt.Sprintf("Ignored: %s", res.Error)
+			return Status{
+				State:   "N/A",
+				Version: "",
+				Status:  invalidMsg,
+			}
 		}
 	}
 
-	// Get settings version from spec or get the latest version from registered conversions.
+	// Fill the 'version' field. The value is a spec.version or the latest version from registered conversions.
+	// Also create warning if version is unknown or outdated.
 	versionWarning := ""
 	version := ""
-	chain := conversion.Registry().Chain(cfg.GetName())
 	if cfg.Spec.Version == 0 {
 		// Use latest version if spec.version is empty.
 		version = strconv.Itoa(chain.LatestVersion())
@@ -85,7 +88,7 @@ func (s *StatusReporter) ForConfig(cfg *d8cfg_v1alpha1.ModuleConfig, bundleName 
 		}
 	}
 
-	// Special case: ModuleConfig/global.
+	// 'global' config is always enabled.
 	if cfg.GetName() == "global" {
 		return Status{
 			State:   "Enabled",
@@ -94,13 +97,7 @@ func (s *StatusReporter) ForConfig(cfg *d8cfg_v1alpha1.ModuleConfig, bundleName 
 		}
 	}
 
-	// First, get effective "enabled" from ModuleManager.
-	enabled := "Disabled"
-	isModuleEnabled := s.moduleManager.IsModuleEnabled(cfg.GetName())
-	if isModuleEnabled {
-		enabled = "Enabled"
-	}
-
+	// Figure out additional statuses for known modules.
 	statusMsgs := make([]string, 0)
 	if versionWarning != "" {
 		statusMsgs = append(statusMsgs, versionWarning)
@@ -108,8 +105,10 @@ func (s *StatusReporter) ForConfig(cfg *d8cfg_v1alpha1.ModuleConfig, bundleName 
 
 	mod := s.moduleManager.GetModule(cfg.GetName())
 
-	// Calculate status for enabled module.
-	if isModuleEnabled {
+	// Calculate state and status.
+	stateMsg := "Disabled"
+	if s.moduleManager.IsModuleEnabled(cfg.GetName()) {
+		stateMsg = "Enabled"
 		lastHookErr := mod.State.GetLastHookErr()
 		if lastHookErr != nil {
 			statusMsgs = append(statusMsgs, fmt.Sprintf("HookError: %v", lastHookErr))
@@ -118,14 +117,17 @@ func (s *StatusReporter) ForConfig(cfg *d8cfg_v1alpha1.ModuleConfig, bundleName 
 			statusMsgs = append(statusMsgs, fmt.Sprintf("ModuleError: %v", mod.State.LastModuleErr))
 		}
 	} else {
-		// Consider merged static enabled flags as '*Enabled flags from the bundle'.
-		enabledByBundle := mergeEnabled(mod.CommonStaticConfig.IsEnabled, mod.StaticConfig.IsEnabled)
 		// Special case: no enabled flag in ModuleConfig, module disabled by bundle.
-		if cfg.Spec.Enabled == nil && !enabledByBundle {
-			statusMsgs = append(statusMsgs, fmt.Sprintf("Info: disabled by %s bundle", bundleName))
+		if cfg.Spec.Enabled == nil {
+			// Consider merged static enabled flags as '*Enabled flags from the bundle'.
+			enabledMsg := "disabled"
+			if mergeEnabled(mod.CommonStaticConfig.IsEnabled, mod.StaticConfig.IsEnabled) {
+				enabledMsg = "enabled"
+			}
+			statusMsgs = append(statusMsgs, fmt.Sprintf("Info: %s by %s bundle", enabledMsg, bundleName))
 		}
 
-		// Special case: enabled in config but disabled by script.
+		// Special case: explicitly enabled by the config but effectively disabled by the ModuleManager.
 		if cfg.Spec.Enabled != nil && *cfg.Spec.Enabled {
 			statusMsgs = append(statusMsgs, "Info: turned off by 'enabled'-script, refer to the module documentation")
 		}
@@ -133,7 +135,7 @@ func (s *StatusReporter) ForConfig(cfg *d8cfg_v1alpha1.ModuleConfig, bundleName 
 
 	return Status{
 		Version: version,
-		State:   enabled,
+		State:   stateMsg,
 		Status:  strings.Join(statusMsgs, ", "),
 	}
 }

--- a/go_lib/deckhouse-config/testdata/validator/global/openapi/config-values.yaml
+++ b/go_lib/deckhouse-config/testdata/validator/global/openapi/config-values.yaml
@@ -1,0 +1,31 @@
+# Schema with default values in required fields.
+type: object
+properties:
+  paramStr:
+    type: string
+  loadBalancer:
+    type: object
+  tcpEnabled:
+    type: boolean
+    default: true
+    x-examples: [true, false]
+  udpEnabled:
+    type: boolean
+    default: false
+    x-examples: [true, false]
+oneOf:
+  - properties:
+      tcpEnabled:
+        enum: [true]
+      udpEnabled:
+        enum: [true]
+  - properties:
+      tcpEnabled:
+        enum: [true]
+      udpEnabled:
+        enum: [false]
+  - properties:
+      tcpEnabled:
+        enum: [false]
+      udpEnabled:
+        enum: [true]

--- a/modules/003-deckhouse-config/hooks/update_status_test.go
+++ b/modules/003-deckhouse-config/hooks/update_status_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Module :: deckhouse-config :: hooks :: update ModuleConfig sta
 			mm := mock.NewModuleManager(
 				mock.NewModule("module-one", nil, mock.EnabledByScript),
 			)
-			err := mm.InitModuleValuesValidator("module-one", "testdata/update-status/modules/001-module-one")
+			err := mm.AddOpenAPISchemas("module-one", "testdata/update-status/modules/001-module-one")
 			Expect(err).ShouldNot(HaveOccurred())
 			d8config.InitService(mm)
 
@@ -86,7 +86,7 @@ var _ = Describe("Module :: deckhouse-config :: hooks :: update ModuleConfig sta
 			mm := mock.NewModuleManager(
 				mock.NewModule("module-one", mock.EnabledByBundle, mock.DisabledByScript),
 			)
-			err := mm.InitModuleValuesValidator("module-one", "testdata/update-status/modules/001-module-one")
+			err := mm.AddOpenAPISchemas("module-one", "testdata/update-status/modules/001-module-one")
 			Expect(err).ShouldNot(HaveOccurred())
 			d8config.InitService(mm)
 

--- a/testing/conversion/init.go
+++ b/testing/conversion/init.go
@@ -64,7 +64,7 @@ func SetupConversionTester() *ConversionTester {
 		mm := mock.NewModuleManager(
 			mock.NewModule(moduleName, nil, mock.EnabledByScript),
 		)
-		err := mm.InitModuleValuesValidator(moduleName, modulePath)
+		err := mm.AddOpenAPISchemas(moduleName, modulePath)
 		Expect(err).ShouldNot(HaveOccurred(), "should load openapi schemas for module '%s' from '%s'", moduleName, modulePath)
 		d8config.InitService(mm)
 	})


### PR DESCRIPTION
## Description

Validate raw spec.settings is not compatible with addon-operator behaviour. Addon-operator applies defaults before validating "config values" (see [module_manager.go](https://github.com/flant/addon-operator/blob/main/pkg/module_manager/module_manager.go#L979-L981)).

## Why do we need it, and what problem does it solve?

deckhouse-config module treats valid spec.settings as invalid and disables previously enabled module.

## What is the expected result?

Should not disable modules on update v1.40 -> v1.41.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse-config
type: fix
summary: Apply defaults before spec.settings validation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
