### PR TITLE
[user-authz]: Re-generate certificate automatically

### DIFF
--- a/ee/modules/140-user-authz/images/webhook/web/server.go
+++ b/ee/modules/140-user-authz/images/webhook/web/server.go
@@ -21,8 +21,8 @@ import (
 const (
 	// Webhook tls certificates
 	sslWebhookPath = "/etc/ssl/user-authz-webhook/"
-	sslListenCert  = sslWebhookPath + "webhook-server.crt"
-	sslListenKey   = sslWebhookPath + "webhook-server.key"
+	sslListenCert  = sslWebhookPath + "tls.crt"
+	sslListenKey   = sslWebhookPath + "tls.key"
 
 	// CA to verify kube-apiserver client certificate
 	// https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers

--- a/ee/modules/140-user-authz/templates/webhook/configmap-control-plane-configurator.yaml
+++ b/ee/modules/140-user-authz/templates/webhook/configmap-control-plane-configurator.yaml
@@ -9,5 +9,5 @@ metadata:
 data:
   url: https://127.0.0.1:40443/
   ca: |
-    {{- .Values.userAuthz.internal.webhookCA | nindent 4 }}
+    {{- .Values.userAuthz.internal.webhookCertificate.ca | nindent 4 }}
 {{- end }}

--- a/ee/modules/140-user-authz/templates/webhook/daemonset.yaml
+++ b/ee/modules/140-user-authz/templates/webhook/daemonset.yaml
@@ -71,9 +71,9 @@ spec:
             - curl
             - -ksS
             - --cert
-            - /etc/ssl/user-authz-webhook/webhook-server.crt
+            - /etc/ssl/user-authz-webhook/tls.crt
             - --key
-            - /etc/ssl/user-authz-webhook/webhook-server.key
+            - /etc/ssl/user-authz-webhook/tls.key
             - https://127.0.0.1:40443/healthz
           # Wait for one minute before restarting the container to avoid crashloopbackoofs in case if apiserver restarts
           initialDelaySeconds: 5

--- a/ee/modules/140-user-authz/templates/webhook/secret.yaml
+++ b/ee/modules/140-user-authz/templates/webhook/secret.yaml
@@ -1,4 +1,9 @@
 {{- if .Values.userAuthz.enableMultiTenancy }}
+{{- /*
+  Due to the migration of the secret structure, these values can be empty even with enabled multitenancy.
+  TODO: remove this migration in Deckhouse 1.44
+*/}}
+{{- if .Values.userAuthz.internal.webhookCertificate.ca }}
 ---
 apiVersion: v1
 kind: Secret
@@ -6,8 +11,10 @@ metadata:
   name: user-authz-webhook
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "user-authz-webhook")) | nindent 2 }}
+type: kubernetes.io/tls
 data:
   ca.crt: {{ .Values.userAuthz.internal.webhookCertificate.ca | b64enc }}
   tls.crt: {{ .Values.userAuthz.internal.webhookCertificate.crt | b64enc }}
   tls.key: {{ .Values.userAuthz.internal.webhookCertificate.key | b64enc }}
+{{- end }}
 {{- end }}

--- a/ee/modules/140-user-authz/templates/webhook/secret.yaml
+++ b/ee/modules/140-user-authz/templates/webhook/secret.yaml
@@ -14,7 +14,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "user-authz-webhook")) | nindent 2 }}
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ .Values.userAuthz.internal.webhookCertificate.ca | b64enc }}
+  ca.crt: {{  .Values.userAuthz.internal.webhookCertificate.ca  | b64enc }}
   tls.crt: {{ .Values.userAuthz.internal.webhookCertificate.crt | b64enc }}
   tls.key: {{ .Values.userAuthz.internal.webhookCertificate.key | b64enc }}
 {{- end }}

--- a/ee/modules/140-user-authz/templates/webhook/secret.yaml
+++ b/ee/modules/140-user-authz/templates/webhook/secret.yaml
@@ -1,7 +1,8 @@
 {{- if .Values.userAuthz.enableMultiTenancy }}
 {{- /*
-  Due to the migration of the secret structure, these values can be empty even with enabled multitenancy.
-  TODO: remove this migration in Deckhouse 1.44
+  Due to the migration of the secret structure, these values can be empty
+  even with enabled multitenancy on the first hook run.
+  TODO: (migration) remove in Deckhouse 1.44
 */}}
 {{- if .Values.userAuthz.internal.webhookCertificate.ca }}
 ---

--- a/ee/modules/140-user-authz/templates/webhook/secret.yaml
+++ b/ee/modules/140-user-authz/templates/webhook/secret.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "user-authz-webhook")) | nindent 2 }}
 data:
