### PR TITLE
[docs] Fixed typo in the "Example for Bare metal" page

### DIFF
--- a/modules/402-ingress-nginx/docs/EXAMPLES_RU.md
+++ b/modules/402-ingress-nginx/docs/EXAMPLES_RU.md
@@ -73,7 +73,7 @@ spec:
     value: frontend
 ```
 
-## Пример для Bare metal (При использовании внешнего балансировщик, например Cloudflare, Qrator, Nginx+, Citrix ADC, Kemp и др.)
+## Пример для Bare metal (При использовании внешнего балансировщика, например Cloudflare, Qrator, Nginx+, Citrix ADC, Kemp и др.)
 
 ```yaml
 apiVersion: deckhouse.io/v1


### PR DESCRIPTION
Signed-off-by: krakazyabra <pronin.egor@gmail.com>

## Description
Documentation's typo was fixed in "Example for Bare metal" label (RU)

## Why do we need it, and what problem does it solve?
Because it is typo mistake :)

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
Typo was fixed in "Example for Bare metal" label

```changes
section: docs
type: fix
summary: Fixed typo on the site.
impact_level: low
```
