### PR TITLE
[log-shipper] Add indexes fields for Splunk destination

### DIFF
--- a/modules/460-log-shipper/docs/EXAMPLES.md
+++ b/modules/460-log-shipper/docs/EXAMPLES.md
@@ -222,6 +222,12 @@ spec:
       verifyHostname: false
 ```
 
+> NOTE: Splunk destination doesn't support pod labels for indexes. Consider exporting necessary labels with the `extreaLabels` option.
+```yaml
+extraLabels:
+  pod_label_app: '{{ pod_labels.app }}'
+```
+
 ## Simple Logstash example
 
 To send logs to Logstash, the `tcp` input should be configured on the Logstash instance side, and its codec should be set to `json`.

--- a/modules/460-log-shipper/docs/EXAMPLES.md
+++ b/modules/460-log-shipper/docs/EXAMPLES.md
@@ -222,7 +222,7 @@ spec:
       verifyHostname: false
 ```
 
-> NOTE: Splunk destination doesn't support pod labels for indexes. Consider exporting necessary labels with the `extreaLabels` option.
+> NOTE: Splunk destination doesn't support pod labels for indexes. Consider exporting necessary labels with the `extraLabels` option.
 
 ```yaml
 extraLabels:

--- a/modules/460-log-shipper/docs/EXAMPLES.md
+++ b/modules/460-log-shipper/docs/EXAMPLES.md
@@ -203,7 +203,7 @@ spec:
 It is possible to send logs from Deckhouse to Splunk.
 
 1. Endpoint must be equal to the Splunk instance name with the `8088` port and no path provided, e.g. `https://prd-p-xxxxxx.splunkcloud.com:8088`.
-2. To add a token to ingest logs, go to `Setting` -> `Data inputs` and add a new `HTTP Event Collector`, then copy a token.
+2. To add a token to ingest logs, go to `Setting` -> `Data inputs`, add a new `HTTP Event Collector` and copy a token.
 3. Provide a Splunk index to store logs, e.g., `logs`.
 
 ```yaml

--- a/modules/460-log-shipper/docs/EXAMPLES.md
+++ b/modules/460-log-shipper/docs/EXAMPLES.md
@@ -198,6 +198,30 @@ spec:
       password: c2VjcmV0IC1uCg==
 ```
 
+## Splunk integration
+
+It is possible to send logs from Deckhouse to Splunk.
+
+1. Endpoint must be equal to the Splunk instance name with the `8088` port and no path provided, e.g. `https://prd-p-xxxxxx.splunkcloud.com:8088`.
+2. To add a token to ingest logs, go to `Setting` -> `Data inputs` and add a new `HTTP Event Collector`, then copy a token.
+3. Provide a Splunk index to store logs, e.g., `logs`.
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLogDestination
+metadata:
+  name: splunk
+spec:
+  type: Splunk
+  splunk:
+    endpoint: https://prd-p-xxxxxx.splunkcloud.com:8088
+    token: xxxx-xxxx-xxxx
+    index: logs
+    tls:
+      verifyCertificate: false
+      verifyHostname: false
+```
+
 ## Simple Logstash example
 
 To send logs to Logstash, the `tcp` input should be configured on the Logstash instance side, and its codec should be set to `json`.

--- a/modules/460-log-shipper/docs/EXAMPLES.md
+++ b/modules/460-log-shipper/docs/EXAMPLES.md
@@ -223,6 +223,7 @@ spec:
 ```
 
 > NOTE: Splunk destination doesn't support pod labels for indexes. Consider exporting necessary labels with the `extreaLabels` option.
+
 ```yaml
 extraLabels:
   pod_label_app: '{{ pod_labels.app }}'

--- a/modules/460-log-shipper/docs/EXAMPLES_RU.md
+++ b/modules/460-log-shipper/docs/EXAMPLES_RU.md
@@ -222,6 +222,12 @@ spec:
       verifyHostname: false
 ```
 
