### PR TITLE
[global] fixes in cluster configuration migration process and proxy template for EKS cluster installation

### DIFF
--- a/global-hooks/migrate/migrate_cluster_configuration.go
+++ b/global-hooks/migrate/migrate_cluster_configuration.go
@@ -54,7 +54,8 @@ func clusterConfigurationMigration(input *go_hook.HookInput, dc dependency.Conta
 		Secrets("kube-system").
 		Get(context.TODO(), "d8-cluster-configuration", metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("cannot get Secret/kube-system/d8-cluster-configuration: %v", err)
+		input.LogEntry.Info("cannot get Secret/kube-system/d8-cluster-configuration, proxy configuration migration skipped")
+		return nil
 	}
 
 	configYaml, ok := secret.Data[DataKey]

--- a/global-hooks/migrate/migrate_cluster_configuration_test.go
+++ b/global-hooks/migrate/migrate_cluster_configuration_test.go
@@ -121,8 +121,8 @@ var _ = Describe("Global :: migrate_cluster_configuration ::", func() {
 			f.RunHook()
 		})
 
-		It("Hook should fail", func() {
-			Expect(f).To(Not(ExecuteSuccessfully()))
+		It("Hook should not fail", func() {
+			Expect(f).To(ExecuteSuccessfully())
 		})
 	})
 

--- a/helm_lib/templates/_envs_for_proxy.tpl
+++ b/helm_lib/templates/_envs_for_proxy.tpl
@@ -1,26 +1,28 @@
 {{- /* Usage: {{ include "helm_lib_envs_for_proxy" . }} */ -}}
 {{- define "helm_lib_envs_for_proxy" }}
   {{- $context := . -}}
-  {{- if $context.Values.global.clusterConfiguration.proxy }}
-    {{- if $context.Values.global.clusterConfiguration.proxy.httpProxy }}
+  {{- if $context.Values.global.clusterConfiguration }}
+    {{- if $context.Values.global.clusterConfiguration.proxy }}
+      {{- if $context.Values.global.clusterConfiguration.proxy.httpProxy }}
 - name: HTTP_PROXY
   value: {{ $context.Values.global.clusterConfiguration.proxy.httpProxy | quote }}
 - name: http_proxy
   value: {{ $context.Values.global.clusterConfiguration.proxy.httpProxy | quote }}
-    {{- end }}
-    {{- if $context.Values.global.clusterConfiguration.proxy.httpsProxy }}
+      {{- end }}
+      {{- if $context.Values.global.clusterConfiguration.proxy.httpsProxy }}
 - name: HTTPS_PROXY
   value: {{ $context.Values.global.clusterConfiguration.proxy.httpsProxy | quote }}
 - name: https_proxy
   value: {{ $context.Values.global.clusterConfiguration.proxy.httpsProxy | quote }}
-    {{- end }}
-    {{- $noProxy := list "127.0.0.1" "169.254.169.254" $context.Values.global.clusterConfiguration.clusterDomain $context.Values.global.clusterConfiguration.podSubnetCIDR $context.Values.global.clusterConfiguration.serviceSubnetCIDR }}
-    {{- if $context.Values.global.clusterConfiguration.proxy.noProxy }}
-      {{- $noProxy = concat $noProxy $context.Values.global.clusterConfiguration.proxy.noProxy }}
-    {{- end }}
+      {{- end }}
+      {{- $noProxy := list "127.0.0.1" "169.254.169.254" $context.Values.global.clusterConfiguration.clusterDomain $context.Values.global.clusterConfiguration.podSubnetCIDR $context.Values.global.clusterConfiguration.serviceSubnetCIDR }}
+      {{- if $context.Values.global.clusterConfiguration.proxy.noProxy }}
+        {{- $noProxy = concat $noProxy $context.Values.global.clusterConfiguration.proxy.noProxy }}
+      {{- end }}
 - name: NO_PROXY
   value: {{ $noProxy | join "," | quote }}
 - name: no_proxy
   value: {{ $noProxy | join "," | quote }}
+    {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixes in cluster configuration migration process and proxy template (if installed in EKS cluster, the absence of proxy settings will be ignored)

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Installation in EKS cluster fails due to the lack of a secret with proxy settings. This fix will allow Deckhouse to ignore secret's absence.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Deckhouse installation in Amazon EKS now will complete successfully.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: global
type: fix
summary: Fixes in cluster configuration migration process and proxy template for EKS cluster installation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
