### PR TITLE
[linstor] Collect general statistics

### DIFF
--- a/modules/041-linstor/hooks/metrics.go
+++ b/modules/041-linstor/hooks/metrics.go
@@ -1,0 +1,301 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/go_lib/telemetry"
+)
+
+const (
+	linstorNodesSnapshot     = "linstor_nodes"
+	linstorSPsSnapshot       = "linstor_storagepools"
+	linstorRDsSnapshot       = "linstor_resource_definitions"
+	linstorResourcesSnapshot = "linstor_resources"
+	linstorCRDsSnapshot      = "linstor_crds"
+	nodeTypeSatellite        = 2
+)
+
+type linstorNodeSnapshot struct {
+	Type int64
+}
+
+type linstorSPSnapshot struct {
+	Driver string
+}
+
+type linstorRDSnapshot struct {
+	IsSnapshot bool
+}
+
+type linstorResourceSnapshot struct {
+	IsSnapshot bool
+}
+
+type linstorObj struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	Spec              map[string]interface{}
+}
+
+var linstorMetricsHookConfig = &go_hook.HookConfig{
+	Queue: "/modules/linstor/metrics",
+	Kubernetes: []go_hook.KubernetesConfig{
+		// A bindings with dynamic kind have index 0-4 for simplicity.
+		{
+			Name:       linstorNodesSnapshot,
+			ApiVersion: "",
+			Kind:       "",
+			FilterFunc: applyLinstorNodeFilter,
+		},
+		{
+			Name:       linstorSPsSnapshot,
+			ApiVersion: "",
+			Kind:       "",
+			FilterFunc: applyLinstorSPFilter,
+		},
+		{
+			Name:       linstorRDsSnapshot,
+			ApiVersion: "",
+			Kind:       "",
+			FilterFunc: applyLinstorRDFilter,
+		},
+		{
+			Name:       linstorResourcesSnapshot,
+			ApiVersion: "",
+			Kind:       "",
+			FilterFunc: applyLinstorResourceFilter,
+		},
+		{
+			Name:       linstorCRDsSnapshot,
+			ApiVersion: "apiextensions.k8s.io/v1",
+			Kind:       "CustomResourceDefinition",
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{
+					"nodes.internal.linstor.linbit.com",
+					"nodestorpool.internal.linstor.linbit.com",
+					"resourcedefinitions.internal.linstor.linbit.com",
+					"resources.internal.linstor.linbit.com"},
+			},
+			FilterFunc: applyCRDVersionsFilter,
+		},
+	},
+}
+
+var _ = sdk.RegisterFunc(linstorMetricsHookConfig, collectLinstorMetrics)
+
+func applyCRDVersionsFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var s apiextensions.CustomResourceDefinition
+	err := sdk.FromUnstructured(obj, &s)
+	if err != nil {
+		return "", err
+	}
+
+	for _, v := range s.Spec.Versions {
+		if v.Storage {
+			return v.Name, nil
+		}
+	}
+	return "", fmt.Errorf("Can not find storage version for %s", s.Name)
+}
+
+func applyLinstorNodeFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var s linstorObj
+	err := sdk.FromUnstructured(obj, &s)
+	if err != nil {
+		return "", err
+	}
+
+	nodeType, ok := s.Spec["node_type"].(int64)
+	if !ok {
+		nodeTypeFloat64, _ := s.Spec["node_type"].(float64)
+		nodeType = int64(nodeTypeFloat64)
+	}
+
+	return linstorNodeSnapshot{
+		Type: nodeType,
+	}, nil
+}
+
+func applyLinstorSPFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var s linstorObj
+	err := sdk.FromUnstructured(obj, &s)
+	if err != nil {
+		return "", err
+	}
+
+	driverName, _ := s.Spec["driver_name"].(string)
+
+	return linstorSPSnapshot{
+		Driver: driverName,
+	}, nil
+}
+
+func applyLinstorRDFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var s linstorObj
+	err := sdk.FromUnstructured(obj, &s)
+	if err != nil {
+		return "", err
+	}
+
+	snapshotName, _ := s.Spec["snapshot_name"].(string)
+
+	return linstorRDSnapshot{
+		IsSnapshot: snapshotName != "",
+	}, nil
+}
+
+func applyLinstorResourceFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var s linstorObj
+	err := sdk.FromUnstructured(obj, &s)
+	if err != nil {
+		return "", err
+	}
+
+	snapshotName, _ := s.Spec["snapshot_name"].(string)
+
+	return linstorResourceSnapshot{
+		IsSnapshot: snapshotName != "",
+	}, nil
+}
+
+// collectLinstorMetrics
+//
+// synopsis:
+//
+//	Waits for internal LINSTOR resources be installed then
+//	collects general statistics from them
+func collectLinstorMetrics(input *go_hook.HookInput) error {
+	input.MetricsCollector.Set(telemetry.WrapName("linstor_enabled"), 1, map[string]string{})
+
+	// LINSTOR manages it's own internal CRDs, so we need to wait for them before starting the watch
+	if linstorMetricsHookConfig.Kubernetes[0].Kind == "" {
+		var version string
+		for _, sRaw := range input.Snapshots[linstorCRDsSnapshot] {
+			discoveredVersion := sRaw.(string)
+			if version == "" {
+				version = discoveredVersion
+			} else if version != discoveredVersion {
+				return fmt.Errorf("LINSTOR internal CRDs have different storage versions")
+			}
+		}
+
+		if len(input.Snapshots[linstorCRDsSnapshot]) >= 4 {
+			// LINSTOR installed
+			input.LogEntry.Infof("LINSTOR internal CRDs installed, update kind for binding linstor resources to collect metrics")
+			apiVersion := "internal.linstor.linbit.com/" + version
+			*input.BindingActions = append(*input.BindingActions, go_hook.BindingAction{
+				Name:       linstorNodesSnapshot,
+				Action:     "UpdateKind",
+				ApiVersion: apiVersion,
+				Kind:       "Nodes",
+			})
+			*input.BindingActions = append(*input.BindingActions, go_hook.BindingAction{
+				Name:       linstorSPsSnapshot,
+				Action:     "UpdateKind",
+				ApiVersion: apiVersion,
+				Kind:       "NodeStorPool",
+			})
+			*input.BindingActions = append(*input.BindingActions, go_hook.BindingAction{
+				Name:       linstorRDsSnapshot,
+				Action:     "UpdateKind",
+				ApiVersion: apiVersion,
+				Kind:       "ResourceDefinitions",
+			})
+			*input.BindingActions = append(*input.BindingActions, go_hook.BindingAction{
+				Name:       linstorResourcesSnapshot,
+				Action:     "UpdateKind",
+				ApiVersion: apiVersion,
+				Kind:       "Resources",
+			})
+			// Save new kind as current kind.
+			linstorMetricsHookConfig.Kubernetes[0].Kind = "Nodes"
+			linstorMetricsHookConfig.Kubernetes[0].ApiVersion = apiVersion
+			linstorMetricsHookConfig.Kubernetes[1].Kind = "NodeStorPool"
+			linstorMetricsHookConfig.Kubernetes[1].ApiVersion = apiVersion
+			linstorMetricsHookConfig.Kubernetes[2].Kind = "ResourceDefinitions"
+			linstorMetricsHookConfig.Kubernetes[2].ApiVersion = apiVersion
+			linstorMetricsHookConfig.Kubernetes[3].Kind = "Resources"
+			linstorMetricsHookConfig.Kubernetes[3].ApiVersion = apiVersion
+			// Binding changed, hook will be restarted with new objects in snapshot.
+			return nil
+		}
+		// LINSTOR is not yet installed, do nothing
+		return nil
+	}
+
+	// Start main hook logic
+
+	// Collect general amount of lisntor nodes
+	var linstorSatellitesCount float64
+	for _, sRaw := range input.Snapshots[linstorNodesSnapshot] {
+		s := sRaw.(linstorNodeSnapshot)
+
+		if s.Type == nodeTypeSatellite {
+			linstorSatellitesCount++
+		}
+	}
+	input.MetricsCollector.Set(telemetry.WrapName("linstor_satellites"), linstorSatellitesCount, map[string]string{})
+
+	// Collect general amount of lisntor storage pools by type
+	linstorStoragePoolsCount := make(map[string]float64)
+	for _, sRaw := range input.Snapshots[linstorSPsSnapshot] {
+		s := sRaw.(linstorSPSnapshot)
+		if s.Driver != "" {
+			linstorStoragePoolsCount[s.Driver]++
+		}
+	}
+	for driver, count := range linstorStoragePoolsCount {
+		input.MetricsCollector.Set(telemetry.WrapName("linstor_storage_pools"), count, map[string]string{
+			"driver": driver,
+		})
+	}
+
+	// Collect general amount of lisntor resource definitions and snapshot definitions
+	var linstorResourceDefinitionsCount float64
+	var linstorSnapshotDefinitionsCount float64
+	for _, sRaw := range input.Snapshots[linstorRDsSnapshot] {
+		s := sRaw.(linstorRDSnapshot)
+		if s.IsSnapshot {
+			linstorSnapshotDefinitionsCount++
+		} else {
+			linstorResourceDefinitionsCount++
+		}
+	}
+	input.MetricsCollector.Set(telemetry.WrapName("linstor_resource_definitions"), linstorResourceDefinitionsCount, map[string]string{})
+	input.MetricsCollector.Set(telemetry.WrapName("linstor_snapshot_definitions"), linstorSnapshotDefinitionsCount, map[string]string{})
+
+	// Collect general amount of lisntor resources
+	var linstorResourcesCount float64
+	for _, sRaw := range input.Snapshots[linstorResourcesSnapshot] {
+		s := sRaw.(linstorResourceSnapshot)
+		if !s.IsSnapshot {
+			linstorResourcesCount++
+		}
+	}
+	input.MetricsCollector.Set(telemetry.WrapName("linstor_resources"), linstorResourcesCount, map[string]string{})
+
+	return nil
+}

