### PR TITLE
[upmeter] Fixing D8UpmeterProbeGarbageNamespaces alert

### DIFF
--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -337,7 +337,7 @@
     - alert: D8UpmeterProbeGarbageNamespaces
       expr: |
         (
-          count (kube_namespace_status_phase{namespace=~"upmeter-.*"})
+          count (kube_namespace_status_phase{namespace=~"upmeter-.*",phase="Active"})
           /
           count (kube_pod_labels{namespace="d8-upmeter", label_app="upmeter-agent"})
         ) >= 2

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -337,7 +337,7 @@
     - alert: D8UpmeterProbeGarbageNamespaces
       expr: |
         (
-          count (kube_namespace_status_phase{namespace=~"upmeter-.*",phase="Active"})
+          sum (kube_namespace_status_phase{namespace=~"upmeter-.*})
           /
           count (kube_pod_labels{namespace="d8-upmeter", label_app="upmeter-agent"})
         ) >= 2

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -337,7 +337,7 @@
     - alert: D8UpmeterProbeGarbageNamespaces
       expr: |
         (
-          sum (kube_namespace_status_phase{namespace=~"upmeter-.*})
+          sum (kube_namespace_status_phase{namespace=~"upmeter-.*"})
           /
           count (kube_pod_labels{namespace="d8-upmeter", label_app="upmeter-agent"})
         ) >= 2


### PR DESCRIPTION
## Description
Fixing D8UpmeterProbeGarbageNamespaces alert from upmeter module.

## Why do we need it, and what problem does it solve?
There shouldn't be false alerts.

## What is the expected result?
There aren't false alert.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: upmeter
type: fix
summary: Fixing D8UpmeterProbeGarbageNamespaces alert from upmeter module.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
