### PR TITLE
It's not allowed to group alerts with themselves

### DIFF
--- a/modules/040-node-manager/monitoring/prometheus-rules/early-oom.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/early-oom.tpl
@@ -12,8 +12,8 @@
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      plk_create_group_if_not_exists__d8_early_oom_malfunctioning: "EarlyOOMPodIsNotReady,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      plk_grouped_by__d8_early_oom_malfunctioning: "EarlyOOMPodIsNotReady,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_create_group_if_not_exists__d8_early_oom_malfunctioning: "EarlyOOMPodIsNotReadyGroup,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_early_oom_malfunctioning: "EarlyOOMPodIsNotReadyGroup,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes" 
       plk_labels_as_annotations: "pod"
       summary: >
         The {{`{{$labels.pod}}`}} Pod has detected unavailable PSI subsystem.

--- a/modules/300-prometheus/monitoring/prometheus-rules/emptydir.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/emptydir.yaml
@@ -10,8 +10,8 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      plk_create_group_if_not_exists__deckhouse_module_use_empty_dir: DeckhouseModuleUseEmptyDir,prometheus=deckhouse,kubernetes=~kubernetes
-      plk_group_for__deckhouse_module_use_empty_dir: DeckhouseModuleUseEmptyDir,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_create_group_if_not_exists__deckhouse_module_use_empty_dir: DeckhouseModuleUseEmptyDirGroup,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_group_for__deckhouse_module_use_empty_dir: DeckhouseModuleUseEmptyDirGroup,prometheus=deckhouse,kubernetes=~kubernetes
       summary: Deckhouse module {{ $labels.module_name }} use emptydir as storage.
       description: |
         Deckhouse module {{ $labels.module_name }} use emptydir as storage.


### PR DESCRIPTION
It's not allowed in madison to group alerts with themselves (causes CouldNotCreateEvent errors in the alert manager), so we need to use different group name.