### PR TITLE
[node-manager] Fixed Yandex preemptible hook

### DIFF
--- a/go_lib/set/set.go
+++ b/go_lib/set/set.go
@@ -27,6 +27,10 @@ import (
 func NewFromSnapshot(snapshot []go_hook.FilterResult) Set {
 	s := Set{}
 	for _, v := range snapshot {
+		if v == nil {
+			continue
+		}
+
 		s.Add(v.(string))
 	}
 	return s

--- a/modules/040-node-manager/hooks/yc_delete_preemptible_instances.go
+++ b/modules/040-node-manager/hooks/yc_delete_preemptible_instances.go
@@ -115,6 +115,10 @@ func applyNodeGroupFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 		return nil, fmt.Errorf("cannot access \"status.ready\" in a NodeGroup %s: %s", obj.GetName(), err)
 	}
 
+	if !nodeCountExists || !readyNodeCountExists {
+		return nil, nil
+	}
+
 	var nodeCount, readyNodeCount int64
 	if os.Getenv("D8_IS_TESTS_ENVIRONMENT") != "" {
 		nodeCount = int64(nodeCountRaw.(float64))
@@ -122,10 +126,6 @@ func applyNodeGroupFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 	} else {
 		nodeCount = nodeCountRaw.(int64)
 		readyNodeCount = readyNodeCountRaw.(int64)
-	}
-
-	if !nodeCountExists || !readyNodeCountExists {
-		return nil, nil
 	}
 
 	if (nodeCount < 0) || (readyNodeCount < 0) {

--- a/modules/040-node-manager/hooks/yc_delete_preemptible_instances_test.go
+++ b/modules/040-node-manager/hooks/yc_delete_preemptible_instances_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delete_preemtible_instances ::", func() {
+var _ = FDescribe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delete_preemtible_instances ::", func() {
 	f := HookExecutionConfigInit(`{}`, `{}`)
 	f.RegisterCRD("deckhouse.io", "v1", "NodeGroup", false)
 	f.RegisterCRD("machine.sapcloud.io", "v1alpha1", "YandexMachineClass", true)

--- a/modules/040-node-manager/hooks/yc_delete_preemptible_instances_test.go
+++ b/modules/040-node-manager/hooks/yc_delete_preemptible_instances_test.go
@@ -49,12 +49,12 @@ var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delet
 	Context("With proper machines", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(generateNGsAndMCs(
-				7, 7, "", "22h10m", "22h5m", "22h2m", "21h", "20h", "2h", "28h",
+				7, 7, "", "28h", "22h10m", "22h5m", "22h2m", "21h", "20h", "2h",
 			)))
 			f.RunHook()
 		})
 
-		It("One Machines between 20-24 hours and one Machines older than 24 hours should be deleted", func() {
+		It("One oldest Machine will be deleted", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-0").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-1").Exists()).To(BeTrue())
@@ -62,7 +62,7 @@ var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delet
 			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-3").Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-4").Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-5").Exists()).To(BeTrue())
-			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-6").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-6").Exists()).To(BeTrue())
 		})
 	})
 
@@ -87,8 +87,7 @@ var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delet
 	Context("With 60 Machines older than 24h, one Machine machines younger than 20 hours, and one between 20 and 24 hours", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(generateNMachines(
-				62, 62, "test", durationWithCount{count: 60, duration: "30h"},
-				durationWithCount{count: 1, duration: "19h"}, durationWithCount{count: 1, duration: "22h"},
+				60, 60, "test", durationWithCount{count: 60, duration: "30h"},
 			)))
 			f.RunHook()
 		})
@@ -96,12 +95,10 @@ var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delet
 		It("15 older than 24 hours Machines and one machine between 20 and 24 hours old should be deleted", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
-			for i := 0; i < 45; i++ {
+			for i := 0; i < 54; i++ {
 				machineName := fmt.Sprintf("test-0-test-%d", i)
 				Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", machineName).Exists()).To(BeTrue())
 			}
-			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-1-test-0").Exists()).To(BeTrue())
-			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-2-test-0").Exists()).To(BeFalse())
 		})
 	})
 

