### PR TITLE
[cloud-provier-yandex] Lock route table operations

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -217,7 +217,7 @@ k8s:
     bashible: *bashible_k8s_ge_1_21
     ccm:
       openstack: v1.25.3
-      yandex: v0.25.1
+      yandex: v0.25.2
       aws: v1.25.1
       vsphere: v1.25.0
       azure: v1.25.4

--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -217,7 +217,7 @@ k8s:
     bashible: *bashible_k8s_ge_1_21
     ccm:
       openstack: v1.25.3
-      yandex: v0.25.0
+      yandex: v0.25.1
       aws: v1.25.1
       vsphere: v1.25.0
       azure: v1.25.4

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.21/001-lock-route-table-operations.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.21/001-lock-route-table-operations.patch
@@ -32,7 +32,7 @@ diff --git a/pkg/cloudprovider/yandex/routes.go b/pkg/cloudprovider/yandex/route
 +	klog.Info("ListRoutes called")
 +
 +	if routeAPILock.TryLock() {
-+		routeAPILock.Unlock()
++		defer routeAPILock.Unlock()
 +	} else {
 +		return nil, errors.New("VPC route API locked")
 +	}

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.21/001-lock-route-table-operations.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.21/001-lock-route-table-operations.patch
@@ -1,0 +1,104 @@
+Subject: [PATCH] Added route table API locking
+---
+Index: pkg/cloudprovider/yandex/routes.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/cloudprovider/yandex/routes.go b/pkg/cloudprovider/yandex/routes.go
+--- a/pkg/cloudprovider/yandex/routes.go	(revision 793ac2bd44d4c2eb02e6f62757db215518ef4ff9)
++++ b/pkg/cloudprovider/yandex/routes.go	(date 1674043080967)
+@@ -2,9 +2,12 @@
+
+ import (
+ 	"context"
++	"errors"
+ 	"fmt"
++	"sync"
+
+ 	"github.com/prometheus/common/log"
++	"k8s.io/klog/v2"
+
+ 	v1 "k8s.io/api/core/v1"
+
+@@ -24,7 +27,18 @@
+ 	cpiNodeRoleLabel     = cpiRouteLabelsPrefix + "node-role" // we store Node's name here. The reason for this is lost in time (like tears in rain).
+ )
+
++// these may get called in parallel, but since we have to modify the whole Route Table, we'll synchronize operations
++var routeAPILock sync.Mutex
++
+ func (yc *Cloud) ListRoutes(ctx context.Context, _ string) ([]*cloudprovider.Route, error) {
++	klog.Info("ListRoutes called")
++
++	if routeAPILock.TryLock() {
++		routeAPILock.Unlock()
++	} else {
++		return nil, errors.New("VPC route API locked")
++	}
++
+ 	req := &vpc.GetRouteTableRequest{
+ 		RouteTableId: yc.config.RouteTableID,
+ 	}
+@@ -45,35 +59,6 @@
+ 			continue
+ 		}
+
+-		// let's verify NextHop relevance
+-		currentNextHop := staticRoute.NextHop.(*vpc.StaticRoute_NextHopAddress).NextHopAddress
+-		internalIP, err := yc.getInternalIpByNodeName(nodeName)
+-		if err != nil {
+-			log.Infof("Failed to verify NextHop relevance: %s", err)
+-		} else if currentNextHop != internalIP {
+-			log.Warnf("Changing %q's NextHop from %s to %s", nodeName, currentNextHop, internalIP)
+-
+-			filteredStaticRoutes := filterStaticRoutes(routeTable.StaticRoutes, routeFilterTerm{
+-				termType:        routeFilterAddOrUpdate,
+-				nodeName:        nodeName,
+-				destinationCIDR: staticRoute.Destination.(*vpc.StaticRoute_DestinationPrefix).DestinationPrefix,
+-				nextHop:         internalIP,
+-			})
+-
+-			req := &vpc.UpdateRouteTableRequest{
+-				RouteTableId: yc.config.RouteTableID,
+-				UpdateMask: &field_mask.FieldMask{
+-					Paths: []string{"static_routes"},
+-				},
+-				StaticRoutes: filteredStaticRoutes,
+-			}
+-
+-			_, _, err := yc.yandexService.OperationWaiter(ctx, func() (*operation.Operation, error) { return yc.yandexService.VPCSvc.RouteTableSvc.Update(ctx, req) })
+-			if err != nil {
+-				return nil, err
+-			}
+-		}
+-
+ 		cpiRoutes = append(cpiRoutes, &cloudprovider.Route{
+ 			Name:            nodeName,
+ 			TargetNode:      types.NodeName(nodeName),
+@@ -87,6 +72,12 @@
+ func (yc *Cloud) CreateRoute(ctx context.Context, _ string, _ string, route *cloudprovider.Route) error {
+ 	log.Infof("CreateRoute called with %+v", *route)
+
++	if routeAPILock.TryLock() {
++		defer routeAPILock.Unlock()
++	} else {
++		return errors.New("VPC route API locked")
++	}
++
+ 	rt, err := yc.yandexService.VPCSvc.RouteTableSvc.Get(ctx, &vpc.GetRouteTableRequest{RouteTableId: yc.config.RouteTableID})
+ 	if err != nil {
+ 		return err
+@@ -120,6 +111,12 @@
+ func (yc *Cloud) DeleteRoute(ctx context.Context, _ string, route *cloudprovider.Route) error {
+ 	log.Infof("DeleteRoute called with %+v", *route)
+
++	if routeAPILock.TryLock() {
++		defer routeAPILock.Unlock()
++	} else {
++		return errors.New("VPC route API locked")
++	}
++
+ 	rt, err := yc.yandexService.VPCSvc.RouteTableSvc.Get(ctx, &vpc.GetRouteTableRequest{RouteTableId: yc.config.RouteTableID})
+ 	if err != nil {
+ 		return err

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.21/README.md
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.21/README.md
@@ -1,0 +1,7 @@
+# Patches
+
+## 001-lock-route-table-operations.patch
+
+Lock route tables operations, since we perform whole route table update on each call from cloud-provider controller.
+
+Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/48)

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.22/001-lock-route-table-operations.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.22/001-lock-route-table-operations.patch
@@ -32,7 +32,7 @@ diff --git a/pkg/cloudprovider/yandex/routes.go b/pkg/cloudprovider/yandex/route
 +	klog.Info("ListRoutes called")
 +
 +	if routeAPILock.TryLock() {
-+		routeAPILock.Unlock()
++		defer routeAPILock.Unlock()
 +	} else {
 +		return nil, errors.New("VPC route API locked")
 +	}

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.22/001-lock-route-table-operations.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.22/001-lock-route-table-operations.patch
@@ -1,0 +1,104 @@
+Subject: [PATCH] Added route table API locking
+---
+Index: pkg/cloudprovider/yandex/routes.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/cloudprovider/yandex/routes.go b/pkg/cloudprovider/yandex/routes.go
+--- a/pkg/cloudprovider/yandex/routes.go	(revision 0d17c5c83b817aa2671116003e907bfe56325a9f)
++++ b/pkg/cloudprovider/yandex/routes.go	(date 1674043015583)
+@@ -2,9 +2,12 @@
+
+ import (
+ 	"context"
++	"errors"
+ 	"fmt"
++	"sync"
+
+ 	"github.com/prometheus/common/log"
++	"k8s.io/klog/v2"
+
+ 	v1 "k8s.io/api/core/v1"
+
+@@ -24,7 +27,18 @@
+ 	cpiNodeRoleLabel     = cpiRouteLabelsPrefix + "node-role" // we store Node's name here. The reason for this is lost in time (like tears in rain).
+ )
+
++// these may get called in parallel, but since we have to modify the whole Route Table, we'll synchronize operations
++var routeAPILock sync.Mutex
++
+ func (yc *Cloud) ListRoutes(ctx context.Context, _ string) ([]*cloudprovider.Route, error) {
++	klog.Info("ListRoutes called")
++
++	if routeAPILock.TryLock() {
++		routeAPILock.Unlock()
++	} else {
++		return nil, errors.New("VPC route API locked")
++	}
++
+ 	req := &vpc.GetRouteTableRequest{
+ 		RouteTableId: yc.config.RouteTableID,
+ 	}
+@@ -45,35 +59,6 @@
+ 			continue
+ 		}
+
+-		// let's verify NextHop relevance
+-		currentNextHop := staticRoute.NextHop.(*vpc.StaticRoute_NextHopAddress).NextHopAddress
+-		internalIP, err := yc.getInternalIpByNodeName(nodeName)
+-		if err != nil {
+-			log.Infof("Failed to verify NextHop relevance: %s", err)
+-		} else if currentNextHop != internalIP {
+-			log.Warnf("Changing %q's NextHop from %s to %s", nodeName, currentNextHop, internalIP)
+-
+-			filteredStaticRoutes := filterStaticRoutes(routeTable.StaticRoutes, routeFilterTerm{
+-				termType:        routeFilterAddOrUpdate,
+-				nodeName:        nodeName,
+-				destinationCIDR: staticRoute.Destination.(*vpc.StaticRoute_DestinationPrefix).DestinationPrefix,
+-				nextHop:         internalIP,
+-			})
+-
+-			req := &vpc.UpdateRouteTableRequest{
+-				RouteTableId: yc.config.RouteTableID,
+-				UpdateMask: &field_mask.FieldMask{
+-					Paths: []string{"static_routes"},
+-				},
+-				StaticRoutes: filteredStaticRoutes,
+-			}
+-
+-			_, _, err := yc.yandexService.OperationWaiter(ctx, func() (*operation.Operation, error) { return yc.yandexService.VPCSvc.RouteTableSvc.Update(ctx, req) })
+-			if err != nil {
+-				return nil, err
+-			}
+-		}
+-
+ 		cpiRoutes = append(cpiRoutes, &cloudprovider.Route{
+ 			Name:            nodeName,
+ 			TargetNode:      types.NodeName(nodeName),
+@@ -87,6 +72,12 @@
+ func (yc *Cloud) CreateRoute(ctx context.Context, _ string, _ string, route *cloudprovider.Route) error {
+ 	log.Infof("CreateRoute called with %+v", *route)
+
++	if routeAPILock.TryLock() {
++		defer routeAPILock.Unlock()
++	} else {
++		return errors.New("VPC route API locked")
++	}
++
+ 	rt, err := yc.yandexService.VPCSvc.RouteTableSvc.Get(ctx, &vpc.GetRouteTableRequest{RouteTableId: yc.config.RouteTableID})
+ 	if err != nil {
+ 		return err
+@@ -120,6 +111,12 @@
+ func (yc *Cloud) DeleteRoute(ctx context.Context, _ string, route *cloudprovider.Route) error {
+ 	log.Infof("DeleteRoute called with %+v", *route)
+
++	if routeAPILock.TryLock() {
++		defer routeAPILock.Unlock()
++	} else {
++		return errors.New("VPC route API locked")
++	}
++
+ 	rt, err := yc.yandexService.VPCSvc.RouteTableSvc.Get(ctx, &vpc.GetRouteTableRequest{RouteTableId: yc.config.RouteTableID})
+ 	if err != nil {
+ 		return err

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.22/README.md
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.22/README.md
@@ -1,0 +1,7 @@
+# Patches
+
+## 001-lock-route-table-operations.patch
+
+Lock route tables operations, since we perform whole route table update on each call from cloud-provider controller.
+
+Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/48)

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.23/001-lock-route-table-operations.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.23/001-lock-route-table-operations.patch
@@ -1,0 +1,101 @@
+Subject: [PATCH] Added route table API locking
+---
+Index: pkg/cloudprovider/yandex/routes.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/cloudprovider/yandex/routes.go b/pkg/cloudprovider/yandex/routes.go
+--- a/pkg/cloudprovider/yandex/routes.go	(revision 4355e41b39cb060df9aed3c13f50d2239caa1192)
++++ b/pkg/cloudprovider/yandex/routes.go	(date 1674041456612)
+@@ -3,7 +3,9 @@
+ import (
+ 	"context"
+ 	"fmt"
++	"sync"
+
++	"github.com/pkg/errors"
+ 	"github.com/yandex-cloud/go-genproto/yandex/cloud/operation"
+ 	"github.com/yandex-cloud/go-genproto/yandex/cloud/vpc/v1"
+ 	"google.golang.org/genproto/protobuf/field_mask"
+@@ -18,7 +20,18 @@
+ 	cpiNodeRoleLabel     = cpiRouteLabelsPrefix + "node-role" // we store Node's name here. The reason for this is lost in time (like tears in rain).
+ )
+
++// these may get called in parallel, but since we have to modify the whole Route Table, we'll synchronize operations
++var routeAPILock sync.Mutex
++
+ func (yc *Cloud) ListRoutes(ctx context.Context, _ string) ([]*cloudprovider.Route, error) {
++	klog.Info("ListRoutes called")
++
++	if routeAPILock.TryLock() {
++		routeAPILock.Unlock()
++	} else {
++		return nil, errors.New("VPC route API locked")
++	}
++
+ 	req := &vpc.GetRouteTableRequest{
+ 		RouteTableId: yc.config.RouteTableID,
+ 	}
+@@ -39,35 +52,6 @@
+ 			continue
+ 		}
+
+-		// let's verify NextHop relevance
+-		currentNextHop := staticRoute.NextHop.(*vpc.StaticRoute_NextHopAddress).NextHopAddress
+-		internalIP, err := yc.getInternalIpByNodeName(nodeName)
+-		if err != nil {
+-			klog.Infof("Failed to verify NextHop relevance: %s", err)
+-		} else if currentNextHop != internalIP {
+-			klog.Warningf("Changing %q's NextHop from %s to %s", nodeName, currentNextHop, internalIP)
+-
+-			filteredStaticRoutes := filterStaticRoutes(routeTable.StaticRoutes, routeFilterTerm{
+-				termType:        routeFilterAddOrUpdate,
+-				nodeName:        nodeName,
+-				destinationCIDR: staticRoute.Destination.(*vpc.StaticRoute_DestinationPrefix).DestinationPrefix,
+-				nextHop:         internalIP,
+-			})
+-
+-			req := &vpc.UpdateRouteTableRequest{
+-				RouteTableId: yc.config.RouteTableID,
+-				UpdateMask: &field_mask.FieldMask{
+-					Paths: []string{"static_routes"},
+-				},
+-				StaticRoutes: filteredStaticRoutes,
+-			}
+-
+-			_, _, err := yc.yandexService.OperationWaiter(ctx, func() (*operation.Operation, error) { return yc.yandexService.VPCSvc.RouteTableSvc.Update(ctx, req) })
+-			if err != nil {
+-				return nil, err
+-			}
+-		}
+-
+ 		cpiRoutes = append(cpiRoutes, &cloudprovider.Route{
+ 			Name:            nodeName,
+ 			TargetNode:      types.NodeName(nodeName),
+@@ -81,6 +65,12 @@
+ func (yc *Cloud) CreateRoute(ctx context.Context, _ string, _ string, route *cloudprovider.Route) error {
+ 	klog.Infof("CreateRoute called with %+v", *route)
+
++	if routeAPILock.TryLock() {
++		defer routeAPILock.Unlock()
++	} else {
++		return errors.New("VPC route API locked")
++	}
++
+ 	rt, err := yc.yandexService.VPCSvc.RouteTableSvc.Get(ctx, &vpc.GetRouteTableRequest{RouteTableId: yc.config.RouteTableID})
+ 	if err != nil {
+ 		return err
+@@ -114,6 +104,12 @@
+ func (yc *Cloud) DeleteRoute(ctx context.Context, _ string, route *cloudprovider.Route) error {
+ 	klog.Infof("DeleteRoute called with %+v", *route)
+
++	if routeAPILock.TryLock() {
++		defer routeAPILock.Unlock()
++	} else {
++		return errors.New("VPC route API locked")
++	}
++
+ 	rt, err := yc.yandexService.VPCSvc.RouteTableSvc.Get(ctx, &vpc.GetRouteTableRequest{RouteTableId: yc.config.RouteTableID})
+ 	if err != nil {
+ 		return err

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.23/001-lock-route-table-operations.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.23/001-lock-route-table-operations.patch
@@ -29,7 +29,7 @@ diff --git a/pkg/cloudprovider/yandex/routes.go b/pkg/cloudprovider/yandex/route
 +	klog.Info("ListRoutes called")
 +
 +	if routeAPILock.TryLock() {
-+		routeAPILock.Unlock()
++		defer routeAPILock.Unlock()
 +	} else {
 +		return nil, errors.New("VPC route API locked")
 +	}

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.23/README.md
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.23/README.md
@@ -1,0 +1,7 @@
+# Patches
+
+## 001-lock-route-table-operations.patch
+
+Lock route tables operations, since we perform whole route table update on each call from cloud-provider controller.
+
+Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/48)

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.24/001-lock-route-table-operations.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.24/001-lock-route-table-operations.patch
@@ -29,7 +29,7 @@ diff --git a/pkg/cloudprovider/yandex/routes.go b/pkg/cloudprovider/yandex/route
 +	klog.Info("ListRoutes called")
 +
 +	if routeAPILock.TryLock() {
-+		routeAPILock.Unlock()
++		defer routeAPILock.Unlock()
 +	} else {
 +		return nil, errors.New("VPC route API locked")
 +	}

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.24/001-lock-route-table-operations.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.24/001-lock-route-table-operations.patch
@@ -1,0 +1,101 @@
+Subject: [PATCH] Added route table API locking
+---
+Index: pkg/cloudprovider/yandex/routes.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/cloudprovider/yandex/routes.go b/pkg/cloudprovider/yandex/routes.go
+--- a/pkg/cloudprovider/yandex/routes.go	(revision fd5725566d06883e6102499a1280982401be4432)
++++ b/pkg/cloudprovider/yandex/routes.go	(date 1674041399136)
+@@ -3,7 +3,9 @@
+ import (
+ 	"context"
+ 	"fmt"
++	"sync"
+
++	"github.com/pkg/errors"
+ 	"github.com/yandex-cloud/go-genproto/yandex/cloud/operation"
+ 	"github.com/yandex-cloud/go-genproto/yandex/cloud/vpc/v1"
+ 	"google.golang.org/genproto/protobuf/field_mask"
+@@ -18,7 +20,18 @@
+ 	cpiNodeRoleLabel     = cpiRouteLabelsPrefix + "node-role" // we store Node's name here. The reason for this is lost in time (like tears in rain).
+ )
+
++// these may get called in parallel, but since we have to modify the whole Route Table, we'll synchronize operations
++var routeAPILock sync.Mutex
++
+ func (yc *Cloud) ListRoutes(ctx context.Context, _ string) ([]*cloudprovider.Route, error) {
++	klog.Info("ListRoutes called")
++
++	if routeAPILock.TryLock() {
++		routeAPILock.Unlock()
++	} else {
++		return nil, errors.New("VPC route API locked")
++	}
++
+ 	req := &vpc.GetRouteTableRequest{
+ 		RouteTableId: yc.config.RouteTableID,
+ 	}
+@@ -39,35 +52,6 @@
+ 			continue
+ 		}
+
+-		// let's verify NextHop relevance
+-		currentNextHop := staticRoute.NextHop.(*vpc.StaticRoute_NextHopAddress).NextHopAddress
+-		internalIP, err := yc.getInternalIpByNodeName(nodeName)
+-		if err != nil {
+-			klog.Infof("Failed to verify NextHop relevance: %s", err)
+-		} else if currentNextHop != internalIP {
+-			klog.Warningf("Changing %q's NextHop from %s to %s", nodeName, currentNextHop, internalIP)
+-
+-			filteredStaticRoutes := filterStaticRoutes(routeTable.StaticRoutes, routeFilterTerm{
+-				termType:        routeFilterAddOrUpdate,
+-				nodeName:        nodeName,
+-				destinationCIDR: staticRoute.Destination.(*vpc.StaticRoute_DestinationPrefix).DestinationPrefix,
+-				nextHop:         internalIP,
+-			})
+-
+-			req := &vpc.UpdateRouteTableRequest{
+-				RouteTableId: yc.config.RouteTableID,
+-				UpdateMask: &field_mask.FieldMask{
+-					Paths: []string{"static_routes"},
+-				},
+-				StaticRoutes: filteredStaticRoutes,
+-			}
+-
+-			_, _, err := yc.yandexService.OperationWaiter(ctx, func() (*operation.Operation, error) { return yc.yandexService.VPCSvc.RouteTableSvc.Update(ctx, req) })
+-			if err != nil {
+-				return nil, err
+-			}
+-		}
+-
+ 		cpiRoutes = append(cpiRoutes, &cloudprovider.Route{
+ 			Name:            nodeName,
+ 			TargetNode:      types.NodeName(nodeName),
+@@ -81,6 +65,12 @@
+ func (yc *Cloud) CreateRoute(ctx context.Context, _ string, _ string, route *cloudprovider.Route) error {
+ 	klog.Infof("CreateRoute called with %+v", *route)
+
++	if routeAPILock.TryLock() {
++		defer routeAPILock.Unlock()
++	} else {
++		return errors.New("VPC route API locked")
++	}
++
+ 	rt, err := yc.yandexService.VPCSvc.RouteTableSvc.Get(ctx, &vpc.GetRouteTableRequest{RouteTableId: yc.config.RouteTableID})
+ 	if err != nil {
+ 		return err
+@@ -114,6 +104,12 @@
+ func (yc *Cloud) DeleteRoute(ctx context.Context, _ string, route *cloudprovider.Route) error {
+ 	klog.Infof("DeleteRoute called with %+v", *route)
+
++	if routeAPILock.TryLock() {
++		defer routeAPILock.Unlock()
++	} else {
++		return errors.New("VPC route API locked")
++	}
++
+ 	rt, err := yc.yandexService.VPCSvc.RouteTableSvc.Get(ctx, &vpc.GetRouteTableRequest{RouteTableId: yc.config.RouteTableID})
+ 	if err != nil {
+ 		return err

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.24/README.md
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/1.24/README.md
@@ -1,0 +1,7 @@
+# Patches
+
+## 001-lock-route-table-operations.patch
+
+Lock route tables operations, since we perform whole route table update on each call from cloud-provider controller.
+
+Upstream [PR](https://github.com/deckhouse/yandex-cloud-controller-manager/pull/48)

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
@@ -27,6 +27,12 @@ from: {{ $.Images.BASE_GOLANG_17_ALPINE }}
     {{- else if semverCompare ">=1.21" $version }}
 from: {{ $.Images.BASE_GOLANG_16_ALPINE }}
     {{- end }}
+git:
+- add: /modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+  to: /patches
+  stageDependencies:
+    install:
+    - '**/*'
 mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg
@@ -38,7 +44,6 @@ shell:
     - wget https://github.com/deckhouse/yandex-cloud-controller-manager/archive/{{ $value.ccm.yandex }}.tar.gz -O - | tar -xz --strip-components=1 -C /src/
     - cd /src
     - test -d /patches/{{ $version }} && for patchfile in /patches/{{ $version }}/*.patch ; do patch -p1 < ${patchfile}; done
-    - cat pkg/cloudprovider/yandex/routes.go
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o yandex-cloud-controller-manager cmd/yandex-cloud-controller-manager/main.go
   {{- end }}
 {{- end }}

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
@@ -20,12 +20,8 @@ docker:
 artifact: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $version | replace "." "-" }}
     {{- if semverCompare ">=1.25" $version }}
 from: {{ $.Images.BASE_GOLANG_19_ALPINE }}
-    {{- else if semverCompare ">=1.24" $version }}
-from: {{ $.Images.BASE_GOLANG_18_ALPINE }}
-    {{- else if semverCompare ">=1.23" $version }}
-from: {{ $.Images.BASE_GOLANG_17_ALPINE }}
     {{- else if semverCompare ">=1.21" $version }}
-from: {{ $.Images.BASE_GOLANG_16_ALPINE }}
+from: {{ $.Images.BASE_GOLANG_18_ALPINE }}
     {{- end }}
 git:
 - add: /modules/030-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
@@ -37,6 +37,7 @@ shell:
     - mkdir /src
     - wget https://github.com/deckhouse/yandex-cloud-controller-manager/archive/{{ $value.ccm.yandex }}.tar.gz -O - | tar -xz --strip-components=1 -C /src/
     - cd /src
+    - test -d /patches/{{ $version }} && for patchfile in /patches/{{ $version }}/*.patch ; do patch -p1 < ${patchfile}; done
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o yandex-cloud-controller-manager cmd/yandex-cloud-controller-manager/main.go
   {{- end }}
 {{- end }}

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
@@ -38,6 +38,7 @@ shell:
     - wget https://github.com/deckhouse/yandex-cloud-controller-manager/archive/{{ $value.ccm.yandex }}.tar.gz -O - | tar -xz --strip-components=1 -C /src/
     - cd /src
     - test -d /patches/{{ $version }} && for patchfile in /patches/{{ $version }}/*.patch ; do patch -p1 < ${patchfile}; done
+    - cat pkg/cloudprovider/yandex/routes.go
     - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o yandex-cloud-controller-manager cmd/yandex-cloud-controller-manager/main.go
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

1. Introduced locking to Route Table operations, so that only one operation on a route table can run simultaneously.
2. Disabled useless Route Table updates on ListRoutes().

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Yandex.Cloud introduced harsher API call-limits earlier this year.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Route Table operations are no longer locked on each other. Also, they do not hit the API call limit.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cloud-provider-yandex
type: fix
summary: |
  Changes to CCM:
  1. Introduced locking to Route Table operations, so that only one operation on a route table can run simultaneously.
  2. Disabled useless Route Table updates on ListRoutes().
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
