### PR TITLE
[docs][getting-started] Add note about working through proxy.

### DIFF
--- a/docs/site/_data/getting_started/data.yaml
+++ b/docs/site/_data/getting_started/data.yaml
@@ -54,11 +54,6 @@ installTypes:
           en: Preparing environment
           ru: Подготовка окружения
         template: getting_started/<INSTALL_CODE>/STEP_ENV.md
-#      step4:
-#        name:
-#          en: Setting up cluster
-#          ru: Настройка кластера
-#        template: getting_started/global/step_cluster_setup.html
       step4:
         name:
           en: Installation
@@ -281,11 +276,6 @@ installTypes:
           en: Installation information
           ru: Информация об установке
         template: getting_started/<INSTALL_CODE>/STEP_INSTALL_SCHEMA.md
-#      step3:
-#        name:
-#          en: Setting up cluster
-#          ru: Настройка кластера
-#        template: getting_started/global/step_cluster_setup.html
       step3:
         name:
           en: Installation

--- a/docs/site/_includes/getting_started/global/partials/NOTICES.liquid
+++ b/docs/site/_includes/getting_started/global/partials/NOTICES.liquid
@@ -5,11 +5,17 @@
 {%- if page.platform_type == 'existing' %}
 > **Внимание!** Установка Deckhouse в существующий кластер EKS AWS (Amazon Elastic Kubernetes Service) в настоящий момент не поддерживается.
 {%- endif %}
+{%- if page.platform_code == 'bm-private' %}
+> **Внимание!** В версии Deckhouse 1.42 [изменились](https://github.com/deckhouse/deckhouse/pull/3185) параметры настройки работы через proxy-сервер. Текущее руководство рассчитано на версию Deckhouse 1.41.
+{%- endif %}
 {%- else %}
 {%- if page.platform_code == "azure" %}
 > **Caution!** Only [regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-region) where `Availability Zones` are available are supported.
 {%- endif %}
 {%- if page.platform_type == 'existing' %}
 > **Caution!** Installing Deckhouse into an existing EKS AWS (Amazon Elastic Kubernetes Service) cluster is not currently supported.
+{%- endif %}
+{%- if page.platform_code == 'bm-private' %}
+> **Caution!** The settings for working through a proxy server have [changed](https://github.com/deckhouse/deckhouse/pull/3185) in Deckhouse 1.42. The guide is for Deckhouse 1.41.
 {%- endif %}
 {%- endif %}


### PR DESCRIPTION
Signed-off-by: Artem Kladov <artem.kladov@flant.com>

## Description
Added note about working through proxy.

## Why do we need it, and what problem does it solve?
The settings for working through a proxy server have [changed](https://github.com/deckhouse/deckhouse/pull/3185) in Deckhouse 1.42, but the getting start guide currently supports Deckhouse 1.41.

Ref: #3185 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [X] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Added note about working through proxy.
impact_level: low
```
