### PR TITLE
[deckhouse-config] fix: Support integer number for settings constrained with the float number in multipleOf

### DIFF
--- a/global-hooks/deckhouse-config/startup_sync.go
+++ b/global-hooks/deckhouse-config/startup_sync.go
@@ -152,10 +152,8 @@ func createInitialModuleConfigs(input *go_hook.HookInput, cmData map[string]stri
 			continue
 		}
 		// Update spec.settings to converted settings.
-		if res.IsConverted {
-			cfg.Spec.Settings = res.Settings
-			cfg.Spec.Version = res.Version
-		}
+		cfg.Spec.Settings = res.Settings
+		cfg.Spec.Version = res.Version
 		properCfgs = append(properCfgs, cfg)
 	}
 
@@ -218,14 +216,11 @@ func syncModuleConfigs(input *go_hook.HookInput, generatedCM *v1.ConfigMap, allC
 			input.LogEntry.Errorf("Invalid ModuleConfig/%s will be ignored due to validation error: %v", cfg.GetName(), res.Error)
 			continue
 		}
-		// Update spec.settings to converted settings.
-		if res.IsConverted {
-			cfg.Spec.Settings = res.Settings
-			cfg.Spec.Version = res.Version
-		}
+		cfg.Spec.Settings = res.Settings
+		cfg.Spec.Version = res.Version
+
 		// Note: this message appears only on startup.
-		// TODO(future) switch to Debug after 1.42 release.
-		input.LogEntry.Infof("ModuleConfig/%s is valid", cfg.GetName())
+		input.LogEntry.Debugf("ModuleConfig/%s is valid", cfg.GetName())
 		properCfgs = append(properCfgs, cfg)
 	}
 

--- a/go_lib/deckhouse-config/config_map_section.go
+++ b/go_lib/deckhouse-config/config_map_section.go
@@ -82,11 +82,9 @@ func (s *configMapSection) convertValues() (int, map[string]interface{}, error) 
 	}
 
 	chain := conversion.Registry().Chain(s.name)
-	if chain != nil {
-		latestVersion, latestValues, err = chain.ConvertToLatest(latestVersion, latestValues)
-		if err != nil {
-			return 0, nil, err
-		}
+	latestVersion, latestValues, err = chain.ConvertToLatest(latestVersion, latestValues)
+	if err != nil {
+		return 0, nil, err
 	}
 
 	return latestVersion, latestValues, nil

--- a/go_lib/deckhouse-config/initial_config_loader_test.go
+++ b/go_lib/deckhouse-config/initial_config_loader_test.go
@@ -23,6 +23,7 @@ import (
 
 	kcm "github.com/flant/addon-operator/pkg/kube_config_manager"
 	"github.com/flant/kube-client/client"
+	"github.com/flant/kube-client/fake"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	v1 "k8s.io/api/core/v1"
@@ -46,7 +47,10 @@ func TestInitialConfigLoaderWithConfigMapDeckhouse(t *testing.T) {
 	})
 
 	// KubeClient
-	kubeClient := client.NewFake(nil)
+	mcGVR := d8cfg_v1alpha1.GroupVersionResource()
+	fakeCluster := fake.NewFakeCluster(fake.ClusterVersionV121)
+	fakeCluster.RegisterCRD(mcGVR.Group, mcGVR.Version, "ModuleConfig", false)
+	kubeClient := fakeCluster.Client
 	loader := NewInitialConfigLoader(kubeClient)
 
 	t.Run("No configMaps", func(t *testing.T) {

--- a/modules/003-deckhouse-config/hooks/sync_configmap.go
+++ b/modules/003-deckhouse-config/hooks/sync_configmap.go
@@ -121,10 +121,8 @@ func updateGeneratedConfigMap(input *go_hook.HookInput) error {
 			continue
 		}
 		// Update spec.settings to converted settings.
-		if res.IsConverted {
-			cfg.Spec.Settings = res.Settings
-			cfg.Spec.Version = res.Version
-		}
+		cfg.Spec.Settings = res.Settings
+		cfg.Spec.Version = res.Version
 		properCfgs = append(properCfgs, cfg)
 	}
 


### PR DESCRIPTION
## Description

- Run JSON marshal-unmarshal for latest settings to cast types as in converted settings.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?

This PR fixes panic in MultiplyOfInt during settings validation. It was impossible to configure float parameters.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?

Should not panic with "runtime error: integer divide by zero" when set integer number for field with float multipleOf.

OpenAPI example:
```
      sampling:
        type: number
        minimum: 0.01
        maximum: 100.0
        multipleOf: 0.01
```

And creating this ModuleConfig:

```
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: istio
spec:
  enabled: true
  settings:
    ...
    tracing:
      ...
      sampling: 100.0
```




<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: deckhouse-config
type: fix
summary: Support integer numbers for settings constrained with the float number in `multipleOf`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
