### PR TITLE
[prometheus] Fix remoteWrite tlsConfig render

### DIFF
--- a/modules/300-prometheus/template_tests/prometheus_cr_test.go
+++ b/modules/300-prometheus/template_tests/prometheus_cr_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	"encoding/base64"
+	. "github.com/deckhouse/deckhouse/testing/helm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Module :: prometheus :: helm template :: render prometheus cr", func() {
+	f := SetupHelmConfig(``)
+
+	Context("Default", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", `
+enabledModules: ["vertical-pod-autoscaler-crd", "prometheus"]
+modules:
+  https:
+    mode: CustomCertificate
+  publicDomainTemplate: "%s.example.com"
+  placement: {}
+discovery:
+  d8SpecificNodeCountByRole:
+    system: 1
+    master: 1
+`)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("prometheus", `
+auth: {}
+vpa: {}
+grafana: {}
+https:
+  mode: CustomCertificate
+internal:
+  alertmanagers:
+    byAddress: []
+    byService: []
+    internal: []
+  auth: {}
+  deployDexAuthenticator: true
+  grafana:
+    additionalDatasources: []
+    alertsChannelsConfig:
+      notifiers: []
+  prometheusAPIClientTLS: {}
+  prometheusLongterm:
+    diskSizeGigabytes: 40
+    effectiveStorageClass: ceph-ssd
+    retentionGigabytes: 32
+  prometheusMain:
+    diskSizeGigabytes: 35
+    effectiveStorageClass: default
+    retentionGigabytes: 28
+  prometheusScraperIstioMTLS: {}
+  prometheusScraperTLS: {}
+  remoteWrite:
+  - name: test-remote-write-custom-auth
+    spec:
+      tlsConfig:
+        insecureSkipVerify: true
+      url: https://test-remote-write-custom-auth.domain.com/api/v1/write
+      customAuthToken: Test
+  - name: test-remote-write-basic-auth
+    spec:
+      url: https://test-remote-write-basic-auth.domain.com/api/v1/write
+      basicAuth:
+        password: pass
+        username: user
+  - name: test-remote-write-bearer-token
+    spec:
+      url: https://test-remote-write-bearer-token.domain.com/api/v1/write
+      bearerToken: xxx
+  vpa:
+    longtermMaxCPU: 2933m
+    longtermMaxMemory: 2200Mi
+    maxCPU: 8800m
+    maxMemory: 6600Mi
+longtermMaxDiskSizeGigabytes: 300
+longtermRetentionDays: 0
+longtermScrapeInterval: 5m
+mainMaxDiskSizeGigabytes: 300
+retentionDays: 15
+scrapeInterval: 30s
+`)
+			f.HelmRender()
+		})
+
+		It("Prometheus main must render properly", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+			prometheusMain := f.KubernetesResource("Prometheus", "d8-monitoring", "main")
+			Expect(prometheusMain.Exists()).To(BeTrue())
+			Expect(prometheusMain.Field("spec.remoteWrite").String()).To(MatchYAML(`
+- tlsConfig:
+    insecureSkipVerify: true
+  url: https://test-remote-write-custom-auth.domain.com/api/v1/write
+  headers:
+    X-Auth-Token: Test
+- url: https://test-remote-write-basic-auth.domain.com/api/v1/write
+  basicAuth:
+    username:
+      name: d8-prometheus-remote-write-test-remote-write-basic-auth
+      key: username
+    password:
+      name: d8-prometheus-remote-write-test-remote-write-basic-auth
+      key: password
+- url: https://test-remote-write-bearer-token.domain.com/api/v1/write
+  bearerToken: xxx
+`))
+			rwSecret := f.KubernetesResource("Secret", "d8-monitoring", "d8-prometheus-remote-write-test-remote-write-basic-auth")
+			Expect(rwSecret.Exists()).To(BeTrue())
+			Expect(rwSecret.Field("data.username").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte("user"))))
+			Expect(rwSecret.Field("data.password").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte("pass"))))
+		})
+	})
+})

--- a/modules/300-prometheus/template_tests/prometheus_cr_test.go
+++ b/modules/300-prometheus/template_tests/prometheus_cr_test.go
@@ -18,9 +18,11 @@ package template_tests
 
 import (
 	"encoding/base64"
-	. "github.com/deckhouse/deckhouse/testing/helm"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
 )
 
 var _ = Describe("Module :: prometheus :: helm template :: render prometheus cr", func() {

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -195,7 +195,7 @@ spec:
     {{- end }}
     {{- if .spec.tlsConfig }}
     tlsConfig:
-    {{- .spec.tlsConfig | toYaml | nindent 4 }}
+    {{- .spec.tlsConfig | toYaml | nindent 6 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/modules/300-prometheus/templates/prometheus/prometheus.yaml
+++ b/modules/300-prometheus/templates/prometheus/prometheus.yaml
@@ -195,7 +195,7 @@ spec:
     {{- end }}
     {{- if .spec.tlsConfig }}
     tlsConfig:
-    {{- .spec.tlsConfig | toYaml | nindent 6 }}
+      {{- .spec.tlsConfig | toYaml | nindent 6 }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Konstantin Aksenov <konstantin.aksenov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix indent in Prometheus CR template.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Deckhouse gets stuck on ValidationError
```
  remoteWrite:
  - url: https://victoriametrics-test.domain.com/api/v1/write
    tlsConfig:
    insecureSkipVerify: true

 1. ModuleRun:main:prometheus:Kubernetes-Change-ModuleValues:failures 221:helm upgrade failed: error validating "": error validating data: ValidationError(Prometheus.spec.remoteWrite[0]): unknown field "insecureSkipVerify" in com.coreos.monitoring.v1.Prometheus.spec.remoteWrite
```

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: fix
summary: Fix remoteWrite tlsConfig render
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
