### PR TITLE
[docs][user-authz] Fix the Usage page

### DIFF
--- a/modules/140-user-authz/docs/USAGE.md
+++ b/modules/140-user-authz/docs/USAGE.md
@@ -134,7 +134,7 @@ It may be required to give your machine static access to the Kubernetes API, e.g
 
      ```shell
      kubectl config set-credentials $user_name \
-       --token=$(kubectl -n d8-service-accounts get secret gitlab-runner-deploy -o json |jq -r '.data["token"]' | base64 -d) \
+       --token=$(kubectl -n d8-service-accounts get secret gitlab-runner-deploy-token -o json |jq -r '.data["token"]' | base64 -d) \
        --kubeconfig=$file_name
      ```
 

--- a/modules/140-user-authz/docs/USAGE_RU.md
+++ b/modules/140-user-authz/docs/USAGE_RU.md
@@ -135,7 +135,7 @@ spec:
 
      ```shell
      kubectl config set-credentials $user_name \
-       --token=$(kubectl -n d8-service-accounts get secret gitlab-runner-deploy -o json |jq -r '.data["token"]' | base64 -d) \
+       --token=$(kubectl -n d8-service-accounts get secret gitlab-runner-deploy-token -o json |jq -r '.data["token"]' | base64 -d) \
        --kubeconfig=$file_name
      ```
 


### PR DESCRIPTION
## Description
Fix the Usage page in the user-authz module (incorrect secret name in examples).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: user-authz
type: fix
summary: Fix the Usage page in the documentation.
impact_level: low
```
