### PR TITLE
[deckhouse-config] disable deckhouse-config webhook for uninitialized cluster

### DIFF
--- a/modules/003-deckhouse-config/templates/deckhouse-config-webhook/webhook-configuration.yaml
+++ b/modules/003-deckhouse-config/templates/deckhouse-config-webhook/webhook-configuration.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.global.clusterIsBootstrapped }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -54,3 +55,4 @@ webhooks:
         name: deckhouse-config-webhook
         namespace: d8-system
         path: /validate-cm
+{{ end }}

--- a/modules/003-deckhouse-config/templates/deckhouse-config-webhook/webhook-configuration.yaml
+++ b/modules/003-deckhouse-config/templates/deckhouse-config-webhook/webhook-configuration.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.global.clusterIsBootstrapped }}
+{{- if .Values.global.clusterIsBootstrapped }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -55,4 +55,4 @@ webhooks:
         name: deckhouse-config-webhook
         namespace: d8-system
         path: /validate-cm
-{{ end }}
+{{- end }}


### PR DESCRIPTION
## Description

- Webhook has stuck in Pending status because it requires initialized cluster
- Deckhouse has stuck on global hook trying to update ConfigMap

 deckhouse-config-webhook seems redundant during cluster bootstrap.

## Why do we need it, and what problem does it solve?

Fix race condition "Global hook can't update the ConfigMap because node-manager can't remove the taint "uninitialized" because global hook holds the 'main' queue."

- Sometimes NodeManager does not have time to remove the taint "uninitialized" and Deckhouse Pod is restarted.
- During startup Deckhouse has stuck on global hook trying to update ConfigMap.
- deckhouse-config-webhook can't tolerate "unintialized" and has stuck in Pending status.

It was observed in real installations (not e2e tests) of Static cluster and in Azure.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse-config
type: fix
summary: disable deckhouse-config webhook for uninitialized cluster
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
