### PR TITLE
[docs] Show deprecated status in the `deprecated` option is set

### DIFF
--- a/docs/documentation/_plugins/openapi.rb
+++ b/docs/documentation/_plugins/openapi.rb
@@ -332,7 +332,7 @@ module Jekyll
               end
             end
 
-            if get_hash_value(attributes, 'x-doc-deprecated')
+            if ( get_hash_value(attributes, 'x-doc-deprecated') or get_hash_value(attributes, 'deprecated') )
                 parameterTextContent = sprintf(%q(<span id="%s" data-anchor-id="%s" class="resources__prop_title anchored"><span data-tippy-content="%s">%s</span><span data-tippy-content="%s" class="resources__prop_is_deprecated">%s</span></span>), linkAnchor, linkAnchor, pathString, parameterTitle, get_i18n_term('deprecated_parameter_hint'), get_i18n_term('deprecated_parameter') )
             else
                 parameterTextContent = sprintf(%q(<span id="%s" data-anchor-id="%s" class="resources__prop_name anchored" data-tippy-content="%s">%s</span>), linkAnchor, linkAnchor, pathString, parameterTitle)


### PR DESCRIPTION
## Description
Show the deprecated status of the OpenAPI parameter if the `deprecated` option is set.

## Why do we need it, and what problem does it solve?
Currently, the deprecated status of a parameter on the site is only shown if the `x-doc-deprecated` option of the parameter is true. But there are parameters with the `deprecated` option also. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [X] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: Show the deprecated status of the OpenAPI parameter if the `deprecated` option is set.
impact_level: low
```
