### PR TITLE
[node-local-dns] Switch to "verified" mode

### DIFF
--- a/ee/modules/350-node-local-dns/templates/configmap.yaml
+++ b/ee/modules/350-node-local-dns/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
         success 39936
         denial 9984
         prefetch 10 1m 25%
-        serve_stale 1h immediate
+        serve_stale 1h verified
       }
       reload 2s
       loop


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Switched from "immediate" to "verified" stale_cache mode.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Some programs resolve a Service name only once and then attempt to connect to it without retrying DNS resolution. stale_cache's `immediate` mode results in node-local-dns sending a response (granted, with TTL 0) to the client, and only then attempting to refresh the cache. In `verified` mode, node-local-dns will attempt to first get a fresh response and only send the stale one to the client if the refresh fails.

https://coredns.io/plugins/cache/

https://github.com/coredns/coredns/blob/66f2ac7568ccb0178cc9ce6dbd7320bcd3428d64/plugin/cache/handler.go#L43-L66

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

`stale_cache` always attempts to send a fresh Resource Record to the client.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-local-dns
type: fix
summary: Switched stale cache behavior from `immediate` to `verified`
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
