### PR TITLE
[docs] Fix module status label in the comparison table

### DIFF
--- a/docs/documentation/_includes/revision_comparison_detail_table.liquid
+++ b/docs/documentation/_includes/revision_comparison_detail_table.liquid
@@ -36,7 +36,7 @@
 <tr>
   <td style="text-align: left">
     <a href="{{ modulePath }}"
-    {%- if site.data["modulesFeatureStatus"][moduleName] != '' %} class="comparison-table__module-{{ site.data["modulesFeatureStatus"][moduleName] }}" {% endif -%}
+    {%- if site.data["modulesFeatureStatus"][moduleName] != '' %} class="comparison-table__module comparison-table__module-{{ site.data["modulesFeatureStatus"][moduleName] }}" {% endif -%}
     >{{ moduleName }}</a>
   </td>
   <td style="text-align: center; width: 170px;">

--- a/docs/site/css/docs.scss
+++ b/docs/site/css/docs.scss
@@ -276,7 +276,8 @@
 .sidebar__item_hot > a:before,
 .sidebar__submenu > .sidebar__item_ee > a:before,
 .sidebar__submenu > .sidebar__item_proprietaryOkmeter > a:before,
-.sidebar__submenu > .sidebar__item_experimental > a:before, a.comparison-table__module-experimental:after {
+.sidebar__submenu > .sidebar__item_experimental > a:before,
+a.comparison-table__module:after {
     font-size: 8px;
     color: #fff;
     background: #0066FF;
@@ -292,12 +293,12 @@
     letter-spacing: 1px;
 }
 
-a.comparison-table__module-experimental {
+a.comparison-table__module {
     position: relative;
     display: inline-block;
 }
 
-a.comparison-table__module-experimental:after {
+a.comparison-table__module:after {
     top: 0px;
 }
 


### PR DESCRIPTION
## Description
Fix module status label in the comparison table.
Fix #3478


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: Fix module status label in the comparison table.
impact_level: low
```
