### PR TITLE
[docs] Use the full parameter path in OpenAPI spec

### DIFF
--- a/docs/documentation/_plugins/openapi.rb
+++ b/docs/documentation/_plugins/openapi.rb
@@ -287,18 +287,15 @@ module Jekyll
     # 5 - object with language data which use if there is no data in primary language
     def format_schema(name, attributes, parent, primaryLanguage = nil, fallbackLanguage = nil, ancestors = [], resourceName = '', versionAPI = '')
         result = Array.new()
+        ancestorsPathString = ''
 
-        if name.nil?
+        if name.nil? or name == ''
             fullPath = ancestors + ['element']
             parameterTitle = get_i18n_term('element_of_array').capitalize
-        elsif name != ''
+        else
             fullPath = ancestors + [name]
             parameterTitle = name
-        else
-            puts 'ERROR: Empty parameter name!'
-            puts 'Parent: ', parent
-            puts 'Attributes: ', attributes
-            abort
+            ancestorsPathString = ancestors.slice(1, ancestors.length-1).join('.') + '.' if ancestors.length > 1
         end
 
         linkAnchor = fullPath.join('-').downcase
@@ -333,9 +330,9 @@ module Jekyll
             end
 
             if ( get_hash_value(attributes, 'x-doc-deprecated') or get_hash_value(attributes, 'deprecated') )
-                parameterTextContent = sprintf(%q(<span id="%s" data-anchor-id="%s" class="resources__prop_title anchored"><span data-tippy-content="%s">%s</span><span data-tippy-content="%s" class="resources__prop_is_deprecated">%s</span></span>), linkAnchor, linkAnchor, pathString, parameterTitle, get_i18n_term('deprecated_parameter_hint'), get_i18n_term('deprecated_parameter') )
+                parameterTextContent = sprintf(%q(<span id="%s" data-anchor-id="%s" class="resources__prop_title anchored"><span class="ancestors">%s</span><span>%s</span><span data-tippy-content="%s" class="resources__prop_is_deprecated">%s</span></span>), linkAnchor, linkAnchor, ancestorsPathString, parameterTitle,get_i18n_term('deprecated_parameter_hint'), get_i18n_term('deprecated_parameter') )
             else
-                parameterTextContent = sprintf(%q(<span id="%s" data-anchor-id="%s" class="resources__prop_name anchored" data-tippy-content="%s">%s</span>), linkAnchor, linkAnchor, pathString, parameterTitle)
+                parameterTextContent = sprintf(%q(<span id="%s" data-anchor-id="%s" class="resources__prop_name anchored"><span class="ancestors">%s</span><span>%s</span></span>), linkAnchor, linkAnchor, ancestorsPathString, parameterTitle)
             end
 
             if attributesType != ''

--- a/docs/site/css/components/_resources.scss
+++ b/docs/site/css/components/_resources.scss
@@ -21,7 +21,12 @@
       color: $color-main;
       width: fit-content;
       font-weight: $font-weight-bold;
+      font-family: monospace, monospace;
       padding: 0;
+    }
+
+    &_name > .ancestors, &_title > .ancestors {
+      opacity: 55%;
     }
 
     &_type {
@@ -64,7 +69,7 @@
         color: #ff7a7a;
       }
     }
-    
+
     &_content {
       line-height: 1.2rem;
       font-size: 0.9rem;


### PR DESCRIPTION
Signed-off-by: Artem Kladov <artem.kladov@flant.com>

## Description
Use the full parameter path in an OpenAPI spec instead of only name.
E.g. `storageClass.provision.iops` instead of `iops`. It will help to better understand the scope of a parameter and help to avoid stupid mistakes.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: docs
type: feature
summary: Display the full parameter path in OpenAPI spec.
impact_level: low
```
