### PR TITLE
[docs][getting started] Update guide for installing in a private environment

### DIFF
--- a/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/config.yml.ce.inc
@@ -1,13 +1,9 @@
-# [<en>] General cluster parameters (ClusterConfiguration).
-# [<en>] Version of the Deckhouse API.
-# [<ru>] Секция с общими параметрами кластера (ClusterConfiguration).
-# [<ru>] Используемая версия API Deckhouse Platform.
+# [<en>] General cluster parameters.
+# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#clusterconfiguration
+# [<ru>] Секция с общими параметрами кластера.
+# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#clusterconfiguration
 apiVersion: deckhouse.io/v1
-# [<en>] Type of the configuration section.
-# [<ru>] Тип секции конфигурации.
 kind: ClusterConfiguration
-# [<en>] Type of the infrastructure: bare metal (Static) or Cloud (Cloud).
-# [<ru>] Тип инфраструктуры: bare metal (Static) или облако (Cloud).
 clusterType: Static
 # [<en>] Address space of the cluster's Pods.
 # [<ru>] Адресное пространство Pod’ов кластера.
@@ -15,30 +11,22 @@ podSubnetCIDR: 10.111.0.0/16
 # [<en>] Address space of the cluster's services.
 # [<ru>] Адресное пространство для service’ов кластера.
 serviceSubnetCIDR: 10.222.0.0/16
-# [<en>] Kubernetes version to install.
-# [<ru>] Устанавливаемая версия Kubernetes.
 kubernetesVersion: "1.23"
-# [<en>] Cluster domain (used for local routing).
-# [<ru>] Домен кластера.
 clusterDomain: "cluster.local"
-packagesProxy:
-  uri: https://example.com
-  username: <PROXY-USERNAME>
-  password: <PROXY-PASSWORD>
+# [<en>] Proxy server settings.
+# [<ru>] Настройки proxy-сервера.
+proxy:
+  httpProxy: <HTTP_PROXY_ADDRESS>
+  httpsProxy: <HTTPS_PROXY_ADDRESS>
+  noProxy: <NO_PROXY_LIST>
 ---
-# [<en>] Section for bootstrapping the Deckhouse cluster (InitConfiguration).
-# [<en>] Version of the Deckhouse API.
-# [<ru>] Секция первичной инициализации кластера Deckhouse (InitConfiguration).
-# [<ru>] Используемая версия API Deckhouse.
+# [<en>] Section for bootstrapping the Deckhouse cluster.
+# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#initconfiguration
+# [<ru>] Секция первичной инициализации кластера Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#initconfiguration
 apiVersion: deckhouse.io/v1
-# [<en>] Type of the configuration section.
-# [<ru>] Тип секции конфигурации.
 kind: InitConfiguration
-# [<en>] Deckhouse parameters.
-# [<ru>] Секция с параметрами Deckhouse.
 deckhouse:
-  # [<en>] The release channel in use.
-  # [<ru>] Используемый канал обновлений.
   releaseChannel: Stable
   configOverrides:
     global:
@@ -48,22 +36,18 @@ deckhouse:
         # [<ru>] Шаблон, который будет использоваться для составления адресов системных приложений в кластере.
         # [<ru>] Например, Grafana для %s.example.com будет доступна на домене grafana.example.com.
         publicDomainTemplate: "%s.example.com"
-        # [<en>] Proxy server settings for accessing Deckhouse modules to the Internet.
-        # [<ru>] Настройки proxy-сервера для доступа в Интернет модулей Deckhouse.
-        proxy:
-          httpProxy: <HTTP_PROXY_ADDRESS>
-          httpsProxy: <HTTPS_PROXY_ADDRESS>
-          noProxy: <NO_PROXY_LIST>
     # [<en>] Enable the cni-flannel module.
     # [<ru>] Включить модуль cni-flannel.
+    # [<en>] You might consider changing this.
+    # [<ru>] Возможно, захотите изменить.
     cniFlannelEnabled: true
     # [<en>] Cni-flannel module settings.
     # [<ru>] Настройки модуля cni-flannel.
+    # [<en>] You might consider changing this.
+    # [<ru>] Возможно, захотите изменить.
     cniFlannel:
       # [<en>] Flannel backend, available values are VXLAN (if your servers have L3 connectivity) and HostGW (for L2 networks).
       # [<ru>] Режим работы flannel, допустимые значения VXLAN (если ваши сервера имеют связность L3) или HostGW (для L2-сетей).
-      # [<en>] You might consider changing this.
-      # [<ru>] Возможно, захотите изменить.
       podNetworkMode: VXLAN
   # [<en>] Address of the Docker registry where the Deckhouse images are located.
   # [<ru>] Адрес Docker registry с образами Deckhouse.
