### PR TITLE
[monitoring-kubernetes] Attempt to fix oom_kills:normalized for cgroupfs driver

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/ebpf-exporter.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/ebpf-exporter.yaml
@@ -19,3 +19,9 @@
         * on (raw_container_id) group_left
         max by (raw_container_id) (label_replace(ebpf_exporter_oom_kills{global_oom="0", cgroup_path=~".*slice.*"}, "raw_container_id", "$1", "cgroup_path", ".+cri-containerd-(.+).scope"))
       )
+  - record: oom_kills:normalized
+    expr: |-
+      max by (namespace, pod, container) (
+        kube_pod_container_info * on (uid) group_left
+        max by (uid) (label_replace(ebpf_exporter_oom_kills{global_oom="0", cgroup_path=~".*burstable.*"}, "uid", "$1", "cgroup_path", "/sys/fs/cgroup/memory/kubepods/burstable/pod(.*)"))
+      )


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
- Add one more recording rule `oom_kills:normalized` with label_replace for cgroupfs

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
It works for ebpf_exporter_oom_kills metrics from regular pods ooms

```
ebpf_exporter_oom_kills{cgroup_path="/sys/fs/cgroup/memory/kubepods/burstable/pod50b98f22-1095-48bf-804d-c21da2013bb6", container="kube-rbac-proxy", global_oom="0", instance="192.168.199.70:9434", job="ebpf-exporter", node="k-aksenov-master-0", tier="cluster"}
kube_pod_container_info{container="stress-ng", container_id="containerd://d48ea9823470abbf4b68e846fd4d20837abab32db09984c5fae67669d4af7737", image="docker.io/alexeiled/stress-ng:latest", image_id="docker.io/alexeiled/stress-ng@sha256:91f1313a67e3c8c23f3c75855019d01c4a43e2f872b099f720047f03309d8ad4", image_spec="alexeiled/stress-ng", instance="kube-state-metrics.d8-monitoring.svc.cluster.local.:8080", job="kube-state-metrics", namespace="default", pod="oom-7855f876b7-lhplq", scrape_endpoint="main", uid="50b98f22-1095-48bf-804d-c21da2013bb6"}
```

But it doesn't work for static pods, because cgroup_path doesn't match uid from kube_pod_container_info

```
ebpf_exporter_oom_kills{cgroup_path="/sys/fs/cgroup/memory/kubepods/burstable/pod52c7c29c336a733ae3bc99f62ea70cb6", container="kube-rbac-proxy", global_oom="0", instance="192.168.199.70:9434", job="ebpf-exporter", node="k-aksenov-master-0", tier="cluster", uid="52c7c29c336a733ae3bc99f62ea70cb6"}
kube_pod_container_info{container="oom", container_id="containerd://5631e5c910ad68949ebcc354229ea142f8fe9184042d019a9ec8b728a723fb3f", image="docker.io/alexeiled/stress-ng:latest", image_id="docker.io/alexeiled/stress-ng@sha256:91f1313a67e3c8c23f3c75855019d01c4a43e2f872b099f720047f03309d8ad4", image_spec="alexeiled/stress-ng", instance="kube-state-metrics.d8-monitoring.svc.cluster.local.:8080", job="kube-state-metrics", namespace="default", pod="oom-k-aksenov-master-0", scrape_endpoint="main", uid="cdfa030f-870b-42e9-930d-2a9bfa336eb1"}
```
Seems reasonable to fix for regular pods at least.
![image](https://user-images.githubusercontent.com/14013249/209450497-396d8e52-e51d-415a-b4cf-e8a5d67e0cd1.png)


## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring-kubernetes
type: chore
summary: Attempt to fix oom_kills:normalized for cgroupfs driver
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
