### PR TITLE
[istio] add CLOUD_PROVIDER env var for istio proxy

### DIFF
--- a/ee/modules/110-istio/templates/control-plane/iop.yaml
+++ b/ee/modules/110-istio/templates/control-plane/iop.yaml
@@ -1,8 +1,10 @@
 {{ $supportedProviders := list "aws" "gcp" "azure" }}
-{{ $currentProvider := .Values.global.clusterConfiguration.cloud.provider | lower }}
 {{ $cloudPlatform := "none" }}
-{{ if has $currentProvider $supportedProviders }}
-  {{ $cloudPlatform = $currentProvider }}
+{{ if hasKey .Values.global.clusterConfiguration "cloud" }}
+  {{ $currentProvider := .Values.global.clusterConfiguration.cloud.provider | lower }}
+  {{ if has $currentProvider $supportedProviders }}
+    {{ $cloudPlatform = $currentProvider }}
+  {{ end }}
 {{ end }}
 
 {{- range $version := .Values.istio.internal.versionsToInstall }}

--- a/ee/modules/110-istio/templates/control-plane/iop.yaml
+++ b/ee/modules/110-istio/templates/control-plane/iop.yaml
@@ -1,3 +1,10 @@
+{{ $supportedProviders := list "aws" "gcp" "azure" }}
+{{ $currentProvider := .Values.global.clusterConfiguration.cloud.provider | lower }}
+{{ $cloudPlatform := "none" }}
+{{ if has $currentProvider $supportedProviders }}
+  {{ $cloudPlatform = $currentProvider }}
+{{ end }}
+
 {{- range $version := .Values.istio.internal.versionsToInstall }}
   {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
   {{- $revision := get $versionInfo "revision"}}
@@ -77,6 +84,7 @@ spec:
       mode: {{ get $outboundTrafficPolicyModeDict $.Values.istio.outboundTrafficPolicyMode }}
     defaultConfig:
       proxyMetadata:
+        CLOUD_PLATFORM: {{ $cloudPlatform }}
         ISTIO_META_DNS_CAPTURE: "true"
         PROXY_CONFIG_XDS_AGENT: "true"
       holdApplicationUntilProxyStarts: {{ $.Values.istio.proxyConfig.holdApplicationUntilProxyStarts }}


### PR DESCRIPTION
## Description
Added control of an environment variable for obtaining cloud provider metadata for istio proxy

## Why do we need it, and what problem does it solve?
Automatic cloud provider detection must be disabled to avoid unwanted network interaction

## What is the expected result?
For istio-proxy, getting cloud provider metadata is available for: azure, aws, gcp for other cases - disabled.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Added control of an environment variable for obtaining cloud provider metadata for istio proxy
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