@@ -79,12 +63,10 @@ deckhouse:
   registryCA: <REGISTRY_CA>
 ---
 # [<en>] Section with the parameters of the bare metal cluster (StaticClusterConfiguration).
-# [<en>] Version of the Deckhouse API.
+# [<en>] https://deckhouse.io/documentation/v1/installing/configuration.html#staticclusterconfiguration
 # [<ru>] Секция с параметрами bare metal кластера (StaticClusterConfiguration).
-# [<ru>] Используемая версия API Deckhouse.
+# [<ru>] https://deckhouse.ru/documentation/v1/installing/configuration.html#staticclusterconfiguration
 apiVersion: deckhouse.io/v1
-# [<en>] Type of the configuration section.
-# [<ru>] Тип секции конфигурации.
 kind: StaticClusterConfiguration
 # [<en>] List of internal cluster networks (e.g., '10.0.4.0/24')
 # [<en>] for linking Kubernetes components (kube-apiserver, kubelet etc.).

--- a/docs/site/_includes/getting_started/bm-private/partials/ingress-nginx-controller.yml.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/ingress-nginx-controller.yml.inc
@@ -1,7 +1,7 @@
-# [<en>] Section containing the parameters of nginx ingress controller.
-# [<en>] Version of the Deckhouse API.
-# [<ru>] Секция, описывающая параметры nginx ingress controller.
-# [<ru>] Используемая версия API Deckhouse.
+# [<en>] Section containing the parameters of Nginx Ingress controller.
+# [<en>] https://deckhouse.io/documentation/v1/modules/402-ingress-nginx/cr.html
+# [<ru>] Секция, описывающая параметры Nginx Ingress controller.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/402-ingress-nginx/cr.html
 apiVersion: deckhouse.io/v1
 kind: IngressNginxController
 metadata:

--- a/docs/site/_includes/getting_started/bm-private/partials/user.yml.inc
+++ b/docs/site/_includes/getting_started/bm-private/partials/user.yml.inc
@@ -1,3 +1,7 @@
+# [<en>] RBAC and authorization settings.
+# [<en>] https://deckhouse.io/documentation/v1/modules/140-user-authz/cr.html#clusterauthorizationrule
+# [<ru>] Настройки RBAC и авторизации.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/140-user-authz/cr.html#clusterauthorizationrule
 apiVersion: deckhouse.io/v1
 kind: ClusterAuthorizationRule
 metadata:
@@ -15,10 +19,10 @@ spec:
   # [<en>] Allow user to do kubectl port-forward.
   portForwarding: true
 ---
-# [<en>] Section containing the parameters of the static user.
-# [<ru>] Секция, описывающая параметры статического пользователя.
-# [<en>] Version of the Deckhouse API.
-# [<ru>] Используемая версия API Deckhouse.
+# [<en>] Parameters of the static user.
+# [<en>] https://deckhouse.io/documentation/v1/modules/150-user-authn/cr.html#user
+# [<ru>] Данные статического пользователя.
+# [<ru>] https://deckhouse.ru/documentation/v1/modules/150-user-authn/cr.html#user
 apiVersion: deckhouse.io/v1
 kind: User
 metadata:

--- a/docs/site/_includes/getting_started/global/partials/NOTICES.liquid
+++ b/docs/site/_includes/getting_started/global/partials/NOTICES.liquid
@@ -6,7 +6,7 @@
 > **Внимание!** Установка Deckhouse в существующий кластер EKS AWS (Amazon Elastic Kubernetes Service) в настоящий момент не поддерживается.
 {%- endif %}
 {%- if page.platform_code == 'bm-private' %}
