### PR TITLE
[log-shipper] Add type field for telemetry metrics

### DIFF
--- a/modules/460-log-shipper/hooks/internal/composer/composer.go
+++ b/modules/460-log-shipper/hooks/internal/composer/composer.go
@@ -45,29 +45,30 @@ func FromInput(input *go_hook.HookInput) *Composer {
 	for _, d := range destSnap {
 		dest := d.(v1alpha1.ClusterLogDestination)
 		res.Dest = append(res.Dest, dest)
-		customResourceMetric(input, "ClusterLogDestination", dest.Name, dest.Namespace)
+		customResourceMetric(input, "ClusterLogDestination", dest.Name, dest.Namespace, dest.Spec.Type)
 	}
 
 	for _, s := range sourceSnap {
 		src := s.(v1alpha1.ClusterLoggingConfig)
 		res.Source = append(res.Source, src)
-		customResourceMetric(input, "ClusterLoggingConfig", src.Name, src.Namespace)
+		customResourceMetric(input, "ClusterLoggingConfig", src.Name, src.Namespace, src.Spec.Type)
 	}
 
 	for _, ns := range namespacedSourceSnap {
 		src := ns.(v1alpha1.PodLoggingConfig)
 		res.Source = append(res.Source, v1alpha1.NamespacedToCluster(src))
-		customResourceMetric(input, "PodLoggingConfig", src.Name, src.Namespace)
+		customResourceMetric(input, "PodLoggingConfig", src.Name, src.Namespace, v1alpha1.SourceKubernetesPods)
 	}
 
 	return res
 }
 
-func customResourceMetric(input *go_hook.HookInput, kind, name, namespace string) {
+func customResourceMetric(input *go_hook.HookInput, kind, name, namespace, _type string) {
 	input.MetricsCollector.Set(telemetry.WrapName("log_shipper_custom_resource"), 1, map[string]string{
 		"kind":         kind,
 		"cr_name":      name,
 		"cr_namespace": namespace,
+		"cr_type":      _type,
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Why do we need it, and what problem does it solve?
The type field can hint at how many sources and destinations of each type are used and find the most popular combinations.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: log-shipper
type: feature
summary: Add type field for telemetry metrics
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