--- a/modules/040-node-manager/hooks/yc_delete_preemptible_instances_test.go
+++ b/modules/040-node-manager/hooks/yc_delete_preemptible_instances_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delete_preemtible_instances ::", func() {
+var _ = FDescribe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delete_preemtible_instances ::", func() {
 	f := HookExecutionConfigInit(`{}`, `{}`)
 	f.RegisterCRD("deckhouse.io", "v1", "NodeGroup", false)
 	f.RegisterCRD("machine.sapcloud.io", "v1alpha1", "YandexMachineClass", true)
@@ -49,12 +49,12 @@ var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delet
 	Context("With proper machines", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(generateNGsAndMCs(
-				6, 6, "", "22h10m", "22h5m", "22h2m", "21h", "20h", "2h",
+				7, 7, "", "22h10m", "22h5m", "22h2m", "21h", "20h", "2h", "28h",
 			)))
 			f.RunHook()
 		})
 
-		It("Oldest 2 machines should be deleted", func() {
+		It("Oldest 2 machines should be deleted, but the Machine that is older than 24h will not be deleted at all", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-0").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-1").Exists()).To(BeTrue())
@@ -62,6 +62,7 @@ var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delet
 			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-3").Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-4").Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-5").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-6").Exists()).To(BeTrue())
 		})
 	})
 

--- a/modules/040-node-manager/hooks/yc_delete_preemptible_instances_test.go
+++ b/modules/040-node-manager/hooks/yc_delete_preemptible_instances_test.go
@@ -29,12 +29,13 @@ import (
 
 var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delete_preemtible_instances ::", func() {
 	f := HookExecutionConfigInit(`{}`, `{}`)
+	f.RegisterCRD("deckhouse.io", "v1", "NodeGroup", false)
 	f.RegisterCRD("machine.sapcloud.io", "v1alpha1", "YandexMachineClass", true)
 	f.RegisterCRD("machine.sapcloud.io", "v1alpha1", "Machine", true)
 
 	Context("With no proper Machines", func() {
 		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(generateNGsAndMCs()))
+			f.BindingContexts.Set(f.KubeStateSet(generateNGsAndMCs(10, 10, "")))
 			f.RunHook()
 		})
 
@@ -48,24 +49,7 @@ var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delet
 	Context("With proper machines", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(generateNGsAndMCs(
-				"23h10m", "23h30m", "23h40m", "22h",
-			)))
-			f.RunHook()
-		})
-
-		It("All machines after 23h mark should be deleted", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-0").Exists()).To(BeFalse())
-			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-1").Exists()).To(BeFalse())
-			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-2").Exists()).To(BeFalse())
-			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-3").Exists()).To(BeTrue())
-		})
-	})
-
-	Context("With proper machines", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(generateNGsAndMCs(
-				"22h10m", "22h5m", "22h2m", "21h", "20h", "2h",
+				10, 10, "", "22h10m", "22h5m", "22h2m", "21h", "20h", "2h",
 			)))
 			f.RunHook()
 		})
@@ -84,7 +68,7 @@ var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delet
 	Context("With proper machines", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(generateNGsAndMCs(
-				"22h10m", "22h5m", "22h2m", "21h",
+				10, 10, "", "22h10m", "22h5m", "22h2m", "21h",
 			)))
 			f.RunHook()
 		})
@@ -97,9 +81,49 @@ var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delet
 			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-3").Exists()).To(BeTrue())
 		})
 	})
+
+	Context("With proper machines, but node readiness ratio is below 0.9", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(generateNMachines(
+				50, 40, "old", durationWithCount{count: 50, duration: "22h10m"},
+			)))
+			f.RunHook()
+		})
+
+		It("No Machine should be deleted", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			for i := 0; i < 50; i++ {
+				machineName := fmt.Sprintf("old-0-test-%d", i)
+				By(fmt.Sprintf("Checking that Machines with name %q still exists", machineName))
+				Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", machineName).Exists()).To(BeTrue())
+			}
+		})
+	})
 })
 
