### PR TITLE
[deckhouse-config] Support statuses for external modules

### DIFF
--- a/go_lib/deckhouse-config/service.go
+++ b/go_lib/deckhouse-config/service.go
@@ -43,6 +43,7 @@ func InitService(mm ModuleManager) {
 		transformer:     NewTransformer(possibleNames),
 		configValidator: NewConfigValidator(mm.GetValuesValidator()),
 		statusReporter:  NewModuleInfo(mm, possibleNames),
+		externalNames:   make(map[string]string),
 	}
 }
 
@@ -59,6 +60,9 @@ type ConfigService struct {
 	transformer     *Transformer
 	configValidator *ConfigValidator
 	statusReporter  *StatusReporter
+
+	externalNamesLock sync.RWMutex
+	externalNames     map[string]string
 }
 
 func (srv *ConfigService) PossibleNames() set.Set {
@@ -75,4 +79,23 @@ func (srv *ConfigService) ConfigValidator() *ConfigValidator {
 
 func (srv *ConfigService) StatusReporter() *StatusReporter {
 	return srv.statusReporter
+}
+
+func (srv *ConfigService) SetExternalNames(allExternalNamesToRepos map[string]string) {
+	srv.externalNamesLock.Lock()
+	defer srv.externalNamesLock.Unlock()
+
+	srv.externalNames = allExternalNamesToRepos
+}
+
+func (srv *ConfigService) ExternalNames() map[string]string {
+	srv.externalNamesLock.RLock()
+	defer srv.externalNamesLock.RUnlock()
+
+	res := make(map[string]string)
+	for module, repo := range srv.externalNames {
+		res[module] = repo
+	}
+
+	return res
 }

--- a/go_lib/deckhouse-config/v1alpha1/module_config.go
+++ b/go_lib/deckhouse-config/v1alpha1/module_config.go
@@ -47,6 +47,7 @@ type ModuleConfigSpec struct {
 type ModuleConfigStatus struct {
 	State   string `json:"state"`
 	Version string `json:"version"`
+	Type    string `json:"type"`
 	Status  string `json:"status"`
 }
 

--- a/modules/003-deckhouse-config/crds/module-config.yaml
+++ b/modules/003-deckhouse-config/crds/module-config.yaml
@@ -57,6 +57,9 @@ spec:
                 status:
                   type: string
                   description: "Module state explanation, version warning or last error"
+                type:
+                  type: string
+                  description: "Type of module: embedded or external module"
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/modules/003-deckhouse-config/crds/module-config.yaml
+++ b/modules/003-deckhouse-config/crds/module-config.yaml
@@ -76,6 +76,10 @@ spec:
             in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
             lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
           jsonPath: .metadata.creationTimestamp
+        - name: Type
+          type: string
+          description: "Type of module: embedded or external module"
+          jsonPath: .status.type
         - name: Status
           type: string
           description: "Module state explanation, version warning or last error"

--- a/modules/003-deckhouse-config/hooks/update_status.go
+++ b/modules/003-deckhouse-config/hooks/update_status.go
@@ -119,8 +119,9 @@ func updateModuleConfigStatuses(input *go_hook.HookInput) error {
 		}
 	}
 
+	externalNames := d8config.Service().ExternalNames()
 	for _, cfg := range allConfigs {
-		moduleStatus := d8config.Service().StatusReporter().ForConfig(cfg, bundleName)
+		moduleStatus := d8config.Service().StatusReporter().ForConfig(cfg, bundleName, externalNames)
 		statusPatch := makeStatusPatch(cfg, moduleStatus)
 		if statusPatch != nil {
 			// TODO Switch to debug level in 1.42 release.
@@ -160,6 +161,7 @@ func makeStatusPatch(cfg *d8cfg_v1alpha1.ModuleConfig, moduleStatus d8config.Sta
 		Status:  moduleStatus.Status,
 		State:   moduleStatus.State,
 		Version: moduleStatus.Version,
+		Type:    moduleStatus.Type,
 	}
 }
 
@@ -170,6 +172,8 @@ func isStatusChanged(currentStatus d8cfg_v1alpha1.ModuleConfigStatus, moduleStat
 	case currentStatus.Status != moduleStatus.Status:
 		return true
 	case currentStatus.Version != moduleStatus.Version:
+		return true
+	case currentStatus.Type != moduleStatus.Type:
 		return true
 	}
 	return false


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Support module type (embedded or external) in module config statuses.
![image](https://user-images.githubusercontent.com/30695496/212269063-649134d3-13d2-4955-8bb9-914f57da3352.png)

## Why do we need it, and what problem does it solve?
We need differ external modules when request modules list via `kubectl get mc` command

## What is the expected result?
`kubectl get mc` command should show `Type` column

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse-config
type: feature
summary: Support statuses for external modules
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
