### PR TITLE
[candi] Temporary disable seccomp for kube-controller-manager

### DIFF
--- a/candi/control-plane-kubeadm/patches/kube-controller-manager.yaml.tpl
+++ b/candi/control-plane-kubeadm/patches/kube-controller-manager.yaml.tpl
@@ -75,3 +75,6 @@ metadata:
   namespace: kube-system
 spec:
   dnsPolicy: ClusterFirstWithHostNet
+  securityContext:
+    seccompProfile:
+      type: Unconfined

--- a/candi/control-plane-kubeadm/patches/kube-controller-manager.yaml.tpl
+++ b/candi/control-plane-kubeadm/patches/kube-controller-manager.yaml.tpl
@@ -75,6 +75,8 @@ metadata:
   namespace: kube-system
 spec:
   dnsPolicy: ClusterFirstWithHostNet
+{{- if semverCompare "> 1.21" .clusterConfiguration.kubernetesVersion }}
   securityContext:
     seccompProfile:
       type: Unconfined
+{{- end }}

--- a/candi/control-plane-kubeadm/patches/kube-controller-manager.yaml.tpl
+++ b/candi/control-plane-kubeadm/patches/kube-controller-manager.yaml.tpl
@@ -75,6 +75,7 @@ metadata:
   namespace: kube-system
 spec:
   dnsPolicy: ClusterFirstWithHostNet
+# TODO remove after Docker support is dropped
 {{- if semverCompare "> 1.21" .clusterConfiguration.kubernetesVersion }}
   securityContext:
     seccompProfile:


### PR DESCRIPTION
Signed-off-by: Konstantin Aksenov <konstantin.aksenov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Explicitly set seccompProfile type to Unconfined

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Kubeadm sets seccomp to [RuntimeDefault](https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads) for kube-controller-manager in Kubernetes clusters > 1.21:
```
  securityContext:
    seccompProfile:
      type: RuntimeDefault
```
We still have Docker with different runc versions. And we have problem with ceph rbd in-tree using runc version <= `1.0.0-rc92`:
```
Thread::try_create(): pthread_create failed with error 1./src/common/Thread.cc: In function 'void Thread::create(const char*, size_t)' thread 7f07ccea9340 time 2022-12-27T18:42:01.846784+0000
./src/common/Thread.cc: 165: FAILED ceph_assert(ret == 0)
 ceph version 17.2.0 (43e2e60a7559d3f46c9d53f1ca875fd499a1e35e) quincy (stable)
 1: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0x128) [0x7f07ce02a369]
 2: /usr/lib/x86_64-linux-gnu/ceph/libceph-common.so.2(+0x257525) [0x7f07ce02a525]
 3: /usr/lib/x86_64-linux-gnu/ceph/libceph-common.so.2(+0x32cb4e) [0x7f07ce0ffb4e]
 4: (global_pre_init(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const*, std::vector<char const*, std::allocator<char const*> >&, unsigned int, code_environment_t, int)+0x3ec) [0x55fd31b6655c]
 5: (global_init(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const*, std::vector<char const*, std::allocator<char const*> >&, unsigned int, code_environment_t, int, bool)+0x84) [0x55fd31b689a4]
 6: (rbd::Shell::execute(int, char const**)+0x157) [0x55fd319f80a7]
 7: main()
 8: /lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7f07cd7f2d90]
 9: __libc_start_main()
 10: _start()
```
Runc update or disabling seccomp can fix the problem. I'd prefer to disable seccomp until Docker support isn't dropped.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: chore
summary: Temporary disable seccomp for kube-controller-manager
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
