### PR TITLE
[node-manager] fix ng capacity handling

### DIFF
--- a/modules/040-node-manager/hooks/get_crds.go
+++ b/modules/040-node-manager/hooks/get_crds.go
@@ -371,10 +371,10 @@ func getCRDsHandler(input *go_hook.HookInput) error {
 					nodeCapacity, err := capacity.CalculateNodeTemplateCapacity(nodeGroupInstanceClassKind, instanceClassSpec)
 					if err != nil {
 						input.LogEntry.Errorf("Calculate capacity failed for: %s with spec: %v. Error: %s", nodeGroupInstanceClassKind, instanceClassSpec, err)
-						setNodeGroupErrorStatus(input.PatchCollector, nodeGroup.Name, fmt.Sprintf("%s capacity is not set and instance type could not be found in the built-it types", nodeGroupInstanceClassKind))
-						continue
+						setNodeGroupErrorStatus(input.PatchCollector, nodeGroup.Name, fmt.Sprintf("%s capacity is not set and instance type could not be found in the built-it types. ScaleFromZero would not work until you set a capacity spec into the %s/%s", nodeGroupInstanceClassKind, nodeGroupInstanceClassKind, nodeGroup.Spec.CloudInstances.ClassReference.Name))
+					} else {
+						ngForValues["nodeCapacity"] = nodeCapacity
 					}
-					ngForValues["nodeCapacity"] = nodeCapacity
 				}
 			}
 

--- a/modules/040-node-manager/hooks/internal/autoscaler/capacity/capacity.go
+++ b/modules/040-node-manager/hooks/internal/autoscaler/capacity/capacity.go
@@ -218,6 +218,18 @@ func CalculateNodeTemplateCapacity(instanceClassName string, instanceClassSpec i
 		var spec openStackInstanceClass
 		extractor = &spec
 
+	case "D8TestInstanceClass":
+		// for test purpose
+		testspec := instanceClassSpec.(map[string]interface{})
+		if len(testspec) == 0 {
+			return nil, errors.New("Expected error for test")
+		} else {
+			return &Capacity{
+				CPU:    resource.MustParse("4"),
+				Memory: resource.MustParse("8Gi"),
+			}, nil
+		}
+
 	default:
 		return nil, errors.New("Unknown cloud provider")
 	}

--- a/modules/040-node-manager/hooks/internal/autoscaler/capacity/capacity.go
+++ b/modules/040-node-manager/hooks/internal/autoscaler/capacity/capacity.go
@@ -223,12 +223,11 @@ func CalculateNodeTemplateCapacity(instanceClassName string, instanceClassSpec i
 		testspec := instanceClassSpec.(map[string]interface{})
 		if len(testspec) == 0 {
 			return nil, errors.New("Expected error for test")
-		} else {
-			return &Capacity{
-				CPU:    resource.MustParse("4"),
-				Memory: resource.MustParse("8Gi"),
-			}, nil
 		}
+		return &Capacity{
+			CPU:    resource.MustParse("4"),
+			Memory: resource.MustParse("8Gi"),
+		}, nil
 
 	default:
 		return nil, errors.New("Unknown cloud provider")


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Fix node capacity value generation

## Why do we need it, and what problem does it solve?
In some cases wrong/missing capacity spec can lead to broken ng spec. I think we can set `nodeCapacity` value only if it's valid.  We have a protection inside the templates `{{- if $ng.nodeCapacity }}` so we will have an error and unscalable from zero node group but it would have a change to break a whole node-group spec and remove all nodes (because of `cloudInstances` is not set)

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: Fix node-group template generation when `minPerZone==0` and capacity is not set.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
