### PR TITLE
[user-authn] Read CA from encoded PEM string

### DIFF
--- a/modules/150-user-authn/images/dex/patches/oidc-ca-insecure.patch
+++ b/modules/150-user-authn/images/dex/patches/oidc-ca-insecure.patch
@@ -1,8 +1,8 @@
 diff --git a/connector/oidc/oidc.go b/connector/oidc/oidc.go
-index e345dca0..32a612c5 100644
+index e345dca0..01e6c2e3 100644
 --- a/connector/oidc/oidc.go
 +++ b/connector/oidc/oidc.go
-@@ -3,11 +3,15 @@ package oidc
+@@ -3,9 +3,12 @@ package oidc
 
  import (
  	"context"
@@ -14,11 +14,8 @@ index e345dca0..32a612c5 100644
 +	"net"
  	"net/http"
  	"net/url"
-+	"os"
  	"strings"
- 	"time"
-
-@@ -34,6 +38,10 @@ type Config struct {
+@@ -34,6 +37,10 @@ type Config struct {
 
  	Scopes []string `json:"scopes"` // defaults to "profile" and "email"
 
@@ -29,7 +26,7 @@ index e345dca0..32a612c5 100644
  	// Override the value of email_verified to true in the returned claims
  	InsecureSkipEmailVerified bool `json:"insecureSkipEmailVerified"`
 
-@@ -105,8 +113,41 @@ func knownBrokenAuthHeaderProvider(issuerURL string) bool {
+@@ -105,8 +112,37 @@ func knownBrokenAuthHeaderProvider(issuerURL string) bool {
  // Open returns a connector which can be used to login users through an upstream
  // OpenID Connect provider.
  func (c *Config) Open(id string, logger log.Logger) (conn connector.Connector, err error) {
@@ -40,12 +37,8 @@ index e345dca0..32a612c5 100644
 +
 +	tlsConfig := tls.Config{RootCAs: pool, InsecureSkipVerify: c.InsecureSkipVerify}
 +	for _, rootCA := range c.RootCAs {
-+		rootCABytes, err := os.ReadFile(rootCA)
-+		if err != nil {
-+			return nil, fmt.Errorf("failed to read root-ca: %v", err)
-+		}
-+		if !tlsConfig.RootCAs.AppendCertsFromPEM(rootCABytes) {
-+			return nil, fmt.Errorf("no certs found in root CA file %q", rootCA)
++		if !tlsConfig.RootCAs.AppendCertsFromPEM([]byte(rootCA)) {
++			return nil, fmt.Errorf("cannot add CA from PEM")
 +		}
 +	}
 +


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
Read content directly, not from paths. It is pointless to try to read certificates from files because users cannot mount them.

## Why do we need it, and what problem does it solve?
This is a bug, the previously added feature does not work.

The reason of hotfixing — there is a customer with pilot project and hardly-closed infrastructure. Need to hurry the process up.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: user-authn
summary: Read CA for OIDC provider from encoded PEM string.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
