### PR TITLE
[user-authn] Fix crowd proxy cert generation

### DIFF
--- a/modules/150-user-authn/hooks/generate_crowd_basic_auth_proxy_cert.go
+++ b/modules/150-user-authn/hooks/generate_crowd_basic_auth_proxy_cert.go
@@ -349,11 +349,12 @@ func generateJob(registry, tag, csrb64 string) *batchv1.Job {
 	}
 }
 
+// ways are hardcoded because we know where these files exist on the Deckhouse clusters
+// if you want to grep client-ca-file from kube-apiserver command line, use `ps auxww` to avoid line clipping
 var (
 	script = `set -e
-regex="--requestheader-client-ca-file[=| ][^ ]*"
-ca_path="$([[ $(ps aux| grep kube-apiserver) =~ $regex ]] && echo ${BASH_REMATCH[0]} | awk -F '=| ' '{ print $2 }')"
-key_path="$([[ $ca_path =~ ^(.+?)\.[^\.]+$ ]] && echo ${BASH_REMATCH[1]}).key"
+ca_path="/etc/kubernetes/pki/front-proxy-ca.crt"
+key_path="/etc/kubernetes/pki/front-proxy-ca.key"
 
 csr_config='{"CN":"front-proxy-client","hosts":[""],"key":{"algo": "rsa","size": 2048},"signing":{"default":{"expiry":"72h","usages":["signing","key encipherment","requestheader-client"]}}}'
 signed_cert=$(echo $CSR | base64 -d | cfssl sign -ca=$ca_path -ca-key=$key_path -config=<(echo $csr_config) - )


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Hardcode paths for client ca and key in the script for cfssl

## Why do we need it, and what problem does it solve?
If the kube-apiserver has many arguments, the `ps aux` command may cut some of them and produce an invalid argument on the script input.
We could replace it with `ps auxww', but since this crowd proxy only works on deckhouse clusters, we can hardcode the paths

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: user-authn
type: fix
summary: Fix crowd proxy certificate generation.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
