### PR TITLE
[control-plane-manager] Docs about how to migrate from multi-master to single-master

### DIFF
--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -10,7 +10,7 @@ Adding a master node to a static or hybrid cluster has no difference from adding
 
 ## How do I add a master nodes to a cloud cluster (single-master to a multi-master)?
 
-1. **На локальной машине** запустите контейнер установщика Deckhouse соответствующей редакции и версии (измените адрес container registry при необходимости):
+1. Run the appropriate edition and version of the Deckhouse installer container **on the local machine** (change the container registry address if necessary):
 
    ```bash
    DH_VERSION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/version}') \
@@ -19,20 +19,20 @@ Adding a master node to a static or hybrid cluster has no difference from adding
      registry.deckhouse.io/deckhouse/${DH_EDITION}/install:${DH_VERSION} bash
    ```
 
-1. **В контейнере с инсталлятором** выполните следующую команду и укажите требуемое количество реплик в параметре `masterNodeGroup.replicas`:
+1. **In the installer container**, run the following command and specify the required number of replicas using the `masterNodeGroup.replicas` parameter:
 
    ```bash
    dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
      --ssh-host <MASTER-NODE-0-HOST>
    ```
 
-1. **В контейнере с инсталлятором** выполните следующую команду, для запуска масштабирования:
+1. **In the installer container**, run the following command to start scaling:
 
    ```bash
    dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> --ssh-host <MASTER-NODE-0-HOST>
    ```
 
-1. Дождитесь появления необходимого количества master-узлов в статусе `Ready` и готовности всех экземпляров `control-plane-manager`:
+1. Wait until the required number of master nodes are `Ready` and all `control-plane-manager` instances are up and running:
 
    ```bash
    kubectl -n kube-system wait pod --timeout=10m --for=condition=ContainersReady -l app=d8-control-plane-manager
@@ -40,9 +40,9 @@ Adding a master node to a static or hybrid cluster has no difference from adding
 
 <div id="how-do-i-delete-the-master-node"></div>
 
-## Как уменьшить число master-узлов в облачном кластере (multi-master в single-master)?
+## How do I reduce the number of master nodes in a cloud cluster (multi-master to single-master)?
 
-1. **На локальной машине** запустите контейнер установщика Deckhouse соответствующей редакции и версии (измените адрес container registry при необходимости):
+1. Run the appropriate edition and version of the Deckhouse installer container **on the local machine** (change the container registry address if necessary):
 
    ```bash
    DH_VERSION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/version}') \
@@ -51,25 +51,25 @@ Adding a master node to a static or hybrid cluster has no difference from adding
      registry.deckhouse.io/deckhouse/${DH_EDITION}/install:${DH_VERSION} bash
    ```
 
-1. **В контейнере с инсталлятором** выполните следующую команду и укажите `1` в параметре `masterNodeGroup.replicas`:
+1. Run the following command **in the installer container** and set `masterNodeGroup.replicas` to `1`:
 
    ```bash
    dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> \
      --ssh-user=<USERNAME> --ssh-host <MASTER-NODE-0-HOST>
    ```
 
-1. Снимите следующие лейблы с удаляемых master-узлов:
+1. Remove the following labels from the master nodes to be deleted:
    * `node-role.kubernetes.io/control-plane`
    * `node-role.kubernetes.io/master`
    * `node.deckhouse.io/group`
 
-   Команда для снятия лейблов:
+   Use the following command to remove labels:
 
    ```bash
    kubectl label node <MASTER-NODE-N-NAME> node-role.kubernetes.io/control-plane- node-role.kubernetes.io/master- node.deckhouse.io/group-
    ```
 
-1. Убедитесь, что удаляемые master-узлы пропали из списка членов кластера etcd:
+1. Make sure that the master nodes to be deleted are no longer listed as etcd cluster members:
 
    ```bash
    kubectl -n kube-system exec -ti $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- sh -c \
@@ -78,27 +78,27 @@ Adding a master node to a static or hybrid cluster has no difference from adding
    --endpoints https://127.0.0.1:2379/ member list -w table"
    ```
 
-1. Выполните drain для удаляемых узлов:
+1. Drain the nodes being deleted:
 
    ```bash
    kubectl drain <MASTER-NODE-N-NAME> --ignore-daemonsets --delete-emptydir-data
    ```
 
-1. Выключите виртуальные машины, соответствующие удаляемым узлам, удалите инстансы соответствующих узлов из облака и подключенные к ним диски (`kubernetes-data-master-<N>`).
+1. Shut down the virtual machines corresponding to the nodes to be deleted, remove the instances of those nodes from the cloud and the disks connected to them (`kubernetes-data-master-<N>`).
 
-1. Удалите в кластере Pod'ы, оставшиеся на удаленных узлах:
+1. In the cluster, delete the Pods running on the nodes being deleted:
 
    ```bash
    kubectl delete pods --all-namespaces --field-selector spec.nodeName=<MASTER-NODE-N-NAME> --force
    ```
 
-1. Удалите в кластере объекты Node удаленных узлов:
+1. In the cluster, delete the Nore objects associated with the nodes being deleted:
 
    ```bash
    kubectl delete node <MASTER-NODE-N-NAME>
    ```
 
-1. **В контейнере с инсталлятором** выполните следующую команду, для запуска масштабирования:
+1. **In the installer container**, run the following command to start scaling:
 
    ```bash
    dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> --ssh-host <MASTER-NODE-0-HOST>
@@ -107,7 +107,7 @@ Adding a master node to a static or hybrid cluster has no difference from adding
 ## How do I dismiss the master role while keeping the node?
 
 1. Remove the `node.deckhouse.io/group: master` and `node-role.kubernetes.io/control-plane: ""` labels.
-1. Убедитесь, что удаляемый master-узел пропал из списка членов кластера etcd:
+1. Make sure that the master node to be deleted is no longer listed as a member of the etcd cluster:
 
    ```bash
    kubectl -n kube-system exec -ti $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- sh -c \
@@ -128,9 +128,9 @@ Adding a master node to a static or hybrid cluster has no difference from adding
    rm -rf /var/lib/etcd/member/
    ```
 
-## Как изменить образ ОС в multi-master-кластере?
+## How do I switch to a different OS image in a multi-master cluster?
 
-1. **На локальной машине** запустите контейнер установщика Deckhouse соответствующей редакции и версии (измените адрес container registry при необходимости):
+1. Run the appropriate edition and version of the Deckhouse installer container **on the local machine** (change the container registry address if necessary):
 
    ```bash
    DH_VERSION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/version}') \
@@ -139,29 +139,29 @@ Adding a master node to a static or hybrid cluster has no difference from adding
      registry.deckhouse.io/deckhouse/${DH_EDITION}/install:${DH_VERSION} bash
    ```
 
