### PR TITLE
[linstor] specify default container for kubectl

### DIFF
--- a/modules/041-linstor/templates/linstor-controller/linstorcontroller.yaml
+++ b/modules/041-linstor/templates/linstor-controller/linstorcontroller.yaml
@@ -36,6 +36,8 @@ metadata:
   name: linstor
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "linstor-controller")) | nindent 2 }}
+  annotations:
+    kubectl.kubernetes.io/default-container: linstor-controller
 spec:
   {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 2 }}
   {{- include "helm_lib_tolerations" (tuple . "system") | nindent 2 }}

--- a/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
+++ b/modules/041-linstor/templates/linstor-node/linstorsatelliteset.yaml
@@ -17,6 +17,8 @@ metadata:
   name: linstor-node
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "linstor-node" "workload-resource-policy.deckhouse.io" "every-node")) | nindent 2 }}
+  annotations:
+    kubectl.kubernetes.io/default-container: linstor-satellite
 spec:
   targetRef:
     apiVersion: "apps/v1"


### PR DESCRIPTION
## Description
Specify the default container for `kubectl exec`

## Why do we need it, and what problem does it solve?

When user executes linstor command it shows that command executed in first container.

## What is the expected result?

No warning when executing linstor command

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: linstor
type: chore
summary: Specify the default container for kubectl.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
