### PR TITLE
[prometheus] Fix typo in metrics name for PrometheusLongtermRotatingEarlierThanConfiguredRetentionDays

### DIFF
--- a/modules/300-prometheus/monitoring/prometheus-rules/prometheus-storage.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/prometheus-storage.yaml
@@ -39,7 +39,7 @@
     expr: |
       group by (service) (increase(prometheus_tsdb_size_retentions_total{service="prometheus-longterm"}[24h]) > 0)
       and
-      group by (service) ((time() - prometheus_tsdb_lowest_timestamp_seconds{service="prometheus-longterm"}) / 60 / 60 / 24 < d8_prometheus_longterm_storage_retention_days{prometheus="longterm"})
+      group by (service) ((time() - prometheus_tsdb_lowest_timestamp_seconds{service="prometheus-longterm"}) / 60 / 60 / 24 < d8_prometheus_storage_retention_days{prometheus="longterm"})
       and
       group by (service) (delta(prometheus_tsdb_retention_limit_bytes{service="prometheus-longterm"}[24h]) == 0)
     labels:


### PR DESCRIPTION
Signed-off-by: Gleb Maiorov <gleb.maiorov@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

There is an issue with PrometheusLongtermRotatingEarlierThanConfiguredRetentionDays alert caused by incorrect `d8_prometheus_longterm_storage_retention_days` metric name.

Issue is probably a typo because above there is a correct implementation for `main` Prometheus, and correct metric name [is found](https://github.com/deckhouse/deckhouse/commit/57dce3ca06406e2d240db7cb491a84defb8b7236#diff-e4f26acbfd220e1b5552809e349adc065510c04197ea7051d4354477a7d9c349R46) in the same commit.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This issue causes `longterm` Prometheus to not alert about rotating earlier than configured retention.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

Prometheus will alert about described condition.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus
type: chore
summary: [prometheus] Fix typo in metrics name for PrometheusLongtermRotatingEarlierThanConfiguredRetentionDays
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