-1. **В контейнере с инсталлятором** выполните следующую команду и укажите необходимый образ ОС в параметре `masterNodeGroup.instanceClass` (укажите адреса всех master-узлов в параметре `--ssh-host`):
+1. **In the installer container**, run the following command and specify the required OS image using the `masterNodeGroup.instanceClass` parameter (specify the addresses of all master nodes using the `-ssh-host` parameter):
 
    ```bash
    dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
      --ssh-host <MASTER-NODE-0-HOST> --ssh-host <MASTER-NODE-1-HOST> --ssh-host <MASTER-NODE-2-HOST>
    ```
 
-Следующие действия **выполняйте поочередно на каждом** master-узле, начиная с узла с наивысшим номером (с суффиксом 2) и заканчивая узлом с наименьшим номером (с суффиксом 0).
+Repeat the steps below for **each master node one by one**, starting with the node with the highest number (suffix 2) and ending with the node with the lowest number (suffix 0).
 
-1. Выберите master-узел для обновления (укажите его название):
+1. Select the master node to update (enter its name):
 
    ```bash
    NODE="<MASTER-NODE-N-NAME>"
    ```
 
-1. Выполните следующую команду для снятия лейблов `node-role.kubernetes.io/control-plane`, `node-role.kubernetes.io/master`, `node.deckhouse.io/group` с узла:
+1. Run the following command to remove the `node-role.kubernetes.io/control-plane`, `node-role.kubernetes.io/master`, and `node.deckhouse.io/group` labels from the node:
 
    ```bash
    kubectl label node ${NODE} \
      node-role.kubernetes.io/control-plane- node-role.kubernetes.io/master- node.deckhouse.io/group-
    ```
 
-1. Убедитесь, что узел пропал из списка членов кластера etcd:
+1. Make sure that the node is no longer listed as an etcd cluster member:
 
    ```bash
    kubectl -n kube-system exec -ti $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- sh -c \
@@ -170,40 +170,40 @@ Adding a master node to a static or hybrid cluster has no difference from adding
    --endpoints https://127.0.0.1:2379/ member list -w table"
    ```
 
-1. Выполните `drain` для узла:
+1. Drain the node:
 
    ```bash
    kubectl drain ${NODE} --ignore-daemonsets --delete-emptydir-data
    ```
 
-1. Выключите виртуальную машину, соответствующую узлу, удалите инстанс узла из облака и подключенные к нему диски (kubernetes-data).
+1. Shut down the virtual machine associated with the node, remove the node instance from the cloud and the disks connected to it (`kubernetes-data`).
 
-1. Удалите в кластере Pod'ы, оставшиеся на удаляемом узле:
+1. In the cluster, delete the Pods remaining on the node being deleted:
 
    ```bash
    kubectl delete pods --all-namespaces --field-selector spec.nodeName=${NODE} --force
    ```
 
-1. Удалите в кластере объект Node удаленного узла:
+1. In the cluster, delete the Node object for the node being deleted:
 
    ```bash
    kubectl delete node ${NODE}
    ```
 
-1. **В контейнере с инсталлятором** выполните следующую команду, для создания обновленного узла:
+1. **In the installer container**, run the following command to create the updated node:
 
    ```bash
    dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
      --ssh-host <MASTER-NODE-0-HOST> --ssh-host <MASTER-NODE-1-HOST> --ssh-host <MASTER-NODE-2-HOST>
    ```
 
-1. **На созданном узле** посмотрите журнал systemd-unit'а `bashible.service`. Дождитесь окончания настройки узла, — сообщения `nothing to do` в журнале:
+1. **On the newly created node**, check the systemd-unit log for the `bashible.service`. Wait until the node configuration is complete (you will see a message `nothing to do` in the log):
 
    ```bash
    journalctl -fu bashible.service
    ```
 
-1. Убедитесь, что узел появился в списке членов кластера etcd:
+1. Make sure the node is listed as an etcd cluster member:
 
    ```bash
    kubectl -n kube-system exec -ti $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- sh -c \
@@ -212,23 +212,23 @@ Adding a master node to a static or hybrid cluster has no difference from adding
    --endpoints https://127.0.0.1:2379/ member list -w table"
    ```
 
-1. Убедитесь, что `control-plane-manager` функционирует на узле.
+1. Make sure `control-plane-manager` is running on the node:
 
    ```bash
    kubectl -n kube-system wait pod --timeout=10m --for=condition=ContainersReady \
      -l app=d8-control-plane-manager --field-selector spec.nodeName=${NODE}
    ```
 
-1. Перейдите к обновлению следующего узла.
+1. Proceed to update the next node (repeat the steps above).
 
-## Как изменить образ ОС в single-master-кластере?
+## How do I switch to a different OS image in a single-master cluster?
 
