### PR TITLE
[linstor] fix deckhouse registry regression

### DIFF
--- a/modules/041-linstor/templates/linstor-csi/linstorcsidriver.yaml
+++ b/modules/041-linstor/templates/linstor-csi/linstorcsidriver.yaml
@@ -173,12 +173,12 @@ spec:
   csiControllerServiceAccountName: csi
   csiNodeServiceAccountName: default
   {{- with .Values.global.modulesImages }}
-  csiAttacherImage: "{{ .registry }}:{{ index .tags.common (list "csiExternalAttacher" $kubeVersion.Major $kubeVersion.Minor | join "") }}"
-  csiLivenessProbeImage: "{{ .registry }}:{{ index .tags.common (list "csiLivenessprobe" $kubeVersion.Major $kubeVersion.Minor | join "") }}"
-  csiNodeDriverRegistrarImage: "{{ .registry }}:{{ index .tags.common (list "csiNodeDriverRegistrar" $kubeVersion.Major $kubeVersion.Minor | join "") }}"
-  csiProvisionerImage: "{{ .registry }}:{{ index .tags.common (list "csiExternalProvisioner" $kubeVersion.Major $kubeVersion.Minor | join "") }}"
-  csiResizerImage: "{{ .registry }}:{{ index .tags.common (list "csiExternalResizer" $kubeVersion.Major $kubeVersion.Minor | join "") }}"
-  csiSnapshotterImage: "{{ .registry }}:{{ index .tags.common (list "csiExternalSnapshotter" $kubeVersion.Major $kubeVersion.Minor | join "") }}"
+  csiAttacherImage: "{{ .registry.base }}:{{ index .tags.common (list "csiExternalAttacher" $kubeVersion.Major $kubeVersion.Minor | join "") }}"
+  csiLivenessProbeImage: "{{ .registry.base }}:{{ index .tags.common (list "csiLivenessprobe" $kubeVersion.Major $kubeVersion.Minor | join "") }}"
+  csiNodeDriverRegistrarImage: "{{ .registry.base }}:{{ index .tags.common (list "csiNodeDriverRegistrar" $kubeVersion.Major $kubeVersion.Minor | join "") }}"
+  csiProvisionerImage: "{{ .registry.base }}:{{ index .tags.common (list "csiExternalProvisioner" $kubeVersion.Major $kubeVersion.Minor | join "") }}"
+  csiResizerImage: "{{ .registry.base }}:{{ index .tags.common (list "csiExternalResizer" $kubeVersion.Major $kubeVersion.Minor | join "") }}"
+  csiSnapshotterImage: "{{ .registry.base }}:{{ index .tags.common (list "csiExternalSnapshotter" $kubeVersion.Major $kubeVersion.Minor | join "") }}"
   {{- end }}
   linstorHttpsClientSecret: linstor-client-https-cert
   priorityClassName: ""


### PR DESCRIPTION
## Description

Fix regression introduced by https://github.com/deckhouse/deckhouse/pull/3193

Now the `{{ .registry }}` expands to map instead of string. The template wasn't updated for linstor-csi custom resource. This PR fixes that.

## Why do we need it, and what problem does it solve?

Linstor CSI plugin can't be deployed

## What is the expected result?

Linstor CSI deployed

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: linstor
type: fix
summary: fix deckhouse registry regression
impact_level: low
```