--- a/modules/041-linstor/hooks/metrics_test.go
+++ b/modules/041-linstor/hooks/metrics_test.go
@@ -1,0 +1,425 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: linstor :: hooks :: metrics ", func() {
+	f := HookExecutionConfigInit(`{"linstor":{}}`, "")
+	f.RegisterCRD("internal.linstor.linbit.com", "v1-19-1", "Nodes", false)
+	f.RegisterCRD("internal.linstor.linbit.com", "v1-19-1", "NodeStorPool", false)
+	f.RegisterCRD("internal.linstor.linbit.com", "v1-19-1", "ResourceDefinitions", false)
+	f.RegisterCRD("internal.linstor.linbit.com", "v1-19-1", "Resources", false)
+
+	assertMetric := func(f *HookExecutionConfig, name string, value float64) {
+		metrics := f.MetricsCollector.CollectedMetrics()
+		metricIndex := -1
+		for i, m := range metrics {
+			if m.Name == name {
+				Expect(m.Value).To(Equal(pointer.Float64Ptr(value)))
+				metricIndex = i
+				break
+			}
+		}
+
+		Expect(metricIndex >= 0).To(BeTrue())
+	}
+
+	assertStoragePoolMetric := func(f *HookExecutionConfig, driver string, value float64) {
+		metrics := f.MetricsCollector.CollectedMetrics()
+		metricIndex := -1
+		for i, m := range metrics {
+			if m.Name == "d8_telemetry_linstor_storage_pools" && m.Labels["driver"] == driver {
+				Expect(m.Value).To(Equal(pointer.Float64Ptr(value)))
+				metricIndex = i
+				break
+			}
+		}
+
+		Expect(metricIndex >= 0).To(BeTrue())
+	}
+
+	Context("Empty cluster linstor module enabled", func() {
+		BeforeEach(func() {
+			f.RunHook()
+		})
+
+		It("Executes hook successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("Sets metric lisntor_enabled", func() {
+			assertMetric(f, "d8_telemetry_linstor_enabled", 1)
+		})
+	})
+
+	Context("Linstor installed, collect metrics", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(
+				f.KubeStateSet(`
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nodestorpool.internal.linstor.linbit.com
+spec:
+  group: internal.linstor.linbit.com
+  names:
+    kind: NodeStorPool
+    listKind: NodeStorPoolList
+    plural: nodestorpool
+    singular: nodestorpool
+  scope: Cluster
+  versions:
+  - name: v1-19-1
+    served: true
+    storage: true
+  - name: v1-18-2
+    served: true
+    storage: false
+  - name: v1-17-0
+    served: true
+    storage: false
+  - name: v1-19-1
+    served: true
+    storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nodes.internal.linstor.linbit.com
+spec:
+  group: internal.linstor.linbit.com
+  names:
+    kind: Nodes
+    listKind: NodesList
+    plural: nodes
+    singular: nodes
+  scope: Cluster
+  versions:
+  - name: v1-19-1
+    served: true
+    storage: true
+  - name: v1-18-2
+    served: true
+    storage: false
+  - name: v1-17-0
+    served: true
+    storage: false
+  - name: v1-19-1
+    served: true
+    storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: resourcedefinitions.internal.linstor.linbit.com
+spec:
+  group: internal.linstor.linbit.com
+  names:
+    kind: ResourceDefinitions
+    listKind: ResourceDefinitionsList
+    plural: resourcedefinitions
+    singular: resourcedefinitions
+  scope: Cluster
+  versions:
+  - name: v1-19-1
+    served: true
+    storage: true
+  - name: v1-18-2
+    served: true
+    storage: false
+  - name: v1-17-0
+    served: true
+    storage: false
+  - name: v1-19-1
+    served: true
+    storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: resources.internal.linstor.linbit.com
+spec:
+  group: internal.linstor.linbit.com
+  names:
+    kind: Resources
+    listKind: ResourcesList
+    plural: resources
+    singular: resources
+  scope: Cluster
+  versions:
+  - name: v1-19-1
+    served: true
+    storage: true
+  - name: v1-18-2
+    served: true
+    storage: false
+  - name: v1-17-0
+    served: true
+    storage: false
+  - name: v1-19-1
+    served: true
+    storage: false
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: Nodes
+metadata:
+  name: 531fa09e2545cc9ef5b6b2199c8ef4a60de8db5227610dd5e40bd78d0cb6ad28
+spec:
+  node_dsp_name: linstor-controller-6858f65c69-vjdtr
+  node_flags: 0
+  node_name: LINSTOR-CONTROLLER-6858F65C69-VJDTR
+  node_type: 1
+  uuid: ca8c047d-3243-4d88-b917-4537676636ae
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: Nodes
+metadata:
+  name: 55a2fd2fc05eaa5b1e6a2b572cb2d81a387d1bfe9181340a7dd7c87de5506923
+spec:
+  node_dsp_name: hf-virt-02
+  node_flags: 0
+  node_name: HF-VIRT-02
+  node_type: 2
+  uuid: 367f9e94-a942-425e-b69c-f4b3a8d2d982
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: Nodes
+metadata:
+  name: 70ddbc237fe582721714ddc3856d978f98b0247885ebdc0ed33f31bb39ee2d02
+spec:
+  node_dsp_name: hf-virt-01
+  node_flags: 0
+  node_name: HF-VIRT-01
+  node_type: 2
+  uuid: 884bc58b-2dd1-485a-81c1-b7e9f712f370
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: NodeStorPool
+metadata:
+  name: 38c67058dff7edfdf359cbf5c1892079f2f7721ed7e6b80232aa522461a1968d
+spec:
+  driver_name: LVM_THIN
+  external_locking: false
+  free_space_mgr_dsp_name: hf-virt-03:thindata
+  free_space_mgr_name: HF-VIRT-03:THINDATA
+  node_name: HF-VIRT-03
+  pool_name: THINDATA
+  uuid: 44819636-91ec-4851-8d24-7b860e847657
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: NodeStorPool
+metadata:
+  name: 60b3065c80b9b35f3d149cc8219653b41449a43f81fc0671834a830280ee7774
+spec:
+  driver_name: DISKLESS
+  external_locking: false
+  free_space_mgr_dsp_name: hf-virt-01:DfltDisklessStorPool
+  free_space_mgr_name: HF-VIRT-01:DFLTDISKLESSSTORPOOL
+  node_name: HF-VIRT-01
+  pool_name: DFLTDISKLESSSTORPOOL
+  uuid: f88f39e9-fb69-4831-9b8f-195bf0a9674e
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: NodeStorPool
+metadata:
+  name: 9f065cb41340702a1416a6a0579fcefe0ed5854458b9024535246c038a243e7f
+spec:
+  driver_name: DISKLESS
+  external_locking: false
+  free_space_mgr_dsp_name: hf-virt-02:DfltDisklessStorPool
+  free_space_mgr_name: HF-VIRT-02:DFLTDISKLESSSTORPOOL
+  node_name: HF-VIRT-02
+  pool_name: DFLTDISKLESSSTORPOOL
+  uuid: e9c5dc15-011d-4935-9bec-b662624eaf1f
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: NodeStorPool
+metadata:
+  name: 9fe4604f7057cbc66337151f14477630106f5e9e288d7578d715e247e7ca092c
+spec:
+  driver_name: LVM_THIN
+  external_locking: false
+  free_space_mgr_dsp_name: hf-virt-02:thindata
+  free_space_mgr_name: HF-VIRT-02:THINDATA
+  node_name: HF-VIRT-02
+  pool_name: THINDATA
+  uuid: 12ea214f-da62-4213-bdd7-c37af94c8be2
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: NodeStorPool
+metadata:
+  name: a961f699fcd6b1a70dce624d120af16116b96983386b376d8ff537a5b1e06dba
+spec:
+  driver_name: DISKLESS
+  external_locking: false
+  free_space_mgr_dsp_name: hf-virt-03:DfltDisklessStorPool
+  free_space_mgr_name: HF-VIRT-03:DFLTDISKLESSSTORPOOL
+  node_name: HF-VIRT-03
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: ResourceDefinitions
+metadata:
+  name: 1564c1b78164837b396da496c9749c4d4b30c34a9a62ed687ac4f8171b009cd8
+spec:
+  layer_stack: '[]'
+  parent_uuid: 1dab5087-96be-4657-9078-9c97a1e9220f
+  resource_flags: 641
+  resource_group_name: SC-6123FE2A-DD95-575C-ADF8-C54A4F636D6B
+  resource_name: PVC-31D4A5DB-F498-40CA-9641-7A4DD2C906F6
+  snapshot_dsp_name: back_20230124_110601
+  snapshot_name: BACK_20230124_110601
+  uuid: 0df9b4d3-9621-4d87-8036-2d98f54dc6b3
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: ResourceDefinitions
+metadata:
+  name: c58c4ceb29d213360ffd07456fd31772775a4fb68a2d145cefbe0856bc959f0d
+spec:
+  layer_stack: '["DRBD","STORAGE"]'
+  resource_dsp_name: pvc-31d4a5db-f498-40ca-9641-7a4dd2c906f6
+  resource_flags: 0
+  resource_group_name: SC-6123FE2A-DD95-575C-ADF8-C54A4F636D6B
+  resource_name: PVC-31D4A5DB-F498-40CA-9641-7A4DD2C906F6
+  snapshot_dsp_name: ""
+  snapshot_name: ""
+  uuid: 1dab5087-96be-4657-9078-9c97a1e9220f
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: ResourceDefinitions
+metadata:
+  name: fcd75deb6c2fa8d9af9ba7655f53e725f43ef643c2ab87ae444ba41e2719249f
+spec:
+  layer_stack: '[]'
+  parent_uuid: 1dab5087-96be-4657-9078-9c97a1e9220f
+  resource_flags: 641
+  resource_group_name: SC-6123FE2A-DD95-575C-ADF8-C54A4F636D6B
+  resource_name: PVC-31D4A5DB-F498-40CA-9641-7A4DD2C906F6
+  snapshot_dsp_name: back_20230124_111601
+  snapshot_name: BACK_20230124_111601
+  uuid: 85dffaa3-638d-4f89-bddd-275dde5cb448
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: Resources
+metadata:
+  name: 12eda5d45a722d55085bb5e2b44525a19c3a5674436271031d69002c2440e5fb
+spec:
+  create_timestamp: 1674558447641
+  node_name: HF-VIRT-01
+  resource_flags: 0
+  resource_name: PVC-31D4A5DB-F498-40CA-9641-7A4DD2C906F6
+  snapshot_name: BACK_20230124_110601
+  uuid: 46ef9765-7906-4087-a447-c00e03699e72
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: Resources
+metadata:
+  name: 60bf19e91047e4821c75ac12ba6e3156321c691e445fbd7ef5a6389e65317e64
+spec:
+  create_timestamp: 1674558447641
+  node_name: HF-VIRT-02
+  resource_flags: 0
+  resource_name: PVC-31D4A5DB-F498-40CA-9641-7A4DD2C906F6
+  snapshot_name: BACK_20230124_110601
+  uuid: 226b6d5c-2674-43f0-b83f-8a03bc86534f
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: Resources
+metadata:
+  name: 76b2c363a95c8aa1fd199abe205e7670ddb02f4b20c13b10b077caeeb5830f68
+spec:
+  create_timestamp: 1673963605796
+  node_name: HF-VIRT-01
+  resource_flags: 0
+  resource_name: PVC-31D4A5DB-F498-40CA-9641-7A4DD2C906F6
+  snapshot_name: ""
+  uuid: 6e22191d-78e9-4f4f-ac3f-120ef0616a8b
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: Resources
+metadata:
+  name: 82a81cffa69bde6ece5d1499c0db6063b252b8da93c730c314922ad3249f8293
+spec:
+  create_timestamp: 1673963607093
+  node_name: HF-VIRT-03
+  resource_flags: 388
+  resource_name: PVC-31D4A5DB-F498-40CA-9641-7A4DD2C906F6
+  snapshot_name: ""
+  uuid: 94e6ab9b-56c9-4913-ba69-71a1acd623a3
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: Resources
+metadata:
+  name: 891f22bd43a044f588774c2a51ea07b10b6594e6c6fd906568cf8b8f5b70ee3a
+spec:
+  create_timestamp: 1674559047907
+  node_name: HF-VIRT-01
+  resource_flags: 0
+  resource_name: PVC-31D4A5DB-F498-40CA-9641-7A4DD2C906F6
+  snapshot_name: BACK_20230124_111601
+  uuid: 5bacb49b-048b-4760-87e3-83822ad300c8
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: Resources
+metadata:
+  name: a2591d9e4a91c867301bb015195888702bd9569195835da968125f34cbdd9af9
+spec:
+  create_timestamp: 1674559047907
+  node_name: HF-VIRT-02
+  resource_flags: 0
+  resource_name: PVC-31D4A5DB-F498-40CA-9641-7A4DD2C906F6
+  snapshot_name: BACK_20230124_111601
+  uuid: 5242397e-4c3f-4a3d-a7a6-9cf3f9ff1cdd
+---
+apiVersion: internal.linstor.linbit.com/v1-19-1
+kind: Resources
+metadata:
+  name: e605fdfd97bf10ea0dec2830edb13e8c84484f0f9ea37c2c12fbc9b74284c230
+spec:
+  create_timestamp: 1673963607680
+  node_name: HF-VIRT-02
+  resource_flags: 0
+  resource_name: PVC-31D4A5DB-F498-40CA-9641-7A4DD2C906F6
+  snapshot_name: ""
+  uuid: d843296e-7e9e-4b4e-a32b-b2e2718e9c58
+			`))
+			f.RunHook()
+		})
+
+		It("Executes hook successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("Sets metric for objects", func() {
+			assertMetric(f, "d8_telemetry_linstor_enabled", 1)
+			assertMetric(f, "d8_telemetry_linstor_satellites", 2)
+			assertStoragePoolMetric(f, "LVM_THIN", 2)
+			assertStoragePoolMetric(f, "DISKLESS", 3)
+			assertMetric(f, "d8_telemetry_linstor_resource_definitions", 1)
+			assertMetric(f, "d8_telemetry_linstor_snapshot_definitions", 2)
+			assertMetric(f, "d8_telemetry_linstor_resources", 3)
+		})
+	})
+
+})


### PR DESCRIPTION
## Description

Collect general statistics

## Why do we need it, and what problem does it solve?

We need to understand current usage of linstor module

## What is the expected result?

A new metrics appear in cluster: 
```
d8_telemetry_linstor_enabled
d8_telemetry_linstor_satellites
d8_telemetry_linstor_storage_pools
d8_telemetry_linstor_resource_definitions
d8_telemetry_linstor_snapshot_definitions
d8_telemetry_linstor_resources
```

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section:  linstor
type: feature
summary: Collect general statistics
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