-1. Преобразуйте single-master-кластер в multi-master в соответствии с [инструкцией](#как-добавить master-узлы-в-облачном-кластере-single-master-в-multi-master).
+1. Convert your single-master cluster to a multi-master one, as described in [the guide on adding master nodes to a cluster](#how-do-i-add-a-master-nodes-to-a-cloud-cluster-single-master-to-a-multi-master).
 
-   > Помимо увеличения числа реплик вы можете сразу указать образ с необходимой версией ОС в параметре `masterNode.instanceClass`.
+   > In addition to increasing the number of replicas, you can also specify the image with the required OS version using the `masterNode.instanceClass` parameter.
 
-1. Обновите master-узлы в соответствии с [инструкцией](#как-изменить-образ-ос-в-multi-master-кластере).
-1. Преобразуйте multi-master-кластер в single-master в соответствии с [инструкцией](#как-уменьшить-число-master-узлов-в-облачном-кластере-multi-master-в-single-master)
+1. Update the master nodes following the [instructions](#how-do-i-switch-to-a-different-os-image-in-a-multi-master-cluster).
+1. Convert your multi-master cluster to a single-master one according to [the guide on excluding master nodes from the cluster](#how-do-i-reduce-the-number-of-master-nodes-in-a-cloud-cluster-multi-master-to-single-master).
 
 ## How do I view the list of etcd members?
 

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -286,6 +286,7 @@ You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-
 2. Измените число реплик для masterNodeGroup на требуемое.
 
    Пример:
+
    ```bash
    dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
    --ssh-host <MASTER-NODE-0>
@@ -300,6 +301,7 @@ You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-
 3. Выполните converge.
 
    Пример:
+
     ```bash
     dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> \
     --ssh-user=<USERNAME> \
@@ -326,6 +328,7 @@ You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-
 2. Измените число реплик для masterNodeGroup на требуемое.
 
    Пример:
+
    ```bash
    dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
    --ssh-host <MASTER-NODE-0>
@@ -338,9 +341,9 @@ You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-
    ```
 
 3. Снимите следующие лейблы с удаляемых узлов:
-  * node-role.kubernetes.io/control-plane
-  * node-role.kubernetes.io/master
-  * node.deckhouse.io/group
+* node-role.kubernetes.io/control-plane
+* node-role.kubernetes.io/master
+* node.deckhouse.io/group
 
    Пример:
     ```bash
@@ -348,7 +351,7 @@ You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-
     node-role.kubernetes.io/control-plane- \
     node-role.kubernetes.io/master- \
     node.deckhouse.io/group-
-    ```
+```
 
 4. Убедитесь, что ноды пропали из member'ов etcd.
 
@@ -360,6 +363,7 @@ You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-
 5. Выполните drain для удаляемых узлов.
 
    Пример:
+
    ```bash
    kubectl drain <имя удаляемого узла> --ignore-daemonsets --delete-emptydir-data
    ```
@@ -369,6 +373,7 @@ You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-
 7. Удалите оставшиеся ресурсы с узлов.
 
    Пример:
+
     ```bash
     kubectl delete pods --all-namespaces --field-selector spec.nodeName=<имя удаляемого узла> --force
     ```
@@ -376,6 +381,7 @@ You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-
 8. Удалите ресурсы узлов.
 
    Пример:
+
    ```bash
    kubectl delete node <имя удаляемого узла>
    ```
@@ -383,6 +389,7 @@ You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-
 9. Выполните converge.
 
    Пример:
+
     ```bash
     dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> \
     --ssh-user=<USERNAME> \
@@ -435,6 +442,7 @@ You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-
 * node.deckhouse.io/group
 
 Пример:
+
 ```bash
 kubectl label node <имя удаляемого узла> \
 node-role.kubernetes.io/control-plane- \
@@ -502,11 +510,9 @@ node.deckhouse.io/group-
 
 ## Как изменить образ ОС в single-master кластере
 
-
 1. Преобразуйте single-master в multi-master кластер в соответствии с [инструкцией](#как-увеличить-число-master-узлов)
 
 > Внимание! Помимо увеличения числа реплик, также рекомендуется сразу установить требуемую версию ОС в masterNode.instanceClass.template: <new image version>
 
 2. Обновите master-узлы в соответствии с [инструкцией](#как-изменить-образ-ОС-в-multi-master-кластере)
 3. Преобразуйте multi-master в single-master кластер в соответствии с [инструкцией](#как-уменьшить-число-master-узлов)
-

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -365,8 +365,8 @@ kubectl drain <master-node-name-2> --ignore-daemonsets --delete-emptydir-data
 8. Delete the remaining pods from the deleted nodes.
 
 ```bash
-kubectl delete pods --all-namespaces -o wide --field-selector spec.nodeName=<master-node-name-1>
-kubectl delete pods --all-namespaces -o wide --field-selector spec.nodeName=<master-node-name-2>
+kubectl delete pods --all-namespaces --field-selector spec.nodeName=<master-node-name-1> --force
+kubectl delete pods --all-namespaces --field-selector spec.nodeName=<master-node-name-2> --force
 ```
 
 9. Delete node resources `<master-node-name-1>`, `<master-node-name-1>`.
@@ -382,6 +382,8 @@ dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> \
 --ssh-user=<USERNAME> \
 --ssh-host <master-node-name-0>
 ```
+
+> When running the command, make sure that you plan to delete desired nodes!
 
 11. Make sure that the control-plane-manager is functioning.
 
@@ -453,7 +455,7 @@ kubectl drain ${NODE} --ignore-daemonsets --delete-emptydir-data
 6. Delete the pods remaining on the deleted `<master-node-name-x>` node.
 
 ```bash
-kubectl delete pods --all-namespaces -o wide --field-selector spec.nodeName=${NODE}
+kubectl delete pods --all-namespaces --field-selector spec.nodeName=${NODE} --force
 ```
 
 7. Delete node resource `<master-node-name-x>`.
@@ -471,6 +473,8 @@ dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> \
 --ssh-host <master-node-name-1> \
 --ssh-host <master-node-name-2>
 ```
+
+> When running the command, make sure that you plan to delete the desired node!
 
 9. In the `bashible.service` logs, the newly created `<master-node-name-x>` node should have the message "nothing to do".
 

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -10,6 +10,8 @@ Adding a master node to a static or hybrid cluster has no difference from adding
 
 ## How do I add a master nodes to a cloud cluster (single-master to a multi-master)?
 
+> Before adding nodes, ensure you have the required quotas in the cloud provider.
+
 1. Run the appropriate edition and version of the Deckhouse installer container **on the local machine** (change the container registry address if necessary):
 
    ```bash

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -292,6 +292,8 @@ You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-
    --ssh-host <MASTER-NODE-0>
    ```
 
+Фрагмент конфигурации:
+
    ```yaml
    masterNodeGroup:
      instanceClass:
@@ -334,6 +336,8 @@ You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-
    --ssh-host <MASTER-NODE-0>
    ```
 
+   Фрагмент конфигурации:
+
    ```yaml
    masterNodeGroup:
      instanceClass:
@@ -341,19 +345,20 @@ You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-
    ```
 
 3. Снимите следующие лейблы с удаляемых узлов:
-* node-role.kubernetes.io/control-plane
-* node-role.kubernetes.io/master
-* node.deckhouse.io/group
+  * node-role.kubernetes.io/control-plane
+  * node-role.kubernetes.io/master
+  * node.deckhouse.io/group
 
    Пример:
+
     ```bash
     kubectl label node <имя удаляемого узла> \
     node-role.kubernetes.io/control-plane- \
     node-role.kubernetes.io/master- \
     node.deckhouse.io/group-
-```
+    ```
 
-4. Убедитесь, что ноды пропали из member'ов etcd.
+4. Убедитесь, что узлы пропали из членов кластера etcd.
 
    ```bash
    kubectl -n kube-system exec -ti $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- sh -c \
@@ -417,10 +422,14 @@ You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-
 
 2. Измените образ ОС для masterNodeGroup.
 
+   Пример:
+
    ```bash
    dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
    --ssh-host <MASTER-NODE-0> --ssh-host <MASTER-NODE-1> --ssh-host <MASTER-NODE-2>
    ```
+
+   Фрагмент конфигурации:
 
    ```yaml
    masterNodeGroup:
@@ -441,13 +450,12 @@ You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-
 * node-role.kubernetes.io/master
 * node.deckhouse.io/group
 
-Пример:
-
-```bash
-kubectl label node <имя удаляемого узла> \
-node-role.kubernetes.io/control-plane- \
-node-role.kubernetes.io/master- \
-node.deckhouse.io/group-
+  Пример:
+    ```bash
+    kubectl label node <имя удаляемого узла> \
+    node-role.kubernetes.io/control-plane- \
+    node-role.kubernetes.io/master- \
+    node.deckhouse.io/group-
 ```
 
 3. Убедитесь что узел пропал из членов etcd кластера.
@@ -457,7 +465,7 @@ node.deckhouse.io/group-
    "ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table"
    ```
 
-4. Выполните `drain` для `<MASTER-NODE-X>`.
+4. Выполните `drain` для узла `<MASTER-NODE-X>`.
 
    ```bash
    kubectl drain ${NODE} --ignore-daemonsets --delete-emptydir-data
@@ -489,7 +497,7 @@ node.deckhouse.io/group-
 
    > При выполнении команды убедитесь, что планируется удалить именно требуемые узлы!
 
-9. В логах `bashible.service` на вновь созданной ноде `<MASTER-NODE-X>` должно быть сообщение “nothing to do”.
+9. В логах `bashible.service` на вновь созданном узле `<MASTER-NODE-X>` должно быть сообщение “nothing to do”.
 
    ```bash
    journalctl -fu bashible.service

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -2,62 +2,121 @@
 title: "Managing control plane: FAQ"
 ---
 
-## How do I add a master node?
+<div id="how-do-i-add-a-master-node"></div>
 
-### Static or hybrid cluster
+## How do I add a master node to a static or hybrid cluster?
 
 Adding a master node to a static or hybrid cluster has no difference from adding a regular node to a cluster. To do this, use the corresponding [instruction](../040-node-manager/faq.html#how-do-i-add-a-static-node-to-a-cluster). All the necessary actions to configure a cluster control plane components on the new master nodes are performed automatically. Wait until the master nodes appear in `Ready` status.
 
-### Cloud cluster
+## How do I add a master nodes to a cloud cluster (single-master to a multi-master)?
 
-> Make sure you have all the necessary quota limits, before adding nodes.
+1. **На локальной машине** запустите контейнер установщика Deckhouse соответствующей редакции и версии (измените адрес container registry при необходимости):
 
-To add one or more master nodes to a cloud cluster, follow these steps:
-1. Determine the Deckhouse version and edition used in the cluster by running the following command on the master node or a host with configured kubectl access to the cluster:
-
-   ```shell
-   kubectl -n d8-system get deployment deckhouse \
-   -o jsonpath='version-{.metadata.annotations.core\.deckhouse\.io\/version}, edition-{.metadata.annotations.core\.deckhouse\.io\/edition}' \
-   | tr '[:upper:]' '[:lower:]'
-   ```
-
-1. Run the corresponding version and edition of the Deckhouse installer:
-
-   ```shell
+   ```bash
+   DH_VERSION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/version}') \
+   DH_EDITION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/edition}') \
    docker run --pull=always -it -v "$HOME/.ssh/:/tmp/.ssh/" \
-   registry.deckhouse.io/deckhouse/<DECKHOUSE_EDITION>/install:<DECKHOUSE_VERSION> bash
+     registry.deckhouse.io/deckhouse/${DH_EDITION}/install:${DH_VERSION} bash
    ```
 
-   For example, if the Deckhouse version in the cluster is `v1.28.0` and the Deckhouse edition is `ee`, the command to run the installer will be:
+1. **В контейнере с инсталлятором** выполните следующую команду и укажите требуемое количество реплик в параметре `masterNodeGroup.replicas`:
 
-   ```shell
-   docker run --pull=always -it -v "$HOME/.ssh/:/tmp/.ssh/" registry.deckhouse.io/deckhouse/ee/install:v1.28.0 bash
-   ```
-
-   > Change the container registry address if necessary (e.g, if you use an internal container registry).
-
-1. Run the following command inside the installer container (use the `--ssh-bastion-*` parameters if using a bastion host):
-
-   ```shell
+   ```bash
    dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
-   --ssh-host <SSH_HOST>
+     --ssh-host <MASTER-NODE-0-HOST>
    ```
 
-1. Specify the required number of master node replicas in the `masterNodeGroup.replicas` field and save changes.
-1. Start scaling process by running the following command (specify the appropriate cluster access parameters, as in the previous step):
+1. **В контейнере с инсталлятором** выполните следующую команду, для запуска масштабирования:
 
-   ```shell
-   dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> --ssh-host <SSH_HOST>
+   ```bash
+   dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> --ssh-host <MASTER-NODE-0-HOST>
    ```
 
-1. Answer `Yes` to the question `Do you want to CHANGE objects state in the cloud?`.
+1. Дождитесь появления необходимого количества master-узлов в статусе `Ready` и готовности всех экземпляров `control-plane-manager`:
 
-All the other actions are performed automatically. Wait until the master nodes appears in Ready status.
+   ```bash
+   kubectl -n kube-system wait pod --timeout=10m --for=condition=ContainersReady -l app=d8-control-plane-manager
+   ```
+
+<div id="how-do-i-delete-the-master-node"></div>
+
+## Как уменьшить число master-узлов в облачном кластере (multi-master в single-master)?
+
+1. **На локальной машине** запустите контейнер установщика Deckhouse соответствующей редакции и версии (измените адрес container registry при необходимости):
+
+   ```bash
+   DH_VERSION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/version}') \
+   DH_EDITION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/edition}') \
+   docker run --pull=always -it -v "$HOME/.ssh/:/tmp/.ssh/" \
+     registry.deckhouse.io/deckhouse/${DH_EDITION}/install:${DH_VERSION} bash
+   ```
+
+1. **В контейнере с инсталлятором** выполните следующую команду и укажите `1` в параметре `masterNodeGroup.replicas`:
+
+   ```bash
+   dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> \
+     --ssh-user=<USERNAME> --ssh-host <MASTER-NODE-0-HOST>
+   ```
+
+1. Снимите следующие лейблы с удаляемых master-узлов:
+   * `node-role.kubernetes.io/control-plane`
+   * `node-role.kubernetes.io/master`
+   * `node.deckhouse.io/group`
+
+   Команда для снятия лейблов:
+
+   ```bash
+   kubectl label node <MASTER-NODE-N-NAME> node-role.kubernetes.io/control-plane- node-role.kubernetes.io/master- node.deckhouse.io/group-
+   ```
+
+1. Убедитесь, что удаляемые master-узлы пропали из списка членов кластера etcd:
+
+   ```bash
+   kubectl -n kube-system exec -ti $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- sh -c \
+   "ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt \
+   --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key \
+   --endpoints https://127.0.0.1:2379/ member list -w table"
+   ```
+
+1. Выполните drain для удаляемых узлов:
+
+   ```bash
+   kubectl drain <MASTER-NODE-N-NAME> --ignore-daemonsets --delete-emptydir-data
+   ```
+
+1. Выключите виртуальные машины, соответствующие удаляемым узлам, удалите инстансы соответствующих узлов из облака и подключенные к ним диски (`kubernetes-data-master-<N>`).
+
+1. Удалите в кластере Pod'ы, оставшиеся на удаленных узлах:
+
+   ```bash
+   kubectl delete pods --all-namespaces --field-selector spec.nodeName=<MASTER-NODE-N-NAME> --force
+   ```
+
+1. Удалите в кластере объекты Node удаленных узлов:
+
+   ```bash
+   kubectl delete node <MASTER-NODE-N-NAME>
+   ```
+
+1. **В контейнере с инсталлятором** выполните следующую команду, для запуска масштабирования:
+
+   ```bash
+   dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> --ssh-host <MASTER-NODE-0-HOST>
+   ```
 
 ## How do I dismiss the master role while keeping the node?
 
-1. Remove the `node.deckhouse.io/group: master` and `node-role.kubernetes.io/control-plane: ""` labels, then wait for the etcd member to be automatically deleted.
-2. Exec to the node and run the following commands:
+1. Remove the `node.deckhouse.io/group: master` and `node-role.kubernetes.io/control-plane: ""` labels.
+1. Убедитесь, что удаляемый master-узел пропал из списка членов кластера etcd:
+
+   ```bash
+   kubectl -n kube-system exec -ti $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- sh -c \
+   "ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt \
+   --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key \
+   --endpoints https://127.0.0.1:2379/ member list -w table"
+   ```
+
+1. Exec to the node and run the following commands:
 
    ```shell
    rm -f /etc/kubernetes/manifests/{etcd,kube-apiserver,kube-scheduler,kube-controller-manager}.yaml
@@ -68,6 +127,108 @@ All the other actions are performed automatically. Wait until the master nodes a
    rm -rf /etc/kubernetes/pki/{ca.key,apiserver*,etcd/,front-proxy*,sa.*}
    rm -rf /var/lib/etcd/member/
    ```
+
+## Как изменить образ ОС в multi-master-кластере?
+
+1. **На локальной машине** запустите контейнер установщика Deckhouse соответствующей редакции и версии (измените адрес container registry при необходимости):
+
+   ```bash
+   DH_VERSION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/version}') \
+   DH_EDITION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/edition}') \
+   docker run --pull=always -it -v "$HOME/.ssh/:/tmp/.ssh/" \
+     registry.deckhouse.io/deckhouse/${DH_EDITION}/install:${DH_VERSION} bash
+   ```
+
+1. **В контейнере с инсталлятором** выполните следующую команду и укажите необходимый образ ОС в параметре `masterNodeGroup.instanceClass` (укажите адреса всех master-узлов в параметре `--ssh-host`):
+
+   ```bash
+   dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
+     --ssh-host <MASTER-NODE-0-HOST> --ssh-host <MASTER-NODE-1-HOST> --ssh-host <MASTER-NODE-2-HOST>
+   ```
+
+Следующие действия **выполняйте поочередно на каждом** master-узле, начиная с узла с наивысшим номером (с суффиксом 2) и заканчивая узлом с наименьшим номером (с суффиксом 0).
+
+1. Выберите master-узел для обновления (укажите его название):
+
+   ```bash
+   NODE="<MASTER-NODE-N-NAME>"
+   ```
+
+1. Выполните следующую команду для снятия лейблов `node-role.kubernetes.io/control-plane`, `node-role.kubernetes.io/master`, `node.deckhouse.io/group` с узла:
+
+   ```bash
+   kubectl label node ${NODE} \
+     node-role.kubernetes.io/control-plane- node-role.kubernetes.io/master- node.deckhouse.io/group-
+   ```
+
+1. Убедитесь, что узел пропал из списка членов кластера etcd:
+
+   ```bash
+   kubectl -n kube-system exec -ti $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- sh -c \
+   "ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt \
+   --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key \
+   --endpoints https://127.0.0.1:2379/ member list -w table"
+   ```
+
+1. Выполните `drain` для узла:
+
+   ```bash
+   kubectl drain ${NODE} --ignore-daemonsets --delete-emptydir-data
+   ```
+
+1. Выключите виртуальную машину, соответствующую узлу, удалите инстанс узла из облака и подключенные к нему диски (kubernetes-data).
+
+1. Удалите в кластере Pod'ы, оставшиеся на удаляемом узле:
+
+   ```bash
+   kubectl delete pods --all-namespaces --field-selector spec.nodeName=${NODE} --force
+   ```
+
+1. Удалите в кластере объект Node удаленного узла:
+
+   ```bash
+   kubectl delete node ${NODE}
+   ```
+
+1. **В контейнере с инсталлятором** выполните следующую команду, для создания обновленного узла:
+
+   ```bash
+   dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
+     --ssh-host <MASTER-NODE-0-HOST> --ssh-host <MASTER-NODE-1-HOST> --ssh-host <MASTER-NODE-2-HOST>
+   ```
+
+1. **На созданном узле** посмотрите журнал systemd-unit'а `bashible.service`. Дождитесь окончания настройки узла, — сообщения `nothing to do` в журнале:
+
+   ```bash
+   journalctl -fu bashible.service
+   ```
+
+1. Убедитесь, что узел появился в списке членов кластера etcd:
+
+   ```bash
+   kubectl -n kube-system exec -ti $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- sh -c \
+   "ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt \
+   --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key \
+   --endpoints https://127.0.0.1:2379/ member list -w table"
+   ```
+
+1. Убедитесь, что `control-plane-manager` функционирует на узле.
+
+   ```bash
+   kubectl -n kube-system wait pod --timeout=10m --for=condition=ContainersReady \
+     -l app=d8-control-plane-manager --field-selector spec.nodeName=${NODE}
+   ```
+
+1. Перейдите к обновлению следующего узла.
+
+## Как изменить образ ОС в single-master-кластере?
+
+1. Преобразуйте single-master-кластер в multi-master в соответствии с [инструкцией](#как-добавить master-узлы-в-облачном-кластере-single-master-в-multi-master).
+
+   > Помимо увеличения числа реплик вы можете сразу указать образ с необходимой версией ОС в параметре `masterNode.instanceClass`.
+
+1. Обновите master-узлы в соответствии с [инструкцией](#как-изменить-образ-ос-в-multi-master-кластере).
+1. Преобразуйте multi-master-кластер в single-master в соответствии с [инструкцией](#как-уменьшить-число-master-узлов-в-облачном-кластере-multi-master-в-single-master)
 
 ## How do I view the list of etcd members?
 
@@ -271,256 +432,3 @@ We recommend encrypting etcd snapshot backups as well as backup of the directory
 You can use one of third-party files backup tools, for example: [Restic](https://restic.net/), [Borg](https://borgbackup.readthedocs.io/en/stable/), [Duplicity](https://duplicity.gitlab.io/), etc.
 
 You can see [here](https://github.com/deckhouse/deckhouse/blob/main/modules/040-control-plane-manager/docs/internal/ETCD_RECOVERY.md) for learn about etcd disaster recovery procedures from snapshots.
-
-## Как увеличить число master-узлов
-
-1. Запустите контейнер установщика Deckhouse соответствующей редакции и версии (на локальной машине).
-
-    ```bash
-    DH_VERSION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/version}') \
-    DH_EDITION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/edition}') \
-    docker run --pull=always -it -v "$HOME/.ssh/:/tmp/.ssh/" \                                                                                        
-    registry.deckhouse.io/deckhouse/${DH_EDITION}/install:${DH_VERSION} bash
-    ```
-
-2. Измените число реплик для masterNodeGroup на требуемое.
-
-   Пример:
-
-   ```bash
-   dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
-   --ssh-host <MASTER-NODE-0>
-   ```
-
-Фрагмент конфигурации:
-
-   ```yaml
-   masterNodeGroup:
-     instanceClass:
-       replicas: <требуемое число реплик>
-   ```
-
-3. Выполните converge.
-
-   Пример:
-
-    ```bash
-    dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> \
-    --ssh-user=<USERNAME> \
-    --ssh-host <MASTER-NODE-0>
-    ```
-
-4. Убедитесь, что `control-plane-manager` функционирует.
-
-    ```bash
-    kubectl -n kube-system wait pod --timeout=10m --for=condition=ContainersReady -l app=d8-control-plane-manager
-    ```
-
-## Как уменьшить число master-узлов
-
-1. Запустите контейнер установщика Deckhouse соответствующей редакции и версии (на локальной машине).
-
-    ```bash
-    DH_VERSION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/version}') \
-    DH_EDITION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/edition}') \
-    docker run --pull=always -it -v "$HOME/.ssh/:/tmp/.ssh/" \                                                                                        
-    registry.deckhouse.io/deckhouse/${DH_EDITION}/install:${DH_VERSION} bash
-    ```
-
-2. Измените число реплик для masterNodeGroup на требуемое.
-
-   Пример:
-
-   ```bash
-   dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
-   --ssh-host <MASTER-NODE-0>
-   ```
-
-   Фрагмент конфигурации:
-
-   ```yaml
-   masterNodeGroup:
-     instanceClass:
-       replicas: <требуемое число реплик>
-   ```
-
-3. Снимите следующие лейблы с удаляемых узлов:
-  * node-role.kubernetes.io/control-plane
-  * node-role.kubernetes.io/master
-  * node.deckhouse.io/group
-
-   Пример:
-
-    ```bash
-    kubectl label node <имя удаляемого узла> \
-    node-role.kubernetes.io/control-plane- \
-    node-role.kubernetes.io/master- \
-    node.deckhouse.io/group-
-    ```
-
-4. Убедитесь, что узлы пропали из членов кластера etcd.
-
-   ```bash
-   kubectl -n kube-system exec -ti $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- sh -c \
-   "ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table"
-   ```
-
-5. Выполните drain для удаляемых узлов.
-
-   Пример:
-
-   ```bash
-   kubectl drain <имя удаляемого узла> --ignore-daemonsets --delete-emptydir-data
-   ```
-
-6. Выключите (poweroff) удаляемый узел и удалите инстансы соответствующих узлов из облака и подключенные к ним диски (kubernetes-data).
-
-7. Удалите оставшиеся ресурсы с узлов.
-
-   Пример:
-
-    ```bash
-    kubectl delete pods --all-namespaces --field-selector spec.nodeName=<имя удаляемого узла> --force
-    ```
-
-8. Удалите ресурсы узлов.
-
-   Пример:
-
-   ```bash
-   kubectl delete node <имя удаляемого узла>
-   ```
-
-9. Выполните converge.
-
-   Пример:
-
-    ```bash
-    dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> \
-    --ssh-user=<USERNAME> \
-    --ssh-host <MASTER-NODE-0>
-    ```
-
-   > При выполнении команды убедитесь, что планируется удалить именно требуемые ноды!
-
-10. Убедитесь, что `control-plane-manager` функционирует.
-
-    ```bash
-    kubectl -n kube-system wait pod --timeout=10m --for=condition=ContainersReady -l app=d8-control-plane-manager
-    ```
-
-## Как изменить образ ОС в multi-master кластере
-
-1. Запустите контейнер установщика Deckhouse соответствующей редакции и версии (на локальной машине).
-
-    ```bash
-    DH_VERSION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/version}') \
-    DH_EDITION=$(kubectl -n d8-system get deployment deckhouse -o jsonpath='{.metadata.annotations.core\.deckhouse\.io\/edition}') \
-    docker run --pull=always -it -v "$HOME/.ssh/:/tmp/.ssh/" \                                                                                        
-    registry.deckhouse.io/deckhouse/${DH_EDITION}/install:${DH_VERSION} bash
-    ```
-
-2. Измените образ ОС для masterNodeGroup.
-
-   Пример:
-
-   ```bash
-   dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
-   --ssh-host <MASTER-NODE-0> --ssh-host <MASTER-NODE-1> --ssh-host <MASTER-NODE-2>
-   ```
-
-   Фрагмент конфигурации:
-
-   ```yaml
-   masterNodeGroup:
-     instanceClass:
-       template: <new image version>
-   ```
-
-> Следующие действия выполняйте поочередно на всех master-узлах, начиная с последнего (с суффиксом 2) и заканчивая первым (с суффиксом 0):
-
-1. Выберите master-узел для обновления.
-
-   ```bash
-   NODE="<MASTER-NODE-X>"
-   ```
-
-2. Снимите следующие лейблы с удаляемых узлов:
-* node-role.kubernetes.io/control-plane
-* node-role.kubernetes.io/master
-* node.deckhouse.io/group
-
-  Пример:
-    ```bash
-    kubectl label node <имя удаляемого узла> \
-    node-role.kubernetes.io/control-plane- \
-    node-role.kubernetes.io/master- \
-    node.deckhouse.io/group-
-```
-
-3. Убедитесь что узел пропал из членов etcd кластера.
-
-   ```bash
-   kubectl -n kube-system exec -ti $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- sh -c \
-   "ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table"
-   ```
-
-4. Выполните `drain` для узла `<MASTER-NODE-X>`.
-
-   ```bash
-   kubectl drain ${NODE} --ignore-daemonsets --delete-emptydir-data
-   ```
-
-5. Выключите (poweroff) `<MASTER-NODE-X>`, удалите инстанс узла из облака и подключенные к нему диски (kubernetes-data).
-
-6. Удалите Pod'ы, оставшиеся на удаляемом узле `<MASTER-NODE-X>`.
-
-   ```bash
-   kubectl delete pods --all-namespaces --field-selector spec.nodeName=${NODE} --force
-   ```
-
-7. Удалите объект Node `<MASTER-NODE-X>`.
-
-   ```bash
-   kubectl delete node ${NODE}
-   ```
-
-8. Выполните converge.
-
-   ```bash
-   dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> \
-   --ssh-user=<USERNAME> \
-   --ssh-host <MASTER-NODE-0> \
-   --ssh-host <MASTER-NODE-1> \
-   --ssh-host <MASTER-NODE-2>
-   ```
-
-   > При выполнении команды убедитесь, что планируется удалить именно требуемые узлы!
-
-9. В логах `bashible.service` на вновь созданном узле `<MASTER-NODE-X>` должно быть сообщение “nothing to do”.
-
-   ```bash
-   journalctl -fu bashible.service
-   ```
-
-10. Убедитесь, что узел появился в членах кластера etcd.
-
-    ```bash
-    kubectl -n kube-system exec -ti $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- sh -c \
-    "ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table"
-    ```
-
-11. Убедитесь, что `control-plane-manager` функционирует на узле `<MASTER-NODE-X>`.
-
-    ```bash
-    kubectl -n kube-system wait pod --timeout=10m --for=condition=ContainersReady -l app=d8-control-plane-manager --field-selector spec.nodeName=${NODE}
-    ```
-
-## Как изменить образ ОС в single-master кластере
-
-1. Преобразуйте single-master в multi-master кластер в соответствии с [инструкцией](#как-увеличить-число-master-узлов)
-
-> Внимание! Помимо увеличения числа реплик, также рекомендуется сразу установить требуемую версию ОС в masterNode.instanceClass.template: <new image version>
-
-2. Обновите master-узлы в соответствии с [инструкцией](#как-изменить-образ-ОС-в-multi-master-кластере)
-3. Преобразуйте multi-master в single-master кластер в соответствии с [инструкцией](#как-уменьшить-число-master-узлов)

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -199,7 +199,7 @@ title: "Управление control plane: FAQ"
      --ssh-host <MASTER-NODE-0-HOST> --ssh-host <MASTER-NODE-1-HOST> --ssh-host <MASTER-NODE-2-HOST>
    ```
 
