### PR TITLE
[ci] Turn on canary deploy for the Beta release channel

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -6,8 +6,8 @@
     interval: "5m"
   "beta":
     enabled: false
-    waves: 1
-    interval: "1m"
+    waves: 3
+    interval: "30m"
   "early-access":
     enabled: true
     waves: 6


### PR DESCRIPTION
## Description
Turn on canary deploy for the Beta release channel.

## Changelog entries
```changes
section: ci
type: chore
summary: Turn on canary deploy for the Beta release channel.
impact_level: low
```
