### PR TITLE
[bashible] fix bb-event-error-create

### DIFF
--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -36,20 +36,18 @@ function bb-event-error-create() {
         kind: Event
         metadata:
           name: bashible-error-${eventName}
-          annotations:
-            timestamp: '$(date -u +"%Y-%m-%dT%H:%M:%SZ")'
         regarding:
           apiVersion: v1
           kind: Node
           name: '$(hostname -s)'
           uid: "$(kubectl_exec get node $(hostname -s) -o jsonpath='{.metadata.uid}')"
         note: '$(tail -c 500 ${eventLog})'
-        reason: Failed
+        reason: BashibleStepFailed
         type: Warning
         reportingController: bashible
         reportingInstance: '$(hostname -s)'
         eventTime: '$(date -u +"%Y-%m-%dT%H:%M:%S.%6NZ")'
-        action: "Binding"
+        action: "BashibleStepExecution"
 EOF
 }
 

--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -31,7 +31,7 @@ function bb-event-error-create() {
     step="$1"
     eventName="$(echo -n "$(hostname -s)")-$(echo $step | sed 's#.*/##; s/_/-/g')"
     eventLog="/var/lib/bashible/step.log"
-    kubectl_exec apply -f - || true <<EOF
+    kubectl_exec apply -f - <<EOF || true
         apiVersion: events.k8s.io/v1
         kind: Event
         metadata:

--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -27,10 +27,11 @@ function bb-event-error-create() {
     # underscore with dash due to regexp.
     # All of stderr outputs are stored in the eventLog file.
     # step is used as argument for function call.
+    # If event creation failed, error from kubectl suppressed.
     step="$1"
     eventName="$(echo -n "$(hostname -s)")-$(echo $step | sed 's#.*/##; s/_/-/g')"
     eventLog="/var/lib/bashible/step.log"
-    kubectl_exec apply -f - <<EOF
+    kubectl_exec apply -f - || true <<EOF
         apiVersion: events.k8s.io/v1
         kind: Event
         metadata:

--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -30,7 +30,7 @@ function bb-event-error-create() {
     step="$1"
     eventName="$(echo -n "$(hostname -s)")-$(echo $step | sed 's#.*/##; s/_/-/g')"
     eventLog="/var/lib/bashible/step.log"
-    kubectl apply -f - <<EOF
+    kubectl_exec apply -f - <<EOF
         apiVersion: events.k8s.io/v1
         kind: Event
         metadata:
@@ -41,7 +41,7 @@ function bb-event-error-create() {
           apiVersion: v1
           kind: Node
           name: '$(hostname -s)'
-          uid: "$(kubectl get node $(hostname -s) -o jsonpath='{.metadata.uid}')"
+          uid: "$(kubectl_exec get node $(hostname -s) -o jsonpath='{.metadata.uid}')"
         note: '$(tail -c 500 ${eventLog})'
         reason: Failed
         type: Warning

--- a/candi/bashible/common-steps/node-group/050_configure_and_start_containerd.sh.tpl
+++ b/candi/bashible/common-steps/node-group/050_configure_and_start_containerd.sh.tpl
@@ -22,6 +22,7 @@ _on_containerd_config_changed() {
 if bb-flag? containerd-need-restart; then
   bb-log-warning "'containerd-need-restart' flag was set. Containerd should be restarted!"
   _on_containerd_config_changed
+  bb-flag-unset containerd-need-restart
 fi
 
 bb-event-on 'bb-sync-file-changed' '_on_containerd_config_changed'

--- a/modules/040-node-manager/templates/bashible/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/bashible/rbac-for-us.yaml
@@ -56,7 +56,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: bashible-events
+  name: d8:node-manager:bashible-events
   namespace: default
   {{- include "helm_lib_module_labels" (list . ) | nindent 2 }}
 rules:
@@ -121,13 +121,13 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: bashible-events
+  name: d8:node-manager:bashible-events
   namespace: default
   {{- include "helm_lib_module_labels" (list . ) | nindent 2 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: bashible-events
+  name: d8:node-manager:bashible-events
 subjects:
   - kind: Group
     name: system:nodes

--- a/modules/040-node-manager/templates/bashible/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/bashible/rbac-for-us.yaml
@@ -54,6 +54,20 @@ rules:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: bashible-events
+  namespace: default
+  {{- include "helm_lib_module_labels" (list . ) | nindent 2 }}
+rules:
+  - apiGroups: ["events.k8s.io"]
+    resources:
+      - events
+    verbs:
+      - "*"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: bashible
@@ -102,6 +116,22 @@ subjects:
 - kind: Group
   name: system:bootstrappers:d8-node-manager
   apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:nodes:bashible-events
+  namespace: default
+  {{- include "helm_lib_module_labels" (list . ) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: bashible-events
+subjects:
+  - kind: Group
+    name: system:nodes
+    apiGroup: rbac.authorization.k8s.io
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/040-node-manager/templates/bashible/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/bashible/rbac-for-us.yaml
@@ -121,7 +121,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: system:nodes:bashible-events
+  name: bashible-events
   namespace: default
   {{- include "helm_lib_module_labels" (list . ) | nindent 2 }}
 roleRef:

--- a/modules/040-node-manager/templates/bashible/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/bashible/rbac-for-us.yaml
@@ -62,9 +62,13 @@ metadata:
 rules:
   - apiGroups: ["events.k8s.io"]
     resources:
-      - events
+    - events
     verbs:
-      - "*"
+    - get
+    - list
+    - create
+    - update
+    - patch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/testing/matrix/linter/rules/roles/placement.go
+++ b/testing/matrix/linter/rules/roles/placement.go
@@ -316,7 +316,7 @@ func handleNestedRBACForUs(m utils.Module, object storage.StoreObject, shortPath
 
 	switch {
 	case strings.HasPrefix(objectName, localPrefix):
-		if namespace != m.Namespace {
+		if namespace != m.Namespace && namespace != "default" {
 			return errors.NewLintRuleError(
 				"MANIFEST053",
 				object.Identity(),

--- a/testing/matrix/linter/rules/roles/placement.go
+++ b/testing/matrix/linter/rules/roles/placement.go
@@ -316,7 +316,7 @@ func handleNestedRBACForUs(m utils.Module, object storage.StoreObject, shortPath
 
 	switch {
 	case strings.HasPrefix(objectName, localPrefix):
-		if namespace != m.Namespace && namespace != "default" {
+		if namespace != m.Namespace {
 			return errors.NewLintRuleError(
 				"MANIFEST053",
 				object.Identity(),


### PR DESCRIPTION
Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix error in bb-event-error-create bashible function.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
1. When bashible tries to create an event, we get an error because we do not have access from system:nodes group to events.k8s.io api.
2. If cluster in bootstrapping state, we cannot have working API to send events, so we simply suppress event creating errors to prevent bashible fail. 
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: Fix error in bb-event-error-create bashible function.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
