### PR TITLE
[prometheus] lock main queue during update

### DIFF
--- a/modules/040-control-plane-manager/hooks/lock_main_queue.go
+++ b/modules/040-control-plane-manager/hooks/lock_main_queue.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Flant JSC
+Copyright 2022 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/040-control-plane-manager/hooks/lock_main_queue.go
+++ b/modules/040-control-plane-manager/hooks/lock_main_queue.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Flant JSC
+Copyright 2021 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/300-prometheus/hooks/lock_main_queue_during_update.go
+++ b/modules/300-prometheus/hooks/lock_main_queue_during_update.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+)
+
+/*
+Description:
+	locks deckhouse main queue while prometheus Pod will be Ready
+*/
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue:       "main",
+	OnAfterHelm: &go_hook.OrderedConfig{Order: 20},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                         "prometheus_main_pod",
+			ApiVersion:                   "v1",
+			Kind:                         "Pod",
+			ExecuteHookOnEvents:          pointer.BoolPtr(false),
+			ExecuteHookOnSynchronization: pointer.BoolPtr(false),
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-monitoring"},
+				},
+			},
+			LabelSelector: &v1.LabelSelector{
+				MatchLabels: map[string]string{
+					"prometheus": "main",
+				},
+			},
+			FilterFunc: lockQueueFilterPod,
+		},
+	},
+}, handleLockMainQueue)
+
+type prometheusPod struct {
+	Name    string
+	IsReady bool
+}
+
+func lockQueueFilterPod(unstructured *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var pod corev1.Pod
+
+	err := sdk.FromUnstructured(unstructured, &pod)
+	if err != nil {
+		return nil, err
+	}
+
+	var isReady bool
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			isReady = true
+			break
+		}
+	}
+
+	cpod := prometheusPod{
+		Name:    pod.Name,
+		IsReady: isReady,
+	}
+
+	return cpod, nil
+}
+
+func handleLockMainQueue(input *go_hook.HookInput) error {
+	if !input.Values.Get("global.clusterIsBootstrapped").Bool() {
+		input.LogEntry.Info("Cluster is not yet bootstrapped, not locking main queue")
+		return nil
+	}
+
+	if !input.Values.Get("global.discovery.clusterControlPlaneIsHighlyAvailable").Bool() {
+		return nil
+	}
+
+	snap := input.Snapshots["prometheus_main_pod"]
+
+	if len(snap) == 0 {
+		return fmt.Errorf("lock the main queue: waiting for at least one prometheus-main pod with ready status")
+	}
+
+	readyCount := 0
+	for _, spod := range snap {
+		pod := spod.(prometheusPod)
+
+		if pod.IsReady {
+			readyCount++
+		}
+	}
+
+	if readyCount == 0 {
+		return fmt.Errorf("lock the main queue: waiting for at least one prometheus-main Pod to become Ready")
+	}
+
+	return nil
+}

--- a/modules/300-prometheus/hooks/lock_main_queue_during_update.go
+++ b/modules/300-prometheus/hooks/lock_main_queue_during_update.go
@@ -92,7 +92,14 @@ func handleLockMainQueue(input *go_hook.HookInput) error {
 		return nil
 	}
 
