### PR TITLE
[global] modify modules_images_tags to support external modules

### DIFF
--- a/global-hooks/discovery/modules_images_tags.go
+++ b/global-hooks/discovery/modules_images_tags.go
@@ -48,10 +48,8 @@ func discoveryModulesImagesTags(input *go_hook.HookInput) error {
 	}
 
 	modulesTagsObj := readModulesImagesTags(input, externalModulesDir)
-	if modulesTagsObj != nil {
-		for k, v := range modulesTagsObj {
-			tagsObj[k] = v
-		}
+	for k, v := range modulesTagsObj {
+		tagsObj[k] = v
 	}
 
 	input.Values.Set("global.modulesImages.tags", tagsObj)

--- a/global-hooks/discovery/modules_images_tags.go
+++ b/global-hooks/discovery/modules_images_tags.go
@@ -18,32 +18,95 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"regexp"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	"github.com/iancoleman/strcase"
 )
+
+var re = regexp.MustCompile(`^([0-9]+)-([a-zA-Z-]+)$`)
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnStartup: &go_hook.OrderedConfig{Order: 10},
 }, discoveryModulesImagesTags)
 
 func discoveryModulesImagesTags(input *go_hook.HookInput) error {
+	// Discover main deckhouse images tags file
 	tagsFile := "/deckhouse/modules/images_tags.json"
+	externalModulesDir := "/deckhouse/external-modules/modules"
+
 	if os.Getenv("D8_IS_TESTS_ENVIRONMENT") != "" {
 		tagsFile = os.Getenv("D8_TAGS_TMP_FILE")
+		externalModulesDir = "testdata/modules-images-tags/external-modules"
 	}
 
-	tagsContent, err := os.ReadFile(tagsFile)
+	tagsObj, err := parseImagesTagsFile(tagsFile)
 	if err != nil {
-		return fmt.Errorf("cannot read images tags files: %w", err)
+		return err
 	}
 
-	var tagsObj map[string]interface{}
-	if err := json.Unmarshal(tagsContent, &tagsObj); err != nil {
-		return fmt.Errorf("invalid images tags json: %w", err)
+	modulesTagsObj := readModulesImagesTags(input, externalModulesDir)
+	if modulesTagsObj != nil {
+		for k, v := range modulesTagsObj {
+			tagsObj[k] = v
+		}
 	}
 
 	input.Values.Set("global.modulesImages.tags", tagsObj)
 
 	return nil
+}
+
+func parseImagesTagsFile(filePath string) (map[string]interface{}, error) {
+	tagsContent, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read images tags files: %w", err)
+	}
+
+	var tagsObj map[string]interface{}
+	if err := json.Unmarshal(tagsContent, &tagsObj); err != nil {
+		return nil, fmt.Errorf("invalid images tags json: %w", err)
+	}
+
+	return tagsObj, nil
+}
+
+func readModulesImagesTags(input *go_hook.HookInput, modulesDir string) map[string]interface{} {
+	tagsObj := make(map[string]interface{})
+
+	dirItems, err := os.ReadDir(modulesDir)
+	if err != nil {
+		input.LogEntry.Warning(err)
+		return nil
+	}
+
+	for _, dirItem := range dirItems {
+		evalPath := filepath.Join(modulesDir, dirItem.Name())
+		evalPath, err = filepath.EvalSymlinks(evalPath)
+		if err != nil {
+			input.LogEntry.Warning(err)
+			continue
+		}
+
+		fi, err := os.Stat(evalPath)
+		if err != nil {
+			input.LogEntry.Warning(err)
+			continue
+		}
+		if !fi.Mode().IsDir() {
+			continue
+		}
+
+		moduleTagsObj, err := parseImagesTagsFile(filepath.Join(evalPath, "images_tags.json"))
+		if err != nil {
+			input.LogEntry.Warning(err)
+			continue
+		}
+
+		moduleNameLowerCamel := strcase.ToLowerCamel(re.ReplaceAllString(dirItem.Name(), "$2"))
+		tagsObj[moduleNameLowerCamel] = moduleTagsObj
+	}
+	return tagsObj
 }

