### PR TITLE
[ci] Allow to exec slash command for collaborator instead contributor

### DIFF
--- a/.github/workflow_templates/dispatch-slash-command.yml
+++ b/.github/workflow_templates/dispatch-slash-command.yml
@@ -66,7 +66,7 @@ jobs:
             }
 
             // For slash commands on pull requests, e.g. 'e2e abort' command.
-            // The right way is to give slash commands to the collabrator instead of the сontributor. Why?
+            // The right way is to give slash commands to the collaborator instead of the contributor. Why?
             // During the experiments it turned out that:
             // Member is a member of the github organization and the organization is public (here https://github.com/orgs/deckhouse/people)
             // Collaborator is a member of github and the organization is private (here https://github.com/orgs/deckhouse/people)

--- a/.github/workflow_templates/dispatch-slash-command.yml
+++ b/.github/workflow_templates/dispatch-slash-command.yml
@@ -66,7 +66,7 @@ jobs:
             }
 
             // For slash commands on pull requests, e.g. 'e2e abort' command.
-            if (isPR && (authorAssociation === 'OWNER' || authorAssociation === 'MEMBER' || authorAssociation === 'CONTRIBUTOR' || (isPrivate && authorAssociation === 'COLLABORATOR'))) {
+            if (isPR && (authorAssociation === 'OWNER' || authorAssociation === 'MEMBER' || authorAssociation === 'COLLABORATOR' || (isPrivate && authorAssociation === 'COLLABORATOR'))) {
               core.notice(`Comment on pull request.`);
               return core.setOutput('trigger_for_pull_request', 'true');
             }

--- a/.github/workflow_templates/dispatch-slash-command.yml
+++ b/.github/workflow_templates/dispatch-slash-command.yml
@@ -66,7 +66,12 @@ jobs:
             }
 
             // For slash commands on pull requests, e.g. 'e2e abort' command.
-            if (isPR && (authorAssociation === 'OWNER' || authorAssociation === 'MEMBER' || authorAssociation === 'COLLABORATOR' || (isPrivate && authorAssociation === 'COLLABORATOR'))) {
+            // The right way is to give slash commands to the collabrator instead of the сontributor. Why?
+            // During the experiments it turned out that:
+            // Member is a member of the github organization and the organization is public (here https://github.com/orgs/deckhouse/people)
+            // Collaborator is a member of github and the organization is private (here https://github.com/orgs/deckhouse/people)
+            // Contributor is a person who is not a member of github, but has contributed to the repository.
+            if (isPR && (authorAssociation === 'OWNER' || authorAssociation === 'MEMBER' || authorAssociation === 'COLLABORATOR' )) {
               core.notice(`Comment on pull request.`);
               return core.setOutput('trigger_for_pull_request', 'true');
             }

--- a/.github/workflow_templates/dispatch-slash-command.yml
+++ b/.github/workflow_templates/dispatch-slash-command.yml
@@ -71,7 +71,7 @@ jobs:
             // Member is a member of the github organization and the organization is public (here https://github.com/orgs/deckhouse/people)
             // Collaborator is a member of github and the organization is private (here https://github.com/orgs/deckhouse/people)
             // Contributor is a person who is not a member of github, but has contributed to the repository.
-            if (isPR && (authorAssociation === 'OWNER' || authorAssociation === 'MEMBER' || authorAssociation === 'COLLABORATOR' )) {
+            if (isPR && (authorAssociation === 'OWNER' || authorAssociation === 'MEMBER' || authorAssociation === 'COLLABORATOR')) {
               core.notice(`Comment on pull request.`);
               return core.setOutput('trigger_for_pull_request', 'true');
             }

--- a/.github/workflows/dispatch-slash-command.yml
+++ b/.github/workflows/dispatch-slash-command.yml
@@ -70,7 +70,7 @@ jobs:
             }
 
             // For slash commands on pull requests, e.g. 'e2e abort' command.
-            // The right way is to give slash commands to the collabrator instead of the сontributor. Why?
+            // The right way is to give slash commands to the collaborator instead of the contributor. Why?
             // During the experiments it turned out that:
             // Member is a member of the github organization and the organization is public (here https://github.com/orgs/deckhouse/people)
             // Collaborator is a member of github and the organization is private (here https://github.com/orgs/deckhouse/people)

--- a/.github/workflows/dispatch-slash-command.yml
+++ b/.github/workflows/dispatch-slash-command.yml
@@ -70,7 +70,12 @@ jobs:
             }
 
             // For slash commands on pull requests, e.g. 'e2e abort' command.
-            if (isPR && (authorAssociation === 'OWNER' || authorAssociation === 'MEMBER' || authorAssociation === 'COLLABORATOR' || (isPrivate && authorAssociation === 'COLLABORATOR'))) {
+            // The right way is to give slash commands to the collabrator instead of the сontributor. Why?
+            // During the experiments it turned out that:
+            // Member is a member of the github organization and the organization is public (here https://github.com/orgs/deckhouse/people)
+            // Collaborator is a member of github and the organization is private (here https://github.com/orgs/deckhouse/people)
+            // Contributor is a person who is not a member of github, but has contributed to the repository.
+            if (isPR && (authorAssociation === 'OWNER' || authorAssociation === 'MEMBER' || authorAssociation === 'COLLABORATOR')) {
               core.notice(`Comment on pull request.`);
               return core.setOutput('trigger_for_pull_request', 'true');
             }

--- a/.github/workflows/dispatch-slash-command.yml
+++ b/.github/workflows/dispatch-slash-command.yml
@@ -70,7 +70,7 @@ jobs:
             }
 
             // For slash commands on pull requests, e.g. 'e2e abort' command.
-            if (isPR && (authorAssociation === 'OWNER' || authorAssociation === 'MEMBER' || authorAssociation === 'CONTRIBUTOR' || (isPrivate && authorAssociation === 'COLLABORATOR'))) {
+            if (isPR && (authorAssociation === 'OWNER' || authorAssociation === 'MEMBER' || authorAssociation === 'COLLABORATOR' || (isPrivate && authorAssociation === 'COLLABORATOR'))) {
               core.notice(`Comment on pull request.`);
               return core.setOutput('trigger_for_pull_request', 'true');
             }


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
The right way is to give slash commands to the collabrator instead of the contributor. Why? 
During the experiments it turned out that 
Member is a member of the github organization and the organization is public (here https://github.com/orgs/deckhouse/people)
A Collaborator is a member of github and the organization is private (here https://github.com/orgs/deckhouse/people)
Contributor is a person who is not a member of github, but has contributed to the repository.

## Why do we need it, and what problem does it solve?
Members with private membership in organization can not run abortion of failed e2e.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: ci
type: fix
summary: Allow to exec slash command for collaborator instead contributor
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