-1. **На созданном узле** посмотрите журнал systemd-unit'а `bashible.service`. Дождитесь окончания настройки узла, — сообщения `nothing to do` в журнале:
+1. **На созданном узле** посмотрите журнал systemd-unit'а `bashible.service`. Дождитесь окончания настройки узла — в журнале появится сообщение `nothing to do`:
 
    ```bash
    journalctl -fu bashible.service

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -28,7 +28,7 @@ title: "Управление control plane: FAQ"
      --ssh-host <MASTER-NODE-0-HOST>
    ```
 
-1. **В контейнере с инсталлятором** выполните следующую команду, для запуска масштабирования:
+1. **В контейнере с инсталлятором** выполните следующую команду для запуска масштабирования:
 
    ```bash
    dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> --ssh-host <MASTER-NODE-0-HOST>

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -192,7 +192,7 @@ title: "Управление control plane: FAQ"
    kubectl delete node ${NODE}
    ```
 
-1. **В контейнере с инсталлятором** выполните следующую команду, для создания обновленного узла:
+1. **В контейнере с инсталлятором** выполните следующую команду для создания обновленного узла:
 
    ```bash
    dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -287,6 +287,7 @@ done
 2. Измените число реплик для masterNodeGroup на требуемое.
 
    Пример:
+
    ```bash
    dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
    --ssh-host <MASTER-NODE-0>