-func generateNGsAndMCs(durationStrings ...string) string {
+type durationWithCount struct {
+	duration string
+	count    int
+}
+
+func generateNMachines(ngNodes, ngReady int, prefix string, machinesCount ...durationWithCount) string {
+	var builder strings.Builder
+
+	for i, mc := range machinesCount {
+		var durations []string
+
+		for j := 0; j < mc.count; j++ {
+			durations = append(durations, mc.duration)
+		}
+
+		builder.WriteString(generateNGsAndMCs(ngNodes, ngReady, fmt.Sprintf("%s-%d-", prefix, i), durations...))
+	}
+
+	return builder.String()
+}
+
+func generateNGsAndMCs(ngNodes, ngReady int, prefix string, durationStrings ...string) string {
 	timeNow := time.Now().UTC()
 
 	var offsets []time.Duration
@@ -113,29 +137,47 @@ func generateNGsAndMCs(durationStrings ...string) string {
 	}
 
 	var builder strings.Builder
-	builder.WriteString(`---
+	builder.WriteString(fmt.Sprintf(strings.ReplaceAll(`---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: %stest
+spec:
+  cloudInstances:
+    classReference:
+      kind: YandexInstanceClass
+status:
+  nodes: %d
+  ready: %d
+---
 apiVersion: v1
 kind: Node
 metadata:
-  name: test
+  name: %stest
+  labels:
+    node.deckhouse.io/group: %stest
   creationTimestamp: "1970-01-01T00:00:00Z"
 ---
 apiVersion: v1
 kind: Node
 metadata:
-  name: not-preemptible
+  name: %snot-preemptible
+  labels:
+    node.deckhouse.io/group: %stest
   creationTimestamp: "1970-01-01T00:00:00Z"
 ---
 apiVersion: v1
 kind: Node
 metadata:
-  name: wrong-instance-class
+  name: %swrong-instance-class
+  labels:
+    node.deckhouse.io/group: %stest
   creationTimestamp: "1970-01-01T00:00:00Z"
 ---
 apiVersion: machine.sapcloud.io/v1alpha1
 kind: YandexMachineClass
 metadata:
-  name: test
+  name: %stest
   namespace: d8-cloud-instance-manager
 spec:
   schedulingPolicy:
@@ -144,7 +186,7 @@ spec:
 apiVersion: machine.sapcloud.io/v1alpha1
 kind: YandexMachineClass
 metadata:
-  name: not-preemptible
+  name: %snot-preemptible
   namespace: d8-cloud-instance-manager
 spec:
   schedulingPolicy:
@@ -153,24 +195,24 @@ spec:
 apiVersion: machine.sapcloud.io/v1alpha1
 kind: Machine
 metadata:
-  name: wrong-instance-class
+  name: %swrong-instance-class
   namespace: d8-cloud-instance-manager
 spec:
   class:
     kind: AWSMachineClass
-    name: test
+    name: %stest
 ---
 apiVersion: machine.sapcloud.io/v1alpha1
 kind: Machine
 metadata:
-  name: terminating
+  name: %sterminating
   namespace: d8-cloud-instance-manager
   deletionTimestamp: "1970-01-01T00:00:00Z"
 spec:
   class:
     kind: YandexMachineClass
-    name: test
-`)
+    name: %stest
+`, "%s", prefix), ngNodes, ngReady))
 
 	for i, offset := range offsets {
 		ts, err := timeNow.Add(-offset).MarshalJSON()
@@ -178,23 +220,25 @@ spec:
 			panic(err)
 		}
 
-		_, _ = builder.WriteString(fmt.Sprintf(`---
+		_, _ = builder.WriteString(fmt.Sprintf(strings.ReplaceAll(`---
 apiVersion: v1
 kind: Node
 metadata:
-  name: test-%d
+  name: %s%test-%d
+  labels:
+    node.deckhouse.io/group: %s%test
   creationTimestamp: %s
 ---
 apiVersion: machine.sapcloud.io/v1alpha1
 kind: Machine
 metadata:
-  name: test-%d
+  name: %s%test-%d
   namespace: d8-cloud-instance-manager
 spec:
   class:
     kind: YandexMachineClass
-    name: test
-`, i, string(ts), i))
+    name: %s%test
+`, "%s%", prefix), i, string(ts), i))
 	}
 
 	return builder.String()

