### PR TITLE
[candi] Migrate to NAT gateway in yandex cloud Standard layout

### DIFF
--- a/candi/cloud-providers/yandex/layouts/standard/base-infrastructure/main.tf
+++ b/candi/cloud-providers/yandex/layouts/standard/base-infrastructure/main.tf
@@ -25,6 +25,7 @@ locals {
 
 module "vpc_components" {
   source = "../../../terraform-modules/vpc-components"
+  layout = local.layout
   prefix = local.prefix
   network_id = local.network_id
   node_network_cidr = local.node_network_cidr

--- a/candi/cloud-providers/yandex/layouts/standard/variables.tf
+++ b/candi/cloud-providers/yandex/layouts/standard/variables.tf
@@ -49,4 +49,5 @@ locals {
   dhcp_domain_name_servers = local.dhcp_options != null ? lookup(local.dhcp_options, "domainNameServers", null) : null
 
   labels = lookup(var.providerClusterConfiguration, "labels", {})
+  layout = var.providerClusterConfiguration.layout
 }

--- a/candi/cloud-providers/yandex/layouts/with-nat-instance/base-infrastructure/main.tf
+++ b/candi/cloud-providers/yandex/layouts/with-nat-instance/base-infrastructure/main.tf
@@ -26,6 +26,7 @@ locals {
 
 module "vpc_components" {
   source = "../../../terraform-modules/vpc-components"
+  layout = local.layout
   prefix = local.prefix
   network_id = local.network_id
   node_network_cidr = local.node_network_cidr
@@ -34,7 +35,6 @@ module "vpc_components" {
   dhcp_domain_name = local.dhcp_domain_name
   dhcp_domain_name_servers = local.dhcp_domain_name_servers
 
-  should_create_nat_instance = true
   nat_instance_external_address = local.nat_instance_external_address
   nat_instance_internal_address = local.nat_instance_internal_address
   nat_instance_internal_subnet_id = local.nat_instance_internal_subnet_id

--- a/candi/cloud-providers/yandex/layouts/with-nat-instance/variables.tf
+++ b/candi/cloud-providers/yandex/layouts/with-nat-instance/variables.tf
@@ -54,4 +54,5 @@ locals {
   dhcp_domain_name_servers = local.dhcp_options != null ? lookup(local.dhcp_options, "domainNameServers", null) : null
 
   labels = lookup(var.providerClusterConfiguration, "labels", {})
+  layout = var.providerClusterConfiguration.layout
 }

--- a/candi/cloud-providers/yandex/layouts/without-nat/base-infrastructure/main.tf
+++ b/candi/cloud-providers/yandex/layouts/without-nat/base-infrastructure/main.tf
@@ -23,6 +23,7 @@ locals {
 
 module "vpc_components" {
   source = "../../../terraform-modules/vpc-components"
+  layout = local.layout
   prefix = local.prefix
   network_id = local.network_id
   node_network_cidr = local.node_network_cidr

--- a/candi/cloud-providers/yandex/layouts/without-nat/variables.tf
+++ b/candi/cloud-providers/yandex/layouts/without-nat/variables.tf
@@ -49,4 +49,5 @@ locals {
   dhcp_domain_name_servers = local.dhcp_options != null ? lookup(local.dhcp_options, "domainNameServers", null) : null
 
   labels = lookup(var.providerClusterConfiguration, "labels", {})
+  layout = var.providerClusterConfiguration.layout
 }

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/main.tf
@@ -65,7 +65,7 @@ resource "yandex_vpc_route_table" "kube" {
   dynamic "static_route" {
     for_each = local.is_standard || local.is_with_nat_instance ? local.next_hop_address : []
     content {
-      destination_prefix = local.is_with_nat_instance ? "0.0.0.0/0" : null
+      destination_prefix = "0.0.0.0/0"
       next_hop_address   = static_route.value
       gateway_id         = local.is_standard ? yandex_vpc_gateway.kube[0].id : null
     }

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/main.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/main.tf
@@ -22,11 +22,17 @@ locals {
   not_have_existing_subnet_a = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-a", null) == null)
   not_have_existing_subnet_b = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-b", null) == null)
   not_have_existing_subnet_c = local.should_create_subnets || (lookup(var.existing_zone_to_subnet_id_map, "ru-central1-c", null) == null)
+
+  is_with_nat_instance = var.layout == "WithNATInstance"
+  is_standard          = var.layout == "Standard"
+
+  #For layout WithNATInstance we use next_hop_address and destination_prefix, for layout Standard we use created gateway
+  next_hop_address = local.is_with_nat_instance ? [local.nat_instance_internal_address_calculated] : [null]
 }
 
 data "yandex_vpc_subnet" "kube_a" {
-  count      = local.not_have_existing_subnet_a ? 0 : 1
-  subnet_id  = var.existing_zone_to_subnet_id_map.ru-central1-a
+  count     = local.not_have_existing_subnet_a ? 0 : 1
+  subnet_id = var.existing_zone_to_subnet_id_map.ru-central1-a
 }
 
 data "yandex_vpc_subnet" "kube_b" {
@@ -39,9 +45,16 @@ data "yandex_vpc_subnet" "kube_c" {
   subnet_id = var.existing_zone_to_subnet_id_map.ru-central1-c
 }
 
+resource "yandex_vpc_gateway" "kube" {
+  count  = local.is_standard ? 1 : 0
+  name   = var.prefix
+  labels = var.labels
+  shared_egress_gateway {}
+}
+
 resource "yandex_vpc_route_table" "kube" {
-  name           = var.prefix
-  network_id     = var.network_id
+  name       = var.prefix
+  network_id = var.network_id
 
   lifecycle {
     ignore_changes = [
@@ -49,11 +62,12 @@ resource "yandex_vpc_route_table" "kube" {
     ]
   }
 
-  dynamic static_route {
-    for_each = var.should_create_nat_instance ? [local.nat_instance_internal_address_calculated] : []
+  dynamic "static_route" {
+    for_each = local.is_standard || local.is_with_nat_instance ? local.next_hop_address : []
     content {
-      destination_prefix = "0.0.0.0/0"
-      next_hop_address = static_route.value
+      destination_prefix = local.is_with_nat_instance ? "0.0.0.0/0" : null
+      next_hop_address   = static_route.value
+      gateway_id         = local.is_standard ? yandex_vpc_gateway.kube[0].id : null
     }
   }
 
@@ -71,7 +85,7 @@ resource "yandex_vpc_subnet" "kube_a" {
   dynamic "dhcp_options" {
     for_each = (var.dhcp_domain_name != null) || (var.dhcp_domain_name_servers != null) ? [1] : []
     content {
-      domain_name = var.dhcp_domain_name
+      domain_name         = var.dhcp_domain_name
       domain_name_servers = var.dhcp_domain_name_servers
     }
   }
@@ -96,7 +110,7 @@ resource "yandex_vpc_subnet" "kube_b" {
   dynamic "dhcp_options" {
     for_each = (var.dhcp_domain_name != null) || (var.dhcp_domain_name_servers != null) ? [1] : []
     content {
-      domain_name = var.dhcp_domain_name
+      domain_name         = var.dhcp_domain_name
       domain_name_servers = var.dhcp_domain_name_servers
     }
   }
@@ -121,7 +135,7 @@ resource "yandex_vpc_subnet" "kube_c" {
   dynamic "dhcp_options" {
     for_each = (var.dhcp_domain_name != null) || (var.dhcp_domain_name_servers != null) ? [1] : []
     content {
-      domain_name = var.dhcp_domain_name
+      domain_name         = var.dhcp_domain_name
       domain_name_servers = var.dhcp_domain_name_servers
     }
   }

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 data "yandex_compute_image" "nat_image" {
-  count = var.should_create_nat_instance ? 1 : 0
+  count  = local.is_with_nat_instance ? 1 : 0
   family = "nat-instance-ubuntu"
 }
 
@@ -61,7 +61,7 @@ locals {
 
   # but if user pass nat instance internal address directly (it for backward compatibility) use passed address,
   # else get 10 host address from cidr which got in previous step
-  nat_instance_internal_address_calculated = var.should_create_nat_instance ? (var.nat_instance_internal_address == null ? cidrhost(local.nat_instance_cidr, 10) : var.nat_instance_internal_address) : null
+  nat_instance_internal_address_calculated = local.is_with_nat_instance ? (var.nat_instance_internal_address == null ? cidrhost(local.nat_instance_cidr, 10) : var.nat_instance_internal_address) : null
 
   assign_external_ip_address = var.nat_instance_external_subnet_id == null ? true : false
 
@@ -92,7 +92,7 @@ locals {
 }
 
 resource "yandex_compute_instance" "nat_instance" {
-  count = var.should_create_nat_instance ? 1 : 0
+  count = local.is_with_nat_instance ? 1 : 0
 
   name         = join("-", [var.prefix, "nat"])
   hostname     = join("-", [var.prefix, "nat"])

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/outputs.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/outputs.tf
@@ -31,5 +31,5 @@ output "zone_to_subnet_id_map" {
 }
 
 output "nat_instance_name" {
-  value = var.should_create_nat_instance ? yandex_compute_instance.nat_instance[0].name : ""
+  value = local.is_with_nat_instance ? yandex_compute_instance.nat_instance[0].name : ""
 }

--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/variables.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/variables.tf
@@ -40,9 +40,8 @@ variable "existing_zone_to_subnet_id_map" {
   default = {}
 }
 
-variable "should_create_nat_instance" {
-  type = bool
-  default = false
+variable "layout" {
+  type = string
 }
 
 variable "nat_instance_external_address" {

--- a/candi/terraform_versions.yml
+++ b/candi/terraform_versions.yml
@@ -28,4 +28,4 @@ vsphere:
 yandex:
   namespace: yandex-cloud
   type: yandex
-  version: 0.74.0
+  version: 0.83.0


### PR DESCRIPTION
Signed-off-by: Konstantin Aksenov <konstantin.aksenov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- Update terraform yandex provider to [v0.83.0](https://github.com/yandex-cloud/terraform-provider-yandex/releases/tag/v0.83.0)
- Use NAT gateway instead of deprecated feature "[NAT to the internet](https://cloud.yandex.com/en-ru/docs/vpc/operations/enable-nat)"

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
"NAT to the internet" is deprecated. New clusters can't be created using layout Standard.
If you have layout Standard, follow the [migration guide](https://docs.google.com/document/d/1ssFEfX1jL7YiGD0_ZyJc1awofjQRJeRlABFmXk3E3ws) to start using the new ["NAT gateway"](https://cloud.yandex.com/en-ru/docs/vpc/operations/create-nat-gateway) feature after Deckhouse release 1.42 is installed in an existing cluster.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] Standard layout checked manually.
- [x] WithNATInstance layout checked manually.
- [x] Check terraform changes on existing clusters.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: feature
summary: Migrate to NAT gateway in yandex cloud Standard layout
impact: |
  If you have layout Standard, follow the [migration guide](https://docs.google.com/document/d/1ssFEfX1jL7YiGD0_ZyJc1awofjQRJeRlABFmXk3E3ws) to start using the new ["NAT gateway"](https://cloud.yandex.com/en-ru/docs/vpc/operations/create-nat-gateway) feature.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
