### PR TITLE
[deckhouse] Fix backquotes rendering in DeckhouseRelease changelog

### DIFF
--- a/modules/002-deckhouse/hooks/check_deckhouse_release_test.go
+++ b/modules/002-deckhouse/hooks/check_deckhouse_release_test.go
@@ -403,7 +403,7 @@ status:
 
 	Context("Release with changelog", func() {
 		BeforeEach(func() {
-			changelog_tpl := `
+			changelogTemplate := `
 cert-manager:
   fixes:
     - summary: Remove D8CertmanagerOrphanSecretsWithoutCorrespondingCertificateResources
@@ -426,7 +426,7 @@ global:
       pull_request: https://github.com/deckhouse/deckhouse/pull/523
 `
 
-			changelog := fmt.Sprintf(changelog_tpl, "`control-plane`") // global.features[0].description
+			changelog := fmt.Sprintf(changelogTemplate, "`control-plane`") // global.features[0].description
 
 			dependency.TestDC.CRClient.ImageMock.Return(&fake.FakeImage{
 				LayersStub: func() ([]v1.Layer, error) {

--- a/werf.yaml
+++ b/werf.yaml
@@ -586,7 +586,7 @@ shell:
       # changelog exists only for tags, we have to skip it for branches
       {{- $changelog := index (.Files.Glob "CHANGELOG/CHANGELOG-*") (printf "CHANGELOG/CHANGELOG-%s.yml" (env "CI_COMMIT_REF_NAME")) }}
       {{ if $changelog }}
-      cat <<EOF > /changelog.yaml
+      cat <<"EOF" > /changelog.yaml
       {{ $changelog | nindent 6 }}
       EOF
       {{ end }}


### PR DESCRIPTION
Signed-off-by: Eugene Shevchenko <evgeny.shevchenko@flant.com>

## Description

Make backquotes in the changelog YAML render in DeckhouseRelease resource.

How it looks now:

```yaml
upmeter:
- pull_request: https://github.com/deckhouse/deckhouse/pull/1729
  summary: The  and  options are deprecated. Consider using the  module.
```

## Why do we need it, and what problem does it solve?

It only fixes unrendered backquotes in the DeckhouseRelease resource. So the text will be generally readable.

## What is the expected result?

In new DeckhouseRelease resource, the changelog will be rendered as with backquotes.

```yaml
upmeter:
- pull_request: https://github.com/deckhouse/deckhouse/pull/1729
  summary: The `auth.username` and `auth.password` options are deprecated.
    Consider using the `user-authn` module.
```


## Checklist
- [x] The code is covered by unit tests.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fixed unrendered backquotes in the DeckhouseRelease resource.
```