@@ -301,6 +302,7 @@ done
 3. Выполните converge.
 
    Пример:
+
     ```bash
     dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> \
     --ssh-user=<USERNAME> \
@@ -327,11 +329,12 @@ done
 2. Измените число реплик для masterNodeGroup на требуемое.
 
    Пример:
+
    ```bash
    dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
    --ssh-host <MASTER-NODE-0>
    ```
-   
+
    ```yaml
    masterNodeGroup:
      instanceClass:
@@ -344,6 +347,7 @@ done
     * node.deckhouse.io/group
 
     Пример:
+
     ```bash
     kubectl label node <имя удаляемого узла> \
     node-role.kubernetes.io/control-plane- \
@@ -361,6 +365,7 @@ done
 5. Выполните drain для удаляемых узлов.
 
    Пример:
+
    ```bash
    kubectl drain <имя удаляемого узла> --ignore-daemonsets --delete-emptydir-data
    ```
@@ -370,6 +375,7 @@ done
 7. Удалите оставшиеся ресурсы с узлов.
 
     Пример:
+
     ```bash
     kubectl delete pods --all-namespaces --field-selector spec.nodeName=<имя удаляемого узла> --force
     ```
@@ -377,6 +383,7 @@ done
 8. Удалите ресурсы узлов.
 
    Пример:
+
    ```bash
    kubectl delete node <имя удаляемого узла>
    ```
@@ -384,6 +391,7 @@ done
 9. Выполните converge.
 
     Пример:
+
     ```bash
     dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> \
     --ssh-user=<USERNAME> \