+> NOTE: Splunk destination не поддерживает метки Pod'а для индексирования. Рассмотрите возможность добавления нужных меток при помощи опции `extreaLabels`.
+```yaml
+extraLabels:
+  pod_label_app: '{{ pod_labels.app }}'
+```
+
 ## Простой пример Logstash
 
 Чтобы отправлять логи в Logstash, на стороне Logstash должен быть настроен входящий поток `tcp`, и его кодек должен быть — `json`.

--- a/modules/460-log-shipper/docs/EXAMPLES_RU.md
+++ b/modules/460-log-shipper/docs/EXAMPLES_RU.md
@@ -203,7 +203,7 @@ spec:
 Существует возможность отсылать события из Deckhouse в Splunk.
 
 1. Endpoint должен быть таким же как имя вашего экземпляра Splunk с портом `8088` и без указания пути, например, `https://prd-p-xxxxxx.splunkcloud.com:8088`.
-2. Чтобы добавить token для доступа, откройте пункт меню `Setting` -> `Data inputs` и добавьте новый `HTTP Event Collector`, после скопируйте token.
+2. Чтобы добавить token для доступа, откройте пункт меню `Setting` -> `Data inputs`, добавьте новый `HTTP Event Collector` и скопируйте token.
 3. Укажите индекс Splunk для хранения логов, например, `logs`.
 
 ```yaml

--- a/modules/460-log-shipper/docs/EXAMPLES_RU.md
+++ b/modules/460-log-shipper/docs/EXAMPLES_RU.md
@@ -222,7 +222,7 @@ spec:
       verifyHostname: false
 ```
 
-> NOTE: Splunk destination не поддерживает метки Pod'а для индексирования. Рассмотрите возможность добавления нужных меток при помощи опции `extreaLabels`.
+> NOTE: Splunk destination не поддерживает метки Pod'а для индексирования. Рассмотрите возможность добавления нужных меток при помощи опции `extraLabels`.
 
 ```yaml
 extraLabels:

--- a/modules/460-log-shipper/docs/EXAMPLES_RU.md
+++ b/modules/460-log-shipper/docs/EXAMPLES_RU.md
@@ -198,6 +198,30 @@ spec:
       password: c2VjcmV0IC1uCg==
 ```
 
+## Пример интеграции со Splunk
+
+Существует возможность отсылать события из Deckhouse в Splunk.
+
+1. Endpoint должен быть таким же как имя вашего экземпляра Splunk с портом `8088` и без указания пути, например, `https://prd-p-xxxxxx.splunkcloud.com:8088`.
+2. Чтобы добавить token для доступа, откройте пункт меню `Setting` -> `Data inputs` и добавьте новый `HTTP Event Collector`, после скопируйте token.
+3. Укажите индекс Splunk для хранения логов, например, `logs`.
+
+```yaml
+apiVersion: deckhouse.io/v1alpha1
+kind: ClusterLogDestination
+metadata:
+  name: splunk
+spec:
+  type: Splunk
+  splunk:
+    endpoint: https://prd-p-xxxxxx.splunkcloud.com:8088
+    token: xxxx-xxxx-xxxx
+    index: logs
+    tls:
+      verifyCertificate: false
+      verifyHostname: false
+```
+
 ## Простой пример Logstash
 
 Чтобы отправлять логи в Logstash, на стороне Logstash должен быть настроен входящий поток `tcp`, и его кодек должен быть — `json`.

--- a/modules/460-log-shipper/docs/EXAMPLES_RU.md
+++ b/modules/460-log-shipper/docs/EXAMPLES_RU.md
@@ -223,6 +223,7 @@ spec:
 ```
 
 > NOTE: Splunk destination не поддерживает метки Pod'а для индексирования. Рассмотрите возможность добавления нужных меток при помощи опции `extreaLabels`.
+
 ```yaml
 extraLabels:
   pod_label_app: '{{ pod_labels.app }}'

