### PR TITLE
[cni-cilium] add labels config value

### DIFF
--- a/modules/021-cni-cilium/openapi/config-values.yaml
+++ b/modules/021-cni-cilium/openapi/config-values.yaml
@@ -7,7 +7,7 @@ properties:
   labelsRegex:
     type: array
     description: |
-      Labels regexes to reduce identity cardinality.
+      Labels regexes to reduce [identity cardinality](https://docs.cilium.io/en/stable/operations/performance/scalability/identity-relevant-labels/#limiting-identity-relevant-labels).
 
       Each label should be set in the format of YAML quoted string with special symbols escaping.
     x-doc-examples:

--- a/modules/021-cni-cilium/openapi/config-values.yaml
+++ b/modules/021-cni-cilium/openapi/config-values.yaml
@@ -4,13 +4,16 @@ properties:
     type: boolean
     default: false
     description: Enabled debug logging for Cilium components.
-  cleanState:
-    type: boolean
-    default: false
+  labelsRegex:
+    type: array
     description: |
-      Clean all persistent state.
+      Labels regexes to reduce identity cardinality.
 
-      Must be reverted ASAP once all components are started with fresh state.
+      Each label should be set in the format of YAML quoted string with special symbols escaping.
+    x-doc-examples:
+      - ["k8s:!app\\.kubernetes\\.io", "k8s:io\\.cilium\\.k8s\\.policy"]
+    items:
+      type: string
   createNodeRoutes:
     type: boolean
     description: |

--- a/modules/021-cni-cilium/openapi/doc-ru-config-values.yaml
+++ b/modules/021-cni-cilium/openapi/doc-ru-config-values.yaml
@@ -4,7 +4,7 @@ properties:
     description: Включает отладочный уровень логирования для компонентов Cilium.
   labelsRegex:
     description: |
-      Regex-ы лейблов для уменьшения количества создаваемых identity.
+      Regex-ы лейблов для уменьшения [количества создаваемых identity](https://docs.cilium.io/en/stable/operations/performance/scalability/identity-relevant-labels/#limiting-identity-relevant-labels).
 
       Каждый лейбл должен задаваться в формате YAML quoted string с экранированием спецсимволов.
   createNodeRoutes:

--- a/modules/021-cni-cilium/openapi/doc-ru-config-values.yaml
+++ b/modules/021-cni-cilium/openapi/doc-ru-config-values.yaml
@@ -2,17 +2,16 @@ type: object
 properties:
   debugLogging:
     description: Включает отладочный уровень логирования для компонентов Cilium.
-  cleanState:
+  labelsRegex:
     description: |
-      Включает очистку сохраненного статуса.
+      Regex-ы лейблов для уменьшения количества создаваемых identity.
 
-      Отключите, как только все компоненты Cilium запустятся со сброшенным статусом.
+      Каждый лейбл должен задаваться в формате YAML quoted string с экранированием спецсимволов.
   createNodeRoutes:
     description: |
       Включает создание маршрутов к Pod'ам на других узлах.
 
       Все узлы должны находиться в одной сети L2.
-
   tunnelMode:
     description: |
       Режим работы туннеля.
@@ -29,7 +28,6 @@ properties:
   bpfLBMode:
     description: |
       Режим работы балансировщика eBPF.
-
   resourcesManagement:
     description: |
       Настройки управления ресурсами cilium agent.

--- a/modules/021-cni-cilium/openapi/openapi-case-tests.yaml
+++ b/modules/021-cni-cilium/openapi/openapi-case-tests.yaml
@@ -1,12 +1,13 @@
 positive:
   configValues:
   - debugLogging: true
-    cleanState: true
+    labelsRegex:
+    - "k8s:!app\\.kubernetes\\.io"
+    - "k8s:io\\.cilium\\.k8s\\.policy"
     createNodeRoutes: true
     svcSourceRangeCheck: true
     policyAuditMode: true
   - debugLogging: false
-    cleanState: false
     createNodeRoutes: false
     svcSourceRangeCheck: false
     policyAuditMode: false

--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -28,7 +28,7 @@ data:
 
   {{- if .Values.cniCilium.labelsRegex }}
   labels: {{.Values.cniCilium.labelsRegex | join " " | quote }}
-  {{-end }}
+  {{- end }}
 
   {{- if eq .Values.cniCilium.internal.mode "VXLAN" }}
   tunnel: "vxlan"

--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -22,10 +22,13 @@ data:
   enable-ipv4: "true"
   enable-ipv6: "false"
 
-  clean-cilium-state: {{ .Values.cniCilium.cleanState | quote }}
   enable-bpf-tproxy: "true"
 
   bpf-lb-bypass-fib-lookup: "false" # TODO: https://docs.cilium.io/en/v1.11/gettingstarted/kubeproxy-free/#nodeport-with-fhrp-vpc
+
+  {{- if .Values.cniCilium.labelsRegex }}
+  labels: {{.Values.cniCilium.labelsRegex | join " " | quote }}
+  {{-end }}
 
   {{- if eq .Values.cniCilium.internal.mode "VXLAN" }}
   tunnel: "vxlan"


### PR DESCRIPTION
Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add labels config value.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
https://docs.cilium.io/en/stable/operations/performance/scalability/identity-relevant-labels/#limiting-identity-relevant-labels
This PR adds config parameter to limit the set of identity-relevant labels to avoid frequent creation of new security identities in large environments.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
-->

```changes
section: cni-cilium
type: feature
summary: Added Deckouse config value for cilium entity labels
impact: Cilium pods should be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
