### PR TITLE
[deckhouse]: Add auth to update notification

### DIFF
--- a/modules/002-deckhouse/hooks/internal/updater/notification.go
+++ b/modules/002-deckhouse/hooks/internal/updater/notification.go
@@ -33,25 +33,29 @@ type NotificationConfig struct {
 	WebhookURL              string
 	SkipTLSVerify           bool
 	MinimalNotificationTime v1alpha1.Duration
-	Auth                    *Auth
+	Auth                    *Auth `json:"auth,omitempty"`
 }
 
 type Auth struct {
-	Username string
-	Password string
-	Token    string
+	Basic *BasicAuth `json:"basic,omitempty"`
+	Token *string    `json:"bearerToken,omitempty"`
+}
+
+type BasicAuth struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
 }
 
 func (a *Auth) Fill(req *http.Request) {
 	if a == nil {
 		return
 	}
-	if a.Username != "" && a.Password != "" {
-		req.SetBasicAuth(a.Username, a.Password)
+	if a.Basic != nil {
+		req.SetBasicAuth(a.Basic.Username, a.Basic.Password)
 		return
 	}
-	if a.Token != "" {
-		req.Header.Set("Authorization", "Bearer "+a.Token)
+	if a.Token != nil {
+		req.Header.Set("Authorization", "Bearer "+*a.Token)
 	}
 }
 

--- a/modules/002-deckhouse/hooks/internal/updater/updater.go
+++ b/modules/002-deckhouse/hooks/internal/updater/updater.go
@@ -67,8 +67,11 @@ type DeckhouseUpdater struct {
 	notificationConfig *NotificationConfig
 }
 
-func NewDeckhouseUpdater(input *go_hook.HookInput, mode string, data DeckhouseReleaseData, podIsReady, isBootstrapping bool) *DeckhouseUpdater {
-	nConfig := ParseNotificationConfigFromValues(input)
+func NewDeckhouseUpdater(input *go_hook.HookInput, mode string, data DeckhouseReleaseData, podIsReady, isBootstrapping bool) (*DeckhouseUpdater, error) {
+	nConfig, err := ParseNotificationConfigFromValues(input)
+	if err != nil {
+		return nil, fmt.Errorf("parsing notification config: %v", err)
+	}
 	now := time.Now().UTC()
 	if os.Getenv("D8_IS_TESTS_ENVIRONMENT") != "" {
 		now = time.Date(2021, 01, 01, 13, 30, 00, 00, time.UTC)
@@ -85,7 +88,7 @@ func NewDeckhouseUpdater(input *go_hook.HookInput, mode string, data DeckhouseRe
 		deckhouseIsBootstrapping:    isBootstrapping,
 		releaseData:                 data,
 		notificationConfig:          nConfig,
-	}
+	}, nil
 }
 
 // for patch we check less conditions, then for minor release

--- a/modules/002-deckhouse/hooks/update_deckhouse_image.go
+++ b/modules/002-deckhouse/hooks/update_deckhouse_image.go
@@ -164,7 +164,10 @@ func updateDeckhouse(input *go_hook.HookInput, dc dependency.Container) error {
 
 	// initialize deckhouseUpdater
 	approvalMode := input.Values.Get("deckhouse.update.mode").String()
-	deckhouseUpdater := updater.NewDeckhouseUpdater(input, approvalMode, releaseData, deckhousePod.Ready, deckhousePod.isBootstrapImage())
+	deckhouseUpdater, err := updater.NewDeckhouseUpdater(input, approvalMode, releaseData, deckhousePod.Ready, deckhousePod.isBootstrapImage())
+	if err != nil {
+		return fmt.Errorf("initializing deckhouse updater: %v", err)
+	}
 
 	if deckhousePod.Ready {
 		input.MetricsCollector.Expire(metricUpdatingGroup)

--- a/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
+++ b/modules/002-deckhouse/hooks/update_deckhouse_image_test.go
@@ -630,9 +630,6 @@ metadata:
 	})
 
 	Context("Notification: basic auth", func() {
-		// type auth struct {
-		// 	Basic updater.BasicAuth `json:"basic"`
-		// }
 		var (
 			username string
 			password string
@@ -662,9 +659,6 @@ metadata:
 	})
 
 	Context("Notification: bearer token auth", func() {
-		// type auth struct {
-		// 	Token string `json:"bearerToken"`
-		// }
 		var (
 			headerValue string
 		)

--- a/modules/002-deckhouse/openapi/config-values.yaml
+++ b/modules/002-deckhouse/openapi/config-values.yaml
@@ -137,7 +137,7 @@ properties:
                 "requirements":  {"k8s": "1.20.0"},
                 "changelogLink": "https://github.com/deckhouse/deckhouse/changelog/1.36.md",
                 "applyTime": "2023-01-01T14:30:00Z00:00",
-                "message": "New Deckhouse Release 1.36 is available. Release will be applied at: Friday, 01-Jan-22 14:30:00 UTC"
+                "message": "New Deckhouse Release 1.36 is available. Release will be applied at: Friday, 01-Jan-23 14:30:00 UTC"
               }
               ```
 

--- a/modules/002-deckhouse/openapi/config-values.yaml
+++ b/modules/002-deckhouse/openapi/config-values.yaml
@@ -39,6 +39,9 @@ properties:
         notification:
           webhook: https://release-webhook.mydomain.com
           minimalNotificationTime: 6h
+          auth:
+            username: user
+            password: password
     properties:
       mode:
         type: string
@@ -161,6 +164,31 @@ properties:
               The update mechanism ensures that Deckhouse will not be updated before the specified time.
 
               When using update windows, the Deckhouse update after the notification will happen at the nearest possible update window, but not before the time specified in `minimalNotificationTime` expires.
+          auth:
+            type: object
+            description: |
+              Authentication settings for the webhook.
+
+              If the parameter is omitted, the webhook will be called without authentication.
+            properties:
+              username:
+                type: string
+                description: |
+                  The username for the webhook.
+
+                  The username and password will be sent in the `Authorization` header in the format `Basic <base64(username:password)>`.
+              password:
+                type: string
+                description: |
+                  The password for the webhook.
+
+                  The username and password will be sent in the `Authorization` header in the format `Basic <base64(username:password)>`.
+              token:
+                type: string
+                description: |
+                  The token for the webhook.
+
+                  The token will be sent in the `Authorization` header in the format `Bearer <token>`.
   nodeSelector:
     type: object
     additionalProperties:

--- a/modules/002-deckhouse/openapi/config-values.yaml
+++ b/modules/002-deckhouse/openapi/config-values.yaml
@@ -40,8 +40,9 @@ properties:
           webhook: https://release-webhook.mydomain.com
           minimalNotificationTime: 6h
           auth:
-            username: user
-            password: password
+            basic:
+              username: user
+              password: password
     properties:
       mode:
         type: string

--- a/modules/002-deckhouse/openapi/config-values.yaml
+++ b/modules/002-deckhouse/openapi/config-values.yaml
@@ -166,29 +166,42 @@ properties:
               When using update windows, the Deckhouse update after the notification will happen at the nearest possible update window, but not before the time specified in `minimalNotificationTime` expires.
           auth:
             type: object
+            oneOf:
+              - required: [ basic ]
+              - required: [ bearerToken ]
             description: |
               Authentication settings for the webhook.
 
               If the parameter is omitted, the webhook will be called without authentication.
             properties:
-              username:
+              basic:
+                type: object
+                description: |
+                  Basic authentication settings for the webhook.
+
+                  If the parameter is omitted, the webhook will be called without authentication.
+                required:
+                  - username
+                  - password
+                properties:
+                  username:
+                    type: string
+                    description: |
+                      The username for the webhook.
+
+                      The username and password will be sent in the `Authorization` header in the format `Basic <base64(username:password)>`.
+                  password:
+                    type: string
+                    description: |
+                        The password for the webhook.
+
+                        The username and password will be sent in the `Authorization` header in the format `Basic <base64(username:password)>`.
+              bearerToken:
                 type: string
                 description: |
-                  The username for the webhook.
+                    The token for the webhook.
 
-                  The username and password will be sent in the `Authorization` header in the format `Basic <base64(username:password)>`.
-              password:
-                type: string
-                description: |
-                  The password for the webhook.
-
-                  The username and password will be sent in the `Authorization` header in the format `Basic <base64(username:password)>`.
-              token:
-                type: string
-                description: |
-                  The token for the webhook.
-
-                  The token will be sent in the `Authorization` header in the format `Bearer <token>`.
+                    The token will be sent in the `Authorization` header in the format `Bearer <token>`.
   nodeSelector:
     type: object
     additionalProperties:

--- a/modules/002-deckhouse/openapi/doc-ru-config-values.yaml
+++ b/modules/002-deckhouse/openapi/doc-ru-config-values.yaml
@@ -93,6 +93,19 @@ properties:
               Механизм обновления гарантирует, что Deckhouse не обновится раньше указанного времени.
 
               При использовании окон обновлений, обновление Deckhouse после оповещения произойдет в ближайшее возможное окно обновлений, но не ранее чем истечет указанное в `minimalNotificationTime` время.
+          auth:
+            description: |
+              Структура, описывающая способ авторизации на webhook.
+
+              Если не указано — авторизация не используется.
+            properties:
+              username:
+                description: Имя пользователя для авторизации на webhook.
+              password:
+                description: Пароль для авторизации на webhook.
+              token:
+                description: Токен для авторизации на webhook.
+
   nodeSelector:
     description: |
       Структура, аналогичная `spec.nodeSelector` Kubernetes Pod.

--- a/modules/002-deckhouse/openapi/doc-ru-config-values.yaml
+++ b/modules/002-deckhouse/openapi/doc-ru-config-values.yaml
@@ -74,7 +74,7 @@ properties:
                 "requirements":  {"k8s": "1.20.0"},
                 "changelogLink": "https://github.com/deckhouse/deckhouse/changelog/1.36.md",
                 "applyTime": "2023-01-01T14:30:00Z00:00",
-                "message": "New Deckhouse Release 1.36 is available. Release will be applied at: Friday, 01-Jan-22 14:30:00 UTC"
+                "message": "New Deckhouse Release 1.36 is available. Release will be applied at: Friday, 01-Jan-23 14:30:00 UTC"
               }
               ```
 

--- a/modules/002-deckhouse/openapi/openapi-case-tests.yaml
+++ b/modules/002-deckhouse/openapi/openapi-case-tests.yaml
@@ -13,6 +13,18 @@ positive:
           to: '13:00'
   - update:
       mode: Auto
+  - update:
+      notification:
+        webhook: https://example.com/webhook
+        auth:
+          basic:
+            username: user
+            password: pass
+  - update:
+      notification:
+        webhook: https://example.com/webhook
+        auth:
+          bearerToken: token
   values:
   - internal:
       currentReleaseImageName: registry.deckhouse.io/deckhouse/ce/dev@sha256:e9e41b1abc067bd59f1cdf2d7c44cb80911b733d3d711209abd291c9458e51c4


### PR DESCRIPTION

## Description

Add authentication settings to the update notification hook.

## Why do we need it, and what problem does it solve?

For the inner Flant infrastructure, we need to be able to send update notifications to the clients
from their clusters.

## What is the expected result?

The update notification hook can be configured to send  authenticated notifications requests.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Added authentication settings to the update notification hook
```
