### PR TITLE
Python runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,4 @@ bin/
 # Python dev environment
 __pycache__/
 *.py[cod]
-*$py.class
 .pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,6 @@ bin/
 
 # Python dev environment
 __pycache__/
+*.py[cod]
+*$py.class
 .pytest_cache/

--- a/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
+++ b/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
@@ -26,6 +26,10 @@ ansible:
         src: https://github.com/fsaintjacques/semver-tool/archive/2.1.0.tar.gz
         remote_src: yes
         dest: /usr/local/bin
+    - name: "Install python"
+      apk:
+        name:
+          - python3
 git:
 - add: /modules
   to: /available_hooks
@@ -35,5 +39,9 @@ git:
   to: /entrypoint.sh
 - add: /shell_lib/semver.sh
   to: /frameworks/shell/semver.sh
+- add: /python_lib
+  to: /frameworks/python
 docker:
+  ENV:
+    PYTHONPATH: /frameworks/python
   ENTRYPOINT: ["/entrypoint.sh"]

--- a/python_lib/sitecustomize.py
+++ b/python_lib/sitecustomize.py
@@ -20,32 +20,30 @@ import sys
 def find_module_root(path):
     """Returns module root path and module name for hook being executed.
 
-    E.g. for hook path /deckhouse/modules/999-zz-python/hooks/detect_array.py
-    module root path is /deckhouse/modules/999-zz-python and module name is 999-zz-python
+    E.g. for hook
+        /deckhouse/modules/999-my-module/hooks/my_hook.py
+    module root is
+        /deckhouse/modules/999-my-module
 
     Args:
         path (str): hook absolute path
-
     Returns:
-        (str, str): module root and module dir name, last segment of the root
+        (str): module root
     """
     while True:
-        parent, name = os.path.split(path)
+        parent, _ = os.path.split(path)
         # Don't stick to absolute path (/deckhouse/modules) to keep it portable
         if os.path.split(parent)[1] == "modules":
-            break
+            return path  # we are in the module root
         path = parent
-    return path, name
 
 
 hook_path = os.path.abspath(sys.argv[0])
-mod_root, mod_dirname = find_module_root(hook_path)
+mod_root = find_module_root(hook_path)
 
-# Add Python packages discovery for module hooks
+# Add Python packages discovery for module hooks, $D8_MODULE_ROOT/lib/python/dist
 if mod_root:
     lib_path = os.path.join(mod_root, "lib", "python", "dist")
     sys.path.append(lib_path)
 
-# Add module name to env for simpler discovery, consumed by Deckhouse hook lib for Python
-if mod_dirname:
-    os.environ["D8_MODULE_DIRNAME"] = mod_dirname
+    os.environ["D8_MODULE_ROOT"] = mod_root

--- a/python_lib/sitecustomize.py
+++ b/python_lib/sitecustomize.py
@@ -32,7 +32,7 @@ def find_module_root(path):
     """
     while True:
         parent, _ = os.path.split(path)
-        # Don't stick to absolute path (/deckhouse/modules) to keep it portable
+        # Not using absolute path (/deckhouse/modules) to keep it portable
         if os.path.split(parent)[1] == "modules":
             return path  # we are in the module root
         path = parent

--- a/python_lib/sitecustomize.py
+++ b/python_lib/sitecustomize.py
@@ -31,7 +31,7 @@ def find_module_root(path):
     """
     while True:
         parent, name = os.path.split(path)
-        # Don't stick absolute paths to keep it portable on dev machines
+        # Don't stick to absolute path (/deckhouse/modules) to keep it portable
         if os.path.split(parent)[1] == "modules":
             break
         path = parent
@@ -39,13 +39,13 @@ def find_module_root(path):
 
 
 hook_path = os.path.abspath(sys.argv[0])
-mod_root, mod_name = find_module_root(hook_path)
+mod_root, mod_dirname = find_module_root(hook_path)
 
-# Add module python dependencies to PYTHONPATH
+# Add Python packages discovery for module hooks
 if mod_root:
     lib_path = os.path.join(mod_root, "lib", "python", "dist")
     sys.path.append(lib_path)
 
-# Add module name to env for simpler discovery, consumed by deckhouse python lib
-if mod_name:
-    os.environ["D8_MODULE_NAME"] = mod_name
+# Add module name to env for simpler discovery, consumed by Deckhouse hook lib for Python
+if mod_dirname:
+    os.environ["D8_MODULE_DIRNAME"] = mod_dirname

--- a/python_lib/sitecustomize.py
+++ b/python_lib/sitecustomize.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+#
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+
+
+def find_module_root(path):
+    """Returns module root path and module name for hook being executed.
+
+    E.g. for hook path /deckhouse/modules/999-zz-python/hooks/detect_array.py
+    module root path is /deckhouse/modules/999-zz-python and module name is 999-zz-python
+
+    Args:
+        path (str): hook absolute path
+
+    Returns:
+        (str, str): module root and module dir name, last segment of the root
+    """
+    while True:
+        parent, name = os.path.split(path)
+        # Don't stick absolute paths to keep it portable on dev machines
+        if os.path.split(parent)[1] == "modules":
+            break
+        path = parent
+    return path, name
+
+
+hook_path = os.path.abspath(sys.argv[0])
+mod_root, mod_name = find_module_root(hook_path)
+
+# Add module python dependencies to PYTHONPATH
+if mod_root:
+    lib_path = os.path.join(mod_root, "lib", "python", "dist")
+    sys.path.append(lib_path)
+
+# Add module name to env for simpler discovery, consumed by deckhouse python lib
+if mod_name:
+    os.environ["D8_MODULE_NAME"] = mod_name

--- a/werf.yaml
+++ b/werf.yaml
@@ -180,7 +180,7 @@ docker:
 ---
 image: dev-prebuild
 fromImage: common-base
-fromCacheVersion: "2023-01-16.1"
+fromCacheVersion: 2020-05-08.1
 git:
 - add: /
   to: /deckhouse

--- a/werf.yaml
+++ b/werf.yaml
@@ -135,6 +135,7 @@ ansible:
         - busybox-extras
         - vim
         - tini
+        - python3
 
 {{- include "base components" . }}
 
@@ -179,7 +180,7 @@ docker:
 ---
 image: dev-prebuild
 fromImage: common-base
-fromCacheVersion: 2020-05-08.1
+fromCacheVersion: "2023-01-16.1"
 git:
 - add: /
   to: /deckhouse
@@ -192,6 +193,7 @@ git:
   - deckhouse-controller/entrypoint.sh
   - jq_lib
   - helm_lib
+  - python_lib
   excludePaths:
   - docs
   - modules/*/docs
@@ -271,6 +273,7 @@ docker:
   ENV:
     MODULES_DIR: /deckhouse/modules
     GLOBAL_HOOKS_DIR: /deckhouse/global-hooks
+    PYTHONPATH: /deckhouse/python_lib
 ---
 image: tests-prebuild
 fromImage: base-for-go


### PR DESCRIPTION
Signed-off-by: Eugene Shevchenko <evgeny.shevchenko@flant.com>

## Description

Add support for module hooks written in Python

## Why do we need it, and what problem does it solve?

Allows external modules (WIP) with Python hooks to be used. Also, Deckhouse hooks can be written in
Python instead of Bash.

## What is the expected result?

Deckhouse Python hooks can be run and tested.

## Checklist

- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Added Python environment to support Python hooks
```