-> **Внимание!** В версии Deckhouse 1.42 [изменились](https://github.com/deckhouse/deckhouse/pull/3185) параметры настройки работы через proxy-сервер. Текущее руководство рассчитано на версию Deckhouse 1.41.
+> **Внимание!** В версии Deckhouse 1.42 изменились [параметры](../../documentation/v1/installing/configuration.html#parameters-proxy) настройки работы через proxy-сервер ([подробнее](https://github.com/deckhouse/deckhouse/pull/3185)). Текущее руководство рассчитано на версию Deckhouse 1.42+.
 {%- endif %}
 {%- else %}
 {%- if page.platform_code == "azure" %}
@@ -16,6 +16,6 @@
 > **Caution!** Installing Deckhouse into an existing EKS AWS (Amazon Elastic Kubernetes Service) cluster is not currently supported.
 {%- endif %}
 {%- if page.platform_code == 'bm-private' %}
-> **Caution!** The settings for working through a proxy server have [changed](https://github.com/deckhouse/deckhouse/pull/3185) in Deckhouse 1.42. The guide is for Deckhouse 1.41.
+> **Caution!** The [settings for working through a proxy server](../../documentation/v1/installing/configuration.html#parameters-proxy) have changed in Deckhouse 1.42 ([issue](https://github.com/deckhouse/deckhouse/pull/3185)). The guide is for Deckhouse 1.42+.
 {%- endif %}
 {%- endif %}

--- a/docs/site/_includes/getting_started/global/partials/getting-started-setup.js.liquid
+++ b/docs/site/_includes/getting_started/global/partials/getting-started-setup.js.liquid
@@ -12,16 +12,9 @@ function updateNode(selector, storageItemName) {
 function restoreData() {
   {%- if page.platform_code == 'bm-private' %}
   // proxy settings
-  updateNode('#modulesProxyEnabled', 'dhctl-modules-proxy-enabled');
-  updateNode('#modulesProxyHttpsUri', 'dhctl-modules-proxy-https-uri');
-  updateNode('#modulesProxyHttpUri', 'dhctl-modules-proxy-http-uri');
-  updateNode('#modulesNoProxyAddressList', 'dhctl-modules-noproxy-address-list');
-
-  // packagesProxy settings
-  updateNode('#packagesProxyEnabled', 'dhctl-packages-proxy-enabled');
-  updateNode('#packagesProxyPassword', 'dhctl-packages-proxy-password');
-  updateNode('#packagesProxyUsername', 'dhctl-packages-proxy-username');
-  updateNode('#packagesProxyURI', 'dhctl-packages-proxy-uri');
+  updateNode('#proxyHttpURI', 'dhctl-proxy-http-uri');
+  updateNode('#proxyHttpsURI', 'dhctl-proxy-https-uri');
+  updateNode('#noProxyAddressList', 'dhctl-noproxy-address-list');
 
   // registry settings
   updateNode('#registryCA', 'dhctl-registry-ca');
@@ -54,22 +47,21 @@ $(document).ready(function () {
       sessionStorage.setItem('dhctl-domain', $(this).val());
     }
   });
-  // $('#resourceprefix').change(function () {
-  //   sessionStorage.setItem('dhctl-prefix', $(this).val());
-  // });
   $('#sshkey').change(function () {
     sessionStorage.setItem('dhctl-sshkey', $(this).val());
   });
   {%- if page.platform_code == 'bm-private' %}
-  $('#packagesProxyURI').change(function () {
-    sessionStorage.setItem('dhctl-packages-proxy-uri', $(this).val());
+  // proxy
+  $('#proxyHttpURI').change(function () {
+    sessionStorage.setItem('dhctl-proxy-http-uri', $(this).val());
   });
-  $('#packagesProxyUsername').change(function () {
-    sessionStorage.setItem('dhctl-packages-proxy-username', $(this).val());
+  $('#proxyHttpsURI').change(function () {
+    sessionStorage.setItem('dhctl-proxy-https-uri', $(this).val());
   });
-  $('#packagesProxyPassword').change(function () {
-    sessionStorage.setItem('dhctl-packages-proxy-password', $(this).val());
+  $('#noProxyAddressList').change(function () {
+    sessionStorage.setItem('dhctl-noproxy-address-list', $(this).val());
   });
+  // registry
   $('#registryImagesRepo').change(function () {
     sessionStorage.setItem('dhctl-registry-images-repo', $(this).val());
   });
@@ -83,35 +75,6 @@ $(document).ready(function () {
     } else {
       sessionStorage.setItem('dhctl-registry-scheme-http', "false");
       $('.registryca-block').css("display", "block");
-    }
-  });
-  // proxy
-  $('#modulesProxyEnabled').change(function () {
-    if (this.checked) {
-      sessionStorage.setItem('dhctl-modules-proxy-enabled', "true");
-      $('.modulesProxy-block').css("display", "block");
-    } else {
-      sessionStorage.setItem('dhctl-modules-proxy-enabled', "false");
-      $('.modulesProxy-block').css("display", "none");
-    }
-  });
-  $('#modulesProxyHttpsUri').change(function () {
-    sessionStorage.setItem('dhctl-modules-proxy-https-uri', $(this).val());
-  });
-  $('#modulesProxyHttpUri').change(function () {
-    sessionStorage.setItem('dhctl-modules-proxy-http-uri', $(this).val());
-  });
-  $('#modulesNoProxyAddressList').change(function () {
-    sessionStorage.setItem('dhctl-modules-noproxy-address-list', $(this).val());
-  });
-  // packagesProxy
-  $('#packagesProxyEnabled').change(function () {
-    if (this.checked) {
-      sessionStorage.setItem('dhctl-packages-proxy-enabled', "true");
-      $('.packagesProxy-block').css("display", "block");
-    } else {
-      sessionStorage.setItem('dhctl-packages-proxy-enabled', "false");
-      $('.packagesProxy-block').css("display", "none");
     }
   });
   $('#registryCA').change(function () {

--- a/docs/site/_includes/getting_started/global/partials/select_revision.html.liquid
+++ b/docs/site/_includes/getting_started/global/partials/select_revision.html.liquid
@@ -1,7 +1,8 @@
 <script type="text/javascript">const responseFromLicense = {{ site.data.license.response | jsonify }}; const pageLang = '{{ page.lang }}';</script>
 <script type="text/javascript" src='{{ assets["getting-started.js"].digest_path }}'></script>
-{% if page.platform_code == "bm-private" %}
+{% if page.platform_code == "bm-private" -%}
   <script type="text/javascript" src='{{ assets["getting-started-private.js"].digest_path }}'></script>
+  {%- include getting_started/global/partials/NOTICES.liquid %}
 {% endif %}
 <script type="text/javascript" src='{{ assets["getting-started-install.js"].digest_path }}'></script>
 <script type="text/javascript" src='{{ assets["bcrypt.js"].digest_path }}'></script>

--- a/docs/site/_includes/getting_started/global/step_cluster_setup.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup.html
@@ -41,112 +41,48 @@
 {%- endunless %}
 {%- if page.platform_code == 'bm-private' %}
 
-<!-- packages proxy block -->
-<div class="form__row">
-  <div class="form__row--wrap">
-    <label for="packagesProxyEnabled" class="label" title="Enable it if a proxy server is used to download deb or rpm packages">
-      A proxy server is used to download deb or rpm packages
-    </label>
-    <input
-      type="checkbox" id="packagesProxyEnabled"
-      name="packagesProxyEnabled" />
-  </div>
-  <span class="info">
-     Enable it if you cannot directly retrieve deb or rpm packages on your network or if a proxy server is used.
-  </span>
-</div>
-<div class="packagesProxy-block" style="display: none;">
-    <div class="form__row">
-      <label class="label" title="Specify the address of the proxy server for downloading deb or rpm packages">
-        The address of the proxy server for downloading deb or rpm packages (e.g., <code>https://proxy.company.my</code>)
-      </label>
-      <input
-        class="textfield"
-        type="text" id="packagesProxyURI"
-        name="packagesProxyURI" placeholder=""
-        autocomplete="off" />
-    </div>
-
-    <div class="form__row">
-      <label class="label" title="Specify the username for authenticating with the proxy server">
-        The username for authenticating with the proxy server
-      </label>
-      <input
-        class="textfield"
-        type="text" id="packagesProxyUsername"
-        name="packagesProxyUsername" placeholder=""
-        autocomplete="off" />
-      <span class="info">
-         Leave it blank if the proxy server does not use authentication.
-      </span>
-    </div>
-
-    <div class="form__row">
-      <label class="label" title="Specify the password for authenticating with the proxy server">
-        The password for authenticating with the proxy server
-      </label>
-      <input
-        class="textfield"
-        type="text" id="packagesProxyPassword"
-        name="packagesProxyPassword" placeholder=""
-        autocomplete="off" />
-      <span class="info">
-         Leave it blank if the proxy server does not use authentication.
-      </span>
-    </div>
-</div>
-
 <!-- proxy block -->
-<div class="form__row">
-  <div class="form__row--wrap">
-    <label for="modulesProxyEnabled" class="label">
-      A proxy server is used to access the Internet of Deckhouse components
+  <div class="form__row">
+    <label class="label" title="The address of the HTTP proxy server">
+      The address of the HTTP proxy server (examples: <code>http://proxy.company.my</code>, <code>https://user1:p@ssword@proxy.company.my:8443</code>)
     </label>
     <input
-      type="checkbox" id="modulesProxyEnabled"
-      name="modulesProxyEnabled" />
+      class="textfield"
+      type="text" id="proxyHttpURI"
+      name="proxyHttpURI" placeholder="http[s]://[[USER][:PASSWORD]@]proxy.company.my[:PORT]"
+      autocomplete="off"/>
+    <span class="info">
+         Leave it blank if you don't use the HTTP proxy server.
+      </span>
   </div>
-  <span class="info">
-     Some Deckhouse components need Internet access (<a data-proofer-ignore href="/documentation/v1/modules/600-flant-integration/#what-data-does-deckhouse-send">more info</a> about what data does Deckhouse send). Internet access may also be required if you configure modules to send data outside the private environment (metrics, logs, etc.). Enable it if Deckhouse modules need a proxy server in your network to access the Internet.
-  </span>
-</div>
-<div class="modulesProxy-block" style="display: none;">
-    <div class="form__row">
-      <label class="label" title="Specify the HTTP proxy server address for accessign Internet">
-        The address of the HTTP proxy server for accessing Internet (e.g. — <code>http://proxy.company.my:8080</code>)
-      </label>
-      <input
-        class="textfield"
-        type="text" id="modulesProxyHttpUri"
-        name="modulesProxyHttpUri" placeholder=""
-        autocomplete="off" />
-    </div>
 
-    <div class="form__row">
-      <label class="label" title="Specify the HTTPS proxy server address for accessign Internet">
-        The address of the HTTPS proxy server for accessing Internet (e.g. — <code>https://proxy.company.my:8443</code>)
-      </label>
-      <input
-        class="textfield"
-        type="text" id="modulesProxyHttpsUri"
-        name="modulesProxyHttpsUri" placeholder=""
-        autocomplete="off" />
-    </div>
+  <div class="form__row">
+    <label class="label" title="The address of the HTTPS proxy server">
+      The address of the HTTPS proxy server (examples: <code>http://proxy.company.my</code>, <code>https://user1:p@ssword@proxy.company.my:8443</code>)
+    </label>
+    <input
+      class="textfield"
+      type="text" id="proxyHttpsURI"
+      name="proxyHttpsURI" placeholder="http[s]://[[USER][:PASSWORD]@]proxy.company.my[:PORT]"
+      autocomplete="off"/>
+    <span class="info">
+        Leave it blank if you don't use the HTTP proxy server.
+      </span>
+  </div>
 
-    <div class="form__row">
-      <label class="label" title="List of IP addresses and domain names for which the proxy server is not used">
+  <div class="form__row">
+    <label class="label" title="List of IP addresses and domain names for which the proxy server is not used">
         A comma-separated list of IP addresses and domain names for which a proxy server is not used. For wildcard domains, use a domain name with a dot prefix, e.g., ".example.com". (e.g. — <code>127.0.0.1, 192.168.0.0/24, example.com, ".example.com"</code>)
-      </label>
-      <input
-        class="textfield"
-        type="text" id="modulesNoProxyAddressList"
-        name="modulesNoProxyAddressList" placeholder=""
-        autocomplete="off" />
+    </label>
+    <input
+      class="textfield"
+      type="text" id="noProxyAddressList"
+      name="noProxyAddressList" placeholder=""
+      autocomplete="off"/>
       <span class="info">
          Specify a list of IP addresses, networks, and domain names that can be accessed directly without using a proxy server. For wildcard domains, use a domain name with a dot prefix, e.g., ".example.com". Leave it blank if there are no such exceptions.
       </span>
-    </div>
-</div>
+  </div>
 
 <!-- registry block -->
 <div markdown="1">

--- a/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
@@ -41,114 +41,50 @@
 {%- endunless %}
 {%- if page.platform_code == 'bm-private' %}
 
-<!-- packages proxy block -->
-<div class="form__row">
-  <div class="form__row--wrap">
-    <label for="packagesProxyEnabled" class="label">
-      Для скачивания deb или rpm-пакетов используется proxy-сервер
-    </label>
-    <input
-      type="checkbox" id="packagesProxyEnabled"
-      name="packagesProxyEnabled" />
-  </div>
-  <span class="info">
-     Отметьте, если в вашей сети <strong>нет</strong> прямого доступа для скачивания deb или rpm-пакетов и используется proxy-сервер.
-  </span>
-</div>
-<div class="packagesProxy-block" style="display: none;">
-    <div class="form__row">
-      <label class="label" title="Укажите адрес proxy-сервера используемого для скачивания deb или rpm-пакетов">
-        Адрес proxy-сервера, используемого для скачивания deb или rpm-пакетов (например — <code>https://proxy.company.my</code>)
-      </label>
-      <input
-        class="textfield"
-        type="text" id="packagesProxyURI"
-        name="packagesProxyURI" placeholder=""
-        autocomplete="off" />
-    </div>
-
-    <div class="form__row">
-      <label class="label" title="Укажите имя для авторизации на proxy-сервере">
-        Имя для авторизации на proxy-сервере
-      </label>
-      <input
-        class="textfield"
-        type="text" id="packagesProxyUsername"
-        name="packagesProxyUsername" placeholder=""
-        autocomplete="off" />
-      <span class="info">
-         Оставьте пустым, если proxy-сервер не использует авторизацию.
-      </span>
-    </div>
-
-    <div class="form__row">
-      <label class="label" title="Укажите пароль для авторизации на proxy-сервере">
-        Пароль для авторизации на proxy-сервере
-      </label>
-      <input
-        class="textfield"
-        type="text" id="packagesProxyPassword"
-        name="packagesProxyPassword" placeholder=""
-        autocomplete="off" />
-      <span class="info">
-         Оставьте пустым, если proxy-сервер не использует авторизацию.
-      </span>
-    </div>
-</div>
-
 <!-- proxy block -->
-<div class="form__row">
-  <div class="form__row--wrap">
-    <label for="modulesProxyEnabled" class="label">
-      Для доступа в Интернет компонентов Deckhouse используется proxy-сервер
+  <div class="form__row">
+    <label class="label" title="Укажите адрес proxy-сервера для HTTP-трафика">
+      Адрес proxy-сервера для HTTP-трафика (примеры: <code>http://proxy.company.my</code>, <code>https://user1:p@ssword@proxy.company.my:8443</code>)
     </label>
     <input
-      type="checkbox" id="modulesProxyEnabled"
-      name="modulesProxyEnabled" />
-  </div>
-  <span class="info">
-     Некоторым компонентам Deckhouse нужен доступ в Интернет (<a data-proofer-ignore href="/documentation/v1/modules/600-flant-integration/#какие-данные-отправляет-deckhouse">подробнее</a> о том, какие данные отправляет Deckhouse). Также доступ в Интернет может потребоваться, если вы настроите модули на отправку данных за пределы закрытого окружения (метрики мониторинга, логи и т.п.). Отметьте, если в вашей сети для доступа в Интернет модулям Deckhouse необходим proxy-сервер.
-  </span>
-</div>
-<div class="modulesProxy-block" style="display: none;">
-    <div class="form__row">
-      <label class="label" title="Укажите адрес HTTP proxy-сервера используемого для доступа в Интернет">
-        Адрес HTTP proxy-сервера, используемого для доступа в Интернет (например — <code>http://proxy.company.my:8080</code>)
-      </label>
-      <input
-        class="textfield"
-        type="text" id="modulesProxyHttpUri"
-        name="modulesProxyHttpUri" placeholder=""
-        autocomplete="off" />
-    </div>
-
-    <div class="form__row">
-      <label class="label" title="Укажите адрес HTTPS proxy-сервера используемого для доступа в Интернет">
-        Адрес HTTPS proxy-сервера, используемого для доступа в Интернет (например — <code>https://proxy.company.my:8443</code>)
-      </label>
-      <input
-        class="textfield"
-        type="text" id="modulesProxyHttpsUri"
-        name="modulesProxyHttpsUri" placeholder=""
-        autocomplete="off" />
-    </div>
-
-    <div class="form__row">
-      <label class="label" title="Список IP-адресов и доменных имен для которых проксирование не применяется">
-        Список IP-адресов и доменных имен для которых проксирование не применяется (через запятую). Для настройки wildcard-доменов используйте написание вида ".example.com". (например — <code>127.0.0.1, 192.168.0.0/24, example.com, ".example.com"</code>)
-      </label>
-      <input
-        class="textfield"
-        type="text" id="modulesNoProxyAddressList"
-        name="modulesNoProxyAddressList" placeholder=""
-        autocomplete="off" />
-      <span class="info">
-         Укажите список IP-адресов, сетей и доменных имен, к которым есть доступ напрямую, без использования proxy-сервера. Для настройки wildcard-доменов используйте написание вида ".example.com". Оставьте пустым, если таких исключений нет.
+      class="textfield"
+      type="text" id="proxyHttpURI"
+      name="proxyHttpURI" placeholder="http[s]://[[USER][:PASSWORD]@]proxy.company.my[:PORT]"
+      autocomplete="off"/>
+    <span class="info">
+         Оставьте пустым, если proxy-сервер для HTTP-трафика не используется.
       </span>
-    </div>
-</div>
+  </div>
 
-<!-- registry block -->
+  <div class="form__row">
+    <label class="label" title="Укажите адрес proxy-сервера для HTTPS-трафика">
+      Адрес proxy-сервера для HTTPS-трафика (примеры: <code>http://proxy.company.my</code>, <code>https://user1:p@ssword@proxy.company.my:8443</code>)
+    </label>
+    <input
+      class="textfield"
+      type="text" id="proxyHttpsURI"
+      name="proxyHttpsURI" placeholder="http[s]://[[USER][:PASSWORD]@]proxy.company.my[:PORT]"
+      autocomplete="off"/>
+    <span class="info">
+        Оставьте пустым, если proxy-сервер для HTTPS-трафика не используется.
+      </span>
+  </div>
+
+  <div class="form__row">
+    <label class="label" title="Список IP-адресов и доменных имен для которых проксирование не применяется">
+      Список IP-адресов и доменных имен для которых проксирование не применяется (через запятую).
+    </label>
+    <input
+      class="textfield"
+      type="text" id="noProxyAddressList"
+      name="noProxyAddressList" placeholder=""
+      autocomplete="off"/>
+    <span class="info">
+         Укажите список IP-адресов, сетей и доменных имен, к которым есть доступ напрямую, без использования proxy-сервера. Для настройки wildcard-доменов используйте написание вида ".example.com" (пример: <code>127.0.0.1, 192.168.0.0/24, example.com, ".example.com"</code>). Оставьте пустым, если таких исключений нет.
+      </span>
+  </div>
+
+  <!-- registry block -->
 <div markdown="1">
 ### Параметры доступа к хранилищу образов контейнеров (или проксирующему registry)
 

--- a/docs/site/js/getting-started-private.js
+++ b/docs/site/js/getting-started-private.js
@@ -1,26 +1,20 @@
 $(document).ready(function () {
-  let modulesProxyEnabled = sessionStorage.getItem('dhctl-modules-proxy-enabled')
-  let modulesProxyHttpsUri = sessionStorage.getItem('dhctl-modules-proxy-https-uri')
-  let modulesProxyHttpUri = sessionStorage.getItem('dhctl-modules-proxy-http-uri')
-  let modulesNoProxyAddressList = sessionStorage.getItem('dhctl-modules-noproxy-address-list')
-  let packagesProxyEnabled = sessionStorage.getItem('dhctl-packages-proxy-enabled')
-  let packagesProxyUsername = sessionStorage.getItem('dhctl-packages-proxy-username')
-  let packagesProxyPassword = sessionStorage.getItem('dhctl-packages-proxy-password')
-  let packagesProxyURI = sessionStorage.getItem('dhctl-packages-proxy-uri')
+  let proxyHttpsURI = sessionStorage.getItem('dhctl-proxy-https-uri')
+  let proxyHttpURI = sessionStorage.getItem('dhctl-proxy-http-uri')
+  let noProxyAddressList = sessionStorage.getItem('dhctl-noproxy-address-list')
   let registryDockerCfg = sessionStorage.getItem('dhctl-registry-docker-cfg')
   let registryImagesRepo = sessionStorage.getItem('dhctl-registry-images-repo')
   let registrySchemeHTTP = sessionStorage.getItem('dhctl-registry-scheme-http')
   let registryCA = sessionStorage.getItem('dhctl-registry-ca')
 
-  if (modulesNoProxyAddressList && modulesNoProxyAddressList.length > 0) {
-    modulesNoProxyAddressList = modulesNoProxyAddressList.replaceAll(' ', '')
+  if (noProxyAddressList && noProxyAddressList.length > 0) {
+    noProxyAddressList = noProxyAddressList.replaceAll(' ', '')
   }
 
-  if (modulesProxyEnabled && modulesProxyEnabled === "true" &&
-    ((modulesProxyHttpsUri && modulesProxyHttpsUri.length > 0) || (modulesProxyHttpUri && modulesProxyHttpUri.length > 0))) {
-    if (modulesProxyHttpsUri && modulesProxyHttpsUri.length > 0) {
-      update_parameter('dhctl-modules-proxy-https-uri', 'httpsProxy', '<HTTPS_PROXY_ADDRESS>', null, '[config-yml]');
-      if (!(modulesProxyHttpUri && modulesProxyHttpUri.length > 0)) {
+  if ( (proxyHttpsURI && proxyHttpsURI.length > 0) || (proxyHttpURI && proxyHttpURI.length > 0) ) {
+    if (proxyHttpsURI && proxyHttpsURI.length > 0) {
+      update_parameter('dhctl-proxy-https-uri', 'httpsProxy', '<HTTPS_PROXY_ADDRESS>', null, '[config-yml]');
+      if (!(proxyHttpURI && proxyHttpURI.length > 0)) {
         // Delete httpProxy section
         $('code span.na').filter(function () {
           return (this.innerText === "httpProxy");
@@ -33,9 +27,9 @@ $(document).ready(function () {
       }
     }
 
-    if (modulesProxyHttpUri && modulesProxyHttpUri.length > 0) {
-      update_parameter('dhctl-modules-proxy-http-uri', 'httpProxy', '<HTTP_PROXY_ADDRESS>', null, '[config-yml]');
-      if (!(modulesProxyHttpsUri && modulesProxyHttpsUri.length > 0)) {
+    if (proxyHttpURI && proxyHttpURI.length > 0) {
+      update_parameter('dhctl-proxy-http-uri', 'httpProxy', '<HTTP_PROXY_ADDRESS>', null, '[config-yml]');
+      if (!(proxyHttpsURI && proxyHttpsURI.length > 0)) {
         // Delete httpsProxy section
         $('code span.na').filter(function () {
           return (this.innerText === "httpsProxy");
@@ -48,9 +42,9 @@ $(document).ready(function () {
       }
     }
 
-    if (modulesNoProxyAddressList && modulesNoProxyAddressList.length > 0) {
-      modulesNoProxyAddressList = ('["' + modulesNoProxyAddressList.split(',').join('", "') + '"]').replaceAll('""', '"')
-      update_parameter(modulesNoProxyAddressList, 'noProxy', '<NO_PROXY_LIST>', null, '[config-yml]');
+    if (noProxyAddressList && noProxyAddressList.length > 0) {
+      noProxyAddressList = ('["' + noProxyAddressList.split(',').join('", "') + '"]').replaceAll('""', '"')
+      update_parameter(noProxyAddressList, 'noProxy', '<NO_PROXY_LIST>', null, '[config-yml]');
     }
   } else {
     // Delete proxy section
@@ -58,13 +52,13 @@ $(document).ready(function () {
       return (this.innerText === "proxy");
     }).each(function (index) {
       parent = $(this).parent();
-      delete_elements($(this).prev(), 12);
+      delete_elements($(this).prev(), 11);
       parent.html(parent.html().replaceAll(/\n\s+\n/g, "\n"));
     });
     updateTextInSnippet('[config-yml]', /\n\s+#[^#]+\n\s+proxy:\n\s+httpProxy: <HTTP_PROXY_ADDRESS>\n\s+httpsProxy: <HTTPS_PROXY_ADDRESS>\n\s+noProxy: <NO_PROXY_LIST>\n/, "\n");
   }
 
-  if (!(modulesNoProxyAddressList && modulesNoProxyAddressList.length > 0)) {
+  if (!(noProxyAddressList && noProxyAddressList.length > 0)) {
     // Delete noProxy section
     $('code span.na').filter(function () {
       return (this.innerText === "noProxy");
@@ -74,33 +68,6 @@ $(document).ready(function () {
       parent.html(parent.html().replaceAll(/\n\s+\n/g, "\n"));
     });
     updateTextInSnippet('[config-yml]', /\n\s+noProxy: <NO_PROXY_LIST>\n/, "\n");
-  }
-
-  if (packagesProxyEnabled && packagesProxyEnabled === "true" &&
-    packagesProxyUsername && packagesProxyUsername.length > 0 &&
-    packagesProxyPassword && packagesProxyPassword.length > 0 &&
-    packagesProxyURI && packagesProxyURI.length > 0) {
-    update_parameter('dhctl-packages-proxy-uri', 'uri', 'https://example.com', null, '[config-yml]');
-    update_parameter('dhctl-packages-proxy-username', 'username', '<PROXY-USERNAME>', null, '[config-yml]');
-    update_parameter('dhctl-packages-proxy-password', 'password', '<PROXY-PASSWORD>', null, '[config-yml]');
-  } else if (packagesProxyEnabled && packagesProxyEnabled === "true" && packagesProxyURI && packagesProxyURI.length > 0) {
-    // Have proxy without auth.
-    update_parameter('dhctl-packages-proxy-uri', 'uri', 'https://example.com', null, '[config-yml]');
-    $('code span.na').filter(function () {
-      return (this.innerText === "packagesProxy");
-    }).each(function (index) {
-      delete_elements($(this).next().next().next().next().next(), 5);
-    });
-    updateTextInSnippet('[config-yml]', /\s+username: <PROXY-USERNAME>\n\s+password: <PROXY-PASSWORD>\n---/, "\n---");
-  } else {
-    // Have no info to fill packagesProxy array, delete it from config
-    console.log("Have no info to fill packagesProxy array...");
-    $('code span.na').filter(function () {
-      return (this.innerText === "packagesProxy");
-    }).each(function (index) {
-      delete_elements($(this), 10);
-    });
-    updateTextInSnippet('[config-yml]', /packagesProxy.+<PROXY-PASSWORD>\n---/s, "---");
   }
 
   if (registryImagesRepo && registryImagesRepo.length > 0) {


### PR DESCRIPTION
## Description

**Have to be merged after v 1.42 becomes a stable version.**

Update the guide for installing in a private environment according to [changes](https://github.com/deckhouse/deckhouse/pull/3185) in `v1.42`.

## Why do we need it, and what problem does it solve?
The settings for working through a proxy server have changed in Deckhouse 1.42 ([issue](https://github.com/deckhouse/deckhouse/pull/3185)).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [X] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Update the guide for installing in a private environment according to [changes](https://github.com/deckhouse/deckhouse/pull/3185) in `v1.42`.
impact_level: low
```
