### PR TITLE
[user-authn] fix crowd proxy cert generator

### DIFF
--- a/modules/150-user-authn/hooks/generate_crowd_basic_auth_proxy_cert.go
+++ b/modules/150-user-authn/hooks/generate_crowd_basic_auth_proxy_cert.go
@@ -69,9 +69,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			NameSelector: &types.NameSelector{
 				MatchNames: []string{"crowd-basic-auth-cert"},
 			},
-			ExecuteHookOnSynchronization: pointer.BoolPtr(false),
-			ExecuteHookOnEvents:          pointer.BoolPtr(false),
-			FilterFunc:                   filterSecret,
+			FilterFunc: filterSecret,
 		},
 	},
 }, dependency.WithExternalDependencies(generateProxyAuthCert))


### PR DESCRIPTION
## Description
Fixed generate_crowd_basic_auth_proxy_cert.go hook

## Why do we need it, and what problem does it solve?
In a situation where the deckhouse was unable to rotate the certificate, previously it was necessary to restart the deckhouse, now it is enough to remove the expired certificate

## What is the expected result?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: user-authn
type: fix
summary: Fixed generate_crowd_basic_auth_proxy_cert.go hook
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