-  ca.crt: {{ .Values.userAuthz.internal.webhookCA | b64enc }}
-  webhook-server.crt: {{ .Values.userAuthz.internal.webhookServerCrt | b64enc }}
-  webhook-server.key: {{ .Values.userAuthz.internal.webhookServerKey | b64enc }}
+  ca.crt: {{ .Values.userAuthz.internal.webhookCertificate.ca | b64enc }}
+  tls.crt: {{ .Values.userAuthz.internal.webhookCertificate.crt | b64enc }}
+  tls.key: {{ .Values.userAuthz.internal.webhookCertificate.key | b64enc }}
 {{- end }}

--- a/go_lib/hooks/tls_certificate/internal_tls.go
+++ b/go_lib/hooks/tls_certificate/internal_tls.go
@@ -93,12 +93,12 @@ type GenSelfSignedTLSHookConf struct {
 	// FullValuesPathPrefix - prefix full path to store CA certificate TLS private key and cert
 	// full paths will be
 	//   FullValuesPathPrefix + .ca  - CA certificate
-	//   FullValuesPathPrefix + .cert - TLS private key
+	//   FullValuesPathPrefix + .crt - TLS private key
 	//   FullValuesPathPrefix + .key - TLS certificate
 	// Example: FullValuesPathPrefix =  'prometheusMetricsAdapter.internal.adapter'
 	// Values to store:
 	// prometheusMetricsAdapter.internal.adapter.ca
-	// prometheusMetricsAdapter.internal.adapter.cert
+	// prometheusMetricsAdapter.internal.adapter.crt
 	// prometheusMetricsAdapter.internal.adapter.key
 	// Data in values store as plain text
 	// In helm templates you need use `b64enc` function to encode

--- a/go_lib/hooks/tls_certificate/internal_tls.go
+++ b/go_lib/hooks/tls_certificate/internal_tls.go
@@ -35,9 +35,9 @@ const (
 	// ca expiration = 10 years
 	caExpiryDurationStr = "87600h"
 	// certificate expiration - 10 years
-	certExpiryDuration = 10 * 365 * 24 * time.Hour
+	certExpiryDuration = 87600 * time.Hour
 	// when to recreate a certificate - 6 month (total expiration 10 years, so we will have enough time to recreate it)
-	certOutdatedDuration = (365 / 2) * 24 * time.Hour
+	certOutdatedDuration = 4380 * time.Hour
 
 	// certificate encryption algorithm
 	keyAlgorithm = "ecdsa"

--- a/go_lib/hooks/tls_certificate/internal_tls.go
+++ b/go_lib/hooks/tls_certificate/internal_tls.go
@@ -115,7 +115,7 @@ func (gss GenSelfSignedTLSHookConf) path() string {
 }
 
 type certValues struct {
-	Ca  string `json:"ca"`
+	CA  string `json:"ca"`
 	Crt string `json:"crt"`
 	Key string `json:"key"`
 }
@@ -124,7 +124,7 @@ type certValues struct {
 // in values.
 func convCertToValues(cert certificate.Certificate) certValues {
 	return certValues{
-		Ca:  cert.CA,
+		CA:  cert.CA,
 		Crt: cert.Cert,
 		Key: cert.Key,
 	}

--- a/go_lib/hooks/tls_certificate/internal_tls.go
+++ b/go_lib/hooks/tls_certificate/internal_tls.go
@@ -42,6 +42,8 @@ const (
 	// certificate encryption algorithm
 	keyAlgorithm = "ecdsa"
 	keySize      = 256
+
+	SnapshotKey = "secret"
 )
 
 // DefaultSANs helper to generate list of sans for certificate
@@ -133,7 +135,7 @@ func RegisterInternalTLSHook(conf GenSelfSignedTLSHookConf) bool {
 		OnBeforeHelm: &go_hook.OrderedConfig{Order: 5},
 		Kubernetes: []go_hook.KubernetesConfig{
 			{
-				Name:       "secret",
+				Name:       SnapshotKey,
 				ApiVersion: "v1",
 				Kind:       "Secret",
 				NamespaceSelector: &types.NamespaceSelector{
@@ -194,7 +196,7 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(input *go_hook.HookInp
 
 		cn, sans := conf.CN, conf.SANs(input)
 
-		if len(input.Snapshots["secret"]) == 0 {
+		if len(input.Snapshots[SnapshotKey]) == 0 {
 			// No certificate in snapshot => generate a new one.
 			// Secret will be updated by Helm.
 			cert, err = generateNewSelfSignedTLS(input, cn, sans, usages)
@@ -203,7 +205,7 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(input *go_hook.HookInp
 			}
 		} else {
 			// Certificate is in the snapshot => load it.
-			cert = input.Snapshots["secret"][0].(certificate.Certificate)
+			cert = input.Snapshots[SnapshotKey][0].(certificate.Certificate)
 			// update certificate if less than 6 month left. We create certificate for 10 years, so it looks acceptable
 			// and we don't need to create Crontab schedule
 			caOutdated, err := isOutdatedCA(cert.CA)

--- a/go_lib/hooks/tls_certificate/internal_tls.go
+++ b/go_lib/hooks/tls_certificate/internal_tls.go
@@ -35,9 +35,9 @@ const (
 	// ca expiration = 10 years
 	caExpiryDurationStr = "87600h"
 	// certificate expiration - 10 years
-	certExpiryDuration = 87600 * time.Hour
+	certExpiryDuration = 10 * 365 * 24 * time.Hour
 	// when to recreate a certificate - 6 month (total expiration 10 years, so we will have enough time to recreate it)
-	certOutdatedDuration = 4380 * time.Hour
+	certOutdatedDuration = (365 / 2) * 24 * time.Hour
 
 	// certificate encryption algorithm
 	keyAlgorithm = "ecdsa"
@@ -49,7 +49,7 @@ const (
 // DefaultSANs helper to generate list of sans for certificate
 // you can also use helpers:
 //
-//	ClusterDomainSAN(value) to generate sans with respect of cluster domain (ex: "app.default.svc" with "cluster.local" value will give: app.default.svc.cluster.local
+//	ClusterDomainSAN(value) to generate sans with respect of cluster domain (e.g.: "app.default.svc" with "cluster.local" value will give: app.default.svc.cluster.local
 //	PublicDomainSAN(value)
 func DefaultSANs(sans []string) SANsGenerator {
 	return func(input *go_hook.HookInput) []string {

--- a/go_lib/hooks/tls_certificate/internal_tls.go
+++ b/go_lib/hooks/tls_certificate/internal_tls.go
@@ -32,9 +32,9 @@ import (
 )
 
 const (
-	caExpiryDurationStr  = "87600h"          // 10 years
-	certExpiryDuration   = 87600 * time.Hour // 10 years
-	certOutdatedDuration = 4380 * time.Hour  // 6 month, just enough to renew certificate
+	caExpiryDurationStr  = "87600h"                    // 10 years
+	certExpiryDuration   = (24 * time.Hour) * 365 * 10 // 10 years
+	certOutdatedDuration = (24 * time.Hour) * 365 / 2  // 6 month, just enough to renew certificate
 
 	// certificate encryption algorithm
 	keyAlgorithm = "ecdsa"

--- a/go_lib/hooks/tls_certificate/internal_tls.go
+++ b/go_lib/hooks/tls_certificate/internal_tls.go
@@ -218,6 +218,8 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(input *go_hook.HookInp
 				input.LogEntry.Errorf(err.Error())
 			}
 
+			// In case of errors, both these flags are false to avoid regeneration loop for the
+			// certificate.
 			if caOutdated || certOutdated {
 				cert, err = generateNewSelfSignedTLS(input, cn, sans, usages)
 				if err != nil {

--- a/go_lib/hooks/tls_certificate/internal_tls.go
+++ b/go_lib/hooks/tls_certificate/internal_tls.go
@@ -32,12 +32,9 @@ import (
 )
 
 const (
-	// ca expiration = 10 years
-	caExpiryDurationStr = "87600h"
-	// certificate expiration - 10 years
-	certExpiryDuration = 87600 * time.Hour
-	// when to recreate a certificate - 6 month (total expiration 10 years, so we will have enough time to recreate it)
-	certOutdatedDuration = 4380 * time.Hour
+	caExpiryDurationStr  = "87600h"          // 10 years
+	certExpiryDuration   = 87600 * time.Hour // 10 years
+	certOutdatedDuration = 4380 * time.Hour  // 6 month, just enough to renew certificate
 
 	// certificate encryption algorithm
 	keyAlgorithm = "ecdsa"

--- a/go_lib/hooks/tls_certificate/internal_tls.go
+++ b/go_lib/hooks/tls_certificate/internal_tls.go
@@ -120,8 +120,8 @@ type certValues struct {
 	Key string `json:"key"`
 }
 
-// The certificate mapping "cert" -> "crt" for backward compatibility.
-// We are migrating to "crt" naming for certificates.
+// The certificate mapping "cert" -> "crt". We are migrating to "crt" naming for certificates
+// in values.
 func convCertToValues(cert certificate.Certificate) certValues {
 	return certValues{
 		Ca:  cert.CA,
@@ -236,7 +236,6 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(input *go_hook.HookInp
 			}
 		}
 
-		// Note that []byte values will be encoded in base64. Use strings here!
 		input.Values.Set(conf.path(), convCertToValues(cert))
 		return nil
 	}

--- a/modules/140-user-authz/hooks/generate_webhook_certs.go
+++ b/modules/140-user-authz/hooks/generate_webhook_certs.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/go_lib/hooks/tls_certificate"
 	"github.com/deckhouse/deckhouse/modules/140-user-authz/hooks/internal"
-	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
-	k8serror "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (

--- a/modules/140-user-authz/hooks/generate_webhook_certs.go
+++ b/modules/140-user-authz/hooks/generate_webhook_certs.go
@@ -37,7 +37,6 @@ var ErrSkip = fmt.Errorf("skipping")
 
 var _ = tls_certificate.RegisterInternalTLSHook(tls_certificate.GenSelfSignedTLSHookConf{
 	BeforeHookCheck: func(input *go_hook.HookInput) bool {
-
 		// Migrate the secret structure in any case
 		err := dependency.WithExternalDependencies(migrateSecretStructure)(input)
 		if err != nil {
@@ -46,17 +45,7 @@ var _ = tls_certificate.RegisterInternalTLSHook(tls_certificate.GenSelfSignedTLS
 		}
 
 		multitenancyEnabled := input.Values.Get("userAuthz.enableMultiTenancy").Bool()
-		if !multitenancyEnabled {
-			// No need to handle the certificate at all
-			return false
-		}
-
-		if len(input.Snapshots[tls_certificate.SnapshotKey]) == 0 {
-			// Handle the absence of the certificate in the library
-			return true
-		}
-
-		return true
+		return multitenancyEnabled
 	},
 
 	SANs: tls_certificate.DefaultSANs([]string{"127.0.0.1"}),
@@ -80,7 +69,7 @@ var _ = tls_certificate.RegisterInternalTLSHook(tls_certificate.GenSelfSignedTLS
 //	tls.key
 //	ca.crt
 //
-// TODO: remove this migration in Deckhouse 1.44
+// TODO: (migration) remove in Deckhouse 1.44
 func migrateSecretStructure(input *go_hook.HookInput, dc dependency.Container) error {
 	input.Values.Get("userAuthz.enableMultiTenancy").Bool()
 

--- a/modules/140-user-authz/hooks/generate_webhook_certs.go
+++ b/modules/140-user-authz/hooks/generate_webhook_certs.go
@@ -81,7 +81,9 @@ var _ = tls_certificate.RegisterInternalTLSHook(tls_certificate.GenSelfSignedTLS
 //	ca.crt
 //
 // TODO: remove this migration in Deckhouse 1.44
-func migrateSecretStructure(_ *go_hook.HookInput, dc dependency.Container) error {
+func migrateSecretStructure(input *go_hook.HookInput, dc dependency.Container) error {
+	input.Values.Get("userAuthz.enableMultiTenancy").Bool()
+
 	klient, err := dc.GetK8sClient()
 	if err != nil {
 		return fmt.Errorf("cannot get kubernetes client: %v", err)

--- a/modules/140-user-authz/hooks/generate_webhook_certs.go
+++ b/modules/140-user-authz/hooks/generate_webhook_certs.go
@@ -17,109 +17,32 @@ limitations under the License.
 package hooks
 
 import (
-	"fmt"
-
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
-	"github.com/flant/addon-operator/sdk"
-	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/go_lib/certificate"
+	"github.com/deckhouse/deckhouse/go_lib/hooks/tls_certificate"
 	"github.com/deckhouse/deckhouse/modules/140-user-authz/hooks/internal"
 )
+
+var _ = tls_certificate.RegisterInternalTLSHook(tls_certificate.GenSelfSignedTLSHookConf{
+	BeforeHookCheck: func(input *go_hook.HookInput) bool {
+		// Do not generate certificate if it is likely to be unused
+		var (
+			certExists          = len(input.Snapshots[tls_certificate.SnapshotKey]) > 0
+			multitenancyEnabled = input.Values.Get("userAuthz.enableMultiTenancy").Bool()
+		)
+		return !certExists && !multitenancyEnabled
+	},
+
+	SANs: tls_certificate.DefaultSANs([]string{"127.0.0.1"}),
+	CN:   "127.0.0.1",
+
+	Namespace:            internal.Namespace,
+	TLSSecretName:        "user-authz-webhook",
+	FullValuesPathPrefix: "userAuthz.internal.webhookCertificate",
+})
 
 type WebhookSecretData struct {
 	CA     certificate.Authority
 	Server certificate.Authority
-}
-
-const (
-	webhookSnapshotTLS = "secrets"
-)
-
-func applyWebhookSecretRuleFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	secret := &v1.Secret{}
-	err := sdk.FromUnstructured(obj, secret)
-	if err != nil {
-		return nil, err
-	}
-
-	ws := &WebhookSecretData{}
-
-	webhookCA, ok := secret.Data["ca.crt"]
-	if !ok {
-		return nil, fmt.Errorf("'ca.crt' field not found")
-	}
-	webhookServerCrt, ok := secret.Data["webhook-server.crt"]
-	if !ok {
-		return nil, fmt.Errorf("'webhook-server.crt' field not found")
-	}
-	webhookServerKey, ok := secret.Data["webhook-server.key"]
-	if !ok {
-		return nil, fmt.Errorf("'webhook-server.key' field not found")
-	}
-
-	ws.CA.Cert = string(webhookCA)
-	ws.Server.Cert = string(webhookServerCrt)
-	ws.Server.Key = string(webhookServerKey)
-
-	return ws, nil
-}
-
-var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	OnBeforeHelm: &go_hook.OrderedConfig{Order: 5},
-	Queue:        internal.Queue(webhookSnapshotTLS),
-	Kubernetes: []go_hook.KubernetesConfig{
-		{
-			Name:              webhookSnapshotTLS,
-			ApiVersion:        "v1",
-			Kind:              "Secret",
-			NamespaceSelector: internal.NsSelector(),
-			NameSelector:      &types.NameSelector{MatchNames: []string{"user-authz-webhook"}},
-			FilterFunc:        applyWebhookSecretRuleFilter,
-		},
-	},
-}, webhookSecretsHandler)
-
-func webhookSecretsHandler(input *go_hook.HookInput) error {
-	var webhookCA string
-	var webhookServerCrt string
-	var webhookServerKey string
-
-	snapshots := input.Snapshots[webhookSnapshotTLS]
-
-	if len(snapshots) > 0 {
-		snapshot := snapshots[0].(*WebhookSecretData)
-		webhookCA = snapshot.CA.Cert
-		webhookServerCrt = snapshot.Server.Cert
-		webhookServerKey = snapshot.Server.Key
-	} else {
-		enableMultiTenancy := input.Values.Get("userAuthz.enableMultiTenancy").Bool()
-		if !enableMultiTenancy {
-			return nil
-		}
-		if input.Values.Exists("userAuthz.internal.webhookCA") {
-			return nil
-		}
-		var selfSignedCA certificate.Authority
-		selfSignedCA, err := certificate.GenerateCA(input.LogEntry, "user-authz-webhook")
-		if err != nil {
-			return fmt.Errorf("cannot generate selfsigned ca: %v", err)
-		}
-		webhookCert, err := certificate.GenerateSelfSignedCert(input.LogEntry, "user-authz-webhook", selfSignedCA, certificate.WithSANs("127.0.0.1"))
-		if err != nil {
-			return fmt.Errorf("cannot generate selfsigned cert: %v", err)
-		}
-
-		webhookCA = selfSignedCA.Cert
-		webhookServerKey = webhookCert.Key
-		webhookServerCrt = webhookCert.Cert
-	}
-
-	input.Values.Set("userAuthz.internal.webhookCA", webhookCA)
-	input.Values.Set("userAuthz.internal.webhookServerCrt", webhookServerCrt)
-	input.Values.Set("userAuthz.internal.webhookServerKey", webhookServerKey)
-
-	return nil
 }

--- a/modules/140-user-authz/hooks/generate_webhook_certs.go
+++ b/modules/140-user-authz/hooks/generate_webhook_certs.go
@@ -19,7 +19,6 @@ package hooks
 import (
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 
-	"github.com/deckhouse/deckhouse/go_lib/certificate"
 	"github.com/deckhouse/deckhouse/go_lib/hooks/tls_certificate"
 	"github.com/deckhouse/deckhouse/modules/140-user-authz/hooks/internal"
 )
@@ -31,7 +30,7 @@ var _ = tls_certificate.RegisterInternalTLSHook(tls_certificate.GenSelfSignedTLS
 			certExists          = len(input.Snapshots[tls_certificate.SnapshotKey]) > 0
 			multitenancyEnabled = input.Values.Get("userAuthz.enableMultiTenancy").Bool()
 		)
-		return !certExists && !multitenancyEnabled
+		return certExists && multitenancyEnabled
 	},
 
 	SANs: tls_certificate.DefaultSANs([]string{"127.0.0.1"}),
@@ -41,8 +40,3 @@ var _ = tls_certificate.RegisterInternalTLSHook(tls_certificate.GenSelfSignedTLS
 	TLSSecretName:        "user-authz-webhook",
 	FullValuesPathPrefix: "userAuthz.internal.webhookCertificate",
 })
-
-type WebhookSecretData struct {
-	CA     certificate.Authority
-	Server certificate.Authority
-}

--- a/modules/140-user-authz/hooks/generate_webhook_certs.go
+++ b/modules/140-user-authz/hooks/generate_webhook_certs.go
@@ -17,26 +17,93 @@ limitations under the License.
 package hooks
 
 import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/go_lib/hooks/tls_certificate"
 	"github.com/deckhouse/deckhouse/modules/140-user-authz/hooks/internal"
 )
 
+const (
+	certificateSecretName = "user-authz-webhook"
+)
+
+var ErrSkip = fmt.Errorf("skipping")
+
 var _ = tls_certificate.RegisterInternalTLSHook(tls_certificate.GenSelfSignedTLSHookConf{
 	BeforeHookCheck: func(input *go_hook.HookInput) bool {
-		// Do not generate certificate if it is likely to be unused
-		var (
-			certExists          = len(input.Snapshots[tls_certificate.SnapshotKey]) > 0
-			multitenancyEnabled = input.Values.Get("userAuthz.enableMultiTenancy").Bool()
-		)
-		return certExists && multitenancyEnabled
+
+		// Migrate the secret structure in any case
+		err := dependency.WithExternalDependencies(migrateSecretStructure)(input)
+		if err != nil {
+			input.LogEntry.Errorf("migrating secret structure: %v", err)
+			return false // skip hook
+		}
+
+		multitenancyEnabled := input.Values.Get("userAuthz.enableMultiTenancy").Bool()
+		if !multitenancyEnabled {
+			// No need to handle the certificate at all
+			return false
+		}
+
+		if len(input.Snapshots[tls_certificate.SnapshotKey]) == 0 {
+			// Handle the absence of the certificate in the library
+			return true
+		}
+
+		return true
 	},
 
 	SANs: tls_certificate.DefaultSANs([]string{"127.0.0.1"}),
 	CN:   "127.0.0.1",
 
 	Namespace:            internal.Namespace,
-	TLSSecretName:        "user-authz-webhook",
+	TLSSecretName:        certificateSecretName,
 	FullValuesPathPrefix: "userAuthz.internal.webhookCertificate",
 })
+
+// Migration: prior to Deckhouse 1.43, the certificate was stored in fields
+//
+//	webhook-server.crt
+//	webhook-server.key
+//	ca.crt
+//
+// We switch them to the standard structure:
+//
+//	tls.crt
+//	tls.key
+//	ca.crt
+//
+// TODO: remove this migration in Deckhouse 1.44
+func migrateSecretStructure(input *go_hook.HookInput, dc dependency.Container) error {
+	klient, err := dc.GetK8sClient()
+	if err != nil {
+		return fmt.Errorf("cannot get kubernetes client: %v", err)
+	}
+
+	secret, err := klient.CoreV1().Secrets(internal.Namespace).Get(context.TODO(), certificateSecretName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("cannot get secret %s/%s: %v", internal.Namespace, certificateSecretName, err)
+	}
+
+	if secret.Data["tls.crt"] != nil {
+		// Already migrated
+		return nil
+	}
+
+	// After this, the tls certificate library will handle the certificate
+	secret.Data["tls.crt"] = secret.Data["webhook-server.crt"]
+	secret.Data["tls.key"] = secret.Data["webhook-server.key"]
+
+	_, err = klient.CoreV1().Secrets(internal.Namespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("cannot update secret %s/%s: %v", internal.Namespace, certificateSecretName, err)
+	}
+
+	return nil
+}

--- a/modules/140-user-authz/hooks/generate_webhook_certs.go
+++ b/modules/140-user-authz/hooks/generate_webhook_certs.go
@@ -75,7 +75,6 @@ var _ = tls_certificate.RegisterInternalTLSHook(tls_certificate.GenSelfSignedTLS
 //
 // TODO: (migration) remove in Deckhouse 1.44
 func migrateSecretStructure(input *go_hook.HookInput, dc dependency.Container) error {
-
 	klient, err := dc.GetK8sClient()
 	if err != nil {
 		return fmt.Errorf("getting kubernetes client: %v", err)

--- a/modules/140-user-authz/hooks/generate_webhook_certs.go
+++ b/modules/140-user-authz/hooks/generate_webhook_certs.go
@@ -67,7 +67,8 @@ var _ = tls_certificate.RegisterInternalTLSHook(tls_certificate.GenSelfSignedTLS
 	FullValuesPathPrefix: "userAuthz.internal.webhookCertificate",
 })
 
-// Migration: prior to Deckhouse 1.43, the certificate was stored in fields
+// Migration: prior to Deckhouse 1.43, the certificate was stored in these fields. The library
+// expects another structure, so these webhook-* fields are not included in the snapshot.
 //
 //	webhook-server.crt
 //	webhook-server.key
@@ -80,7 +81,7 @@ var _ = tls_certificate.RegisterInternalTLSHook(tls_certificate.GenSelfSignedTLS
 //	ca.crt
 //
 // TODO: remove this migration in Deckhouse 1.44
-func migrateSecretStructure(input *go_hook.HookInput, dc dependency.Container) error {
+func migrateSecretStructure(_ *go_hook.HookInput, dc dependency.Container) error {
 	klient, err := dc.GetK8sClient()
 	if err != nil {
 		return fmt.Errorf("cannot get kubernetes client: %v", err)
@@ -96,7 +97,7 @@ func migrateSecretStructure(input *go_hook.HookInput, dc dependency.Container) e
 		return nil
 	}
 
-	// After this, the tls certificate library will handle the certificate
+	// After this, the tls certificate library will be able to handle the certificate
 	secret.Data["tls.crt"] = secret.Data["webhook-server.crt"]
 	secret.Data["tls.key"] = secret.Data["webhook-server.key"]
 
@@ -105,5 +106,6 @@ func migrateSecretStructure(input *go_hook.HookInput, dc dependency.Container) e
 		return fmt.Errorf("cannot update secret %s/%s: %v", internal.Namespace, certificateSecretName, err)
 	}
 
-	return nil
+	// We have just migrated the secret, so we need to skip the hook to avoid wrong snapshot.
+	return fmt.Errorf("skipping hook (secret %s/%s has been migrated)", internal.Namespace, certificateSecretName)
 }

--- a/modules/140-user-authz/hooks/generate_webhook_certs.go
+++ b/modules/140-user-authz/hooks/generate_webhook_certs.go
@@ -75,7 +75,6 @@ var _ = tls_certificate.RegisterInternalTLSHook(tls_certificate.GenSelfSignedTLS
 //
 // TODO: (migration) remove in Deckhouse 1.44
 func migrateSecretStructure(input *go_hook.HookInput, dc dependency.Container) error {
-	input.Values.Get("userAuthz.enableMultiTenancy").Bool()
 
 	klient, err := dc.GetK8sClient()
 	if err != nil {

--- a/modules/140-user-authz/hooks/generate_webhook_certs_test.go
+++ b/modules/140-user-authz/hooks/generate_webhook_certs_test.go
@@ -47,8 +47,8 @@ metadata:
   namespace: d8-user-authz
 data:
   ca.crt: YQo= # a
-  webhook-server.crt: Ygo= # b
-  webhook-server.key: Ywo= # c
+  tls.crt: Ygo= # b
+  tls.key: Ywo= # c
 `
 
 	stateSecretChanged = `
@@ -59,8 +59,8 @@ metadata:
   namespace: d8-user-authz
 data:
   ca.crt: eAo= # x
-  webhook-server.crt: eQo= # y
-  webhook-server.key: ego= # z
+  tls.crt: eQo= # y
+  tls.key: ego= # z
 `
 )
 
@@ -85,9 +85,9 @@ var _ = Describe("User Authz hooks :: gen webhook certs ::", func() {
 
 			It("Cert data must be stored in values", func() {
 				Expect(f).To(ExecuteSuccessfully())
-				Expect(f.ValuesGet("userAuthz.internal.webhookCA").String()).To(Equal("a\n"))
-				Expect(f.ValuesGet("userAuthz.internal.webhookServerCrt").String()).To(Equal("b\n"))
-				Expect(f.ValuesGet("userAuthz.internal.webhookServerKey").String()).To(Equal("c\n"))
+				Expect(f.ValuesGet("userAuthz.internal.webhookCertificate.ca").String()).To(Equal("a\n"))
+				Expect(f.ValuesGet("userAuthz.internal.webhookCertificate.crt").String()).To(Equal("b\n"))
+				Expect(f.ValuesGet("userAuthz.internal.webhookCertificate.key").String()).To(Equal("c\n"))
 			})
 
 			Context("Secret Changed", func() {
@@ -98,9 +98,9 @@ var _ = Describe("User Authz hooks :: gen webhook certs ::", func() {
 
 				It("New cert data must be stored in values", func() {
 					Expect(f).To(ExecuteSuccessfully())
-					Expect(f.ValuesGet("userAuthz.internal.webhookCA").String()).To(Equal("x\n"))
-					Expect(f.ValuesGet("userAuthz.internal.webhookServerCrt").String()).To(Equal("y\n"))
-					Expect(f.ValuesGet("userAuthz.internal.webhookServerKey").String()).To(Equal("z\n"))
+					Expect(f.ValuesGet("userAuthz.internal.webhookCertificate.ca").String()).To(Equal("x\n"))
+					Expect(f.ValuesGet("userAuthz.internal.webhookCertificate.crt").String()).To(Equal("y\n"))
+					Expect(f.ValuesGet("userAuthz.internal.webhookCertificate.key").String()).To(Equal("z\n"))
 				})
 			})
 		})
@@ -114,9 +114,9 @@ var _ = Describe("User Authz hooks :: gen webhook certs ::", func() {
 
 		It("Cert data must be stored in values", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("userAuthz.internal.webhookCA").String()).To(Equal("a\n"))
-			Expect(f.ValuesGet("userAuthz.internal.webhookServerCrt").String()).To(Equal("b\n"))
-			Expect(f.ValuesGet("userAuthz.internal.webhookServerKey").String()).To(Equal("c\n"))
+			Expect(f.ValuesGet("userAuthz.internal.webhookCertificate.ca").String()).To(Equal("a\n"))
+			Expect(f.ValuesGet("userAuthz.internal.webhookCertificate.crt").String()).To(Equal("b\n"))
+			Expect(f.ValuesGet("userAuthz.internal.webhookCertificate.key").String()).To(Equal("c\n"))
 		})
 	})
 
@@ -131,15 +131,15 @@ var _ = Describe("User Authz hooks :: gen webhook certs ::", func() {
 
 		It("New cert data must be generated and stored to values", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("userAuthz.internal.webhookCA").Exists()).To(BeTrue())
-			Expect(f.ValuesGet("userAuthz.internal.webhookServerCrt").Exists()).To(BeTrue())
-			Expect(f.ValuesGet("userAuthz.internal.webhookServerKey").Exists()).To(BeTrue())
+			Expect(f.ValuesGet("userAuthz.internal.webhookCertificate.ca").Exists()).To(BeTrue())
+			Expect(f.ValuesGet("userAuthz.internal.webhookCertificate.crt").Exists()).To(BeTrue())
+			Expect(f.ValuesGet("userAuthz.internal.webhookCertificate.key").Exists()).To(BeTrue())
 
 			certPool := x509.NewCertPool()
-			ok := certPool.AppendCertsFromPEM([]byte(f.ValuesGet("userAuthz.internal.webhookCA").String()))
+			ok := certPool.AppendCertsFromPEM([]byte(f.ValuesGet("userAuthz.internal.webhookCertificate.ca").String()))
 			Expect(ok).To(BeTrue())
 
-			block, _ := pem.Decode([]byte(f.ValuesGet("userAuthz.internal.webhookServerCrt").String()))
+			block, _ := pem.Decode([]byte(f.ValuesGet("userAuthz.internal.webhookCertificate.crt").String()))
 			Expect(block).ShouldNot(BeNil())
 
 			cert, err := x509.ParseCertificate(block.Bytes)

--- a/modules/140-user-authz/openapi/values.yaml
+++ b/modules/140-user-authz/openapi/values.yaml
@@ -40,12 +40,23 @@ properties:
               type: string
             default: []
         default: {}
-      webhookCA:
-        type: string
-      webhookServerCrt:
-        type: string
-      webhookServerKey:
-        type: string
+      webhookCertificate:
+        type: object
+        default: {}
+        x-required-for-helm:
+          - ca
+          - key
+          - crt
+        properties:
+          ca:
+            type: string
+            x-examples: [ "testca" ]
+          key:
+            type: string
+            x-examples: [ "testkey" ]
+          crt:
+            type: string
+            x-examples: [ "testcrt" ]
       crds:
         type: array
         items:

--- a/modules/140-user-authz/openapi/values.yaml
+++ b/modules/140-user-authz/openapi/values.yaml
@@ -128,9 +128,10 @@ properties:
                         minLength: 1
         default: []
     x-examples:
-    - webhookServerCrt: certificatestring
-      webhookServerKey: keystring
-      webhookCA: castring
+    - webhookCertificate:
+        ca: castring
+        key: keystring
+        crt: certificatestring
       customClusterRoles:
         admin:
           - d8:user-authz:cert-manager:admin

--- a/modules/140-user-authz/openapi/values.yaml
+++ b/modules/140-user-authz/openapi/values.yaml
@@ -42,11 +42,6 @@ properties:
         default: {}
       webhookCertificate:
         type: object
-        default: {}
-        x-required-for-helm:
-          - ca
-          - key
-          - crt
         properties:
           ca:
             type: string

--- a/modules/140-user-authz/template_tests/module_test.go
+++ b/modules/140-user-authz/template_tests/module_test.go
@@ -105,9 +105,9 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 			f.ValuesSet("userAuthz.enableMultiTenancy", true)
 			f.ValuesSet("userAuthz.controlPlaneConfigurator.enabled", true)
 			f.ValuesSet("global.discovery.extensionAPIServerAuthenticationRequestheaderClientCA", "test")
-			f.ValuesSet("userAuthz.internal.webhookCA", "test")
-			f.ValuesSet("userAuthz.internal.webhookServerCrt", "test")
-			f.ValuesSet("userAuthz.internal.webhookServerKey", "test")
+			f.ValuesSet("userAuthz.internal.webhookCertificate.ca", "test")
+			f.ValuesSet("userAuthz.internal.webhookCertificate.crt", "test")
+			f.ValuesSet("userAuthz.internal.webhookCertificate.key", "test")
 
 			f.HelmRender()
 		})


### PR DESCRIPTION

## Description

Switch to the library wrapper for TLS certificate handling.

## Why do we need it, and what problem does it solve?

Ensures that the certificate is always valid.

## What is the expected result?

- The certificate is always valid in the authn webhook
- The certificate fields migrate to common schema.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: user-authz
type: fix
summary: Enabled TLS certificate rotation for the authn webhook
```
