### PR TITLE
[user-authn] OIDC insecure userInfo endpoint

### DIFF
--- a/modules/150-user-authn/images/dex/patches/oidc-ca-insecure.patch
+++ b/modules/150-user-authn/images/dex/patches/oidc-ca-insecure.patch
@@ -1,5 +1,5 @@
 diff --git a/connector/oidc/oidc.go b/connector/oidc/oidc.go
-index e345dca0..a7c3a7c4 100644
+index e345dca0..84e5da99 100644
 --- a/connector/oidc/oidc.go
 +++ b/connector/oidc/oidc.go
 @@ -3,9 +3,12 @@ package oidc
@@ -80,7 +80,7 @@ index e345dca0..a7c3a7c4 100644
  }
  
  func (c *oidcConnector) Close() error {
-@@ -238,7 +276,10 @@ func (c *oidcConnector) HandleCallback(s connector.Scopes, r *http.Request) (ide
+@@ -238,11 +276,14 @@ func (c *oidcConnector) HandleCallback(s connector.Scopes, r *http.Request) (ide
  	if errType := q.Get("error"); errType != "" {
  		return identity, &oauth2Error{errType, q.Get("error_description")}
  	}
@@ -92,3 +92,17 @@ index e345dca0..a7c3a7c4 100644
  	if err != nil {
  		return identity, fmt.Errorf("oidc: failed to get token: %v", err)
  	}
+-	return c.createIdentity(r.Context(), identity, token, createCaller)
++	return c.createIdentity(ctx, identity, token, createCaller)
+ }
+ 
+ // Refresh is used to refresh a session with the refresh token provided by the IdP
+@@ -253,6 +294,8 @@ func (c *oidcConnector) Refresh(ctx context.Context, s connector.Scopes, identit
+ 		return identity, fmt.Errorf("oidc: failed to unmarshal connector data: %v", err)
+ 	}
+ 
++	ctx = context.WithValue(ctx, oauth2.HTTPClient, c.httpClient)
++
+ 	t := &oauth2.Token{
+ 		RefreshToken: string(cd.RefreshToken),
+ 		Expiry:       time.Now().Add(-time.Hour),


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
https://github.com/dexidp/dex/pull/2781

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: user-authn
type: fix
summary: OIDC insecure userInfo endpoint.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
