### PR TITLE
[ingress-nginx] fix manual pod rollout

### DIFF
--- a/modules/402-ingress-nginx/hooks/manual_daemonset_update.go
+++ b/modules/402-ingress-nginx/hooks/manual_daemonset_update.go
@@ -189,7 +189,7 @@ func filterManualDS(obj *unstructured.Unstructured) (go_hook.FilterResult, error
 	return manualDSController{
 		CRName:          ds.GetLabels()["name"],
 		DesiredPodCount: ds.Status.DesiredNumberScheduled,
-		CurrentPodCount: ds.Status.CurrentNumberScheduled,
+		CurrentPodCount: ds.Status.NumberAvailable,
 	}, nil
 }
 

--- a/modules/402-ingress-nginx/hooks/manual_daemonset_update_test.go
+++ b/modules/402-ingress-nginx/hooks/manual_daemonset_update_test.go
@@ -60,7 +60,7 @@ spec:
   updateStrategy:
     type: OnDelete
 status:
-  currentNumberScheduled: 1
+  numberAvailable: 1
   desiredNumberScheduled: 1
 ---
 apiVersion: apps/v1
@@ -178,7 +178,7 @@ spec:
   updateStrategy:
     type: OnDelete
 status:
-  currentNumberScheduled: 3
+  numberAvailable: 3
   desiredNumberScheduled: 3
 ---
 apiVersion: apps/v1
@@ -306,7 +306,7 @@ spec:
   updateStrategy:
     type: OnDelete
 status:
-  currentNumberScheduled: 3
+  numberAvailable: 3
   desiredNumberScheduled: 3
 ---
 apiVersion: apps/v1
@@ -423,7 +423,7 @@ spec:
   updateStrategy:
     type: OnDelete
 status:
-  currentNumberScheduled: 3
+  numberAvailable: 3
   desiredNumberScheduled: 3
 ---
 apiVersion: apps/v1
@@ -541,7 +541,7 @@ spec:
   updateStrategy:
     type: OnDelete
 status:
-  currentNumberScheduled: 1
+  numberAvailable: 1
   desiredNumberScheduled: 3
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Fix manual rollout for HostPort inlet
Close #3107 

## Why do we need it, and what problem does it solve?
We have to use `numberAvailable` field value not `currentNumberScheduled`. Because `numberAvailable` increments when pod is ready and available for at least minReadySeconds time, meanwhile `currentNumberScheduled` increments when pod is binded to a node

## What is the expected result?
```
# kubectl -n d8-ingress-nginx get pods

controller-main-2lc9z   3/3     Running       0          5m7s
controller-main-4ppbn   2/3     Terminating   0          6m42s
```

```
# kubectl -n d8-ingress-nginx get pods

controller-main-2lc9z   3/3     Running       0          5m7s
controller-main-vbqv5   0/3     ContainerCreating   0          0s
```

```
# kubectl -n d8-ingress-nginx get pods

controller-main-2lc9z   3/3     Running       0          5m7s
controller-main-vbqv5   2/3     Running   0          8s
```


```
# kubectl -n d8-ingress-nginx get pods

controller-main-vbqv5   3/3     Running   0          13s
controller-main-2lc9z   3/3     Terminating   0          5m31s
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ingress-nginx
type: fix 
summary: Fix manual pods rollout for HostPort inlet
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
