### PR TITLE
[istio] fix api-proxy ca

### DIFF
--- a/ee/modules/110-istio/images/api-proxy/main.go
+++ b/ee/modules/110-istio/images/api-proxy/main.go
@@ -258,7 +258,7 @@ func main() {
 	router.Handle("/ready", http.HandlerFunc(httpHandlerReady))
 	router.Handle("/", http.HandlerFunc(httpHandlerApiProxy))
 
-	kubeCA, _ := os.ReadFile("/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+	kubeCA, _ := os.ReadFile("/etc/ssl/kube-rbac-proxy-ca.crt")
 	kubeCertPool := x509.NewCertPool()
 	kubeCertPool.AppendCertsFromPEM(kubeCA)
 

--- a/ee/modules/110-istio/templates/kiali/rbac-for-us.yaml
+++ b/ee/modules/110-istio/templates/kiali/rbac-for-us.yaml
@@ -96,6 +96,14 @@ rules:
   resources: ["deployments/http"]
   resourceNames: ["trickster"]
   verbs: ["get", "create", "update", "patch", "delete"]
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - prometheuses
+    - prometheuses/http
+  verbs:
+    - create
+    - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/ee/modules/110-istio/templates/multicluster/api-proxy/deployment.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/deployment.yaml
@@ -92,7 +92,7 @@ spec:
           mountPath: /remote/
         - name: kube-rbac-proxy-ca
           mountPath: /etc/ssl/kube-rbac-proxy-ca.crt
-          subPath: kube-rbac-proxy-ca.crt
+          subPath: ca.crt
       volumes:
       - name: remote-public-metadata
         secret:

--- a/ee/modules/110-istio/templates/multicluster/api-proxy/deployment.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/deployment.yaml
@@ -90,9 +90,16 @@ spec:
         volumeMounts:
         - name: remote-public-metadata
           mountPath: /remote/
+        - name: kube-rbac-proxy-ca
+          mountPath: /etc/ssl/kube-rbac-proxy-ca.crt
+          subPath: kube-rbac-proxy-ca.crt
       volumes:
       - name: remote-public-metadata
         secret:
           defaultMode: 420
           secretName: d8-remote-clusters-public-metadata
+      - name: kube-rbac-proxy-ca
+        configMap:
+          defaultMode: 420
+          name: kube-rbac-proxy-ca.crt
 {{- end }}


### PR DESCRIPTION
## Description
Replace CA for ingress validation for api-proxy, fix kiali `ClusterRole`

## Why do we need it, and what problem does it solve?
CA changed in this pr: https://github.com/deckhouse/deckhouse/pull/3288, we need to use it, otherwise it can broke istio multicluster.

## What is the expected result?
Istio api-proxy will use valid CA for validation

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: istio
type: fix
summary: Replace CA for ingress validation for api-proxy, fix kiali `ClusterRole`
impact: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