--- a/global-hooks/discovery/modules_images_tags.go
+++ b/global-hooks/discovery/modules_images_tags.go
@@ -35,7 +35,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 func discoveryModulesImagesTags(input *go_hook.HookInput) error {
 	// Discover main deckhouse images tags file
 	tagsFile := "/deckhouse/modules/images_tags.json"
-	externalModulesDir := "/deckhouse/external-modules/modules"
+	externalModulesDir := filepath.Join(os.Getenv("EXTERNAL_MODULES_DIR"), "modules")
 
 	if os.Getenv("D8_IS_TESTS_ENVIRONMENT") != "" {
 		tagsFile = os.Getenv("D8_TAGS_TMP_FILE")

--- a/global-hooks/discovery/modules_images_tags_test.go
+++ b/global-hooks/discovery/modules_images_tags_test.go
@@ -50,8 +50,19 @@ var _ = Describe("Global hooks :: discovery :: modules_images_tags ", func() {
 
 			It("Should set tags files content as object into 'global.modulesImages.tags'", func() {
 				Expect(f).To(ExecuteSuccessfully())
-				tag := f.ValuesGet("global.modulesImages.tags.basicAuth.nginx").String()
-				Expect(tag).To(Equal(`valid-tag`))
+				tag := f.ValuesGet("global.modulesImages.tags").String()
+				Expect(tag).To(MatchJSON(`
+{
+	"basicAuth": {
+	  "nginx": "valid-tag"
+	},
+	"testLocal": {
+	  "test": "valid-tag"
+	},
+	"testTest": {
+	  "test": "valid-tag"
+	}
+}`))
 			})
 		})
 

--- a/global-hooks/discovery/testdata/modules-images-tags/external-modules-source/999-test-test/images_tags.json
+++ b/global-hooks/discovery/testdata/modules-images-tags/external-modules-source/999-test-test/images_tags.json
@@ -1,0 +1,1 @@
+{"test": "valid-tag"}

--- a/global-hooks/discovery/testdata/modules-images-tags/external-modules/997-test-local/images_tags.json
+++ b/global-hooks/discovery/testdata/modules-images-tags/external-modules/997-test-local/images_tags.json
@@ -1,0 +1,1 @@
+{"test": "valid-tag"}

--- a/global-hooks/discovery/testdata/modules-images-tags/external-modules/998-test-empty
+++ b/global-hooks/discovery/testdata/modules-images-tags/external-modules/998-test-empty
@@ -1,0 +1,1 @@
+../external-modules-source/998-test-empty

--- a/global-hooks/discovery/testdata/modules-images-tags/external-modules/999-test-test
+++ b/global-hooks/discovery/testdata/modules-images-tags/external-modules/999-test-test
@@ -1,0 +1,1 @@
+../external-modules-source/999-test-test

--- a/werf.yaml
+++ b/werf.yaml
@@ -204,6 +204,7 @@ git:
   - global-hooks/**/*.go
   - candi/cloud-providers/*/layouts
   - candi/cloud-providers/*/terraform-modules
+  - **/testdata
 - url: https://github.com/flant/shell-operator
   tag: v1.1.3
   add: /frameworks/shell

--- a/werf.yaml
+++ b/werf.yaml
@@ -204,7 +204,7 @@ git:
   - global-hooks/**/*.go
   - candi/cloud-providers/*/layouts
   - candi/cloud-providers/*/terraform-modules
-  - **/testdata
+  - '**/testdata'
 - url: https://github.com/flant/shell-operator
   tag: v1.1.3
   add: /frameworks/shell


### PR DESCRIPTION
Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Modify modules_images_tags global hook to support external modules.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This is the part of #3465.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: global
type: feature
summary: modify modules_images_tags to support external modules
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
