### PR TITLE
[node-local-dns] add labels to fix cilium connectivity tests

### DIFF
--- a/ee/modules/350-node-local-dns/templates/daemonset.yaml
+++ b/ee/modules/350-node-local-dns/templates/daemonset.yaml
@@ -53,6 +53,7 @@ spec:
     metadata:
       labels:
         app: node-local-dns
+        k8s-app: node-local-dns # added for compatibility with cilium connectivity tests
     spec:
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}


### PR DESCRIPTION
## Description
Add label for node-local-dns daemonset to fix cilium connectivity tests

## Why do we need it, and what problem does it solve?
Cilium connectivity tests must work properly

## What is the expected result?
Cilium connectivity tests work properly

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-local-dns
type: fix 
summary: Add label for node-local-dns daemonset to fix cilium connectivity tests
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
