### PR TITLE
[helm] set resource version match explicitly

### DIFF
--- a/modules/013-helm/hooks/metrics.go
+++ b/modules/013-helm/hooks/metrics.go
@@ -186,7 +186,10 @@ func getHelm3Releases(ctx context.Context, client k8s.Client, releasesC chan<- *
 			Limit:         objectBatchSize,
 			Continue:      next,
 			// https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-get-and-list
-			ResourceVersion: "0",
+			// set explicit behavior:
+			//   Return data at any resource version. The newest available resource version is preferred, but strong consistency is not required; data at any resource version may be served.
+			ResourceVersion:      "0",
+			ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
 		})
 		if err != nil {
 			return 0, err
@@ -202,7 +205,7 @@ func getHelm3Releases(ctx context.Context, client k8s.Client, releasesC chan<- *
 			if err != nil {
 				return 0, err
 			}
-			// release can contains wrong namespace (set by helm and werf) and confuse user wit hwrong metric
+			// release can contain wrong namespace (set by helm and werf) and confuse user with a wrong metric
 			// fetch namespace from secret is more reliable
 			release.Namespace = secret.Namespace
 			release.HelmVersion = "3"
@@ -227,10 +230,11 @@ func getHelm2Releases(ctx context.Context, client k8s.Client, releasesC chan<- *
 
 	for {
 		cmList, err := client.CoreV1().ConfigMaps("").List(ctx, metav1.ListOptions{
-			LabelSelector:   "OWNER=TILLER,STATUS=DEPLOYED",
-			Limit:           objectBatchSize,
-			Continue:        next,
-			ResourceVersion: "0",
+			LabelSelector:        "OWNER=TILLER,STATUS=DEPLOYED",
+			Limit:                objectBatchSize,
+			Continue:             next,
+			ResourceVersion:      "0",
+			ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
 		})
 		if err != nil {
 			return 0, err
@@ -246,7 +250,7 @@ func getHelm2Releases(ctx context.Context, client k8s.Client, releasesC chan<- *
 			if err != nil {
 				return 0, err
 			}
-			// release can contains wrong namespace (set by helm and werf) and confuse user wit hwrong metric
+			// release can contain wrong namespace (set by helm and werf) and confuse user with a wrong metric
 			// fetch namespace from secret is more reliable
 			release.Namespace = secret.Namespace
 			release.HelmVersion = "2"


### PR DESCRIPTION
Signed-off-by: Yuriy Losev <yuriy.losev@flant.com>

## Description
Set flag explicitly

## Why do we need it, and what problem does it solve?
Avoid reading the docs every time when we met this hook. This does not change hook behavior

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: helm
type: chore
summary: Set resourceVersionMatch flag for secret listing explicitly
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
