### PR TITLE
[ceph-csi] Allow non-admin ceph account for cephfs

### DIFF
--- a/modules/099-ceph-csi/templates/cephfs/secret.yaml
+++ b/modules/099-ceph-csi/templates/cephfs/secret.yaml
@@ -1,0 +1,12 @@
+{{- range $cr := .Values.cephCsi.internal.crs }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-cephfs-{{ $cr.name }}
+  namespace: d8-{{ $.Chart.Name }}
+{{ include "helm_lib_module_labels" (list $ (dict "app" $.Chart.Name)) | indent 2 }}
+stringData:
+  adminID: {{ $cr.spec.userID }}
+  adminKey: {{ $cr.spec.userKey }}
+{{- end }}

--- a/modules/099-ceph-csi/templates/cephfs/storage-classes.yaml
+++ b/modules/099-ceph-csi/templates/cephfs/storage-classes.yaml
@@ -20,11 +20,11 @@ mountOptions:
         {{- end }}
       {{- end }}
 parameters:
-  csi.storage.k8s.io/provisioner-secret-name: csi-{{ $cr.name }}
+  csi.storage.k8s.io/provisioner-secret-name: csi-cephfs-{{ $cr.name }}
   csi.storage.k8s.io/provisioner-secret-namespace: d8-{{ $.Chart.Name }}
-  csi.storage.k8s.io/controller-expand-secret-name: csi-{{ $cr.name }}
+  csi.storage.k8s.io/controller-expand-secret-name: csi-cephfs-{{ $cr.name }}
   csi.storage.k8s.io/controller-expand-secret-namespace: d8-{{ $.Chart.Name }}
-  csi.storage.k8s.io/node-stage-secret-name: csi-{{ $cr.name }}
+  csi.storage.k8s.io/node-stage-secret-name: csi-cephfs-{{ $cr.name }}
   csi.storage.k8s.io/node-stage-secret-namespace: d8-{{ $.Chart.Name }}
   clusterID: {{ $cr.spec.clusterID }}
   fsName: {{ $sc.fsName }}

--- a/modules/099-ceph-csi/templates/rbd/secret.yaml
+++ b/modules/099-ceph-csi/templates/rbd/secret.yaml
@@ -3,14 +3,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: csi-{{ $cr.name }}
+  name: csi-rbd-{{ $cr.name }}
   namespace: d8-{{ $.Chart.Name }}
 {{ include "helm_lib_module_labels" (list $ (dict "app" $.Chart.Name)) | indent 2 }}
 stringData:
-  {{- if eq $cr.spec.userID "admin" }}
-  adminID: {{ $cr.spec.userID }}
-  adminKey: {{ $cr.spec.userKey }}
-  {{- end }}
   userID: {{ $cr.spec.userID }}
   userKey: {{ $cr.spec.userKey }}
 {{- end }}

--- a/modules/099-ceph-csi/templates/rbd/storage-classes.yaml
+++ b/modules/099-ceph-csi/templates/rbd/storage-classes.yaml
@@ -13,11 +13,11 @@ parameters:
   clusterID: {{ $cr.spec.clusterID }}
   pool: {{ $sc.pool }}
   imageFeatures: layering
-  csi.storage.k8s.io/provisioner-secret-name: csi-{{ $cr.name }}
+  csi.storage.k8s.io/provisioner-secret-name: csi-rbd-{{ $cr.name }}
   csi.storage.k8s.io/provisioner-secret-namespace: d8-{{ $.Chart.Name }}
-  csi.storage.k8s.io/controller-expand-secret-name: csi-{{ $cr.name }}
+  csi.storage.k8s.io/controller-expand-secret-name: csi-rbd-{{ $cr.name }}
   csi.storage.k8s.io/controller-expand-secret-namespace: d8-{{ $.Chart.Name }}
-  csi.storage.k8s.io/node-stage-secret-name: csi-{{ $cr.name }}
+  csi.storage.k8s.io/node-stage-secret-name: csi-rbd-{{ $cr.name }}
   csi.storage.k8s.io/node-stage-secret-namespace: d8-{{ $.Chart.Name }}
   csi.storage.k8s.io/fstype: {{ $sc.defaultFSType }}
 reclaimPolicy: {{ $sc.reclaimPolicy }}


### PR DESCRIPTION
Signed-off-by: Vitaliy Snurnitsin <vitaliy.snurnitsin@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Allow non-admin ceph account for cephfs.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
It was necessary to use an account named "admin" for cephfs.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ceph-fs
type: fix
summary: Allow non-admin ceph account for cephfs
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
