### PR TITLE
[prometheus] Fix trickster authentication

### DIFF
--- a/modules/300-prometheus/templates/trickster/configmap.yaml
+++ b/modules/300-prometheus/templates/trickster/configmap.yaml
@@ -25,6 +25,7 @@ data:
           max_value_age_secs = {{ mul .Values.prometheus.retentionDays 86400 }}
           fast_forward_disable = false
           default_step = 30
+          req_rewriter_name = 'set-upstream-user'
 
             [origins.main.tls]
               insecure_skip_verify = true
@@ -32,19 +33,13 @@ data:
             [origins.main.health_check_headers]
               Authorization = 'Bearer $PROMETHEUS_TOKEN'
 
-            [origins.main.paths]
-              [origins.default.paths.root]
-                path = '/'
-
-                  [origins.main.paths.root.response_headers]
-                    Authorization = 'Bearer $PROMETHEUS_TOKEN'
-
         [origins.longterm]
           origin_type = 'prometheus'
           origin_url = 'https://prometheus-longterm.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}.:9090'
           max_value_age_secs = {{ mul .Values.prometheus.longtermRetentionDays 86400 }}
           fast_forward_disable = false
           default_step = 300
+          req_rewriter_name = 'set-upstream-user'
 
             [origins.longterm.tls]
               insecure_skip_verify = true
@@ -52,15 +47,14 @@ data:
             [origins.longterm.health_check_headers]
               Authorization = 'Bearer $PROMETHEUS_TOKEN'
 
-            [origins.longterm.paths]
-              [origins.longterm.paths.root]
-                path = '/'
-
-                  [origins.longterm.paths.root.response_headers]
-                    Authorization = 'Bearer $PROMETHEUS_TOKEN'
-
       [metrics]
         listen_port = 8001
         listen_address = "127.0.0.1"
       [logging]
         log_level = 'info'
+
+    [request_rewriters]
+      [request_rewriters.set-upstream-user]
+        instructions = [
+           ['header', 'set', 'Authorization', 'Bearer $PROMETHEUS_TOKEN'],
+        ]


### PR DESCRIPTION
## Description
Fixed token-based authentication between trickster and prometheus.

## Why do we need it, and what problem does it solve?
The trickster didn't set Authorization header properly and couldn't set it if the original connection had no the header.

## What is the expected result?
It is possible to make request to trickster without a token but with client cert.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: protmetheus
type: fix
summary: Fixed token-based authentication between trickster and prometheus.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
