### PR TITLE
[docs] Clarify the use of the ami parameter in the AWSInstanceClass

### DIFF
--- a/candi/cloud-providers/aws/openapi/doc-ru-instance_class.yaml
+++ b/candi/cloud-providers/aws/openapi/doc-ru-instance_class.yaml
@@ -31,6 +31,8 @@ spec:
                   description: |
                     Образ Amazon Machine Image (AMI ID), который будет использоваться в заказанных инстансах.
 
+                    Если не указан, то используется AMI, определенный в параметре [masterNodeGroup.instanceClass.ami](cluster_configuration.html#parameters-masternodegroup-instanceclass-ami) ресурса `AWSClusterConfiguration`.
+
                     Как найти нужный AMI (в каждом регионе AMI разные):
                     ```shell
                     aws ec2 --region <REGION> describe-images \

--- a/candi/cloud-providers/aws/openapi/instance_class.yaml
+++ b/candi/cloud-providers/aws/openapi/instance_class.yaml
@@ -60,6 +60,8 @@ spec:
                   description: |
                     The Amazon Machine Image (AMI ID) to use in provisioned instances.
 
+                    If omitted, the AMI defined in the [masterNodeGroup.instanceClass.ami](cluster_configuration.html#parameters-masternodegroup-instanceclass-ami) parameter of the `AWSClusterConfiguration` resource is used.
+
                     Here is how you can find the required AMI (each region has its own set of AMIs):
                     ```shell
                     aws ec2 --region <REGION> describe-images \


### PR DESCRIPTION
## Description
Clarify the use of the ami parameter in the AWSInstanceClass.

## Changelog entries
```changes
section: docs
type: chore
summary: Clarify the use of the ami parameter in the AWSInstanceClass.
impact_level: low
```
