### PR TITLE
[ci] Use jekyll 3.9.1

### DIFF
--- a/docs/documentation/Gemfile.lock
+++ b/docs/documentation/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
     http_parser.rb (0.8.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.9.2)
+    jekyll (3.9.1)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)

--- a/docs/site/Gemfile.lock
+++ b/docs/site/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
     http_parser.rb (0.8.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.9.2)
+    jekyll (3.9.1)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)


### PR DESCRIPTION
## Description
Jekyll 3.9.2 builds 5 times slower than 3.9.1.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Use jekyll 3.9.1
impact_level: low
```
