### PR TITLE
[secret-copier] Add annotations with timestamp

### DIFF
--- a/modules/600-secret-copier/hooks/handler.go
+++ b/modules/600-secret-copier/hooks/handler.go
@@ -73,6 +73,12 @@ func ApplyCopierSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 		Type:        secret.Type,
 		Data:        secret.Data,
 	}
+
+	if secret.Namespace != v1.NamespaceDefault {
+		// desired secret (target secret in a namespace) must not have annotations to satisfy DeepEqual function
+		secret.Annotations = nil
+	}
+
 	// Secrets with that label lead to D8CertmanagerOrphanSecretsChecksFailed alerts.
 	delete(s.Labels, "certmanager.k8s.io/certificate-name")
 
@@ -163,9 +169,6 @@ func copierHandler(input *go_hook.HookInput, dc dependency.Container) error {
 		// Secrets that are not in namespace `default` are existing Secrets.
 		if secret.Namespace != v1.NamespaceDefault {
 			path := SecretPath(secret)
-			// remove annotations because desired secret doesn't have them
-			// annotations map have to be nil that secrets are equal
-			secret.Annotations = nil
 			secretsExists[path] = secret
 			continue
 		}

--- a/modules/600-secret-copier/hooks/handler.go
+++ b/modules/600-secret-copier/hooks/handler.go
@@ -76,7 +76,7 @@ func ApplyCopierSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 
 	if secret.Namespace != v1.NamespaceDefault {
 		// desired secret (target secret in a namespace) must not have annotations to satisfy DeepEqual function
-		secret.Annotations = nil
+		s.Annotations = nil
 	}
 
 	// Secrets with that label lead to D8CertmanagerOrphanSecretsChecksFailed alerts.

--- a/modules/600-secret-copier/hooks/handler.go
+++ b/modules/600-secret-copier/hooks/handler.go
@@ -159,12 +159,13 @@ func copierHandler(input *go_hook.HookInput, dc dependency.Container) error {
 	secretsDesired := make(map[string]*Secret)
 	for _, s := range secrets {
 		secret := s.(*Secret)
-		// remove annotations because desired secret doesn't have them
-		// annotations map have to be nil that secrets are equal
-		secret.Annotations = nil
+
 		// Secrets that are not in namespace `default` are existing Secrets.
 		if secret.Namespace != v1.NamespaceDefault {
 			path := SecretPath(secret)
+			// remove annotations because desired secret doesn't have them
+			// annotations map have to be nil that secrets are equal
+			secret.Annotations = nil
 			secretsExists[path] = secret
 			continue
 		}

--- a/modules/600-secret-copier/hooks/handler.go
+++ b/modules/600-secret-copier/hooks/handler.go
@@ -159,6 +159,8 @@ func copierHandler(input *go_hook.HookInput, dc dependency.Container) error {
 	secretsDesired := make(map[string]*Secret)
 	for _, s := range secrets {
 		secret := s.(*Secret)
+		// remove annotations because desired secret doesn't have them
+		// annotations map have to be nil that secrets are equal
 		secret.Annotations = nil
 		// Secrets that are not in namespace `default` are existing Secrets.
 		if secret.Namespace != v1.NamespaceDefault {

--- a/modules/600-secret-copier/hooks/handler.go
+++ b/modules/600-secret-copier/hooks/handler.go
@@ -244,6 +244,9 @@ func createSecret(k8 k8s.Client, secret *Secret) error {
 			Name:      secret.Name,
 			Namespace: secret.Namespace,
 			Labels:    secret.Labels,
+			Annotations: map[string]string{
+				"secret-copier.deckhouse.io/created-at": time.Now().UTC().Format(time.RFC3339),
+			},
 		},
 		Data: secret.Data,
 		Type: secret.Type,
@@ -273,6 +276,9 @@ func updateSecret(k8 k8s.Client, secret *Secret) error {
 			Name:      secret.Name,
 			Namespace: secret.Namespace,
 			Labels:    secret.Labels,
+			Annotations: map[string]string{
+				"secret-copier.deckhouse.io/updated-at": time.Now().UTC().Format(time.RFC3339),
+			},
 		},
 		Data: secret.Data,
 		Type: secret.Type,

--- a/modules/600-secret-copier/hooks/handler.go
+++ b/modules/600-secret-copier/hooks/handler.go
@@ -159,6 +159,7 @@ func copierHandler(input *go_hook.HookInput, dc dependency.Container) error {
 	secretsDesired := make(map[string]*Secret)
 	for _, s := range secrets {
 		secret := s.(*Secret)
+		secret.Annotations = nil
 		// Secrets that are not in namespace `default` are existing Secrets.
 		if secret.Namespace != v1.NamespaceDefault {
 			path := SecretPath(secret)


### PR DESCRIPTION
## Description
Add annotation to a copied secret

## Why do we need it, and what problem does it solve?
It's useful for debug purposes to have an annotation when secret was created/update by secret-copier

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: secret-copier
type: chore
summary: Add annotation with create/update timestamp to copied secrets
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