@@ -392,12 +400,12 @@ done
 
     > При выполнении команды убедитесь, что планируется удалить именно требуемые ноды!
 
-10. Убедитесь, что `control-plane-manager` функционирует. 
+10. Убедитесь, что `control-plane-manager` функционирует.
 
     ```bash
     kubectl -n kube-system wait pod --timeout=10m --for=condition=ContainersReady -l app=d8-control-plane-manager
     ```
-    
+
 ## Как изменить образ ОС в multi-master кластере
 
 1. Запустите контейнер установщика Deckhouse соответствующей редакции и версии (на локальной машине).
@@ -408,7 +416,7 @@ done
     docker run --pull=always -it -v "$HOME/.ssh/:/tmp/.ssh/" \                                                                                        
     registry.deckhouse.io/deckhouse/${DH_EDITION}/install:${DH_VERSION} bash
     ```
-   
+
 2. Измените образ ОС для masterNodeGroup.
 
    ```bash
@@ -431,9 +439,9 @@ done
    ```
 
 2. Снимите следующие лейблы с удаляемых узлов:
-  * node-role.kubernetes.io/control-plane
-  * node-role.kubernetes.io/master
-  * node.deckhouse.io/group
+* node-role.kubernetes.io/control-plane
+* node-role.kubernetes.io/master
+* node.deckhouse.io/group
 
    Пример:
     ```bash
