### PR TITLE
[ingress-nginx] change certificate expiry date

### DIFF
--- a/modules/402-ingress-nginx/hooks/order_certificates.go
+++ b/modules/402-ingress-nginx/hooks/order_certificates.go
@@ -101,9 +101,9 @@ func orderCertificate(input *go_hook.HookInput, dc dependency.Container) error {
 			return fmt.Errorf("can't get Secret %s: %v", secretName, err)
 		}
 
-		// If existing Certificate expires in more than 7 days — use it.
+		// If existing Certificate expires in more than 365 days — use it.
 		if secret != nil && len(secret.Cert) > 0 && len(secret.Key) > 0 {
-			shouldGenerateNewCert, err := certificate.IsCertificateExpiringSoon([]byte(secret.Cert), time.Hour*24*7)
+			shouldGenerateNewCert, err := certificate.IsCertificateExpiringSoon([]byte(secret.Cert), time.Hour*24*365) // 1 year
 			if err != nil {
 				return err
 			}
@@ -135,7 +135,7 @@ func orderCertificate(input *go_hook.HookInput, dc dependency.Container) error {
 			fmt.Sprintf("nginx-ingress:%s", controller.Name),
 			caAuthority,
 			certificate.WithGroups("ingress-nginx:auth"),
-			certificate.WithSigningDefaultExpiry(87600*time.Hour),
+			certificate.WithSigningDefaultExpiry(10*365*24*time.Hour), // 10 years
 			certificate.WithSigningDefaultUsage([]string{
 				"signing",
 				"key encipherment",

--- a/modules/402-ingress-nginx/hooks/order_certificates_test.go
+++ b/modules/402-ingress-nginx/hooks/order_certificates_test.go
@@ -43,7 +43,7 @@ var _ = Describe("ingress-nginx :: hooks :: order_certificates", func() {
 	var logEntry = log.WithContext(context.TODO())
 
 	selfSignedCA, _ := certificate.GenerateCA(logEntry, "kube-rbac-proxy-ca-key-pair")
-	cert, _ := certificate.GenerateSelfSignedCert(logEntry, "test", selfSignedCA)
+	cert, _ := certificate.GenerateSelfSignedCert(logEntry, "test", selfSignedCA, certificate.WithSigningDefaultExpiry(10*365*24*time.Hour))
 
 	Context(":: empty_cluster", func() {
 		BeforeEach(func() {


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Change certificate expiry time to 1 year

## Why do we need it, and what problem does it solve?
We have to reload an ingress when certificate is change. And we have CA certificate is valid for 10 years. 
We can recreate certificate 1 year before expiration to be sure that certificate will be reloaded inside the pod

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ingress-nginx
type: fix 
summary: Change certificate expiry time
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