--- a/modules/460-log-shipper/hooks/internal/vector/destination/splunk.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/splunk.go
@@ -73,7 +73,7 @@ func NewSplunk(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Splunk {
 		"pod_ip",
 		"stream",
 		"pod_owner",
-		"pod_labels",
+		// "pod_labels", Splunk does not support objects with dynamic keys for indexes, consider using extraLabels
 	}
 
 	// Send extra labels as indexed fields

--- a/modules/460-log-shipper/hooks/internal/vector/destination/splunk.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/splunk.go
@@ -34,7 +34,9 @@ type Splunk struct {
 
 	Index string `json:"index,omitempty"`
 
-	TLS CommonTLS `json:"tls,omitempty"`
+	IndexedFields []string `json:"indexed_fields,omitempty"`
+
+	TLS CommonTLS `json:"tls"`
 }
 
 func NewSplunk(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Splunk {
@@ -71,9 +73,19 @@ func NewSplunk(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Splunk {
 		TLS:   tls,
 		Index: spec.Index,
 		Encoding: Encoding{
-			Codec:           "text",
+			Codec:           "json",
 			TimestampFormat: "rfc3339",
-			OnlyFields:      []string{"message"},
+		},
+		IndexedFields: []string{
+			"namespace",
+			"container",
+			"image",
+			"pod",
+			"node",
+			"pod_ip",
+			"stream",
+			"pod_labels",
+			"pod_owner",
 		},
 		Endpoint:     spec.Endpoint,
 		DefaultToken: spec.Token,

--- a/modules/460-log-shipper/hooks/internal/vector/destination/splunk.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/splunk.go
@@ -64,7 +64,7 @@ func NewSplunk(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Splunk {
 		tls.VerifyHostname = *spec.TLS.VerifyHostname
 	}
 
-	indexFields := []string{
+	indexedFields := []string{
 		"namespace",
 		"container",
 		"image",
@@ -78,7 +78,7 @@ func NewSplunk(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Splunk {
 
 	// Send extra labels as indexed fields
 	for k := range cspec.ExtraLabels {
-		indexFields = append(indexFields, k)
+		indexedFields = append(indexedFields, k)
 	}
 
 	return &Splunk{
@@ -94,7 +94,7 @@ func NewSplunk(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Splunk {
 			Codec:           "text",
 			TimestampFormat: "rfc3339",
 		},
-		IndexedFields: indexFields,
+		IndexedFields: indexedFields,
 		Endpoint:      spec.Endpoint,
 		DefaultToken:  spec.Token,
 		Compression:   "gzip",

--- a/modules/460-log-shipper/hooks/internal/vector/destination/splunk.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/splunk.go
@@ -73,6 +73,12 @@ func NewSplunk(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Splunk {
 		"pod_ip",
 		"stream",
 		"pod_owner",
+		"pod_labels",
+	}
+
+	// Send extra labels as indexed fields
+	for k := range cspec.ExtraLabels {
+		indexFields = append(indexFields, k)
 	}
 
 	return &Splunk{
@@ -84,8 +90,8 @@ func NewSplunk(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Splunk {
 		TLS:   tls,
 		Index: spec.Index,
 		Encoding: Encoding{
-			ExceptFields:    indexFields, // Do not encode fields used in indexes
-			Codec:           "json",
+			OnlyFields:      []string{"message"}, // Do not encode fields used in indexes
+			Codec:           "text",
 			TimestampFormat: "rfc3339",
 		},
 		IndexedFields: indexFields,

--- a/modules/460-log-shipper/hooks/internal/vector/destination/splunk.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/splunk.go
@@ -64,6 +64,17 @@ func NewSplunk(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Splunk {
 		tls.VerifyHostname = *spec.TLS.VerifyHostname
 	}
 
+	indexFields := []string{
+		"namespace",
+		"container",
+		"image",
+		"pod",
+		"node",
+		"pod_ip",
+		"stream",
+		"pod_owner",
+	}
+
 	return &Splunk{
 		CommonSettings: CommonSettings{
 			Name:   ComposeName(name),
@@ -73,22 +84,13 @@ func NewSplunk(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Splunk {
 		TLS:   tls,
 		Index: spec.Index,
 		Encoding: Encoding{
+			ExceptFields:    indexFields, // Do not encode fields used in indexes
 			Codec:           "json",
 			TimestampFormat: "rfc3339",
 		},
-		IndexedFields: []string{
-			"namespace",
-			"container",
-			"image",
-			"pod",
-			"node",
-			"pod_ip",
-			"stream",
-			"pod_labels",
-			"pod_owner",
-		},
-		Endpoint:     spec.Endpoint,
-		DefaultToken: spec.Token,
-		Compression:  "gzip",
+		IndexedFields: indexFields,
+		Endpoint:      spec.Endpoint,
+		DefaultToken:  spec.Token,
+		Compression:   "gzip",
 	}
 }

--- a/modules/460-log-shipper/hooks/testdata/file-to-splunk/manifests.yaml
+++ b/modules/460-log-shipper/hooks/testdata/file-to-splunk/manifests.yaml
@@ -23,3 +23,5 @@ spec:
     tls:
       verifyCertificate: false
       verifyHostname: false
+  extraLabels:
+    app: "{{ pod_labels.app }}"

--- a/modules/460-log-shipper/hooks/testdata/file-to-splunk/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-splunk/result.json
@@ -27,16 +27,28 @@
         "enabled": false
       },
       "encoding": {
-        "only_fields": [
-          "message"
-        ],
-        "codec": "text",
+        "codec": "json",
         "timestamp_format": "rfc3339"
       },
       "compression": "gzip",
       "default_token": "test-token",
       "endpoint": "192.168.1.1:9200",
-      "index": "{{ test }}"
+      "index": "{{ test }}",
+      "indexed_fields": [
+        "namespace",
+        "container",
+        "image",
+        "pod",
+        "node",
+        "pod_ip",
+        "stream",
+        "pod_labels",
+        "pod_owner"
+      ],
+      "tls": {
+        "verify_hostname": false,
+        "verify_certificate": false
+      }
     }
   }
 }

--- a/modules/460-log-shipper/hooks/testdata/file-to-splunk/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-splunk/result.json
@@ -27,6 +27,16 @@
         "enabled": false
       },
       "encoding": {
+        "except_fields": [
+          "namespace",
+          "container",
+          "image",
+          "pod",
+          "node",
+          "pod_ip",
+          "stream",
+          "pod_owner"
+        ],
         "codec": "json",
         "timestamp_format": "rfc3339"
       },
@@ -42,7 +52,6 @@
         "node",
         "pod_ip",
         "stream",
-        "pod_labels",
         "pod_owner"
       ],
       "tls": {

--- a/modules/460-log-shipper/hooks/testdata/file-to-splunk/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-splunk/result.json
@@ -27,17 +27,10 @@
         "enabled": false
       },
       "encoding": {
-        "except_fields": [
-          "namespace",
-          "container",
-          "image",
-          "pod",
-          "node",
-          "pod_ip",
-          "stream",
-          "pod_owner"
+        "only_fields": [
+          "message"
         ],
-        "codec": "json",
+        "codec": "text",
         "timestamp_format": "rfc3339"
       },
       "compression": "gzip",
@@ -52,7 +45,9 @@
         "node",
         "pod_ip",
         "stream",
-        "pod_owner"
+        "pod_owner",
+        "pod_labels",
+        "app"
       ],
       "tls": {
         "verify_hostname": false,

--- a/modules/460-log-shipper/hooks/testdata/file-to-splunk/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-splunk/result.json
@@ -46,7 +46,6 @@
         "pod_ip",
         "stream",
         "pod_owner",
-        "pod_labels",
         "app"
       ],
       "tls": {


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
* Automatically add indexed fields 
* Do not encode them in original message
* Always set TLS settings

## Why do we need it, and what problem does it solve?
Without this changes, users only see messages in Splunk without Kubernetes metadata attached

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: log-shipper
type: feature
summary: Add indexes fields for Splunk destination.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