@@ -441,7 +449,7 @@ done
     node-role.kubernetes.io/control-plane- \
     node-role.kubernetes.io/master- \
     node.deckhouse.io/group-
-    ```
+```
 
 3. Убедитесь что узел пропал из членов etcd кластера.
 
@@ -455,21 +463,21 @@ done
    ```bash
    kubectl drain ${NODE} --ignore-daemonsets --delete-emptydir-data
    ```
-   
+
 5. Выключите (poweroff) `<MASTER-NODE-X>`, удалите инстанс узла из облака и подключенные к нему диски (kubernetes-data).
 
-6. Удалите Pod'ы, оставшиеся на удаляемом узле `<MASTER-NODE-X>`. 
+6. Удалите Pod'ы, оставшиеся на удаляемом узле `<MASTER-NODE-X>`.
 
    ```bash
    kubectl delete pods --all-namespaces --field-selector spec.nodeName=${NODE} --force
    ```
-   
+
 7. Удалите объект Node `<MASTER-NODE-X>`.
 
    ```bash
    kubectl delete node ${NODE}
    ```
-   
+
 8. Выполните converge.
 
    ```bash
@@ -479,7 +487,7 @@ done
    --ssh-host <MASTER-NODE-1> \
    --ssh-host <MASTER-NODE-2>
    ```
-   
+
    > При выполнении команды убедитесь, что планируется удалить именно требуемые узлы!
 
 9. В логах `bashible.service` на вновь созданной ноде `<MASTER-NODE-X>` должно быть сообщение “nothing to do”.
@@ -487,7 +495,7 @@ done
    ```bash
    journalctl -fu bashible.service
    ```
-   
+
 10. Убедитесь, что узел появился в членах кластера etcd.
 
     ```bash
@@ -503,11 +511,9 @@ done
 
 ## Как изменить образ ОС в single-master кластере
 
-
 1. Преобразуйте single-master в multi-master кластер в соответствии с [инструкцией](#как-увеличить-число-master-узлов)
 
 > Внимание! Помимо увеличения числа реплик, также рекомендуется сразу установить требуемую версию ОС в masterNode.instanceClass.template: <new image version>
 
 2. Обновите master-узлы в соответствии с [инструкцией](#как-изменить-образ-ОС-в-multi-master-кластере)
 3. Преобразуйте multi-master в single-master кластер в соответствии с [инструкцией](#как-уменьшить-число-master-узлов)
-

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -100,7 +100,7 @@ title: "Управление control plane: FAQ"
    kubectl delete node <MASTER-NODE-N-NAME>
    ```
 
