### PR TITLE
[docs][gs][kind] Add note about using d8 with kind on Windows

### DIFF
--- a/docs/site/_includes/getting_started/kind/STEP_INSTALL_SCHEMA.md
+++ b/docs/site/_includes/getting_started/kind/STEP_INSTALL_SCHEMA.md
@@ -5,6 +5,8 @@ Installing Deckhouse on kind, will allow you to get a Kubernetes cluster with De
 Deckhouse will be installed in a **minimal** configuration, with Grafana based [monitoring](/documentation/v1/modules/300-prometheus/) enabled. Some features, such as [node management](/documentation/v1/modules/040-node-manager/) and [control plane management](/documentation/v1/modules/040-control-plane-manager/) will not work. To simplify, the [sslip.io](https://sslip.io ) service is used for working with DNS.
 
 > **Note!** Some providers are blocking work sslip.io and similar services. If you encounter such a problem, put the necessary domain names in the `hosts` file locally, or use a real domain and fix [DNS names template](../../documentation/v1/deckhouse-configure-global.html#parameters-modules-publicdomaintemplate).
+>
+> **Note!** When using kind on Windows, monitoring (Grafana, Prometheus) may not be available or work incorrectly due to the need to use a special kernel for WSL. Read about the solution in [the kind documentation](https://kind.sigs.k8s.io/docs/user/using-wsl2/#kubernetes-service-with-session-affinity).
 
 {% offtopic title="Computer minimal requirements..." %}
 - Operating system: macOS, Windows or Linux.

--- a/docs/site/_includes/getting_started/kind/STEP_INSTALL_SCHEMA_RU.md
+++ b/docs/site/_includes/getting_started/kind/STEP_INSTALL_SCHEMA_RU.md
@@ -5,6 +5,8 @@
 Deckhouse будет установлен в **минимальной** конфигурации с включенным [мониторингом](/documentation/v1/modules/300-prometheus/) на базе Grafana. Некоторые функции, такие как [управление узлами](/documentation/v1/modules/040-node-manager/) и [управление control-plane](/documentation/v1/modules/040-control-plane-manager/), работать не будут. Для упрощения при работе с DNS используется сервис [sslip.io](https://sslip.io). 
 
 > **Внимание!** Некоторые провайдеры блокируют работу sslip.io и подобных сервисов. Если вы столкнулись с такой проблемой, пропишите нужные домены в `hosts`-файл локально, или направьте реальный домен и исправьте [шаблон DNS-имен](../../documentation/v1/deckhouse-configure-global.html#parameters-modules-publicdomaintemplate).
+>
+> **Внимание!** При использовании kind на Windows мониторинг (Grafana, Prometheus) может быть недоступен или работать некорректно. Это связано с необходимостью использовать специальное ядро для WSL. Решение проблемы описано [в документации kind](https://kind.sigs.k8s.io/docs/user/using-wsl2/#kubernetes-service-with-session-affinity).
 
 {% offtopic title="Минимальные требования к компьютеру..." %}
 - Операционная система macOS, Windows или Linux.


### PR DESCRIPTION
## Description
Added note about using Deckhouse with kind on Windows.

## Why do we need it, and what problem does it solve?
When using kind on Windows, Kubernetes Service with `sessionAffinity: ClientIP`  will not be accessible. This feature may cause Prometheus/Grafana to be unavailable.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [X] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: Added note about using Deckhouse with kind on Windows.
impact_level: low
```
