### PR TITLE
[linstor] tolerate drbd problems

### DIFF
--- a/helm_lib/templates/_node_affinity.tpl
+++ b/helm_lib/templates/_node_affinity.tpl
@@ -6,7 +6,7 @@
 {{- end }}
 
 {{- define "helm_lib_internal_check_tolerations_strategy" -}}
-  {{ if not (has . (list "frontend" "monitoring" "system" "master" "any-node" "any-uninitialized-node" "any-node-with-no-csi" "wildcard" )) }}
+  {{ if not (has . (list "frontend" "monitoring" "system" "system-with-drbd-problems" "master" "any-node" "any-uninitialized-node" "any-node-with-no-csi" "wildcard" )) }}
     {{- fail (printf "unknown strategy \"%v\"" .) }}
   {{- end }}
   {{- . -}}
@@ -206,5 +206,17 @@ tolerations:
 {{ include "helm_lib_internal_node_problems_tolerations" $context }}
     {{- end }}
 
+{{- /* System with DRBD problems: Nodes for system components including various drbd problems */ -}}
+  {{- else if eq $strategy "system-with-drbd-problems" }}
+tolerations:
+- key: dedicated.deckhouse.io
+  operator: Equal
+  value: {{ $context.Chart.Name | quote }}
+- key: dedicated.deckhouse.io
+  operator: Equal
+  value: "system"
+- key: drbd.linbit.com/lost-quorum
+- key: drbd.linbit.com/force-io-error
+- key: drbd.linbit.com/ignore-fail-over
   {{- end }}
 {{- end }}

--- a/modules/041-linstor/templates/linstor-affinity-controller/deployment.yaml
+++ b/modules/041-linstor/templates/linstor-affinity-controller/deployment.yaml
@@ -63,7 +63,7 @@ spec:
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "system-with-drbd-problems") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "linstor-affinity-controller")) | nindent 6 }}
       imagePullSecrets:

--- a/modules/041-linstor/templates/linstor-controller/linstorcontroller.yaml
+++ b/modules/041-linstor/templates/linstor-controller/linstorcontroller.yaml
@@ -38,7 +38,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "linstor-controller")) | nindent 2 }}
 spec:
   {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 2 }}
-  {{- include "helm_lib_tolerations" (tuple . "system") | nindent 2 }}
+  {{- include "helm_lib_tolerations" (tuple . "system-with-drbd-problems") | nindent 2 }}
   affinity:
     {{- with (include "helm_lib_node_selector" (tuple . "system")) }}
     nodeAffinity:

--- a/modules/041-linstor/templates/linstor-csi/linstorcsidriver.yaml
+++ b/modules/041-linstor/templates/linstor-csi/linstorcsidriver.yaml
@@ -208,7 +208,7 @@ spec:
     podAntiAffinity: {}
     {{- end }}
   controllerTolerations:
-    {{- index (include "helm_lib_tolerations" (tuple . "system") | fromYaml) "tolerations" | toYaml | nindent 4 }}
+    {{- index (include "helm_lib_tolerations" (tuple . "system-with-drbd-problems") | fromYaml) "tolerations" | toYaml | nindent 4 }}
   enableTopology: true
   resources:
     requests:

--- a/modules/041-linstor/templates/linstor-scheduler/deployment.yaml
+++ b/modules/041-linstor/templates/linstor-scheduler/deployment.yaml
@@ -75,7 +75,7 @@ spec:
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "system-with-drbd-problems") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "linstor-scheduler")) | nindent 6 }}
       imagePullSecrets:

--- a/modules/041-linstor/templates/piraeus-operator/deployment.yaml
+++ b/modules/041-linstor/templates/piraeus-operator/deployment.yaml
@@ -69,7 +69,7 @@ spec:
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "system-with-drbd-problems") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "piraeus-operator")) | nindent 6 }}
       imagePullSecrets:

--- a/modules/041-linstor/templates/spaas/deployment.yaml
+++ b/modules/041-linstor/templates/spaas/deployment.yaml
@@ -62,7 +62,7 @@ spec:
     spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "system-with-drbd-problems") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "spaas")) | nindent 6 }}
       imagePullSecrets:


### PR DESCRIPTION
## Description

Add additional system tolerations to LINSTOR pods

## Why do we need it, and what problem does it solve?

When DRBD has problems linstor ha-controller adds taint to the nodes, that prevents linstor pods get scheduled on this node.

## What is the expected result?

The piraeus linstor pods will be deployed with additional tolerations:

```diff
        tolerations:
        - key: dedicated.deckhouse.io
          operator: Equal
         value: "linstor"
        - key: dedicated.deckhouse.io
          operator: Equal
          value: "system"
+       - key: drbd.linbit.com/lost-quorum
+       - key: drbd.linbit.com/force-io-error
+       - key: drbd.linbit.com/ignore-fail-over
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: linstor
type: fix
summary: Tolerate DRBD problems.
impact_level: low
```