-1. **В контейнере с инсталлятором** выполните следующую команду, для запуска масштабирования:
+1. **В контейнере с инсталлятором** выполните следующую команду для запуска масштабирования:
 
    ```bash
    dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> --ssh-host <MASTER-NODE-0-HOST>

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -368,8 +368,8 @@ kubectl drain <master-node-name-2> --ignore-daemonsets --delete-emptydir-data
 8. Удаляем оставшиеся ресурсы с удаленных нод.
 
 ```bash
-kubectl delete pods --all-namespaces -o wide --field-selector spec.nodeName=<master-node-name-1>
-kubectl delete pods --all-namespaces -o wide --field-selector spec.nodeName=<master-node-name-2>
+kubectl delete pods --all-namespaces --field-selector spec.nodeName=<master-node-name-1> --force
+kubectl delete pods --all-namespaces --field-selector spec.nodeName=<master-node-name-2> --force
 ```
 
 9. Удаляем ресурсы нод `<master-node-name-1>`, `<master-node-name-1>`.
@@ -385,6 +385,8 @@ dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> \
 --ssh-user=<USERNAME> \
 --ssh-host <master-node-name-0>
 ```
+
+> При выполнении команды убедитесь, что планируется удалить именно требуемые ноды!
 
 11. Убеждаемся, что control-plane-manager функционирует. 
 
@@ -456,7 +458,7 @@ kubectl drain ${NODE} --ignore-daemonsets --delete-emptydir-data
 6. Удаляем поды, оставшиеся на удаленной ноде `<master-node-name-x>`. 
 
 ```bash
-kubectl delete pods --all-namespaces -o wide --field-selector spec.nodeName=${NODE}
+kubectl delete pods --all-namespaces --field-selector spec.nodeName=${NODE} --force
 ```
 
 7. Удаляем ресурс ноды `<master-node-name-x>`.
@@ -474,6 +476,8 @@ dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> \
 --ssh-host <master-node-name-1> \
 --ssh-host <master-node-name-2>
 ```
+
+> При выполнении команды убедитесь, что планируется удалить именно требуемую ноду!
 
 9. В логах `bashible.service` на вновь созданной ноде `<master-node-name-x>` должно быть сообщение “nothing to do”.
 

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -409,7 +409,7 @@ docker run --pull=always -it -v "$HOME/.ssh/:/tmp/.ssh/" \
 registry.deckhouse.io/deckhouse/<edition>/install:<version> bash
 ```
 
-3. Меняем образ ОС для masterNodeGroup
+3. Меняем образ ОС для masterNodeGroup.
 
 ```bash
 dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
@@ -475,7 +475,7 @@ dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> \
 --ssh-host <master-node-name-2>
 ```
 
-9. В логах bashible.service на вновь созданной ноде `<master-node-name-x>` должно быть сообщение “nothing to do”.
+9. В логах `bashible.service` на вновь созданной ноде `<master-node-name-x>` должно быть сообщение “nothing to do”.
 
 ```bash
 journalctl -fu bashible.service

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -273,7 +273,7 @@ done
 
 О возможных вариантах восстановления состояния кластера из снимка etcd вы можете узнать [здесь](https://github.com/deckhouse/deckhouse/blob/main/modules/040-control-plane-manager/docs/internal/ETCD_RECOVERY.md).
 
-## Как увеличить число master-узлов
+## Как добавить мастер-узлы (single master в multi master)
 
 1. Запустите контейнер установщика Deckhouse соответствующей редакции и версии (на локальной машине).
 
@@ -317,7 +317,7 @@ done
     kubectl -n kube-system wait pod --timeout=10m --for=condition=ContainersReady -l app=d8-control-plane-manager
     ```
 
-## Как уменьшить число master-узлов
+## Как уменьшить число master-узлов (multi master в single master)
 
 1. Запустите контейнер установщика Deckhouse соответствующей редакции и версии (на локальной машине).
 

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -293,6 +293,8 @@ done
    --ssh-host <MASTER-NODE-0>
    ```
 
+  Фрагмент конфигурации:
+
    ```yaml
    masterNodeGroup:
      instanceClass:
@@ -335,6 +337,8 @@ done
    --ssh-host <MASTER-NODE-0>
    ```
 
+   Фрагмент конфигурации:
+
    ```yaml
    masterNodeGroup:
      instanceClass:
@@ -355,7 +359,7 @@ done
     node.deckhouse.io/group-
     ```
 
-4. Убедитесь, что ноды пропали из member'ов etcd.
+4. Убедитесь, что узлы пропали из членов кластера etcd.
 
    ```bash
    kubectl -n kube-system exec -ti $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- sh -c \
@@ -419,10 +423,14 @@ done
 
 2. Измените образ ОС для masterNodeGroup.
 
+   Пример:
+
    ```bash
    dhctl config edit provider-cluster-configuration --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> \
    --ssh-host <MASTER-NODE-0> --ssh-host <MASTER-NODE-1> --ssh-host <MASTER-NODE-2>
    ```
+
+   Фрагмент конфигурации:
 
    ```yaml
    masterNodeGroup:
@@ -458,7 +466,7 @@ done
    "ETCDCTL_API=3 etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table"
    ```
 
-4. Выполните `drain` для `<MASTER-NODE-X>`.
+4. Выполните `drain` для узла `<MASTER-NODE-X>`.
 
    ```bash
    kubectl drain ${NODE} --ignore-daemonsets --delete-emptydir-data
@@ -490,7 +498,7 @@ done
 
    > При выполнении команды убедитесь, что планируется удалить именно требуемые узлы!
 
-9. В логах `bashible.service` на вновь созданной ноде `<MASTER-NODE-X>` должно быть сообщение “nothing to do”.
+9. В логах `bashible.service` на вновь созданном узле `<MASTER-NODE-X>` должно быть сообщение “nothing to do”.
 
    ```bash
    journalctl -fu bashible.service

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -225,7 +225,7 @@ title: "Управление control plane: FAQ"
 
 ## Как изменить образ ОС в single-master-кластере?
 
-1. Преобразуйте single-master-кластер в multi-master в соответствии с [инструкцией](#как-добавить master-узлы-в-облачном-кластере-single-master-в-multi-master).
+1. Преобразуйте single-master-кластер в multi-master в соответствии с [инструкцией](#как-добавить-master-узлы-в-облачном-кластере-single-master-в-multi-master).
 
    > Помимо увеличения числа реплик вы можете сразу указать образ с необходимой версией ОС в параметре `masterNode.instanceClass`.
 


### PR DESCRIPTION
## Description
Added docs: 
- How to turn a multi-master cluster into a single-master cluster and vice verse.
- How to change the multi-master cluster OS image.


## Why do we need it, and what problem does it solve?
Users have to know how to do it!

## What is the expected result?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: control-plane-manager
type: chore
summary: Added docs about how to turn a multi-master cluster into a single-master cluster and vice versa, and about how to change OS image in a multi-master cluster.
impact_level: low
```
