### PR TITLE
[istio] exclude upmeter-probe-namespace-.* from kiali

### DIFF
--- a/ee/modules/110-istio/templates/kiali/configmap.yaml
+++ b/ee/modules/110-istio/templates/kiali/configmap.yaml
@@ -56,6 +56,7 @@ data:
         # https://www.formauri.es/personal/pgimeno/misc/non-match-regex/?word=ingress
         - ^d8-([^i]|i(i|n(i|g(i|r(i|e(i|si)))))*([^in]|n([^gi]|g([^ir]|r([^ei]|e([^is]|s[^is]))))))*(i(i|n(i|g(i|r(i|e(i|si)))))*(n(g?|gr(e?|es)))?)?$
         - ^kube-system$
+        - ^upmeter-probe-namespace-.+$
     server:
       metrics_enabled: true
       metrics_port: 9090


### PR DESCRIPTION
## Description
exclude `upmeter-probe-namespace-.*` from kiali

## Why do we need it, and what problem does it solve?
get rid of upmeter noise

## What is the expected result?
`upmeter-probe-namespace-.*` namespace is no longer displayed in the kiali dashboard

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: exclude `upmeter-probe-namespace-.*` from kiali
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