-	if !input.Values.Get("global.discovery.clusterControlPlaneIsHighlyAvailable").Bool() {
+	highAvailability := false
+	if input.Values.Exists("global.highAvailability") {
+		highAvailability = input.Values.Get("global.highAvailability").Bool()
+	}
+	if input.Values.Exists("prometheus.highAvailability") {
+		highAvailability = input.Values.Get("prometheus.highAvailability").Bool()
+	}
+	if !highAvailability {
 		return nil
 	}
 

--- a/modules/300-prometheus/hooks/lock_main_queue_during_update_test.go
+++ b/modules/300-prometheus/hooks/lock_main_queue_during_update_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Flant JSC
+Copyright 2022 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/modules/300-prometheus/hooks/lock_main_queue_during_update_test.go
+++ b/modules/300-prometheus/hooks/lock_main_queue_during_update_test.go
@@ -79,6 +79,26 @@ status:
   - type: Ready
     status: 'False'
 `
+		nodes = `
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-1
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-2
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+`
 	)
 
 	f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
@@ -96,7 +116,7 @@ status:
 
 	Context("Cluster having one prometheus main Pod being Ready", func() {
 		BeforeEach(func() {
-			f.KubeStateSet(runningReadyPods)
+			f.KubeStateSet(runningReadyPods + nodes)
 			f.BindingContexts.Set(f.GenerateAfterHelmContext())
 			f.ValuesSet("global.discovery.clusterControlPlaneIsHighlyAvailable", true)
 			f.RunHook()
@@ -109,8 +129,8 @@ status:
 
 	Context("Cluster having not Ready Pods", func() {
 		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(runningNotReadyPods))
-			f.ValuesSet("global.discovery.clusterControlPlaneIsHighlyAvailable", true)
+			f.BindingContexts.Set(f.KubeStateSet(runningNotReadyPods + nodes))
+			f.ValuesSet("global.highAvailability", true)
 			f.RunHook()
 		})
 
@@ -122,7 +142,7 @@ status:
 
 	Context("Cluster having not Ready Pods", func() {
 		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(runningNotReadyPods))
+			f.BindingContexts.Set(f.KubeStateSet(runningNotReadyPods + nodes))
 			f.ValuesSet("global.discovery.clusterControlPlaneIsHighlyAvailable", false)
 			f.RunHook()
 		})

--- a/modules/300-prometheus/hooks/lock_main_queue_during_update_test.go
+++ b/modules/300-prometheus/hooks/lock_main_queue_during_update_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: prometheus :: hooks :: lock_main_queue_during_update ::", func() {
+	const (
+		initValuesString       = `{"global": {"clusterIsBootstrapped": true}}`
+		initConfigValuesString = ``
+		runningReadyPods       = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    prometheus: main
+  name: prometheus-main-0
+  namespace: d8-monitoring
+status:
+  conditions:
+  - type: Ready
+    status: 'True'
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    prometheus: main
+  name: prometheus-main-1
+  namespace: d8-monitoring
+status:
+  conditions:
+  - type: Ready
+    status: 'False'
+`
+		runningNotReadyPods = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    prometheus: main
+  name: prometheus-main-0
+  namespace: d8-monitoring
+status:
+  conditions:
+  - type: Ready
+    status: 'False'
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    prometheus: main
+  name: prometheus-main-1
+  namespace: d8-monitoring
+status:
+  conditions:
+  - type: Ready
+    status: 'False'
+`
+	)
+
+	f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
+
+	Context("Empty cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Should exit without error", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+
+	Context("Cluster having one prometheus main Pod being Ready", func() {
+		BeforeEach(func() {
+			f.KubeStateSet(runningReadyPods)
+			f.BindingContexts.Set(f.GenerateAfterHelmContext())
+			f.ValuesSet("global.discovery.clusterControlPlaneIsHighlyAvailable", true)
+			f.RunHook()
+		})
+
+		It("Must be executed successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+	})
+
+	Context("Cluster having not Ready Pods", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(runningNotReadyPods))
+			f.ValuesSet("global.discovery.clusterControlPlaneIsHighlyAvailable", true)
+			f.RunHook()
+		})
+
+		It("Should exit with error", func() {
+			Expect(f).To(Not(ExecuteSuccessfully()))
+		})
+
+	})
+
+	Context("Cluster having not Ready Pods", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(runningNotReadyPods))
+			f.ValuesSet("global.discovery.clusterControlPlaneIsHighlyAvailable", false)
+			f.RunHook()
+		})
+
+		It("Must be executed successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+	})
+
+})


### PR DESCRIPTION
Signed-off-by: Vitaliy Snurnitsin <vitaliy.snurnitsin@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Lock main queue during deckhouse update in clusters with HA enabled.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When we are updating deckhouse and restarting a prometheus pod - we can left without any monitoring and alerts.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: feature
summary: Lock main queue during deckhouse update in clusters with HA enabled.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
