### PR TITLE
[istio] add kube-rbac-proxy CA certificate to d8-ingress-istio

### DIFF
--- a/ee/modules/110-istio/templates/ingress-gateway-controller/namespace.yaml
+++ b/ee/modules/110-istio/templates/ingress-gateway-controller/namespace.yaml
@@ -6,3 +6,5 @@ metadata:
   annotations:
     extended-monitoring.flant.com/enabled: ""
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+---
+{{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-ingress-%s" .Chart.Name)) }}


### PR DESCRIPTION
## Description
 added kube-rbac-proxy CA certificate to d8-ingress-istio

## Why do we need it, and what problem does it solve?
To fix matrix tests

## What is the expected result?
Matrix tests should not fail

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary:  added kube-rbac-proxy CA certificate to d8-ingress-istio
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