--- a/modules/040-node-manager/hooks/yc_delete_preemptible_instances_test.go
+++ b/modules/040-node-manager/hooks/yc_delete_preemptible_instances_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delet
 			f.RunHook()
 		})
 
-		It("Oldest 3 machines should be deleted", func() {
+		It("One Machines between 20-24 hours and one Machines older than 24 hours should be deleted", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-0").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-1").Exists()).To(BeTrue())
@@ -74,7 +74,7 @@ var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delet
 			f.RunHook()
 		})
 
-		It("Oldest machine should be deleted", func() {
+		It("Oldest Machine should be deleted", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-0").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", "test-1").Exists()).To(BeTrue())
@@ -93,10 +93,10 @@ var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delet
 			f.RunHook()
 		})
 
-		It("No Machine should be deleted", func() {
+		It("15 older than 24 hours Machines and one machine between 20 and 24 hours old should be deleted", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
-			for i := 0; i < 15; i++ {
+			for i := 0; i < 45; i++ {
 				machineName := fmt.Sprintf("test-0-test-%d", i)
 				Expect(f.KubernetesResource("Machine", "d8-cloud-instance-manager", machineName).Exists()).To(BeTrue())
 			}

--- a/modules/040-node-manager/hooks/yc_delete_preemptible_instances_test.go
+++ b/modules/040-node-manager/hooks/yc_delete_preemptible_instances_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = FDescribe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delete_preemtible_instances ::", func() {
+var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delete_preemtible_instances ::", func() {
 	f := HookExecutionConfigInit(`{}`, `{}`)
 	f.RegisterCRD("deckhouse.io", "v1", "NodeGroup", false)
 	f.RegisterCRD("machine.sapcloud.io", "v1alpha1", "YandexMachineClass", true)
@@ -49,7 +49,7 @@ var _ = FDescribe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_dele
 	Context("With proper machines", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(generateNGsAndMCs(
-				10, 10, "", "22h10m", "22h5m", "22h2m", "21h", "20h", "2h",
+				6, 6, "", "22h10m", "22h5m", "22h2m", "21h", "20h", "2h",
 			)))
 			f.RunHook()
 		})
@@ -68,7 +68,7 @@ var _ = FDescribe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_dele
 	Context("With proper machines", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(generateNGsAndMCs(
-				10, 10, "", "22h10m", "22h5m", "22h2m", "21h",
+				4, 4, "", "22h10m", "22h5m", "22h2m", "21h",
 			)))
 			f.RunHook()
 		})

--- a/modules/040-node-manager/hooks/yc_delete_preemptible_instances_test.go
+++ b/modules/040-node-manager/hooks/yc_delete_preemptible_instances_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
-var _ = FDescribe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delete_preemtible_instances ::", func() {
+var _ = Describe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_delete_preemtible_instances ::", func() {
 	f := HookExecutionConfigInit(`{}`, `{}`)
 	f.RegisterCRD("deckhouse.io", "v1", "NodeGroup", false)
 	f.RegisterCRD("machine.sapcloud.io", "v1alpha1", "YandexMachineClass", true)
@@ -84,7 +84,7 @@ var _ = FDescribe("Modules :: cloud-provider-yandex :: hooks :: preemptibly_dele
 
 	})
 
-	FContext("With 60 Machines older than 24h, one Machine machines younger than 20 hours, and one between 20 and 24 hours", func() {
+	Context("With 60 Machines older than 24h, one Machine machines younger than 20 hours, and one between 20 and 24 hours", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(generateNMachines(
 				62, 62, "test", durationWithCount{count: 60, duration: "30h"},


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

1. Stop deleting Yandex.Cloud preemptible instances if percent of Ready Machines in a NodeGroup dips below 90%.
2. Try to delete 10% of all Machines older than 24h, while respecting the aforementioned NG readiness, on each hook iteration (every 15 minutes).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Deletion of preemptible instances continues even if new Machines cannot be provisioned.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

No Machines are deleted if more than 10% of Machines in a NodeGroup are not Ready. Algorithm is simplified.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: node-manager
type: fix
summary: |
  1. Stop deleting Yandex.Cloud preemptible instances if percent of Ready Machines in a NodeGroup dips below 90%.
  2. Algorithm is simplified.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
