### PR TITLE
[global] remove obsolete v1beta1 admissionReviewVersions from different modules

### DIFF
--- a/ee/modules/110-istio/templates/control-plane/mutatingwebhook-global.yaml
+++ b/ee/modules/110-istio/templates/control-plane/mutatingwebhook-global.yaml
@@ -4,7 +4,8 @@
   {{- $versionInfo := get $context.Values.istio.internal.versionMap $context.Values.istio.internal.globalVersion }}
   {{- $revision := get $versionInfo "revision" }}
 - name: {{ $prefix }}sidecar-injector.istio.io
-  admissionReviewVersions: ["v1beta1", "v1"]
+  admissionReviewVersions:
+  - v1
   clientConfig:
     caBundle: {{ $context.Values.istio.internal.ca.cert | b64enc }}
     service:

--- a/ee/modules/110-istio/templates/control-plane/validatingwebhook-global.yaml
+++ b/ee/modules/110-istio/templates/control-plane/validatingwebhook-global.yaml
@@ -12,8 +12,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 webhooks:
   - admissionReviewVersions:
-      - v1beta1
-      - v1
+    - v1
     clientConfig:
       caBundle: {{ .Values.istio.internal.ca.cert | b64enc }}
       service:

--- a/modules/003-deckhouse-config/templates/deckhouse-config-webhook/webhook-configuration.yaml
+++ b/modules/003-deckhouse-config/templates/deckhouse-config-webhook/webhook-configuration.yaml
@@ -17,7 +17,8 @@ webhooks:
           - CREATE
           - UPDATE
           - DELETE
-    admissionReviewVersions: ["v1", "v1beta1"]
+    admissionReviewVersions:
+    - v1
     matchPolicy: Equivalent
     failurePolicy: Fail
     sideEffects: None
@@ -45,7 +46,8 @@ webhooks:
           - CREATE
           - UPDATE
           - DELETE
-    admissionReviewVersions: ["v1", "v1beta1"]
+    admissionReviewVersions:
+    - v1
     matchPolicy: Equivalent
     failurePolicy: Fail
     sideEffects: None

--- a/modules/015-admission-policy-engine/templates/validatingwebhookconfiguration.yaml
+++ b/modules/015-admission-policy-engine/templates/validatingwebhookconfiguration.yaml
@@ -8,7 +8,6 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     caBundle: {{ .Values.admissionPolicyEngine.internal.webhook.ca | b64enc | quote }}
     service:

--- a/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/webhook-configuration.yaml
+++ b/modules/042-kube-dns/templates/sts-pods-hosts-appender-webhook/webhook-configuration.yaml
@@ -12,8 +12,7 @@ webhooks:
   sideEffects: None
   timeoutSeconds: 3
   admissionReviewVersions:
-    - v1
-    - v1beta1
+  - v1
   clientConfig:
     service:
       name: d8-kube-dns-sts-pods-hosts-appender-webhook

--- a/modules/045-snapshot-controller/templates/snapshot-validation-webhook/webhook.yaml
+++ b/modules/045-snapshot-controller/templates/snapshot-validation-webhook/webhook.yaml
@@ -18,7 +18,8 @@ webhooks:
       path: "/volumesnapshot"
       port: 4443
     caBundle: {{ .Values.snapshotController.internal.webhookCert.ca | b64enc }}
-  admissionReviewVersions: ["v1", "v1beta1"]
+  admissionReviewVersions:
+  - v1
   sideEffects: None
   failurePolicy: Fail
   timeoutSeconds: 10

--- a/modules/101-cert-manager/templates/webhook/mutatingwebhookconfiguration.yaml
+++ b/modules/101-cert-manager/templates/webhook/mutatingwebhookconfiguration.yaml
@@ -17,7 +17,8 @@ webhooks:
           - UPDATE
         resources:
           - "*/*"
-    admissionReviewVersions: ["v1"]
+    admissionReviewVersions:
+    - v1
     # This webhook only accepts v1 cert-manager resources.
     # Equivalent matchPolicy ensures that non-v1 resource requests are sent to
     # this webhook (after the resources have been converted to v1).

--- a/modules/101-cert-manager/templates/webhook/validatingwebhookconfiguration.yaml
+++ b/modules/101-cert-manager/templates/webhook/validatingwebhookconfiguration.yaml
@@ -26,7 +26,8 @@ webhooks:
           - UPDATE
         resources:
           - "*/*"
-    admissionReviewVersions: ["v1"]
+    admissionReviewVersions:
+    - v1
     # This webhook only accepts v1 cert-manager resources.
     # Equivalent matchPolicy ensures that non-v1 resource requests are sent to
     # this webhook (after the resources have been converted to v1).

--- a/modules/402-ingress-nginx/templates/controller/admission.yaml
+++ b/modules/402-ingress-nginx/templates/controller/admission.yaml
@@ -36,10 +36,7 @@ webhooks:
     sideEffects: None
     timeoutSeconds: 30
     admissionReviewVersions:
-      - v1
-    {{- if semverCompare "<1.22" $kubernetesVersion}}
-      - v1beta1
-    {{- end }}
+    - v1
     clientConfig:
       service:
         namespace: d8-ingress-nginx
@@ -69,10 +66,7 @@ webhooks:
     sideEffects: None
     timeoutSeconds: 5
     admissionReviewVersions:
-      - v1
-    {{- if semverCompare "<1.22" $kubernetesVersion}}
-      - v1beta1
-    {{- end }}
+    - v1
     clientConfig:
       service:
         namespace: d8-ingress-nginx


### PR DESCRIPTION
## Description
Removed obsolete v1beta1 admissionReviewVersions from modules:
- Istio
- deckhouse-config
- admission-policy-engine
- kube-dns
- snapshot-controller
- cert-manager
- ingress-nginx

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This is done to reduce the load on the apiserver and codebase simplification.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Reduce apiserver load and codebase simplification.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: global
type: chore
summary: Removed obsolete v1beta1 admissionReviewVersions from multiple modules.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
