### PR TITLE
[user-authn] Fix insecure oidc ca patch

### DIFF
--- a/modules/150-user-authn/images/dex/patches/oidc-ca-insecure.patch
+++ b/modules/150-user-authn/images/dex/patches/oidc-ca-insecure.patch
@@ -1,9 +1,9 @@
 diff --git a/connector/oidc/oidc.go b/connector/oidc/oidc.go
-index e345dca0..01e6c2e3 100644
+index e345dca0..a7c3a7c4 100644
 --- a/connector/oidc/oidc.go
 +++ b/connector/oidc/oidc.go
 @@ -3,9 +3,12 @@ package oidc
-
+ 
  import (
  	"context"
 +	"crypto/tls"
@@ -16,16 +16,16 @@ index e345dca0..01e6c2e3 100644
  	"net/url"
  	"strings"
 @@ -34,6 +37,10 @@ type Config struct {
-
+ 
  	Scopes []string `json:"scopes"` // defaults to "profile" and "email"
-
+ 
 +	RootCAs []string `json:"rootCAs"`
 +
 +	InsecureSkipVerify bool `json:"insecureSkipVerify"`
 +
  	// Override the value of email_verified to true in the returned claims
  	InsecureSkipEmailVerified bool `json:"insecureSkipEmailVerified"`
-
+ 
 @@ -105,8 +112,37 @@ func knownBrokenAuthHeaderProvider(issuerURL string) bool {
  // Open returns a connector which can be used to login users through an upstream
  // OpenID Connect provider.
@@ -43,7 +43,7 @@ index e345dca0..01e6c2e3 100644
 +	}
 +
  	ctx, cancel := context.WithCancel(context.Background())
-
+ 
 +	httpClient := &http.Client{
 +		Transport: &http.Transport{
 +			TLSClientConfig: &tlsConfig,
@@ -64,3 +64,31 @@ index e345dca0..01e6c2e3 100644
  	provider, err := oidc.NewProvider(ctx, c.Issuer)
  	if err != nil {
  		cancel()
+@@ -150,6 +186,7 @@ func (c *Config) Open(id string, logger log.Logger) (conn connector.Connector, e
+ 		verifier: provider.Verifier(
+ 			&oidc.Config{ClientID: clientID},
+ 		),
++		httpClient:                httpClient,
+ 		logger:                    logger,
+ 		cancel:                    cancel,
+ 		insecureSkipEmailVerified: c.InsecureSkipEmailVerified,
+@@ -189,6 +226,7 @@ type oidcConnector struct {
+ 	preferredUsernameKey      string
+ 	emailKey                  string
+ 	groupsKey                 string
++	httpClient                *http.Client
+ }
+ 
+ func (c *oidcConnector) Close() error {
+@@ -238,7 +276,10 @@ func (c *oidcConnector) HandleCallback(s connector.Scopes, r *http.Request) (ide
+ 	if errType := q.Get("error"); errType != "" {
+ 		return identity, &oauth2Error{errType, q.Get("error_description")}
+ 	}
+-	token, err := c.oauth2Config.Exchange(r.Context(), q.Get("code"))
++
++	ctx := context.WithValue(r.Context(), oauth2.HTTPClient, c.httpClient)
++
++	token, err := c.oauth2Config.Exchange(ctx, q.Get("code"))
+ 	if err != nil {
+ 		return identity, fmt.Errorf("oidc: failed to get token: %v", err)
+ 	}


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>


## Why do we need it, and what problem does it solve?
It fixes the problem with an invalid x509 certificate error that occurred on exchanging a code

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: user-authn
type: fix
summary:  Fix insecure OIDC Ca patch.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
