### PR TITLE
[namespace-configurator] multiple configurations together fix

### DIFF
--- a/modules/600-namespace-configurator/hooks/handler.go
+++ b/modules/600-namespace-configurator/hooks/handler.go
@@ -74,10 +74,11 @@ func handleNamespaceConfiguration(input *go_hook.HookInput) error {
 	}
 
 	configurations := input.Values.Get("namespaceConfigurator.configurations").Array()
-	var configItem namespaceConfigurationItem
 	var err error
 
 	for _, configuration := range configurations {
+		var configItem namespaceConfigurationItem
+
 		err = configItem.Load(configuration)
 		if err != nil {
 			return err

--- a/modules/600-namespace-configurator/hooks/handler_test.go
+++ b/modules/600-namespace-configurator/hooks/handler_test.go
@@ -83,6 +83,8 @@ configurations:
     labels: {"foo":"bar","bee":null}
     includeNames: ["test1", "test2", "test3", "test4", "test6"]
     excludeNames: ["test2"]
+  - labels: {"qqq":"zzz"}
+    includeNames: ["my*"]
 `))
 			f.BindingContexts.Set(f.KubeStateSet(`
 ---
@@ -127,6 +129,12 @@ metadata:
   name: test6
   labels:
     foo: bar
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: myns
+  labels: {}
 `))
 			f.RunHook()
 		})
@@ -139,28 +147,42 @@ metadata:
 			Expect(ns.Field(`metadata.labels.foo`).Exists()).To(BeTrue())
 			Expect(ns.Field("metadata.labels.foo").String()).To(Equal(`bar`))
 			Expect(ns.Field(`metadata.labels.bee`).Exists()).To(BeFalse())
+			Expect(ns.Field(`metadata.labels.qqq`).Exists()).To(BeFalse())
 
 			ns = f.KubernetesResource("Namespace", "", "test3")
 			Expect(ns.Field(`metadata.labels.foo`).Exists()).To(BeTrue())
 			Expect(ns.Field("metadata.labels.foo").String()).To(Equal(`bar`))
 			Expect(ns.Field(`metadata.labels.bee`).Exists()).To(BeFalse())
+			Expect(ns.Field(`metadata.labels.qqq`).Exists()).To(BeFalse())
+
 			ns = f.KubernetesResource("Namespace", "", "test4")
 			Expect(ns.Field(`metadata.labels.foo`).Exists()).To(BeTrue())
 			Expect(ns.Field("metadata.labels.foo").String()).To(Equal(`bar`))
 			Expect(ns.Field(`metadata.labels.bee`).Exists()).To(BeFalse())
+			Expect(ns.Field(`metadata.labels.qqq`).Exists()).To(BeFalse())
 
 			ns = f.KubernetesResource("Namespace", "", "test2")
 			Expect(ns.Field(`metadata.labels.foo`).Exists()).To(BeTrue())
 			Expect(ns.Field("metadata.labels.foo").String()).To(Equal(`bar`))
 			Expect(ns.Field(`metadata.labels.bee`).Exists()).To(BeFalse())
+			Expect(ns.Field(`metadata.labels.qqq`).Exists()).To(BeFalse())
+
 			ns = f.KubernetesResource("Namespace", "", "test5")
 			Expect(ns.Field(`metadata.labels.foo`).Exists()).To(BeTrue())
 			Expect(ns.Field("metadata.labels.foo").String()).To(Equal(`baz`))
 			Expect(ns.Field(`metadata.labels.bee`).Exists()).To(BeFalse())
+			Expect(ns.Field(`metadata.labels.qqq`).Exists()).To(BeFalse())
+
 			ns = f.KubernetesResource("Namespace", "", "test6")
 			Expect(ns.Field(`metadata.labels.foo`).Exists()).To(BeTrue())
 			Expect(ns.Field("metadata.labels.foo").String()).To(Equal(`bar`))
 			Expect(ns.Field(`metadata.labels.bee`).Exists()).To(BeFalse())
+			Expect(ns.Field(`metadata.labels.qqq`).Exists()).To(BeFalse())
+
+			ns = f.KubernetesResource("Namespace", "", "myns")
+			Expect(ns.Field(`metadata.labels.foo`).Exists()).To(BeFalse())
+			Expect(ns.Field(`metadata.labels.bee`).Exists()).To(BeFalse())
+			Expect(ns.Field(`metadata.labels.qqq`).String()).To(Equal(`zzz`))
 		})
 	})
 


### PR DESCRIPTION
## Description
Bugfix — every configuration patched every namespace matched the filter.

## Why do we need it, and what problem does it solve?
There could be many configurations simultaneously and we must support it.
Why hotfix — there is a customer who eager to use the module.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: namespace-configurator
type: fix
summary: Apply configuration only for namespaces matched the filter in this configuration.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
