### PR TITLE
[vpa] Setting admissionReviewVersions to v1 in mutating webhook

### DIFF
--- a/modules/302-vertical-pod-autoscaler/templates/admission-controller/mutatingwebhookconfiguration.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/admission-controller/mutatingwebhookconfiguration.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "vpa-webhook-config")) | nindent 2 }}
 webhooks:
 - admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     caBundle: {{ printf "%s\n" .Values.verticalPodAutoscaler.internal.CACert | b64enc }}
     service:


### PR DESCRIPTION
## Description
Setting admissionReviewVersions to v1 in mutating webhook.

## Why do we need it, and what problem does it solve?
v1beta1 isn't supported by the new vpa controller.

## What is the expected result?
Mututating webhook work in any k8s setup.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: vpa
type: fix
summary: Setting admissionReviewVersions to v1 in mutating webhook.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
