### PR TITLE
[dhctl] Fixing some cli messages

### DIFF
--- a/dhctl/pkg/kubernetes/client/lease-lock.go
+++ b/dhctl/pkg/kubernetes/client/lease-lock.go
@@ -173,7 +173,7 @@ func (l *LeaseLock) startAutoRenew() {
 func (l *LeaseLock) tryAcquire(force bool) (*coordinationv1.Lease, error) {
 	var lease *coordinationv1.Lease
 
-	prefix := "Don't acquire lease lock."
+	prefix := "Can't acquire lease lock."
 	cannotRenew := func(err error) bool {
 		return strings.HasPrefix(err.Error(), prefix)
 	}
@@ -189,7 +189,7 @@ func (l *LeaseLock) tryAcquire(force bool) (*coordinationv1.Lease, error) {
 		if errors.IsAlreadyExists(err) {
 			lease, err = l.leasesCl.Get(context.TODO(), l.config.Name, metav1.GetOptions{})
 			if err != nil {
-				return fmt.Errorf("%s Don't get current lease %v", prefix, err)
+				return fmt.Errorf("%s Can't get current lease %v", prefix, err)
 			}
 
 			lease, err = l.tryRenew(lease, force)
@@ -239,7 +239,7 @@ func (l *LeaseLock) tryRenew(lease *coordinationv1.Lease, force bool) (*coordina
 			return nil, getCurrentLockerError(lease)
 		}
 
-		log.Warnf("Lease for %v finished on %v, Try renew lease\n", l.config.Identity, lease.Spec.RenewTime.Time)
+		log.Warnf("Lease for %v finished on %v, try to renew lease\n", l.config.Identity, lease.Spec.RenewTime.Time)
 	}
 
 	var newLease *coordinationv1.Lease


### PR DESCRIPTION
## Description
Fixing some cli messages.

## Why do we need it, and what problem does it solve?
There was misunderstanding.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: dhctl
type: fix
summary: Fixing some cli messages.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
