### PR TITLE
[chrony] Adding a dot to the end of each NTP server address to avoid resolve problems. Allowing correction of large time difference

### DIFF
--- a/modules/470-chrony/docs/CONFIGURATION.md
+++ b/modules/470-chrony/docs/CONFIGURATION.md
@@ -7,8 +7,14 @@ title: "The chrony module: configuration"
 ## An example of the configuration
 
 ```yaml
-chrony: |
-  ntpServers:
-  - pool.ntp.org
-  - ntp.ubuntu.com
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: chrony
+spec:
+  settings:
+    ntpServers:
+      - pool.ntp.org
+      - ntp.ubuntu.com
+  version: 1
 ```

--- a/modules/470-chrony/docs/CONFIGURATION_RU.md
+++ b/modules/470-chrony/docs/CONFIGURATION_RU.md
@@ -7,8 +7,14 @@ title: "Модуль chrony: настройки"
 ## Пример конфигурации
 
 ```yaml
-chrony: |
-  ntpServers:
-  - pool.ntp.org
-  - ntp.ubuntu.com
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: chrony
+spec:
+  settings:
+    ntpServers:
+      - pool.ntp.org
+      - ntp.ubuntu.com
+  version: 1
 ```

--- a/modules/470-chrony/images/chrony/start.sh
+++ b/modules/470-chrony/images/chrony/start.sh
@@ -34,11 +34,20 @@ cmdallow 127/8
 allow 127/8
 bindaddress 127.0.0.1
 driftfile /var/run/chrony/chrony.drift
-makestep 1.0 3
+makestep 1.0 -1
 rtcsync
 EOF
 for NTP_SERVER in ${NTP_SERVERS}; do
-  echo "pool ${NTP_SERVER} iburst" >> /var/run/chrony/chrony.conf
+  # Check, if there is an IP address, then pass it to file
+  if [[ $NTP_SERVER =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+      echo "pool ${NTP_SERVER} iburst" >> /var/run/chrony/chrony.conf
+  # Else, if there is a dot in the end of DNS-address, then pass it to file
+  elif [[ $NTP_SERVER =~ ^.*\.$ ]]; then
+      echo "pool ${NTP_SERVER} iburst" >> /var/run/chrony/chrony.conf
+  # In all other cases, we should add dot, then pass it to file
+  else
+      echo "pool ${NTP_SERVER}. iburst" >> /var/run/chrony/chrony.conf
+  fi
 done
 
 # remove stale pidfile

--- a/modules/470-chrony/images/chrony/start.sh
+++ b/modules/470-chrony/images/chrony/start.sh
@@ -38,16 +38,7 @@ makestep 1.0 -1
 rtcsync
 EOF
 for NTP_SERVER in ${NTP_SERVERS}; do
-  # Check, if there is an IP address, then pass it to file
-  if [[ $NTP_SERVER =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-      echo "pool ${NTP_SERVER} iburst" >> /var/run/chrony/chrony.conf
-  # Else, if there is a dot in the end of DNS-address, then pass it to file
-  elif [[ $NTP_SERVER =~ ^.*\.$ ]]; then
-      echo "pool ${NTP_SERVER} iburst" >> /var/run/chrony/chrony.conf
-  # In all other cases, we should add dot, then pass it to file
-  else
-      echo "pool ${NTP_SERVER}. iburst" >> /var/run/chrony/chrony.conf
-  fi
+  echo "pool ${NTP_SERVER} iburst" >> /var/run/chrony/chrony.conf
 done
 
 # remove stale pidfile

--- a/modules/470-chrony/template_tests/module_test.go
+++ b/modules/470-chrony/template_tests/module_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Module :: chrony :: helm template ::", func() {
 			Expect(chronyDaemonSetTest.Field("spec.template.spec.containers.0.env.0").String()).To(MatchJSON(`
   {
     "name": "NTP_SERVERS",
-    "value": "pool.ntp.org ntp.ubuntu.com"
+    "value": "pool.ntp.org. ntp.ubuntu.com."
   }
 `))
 

--- a/modules/470-chrony/templates/daemonset.yaml
+++ b/modules/470-chrony/templates/daemonset.yaml
@@ -58,8 +58,16 @@ spec:
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" (list . (list "SYS_TIME" "CHOWN" "DAC_OVERRIDE" "FOWNER" "FSETID" "KILL" "SETGID" "SETUID" "SETPCAP" "NET_BIND_SERVICE" "NET_RAW" "SYS_CHROOT" "MKNOD" "AUDIT_WRITE" "SETFCAP")) | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "chrony") }}
         env:
+{{ $ntpServers := list }}
+{{- range $value := .Values.chrony.ntpServers }}
+  {{- if regexMatch "(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$" $value }}
+    {{ $ntpServers = append $ntpServers $value }}
+  {{ else }}
+    {{ $ntpServers = append $ntpServers (printf "%s." ($value | trimSuffix ".")) }}
+  {{- end }}
+{{ end }}
         - name: NTP_SERVERS
-          value: {{ join " " .Values.chrony.ntpServers | quote }}
+          value: {{ join " " $ntpServers | quote }}
         ports:
         - name: ntp
           containerPort: 123


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Adding a dot to the end of each NTP server address to avoid resolve problems. Allowing correction of large time difference.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Incorrect DNS resolve is possible in case of wildcard domains in search. In case of a large difference in local time with the world time correction may not work. This PR corrects both situations.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Chrony correct work.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: chrony
type: fix
summary: Adding a dot to the end of each NTP server address to avoid resolve problems. Allowing correction of large time difference.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
