### PR TITLE
[external-modules] External module manager

### DIFF
--- a/candi/bashible/common-steps/all/095_create_external_modules_directory.sh.tpl
+++ b/candi/bashible/common-steps/all/095_create_external_modules_directory.sh.tpl
@@ -12,6 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-mkdir -p /var/lib/deckhouse/external-modules
 mkdir -p /var/lib/deckhouse/external-modules/modules
 chmod -R 777 /var/lib/deckhouse/external-modules

--- a/candi/bashible/common-steps/all/095_create_external_modules_directory.sh.tpl
+++ b/candi/bashible/common-steps/all/095_create_external_modules_directory.sh.tpl
@@ -1,0 +1,17 @@
+# Copyright 2023 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mkdir -p /var/lib/deckhouse/external-modules
+mkdir -p /var/lib/deckhouse/external-modules/modules
+chmod -R 777 /var/lib/deckhouse/external-modules

--- a/candi/bashible/common-steps/all/095_create_external_modules_directory.sh.tpl
+++ b/candi/bashible/common-steps/all/095_create_external_modules_directory.sh.tpl
@@ -13,4 +13,5 @@
 # limitations under the License.
 
 mkdir -p /var/lib/deckhouse/external-modules/modules
-chmod -R 777 /var/lib/deckhouse/external-modules
+chown -hR 65534 /var/lib/deckhouse/external-modules
+chmod -R 0700 /var/lib/deckhouse/external-modules

--- a/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/register-go-hooks.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/deckhouse/deckhouse/modules/000-common/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/002-deckhouse/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/003-deckhouse-config/hooks"
+	_ "github.com/deckhouse/deckhouse/modules/005-external-module-manager/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/010-operator-prometheus-crd/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/010-prometheus-crd/hooks"
 	_ "github.com/deckhouse/deckhouse/modules/010-snapshot-controller-crd/hooks"

--- a/deckhouse-controller/entrypoint.sh
+++ b/deckhouse-controller/entrypoint.sh
@@ -57,6 +57,7 @@ cat <<EOF
 {"msg": "-- Starting Deckhouse using bundle $bundle --"}
 EOF
 
+mkdir -p /deckhouse/external-modules/modules
 coreModulesDir=$(echo ${MODULES_DIR} | awk -F ":" '{print $1}')
 cat ${coreModulesDir}/values-${bundles_map[$bundle]}.yaml >> ${coreModulesDir}/values.yaml
 

--- a/deckhouse-controller/entrypoint.sh
+++ b/deckhouse-controller/entrypoint.sh
@@ -57,7 +57,6 @@ cat <<EOF
 {"msg": "-- Starting Deckhouse using bundle $bundle --"}
 EOF
 
-mkdir -p /deckhouse/external-modules/modules
 coreModulesDir=$(echo ${MODULES_DIR} | awk -F ":" '{print $1}')
 cat ${coreModulesDir}/values-${bundles_map[$bundle]}.yaml >> ${coreModulesDir}/values.yaml
 

--- a/deckhouse-controller/entrypoint.sh
+++ b/deckhouse-controller/entrypoint.sh
@@ -57,7 +57,8 @@ cat <<EOF
 {"msg": "-- Starting Deckhouse using bundle $bundle --"}
 EOF
 
-cat ${MODULES_DIR}/values-${bundles_map[$bundle]}.yaml >> ${MODULES_DIR}/values.yaml
+coreModulesDir=$(echo ${MODULES_DIR} | awk -F ":" '{print $1}')
+cat ${coreModulesDir}/values-${bundles_map[$bundle]}.yaml >> ${coreModulesDir}/values.yaml
 
 set +o pipefail
 set +e

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -174,6 +174,8 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 		},
 	}
 
+	hostPathDirectory := apiv1.HostPathDirectory
+
 	deckhousePodTemplate := apiv1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: deckhouseDeployment.Spec.Selector.MatchLabels,
@@ -196,6 +198,15 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 					Name: "kube",
 					VolumeSource: apiv1.VolumeSource{
 						EmptyDir: &apiv1.EmptyDirVolumeSource{Medium: apiv1.StorageMediumMemory},
+					},
+				},
+				{
+					Name: "external-modules",
+					VolumeSource: apiv1.VolumeSource{
+						HostPath: &apiv1.HostPathVolumeSource{
+							Path: "/var/lib/deckhouse/external-modules",
+							Type: &hostPathDirectory,
+						},
 					},
 				},
 			},
@@ -267,6 +278,10 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 		{
 			Name:  "HELM_HISTORY_MAX",
 			Value: "3",
+		},
+		{
+			Name:  "EXTERNAL_MODULES_DIR",
+			Value: "/deckhouse/external-modules/",
 		},
 		{
 			Name:  "ADDON_OPERATOR_CONFIG_MAP",

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -280,6 +280,10 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 			Value: "3",
 		},
 		{
+			Name:  "MODULES_DIR",
+			Value: "/deckhouse/modules:/deckhouse/external-modules/modules",
+		},
+		{
 			Name:  "EXTERNAL_MODULES_DIR",
 			Value: "/deckhouse/external-modules/",
 		},

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -174,7 +174,7 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 		},
 	}
 
-	hostPathDirectory := apiv1.HostPathDirectory
+	hostPathDirectory := apiv1.HostPathDirectoryOrCreate
 
 	deckhousePodTemplate := apiv1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -251,6 +251,23 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 		Ports: []apiv1.ContainerPort{
 			{Name: "self", ContainerPort: 9650},
 			{Name: "custom", ContainerPort: 9651},
+		},
+		VolumeMounts: []apiv1.VolumeMount{
+			{
+				Name:      "tmp",
+				ReadOnly:  false,
+				MountPath: "/tmp",
+			},
+			{
+				Name:      "kube",
+				ReadOnly:  false,
+				MountPath: "/.kube",
+			},
+			{
+				Name:      "external-modules",
+				ReadOnly:  false,
+				MountPath: "/deckhouse/external-modules",
+			},
 		},
 	}
 

--- a/global-hooks/discovery/modules_images_tags.go
+++ b/global-hooks/discovery/modules_images_tags.go
@@ -37,6 +37,12 @@ func discoveryModulesImagesTags(input *go_hook.HookInput) error {
 
 	tagsFile := "/deckhouse/modules/images_tags.json"
 
+	tagsObj, err := parseImagesTagsFile(tagsFile)
+	if err != nil {
+		return err
+	}
+
+	// external modules
 	if env := os.Getenv("EXTERNAL_MODULES_DIR"); env != "" {
 		externalModulesDir = filepath.Join(env, "modules")
 	}
@@ -44,11 +50,6 @@ func discoveryModulesImagesTags(input *go_hook.HookInput) error {
 	if os.Getenv("D8_IS_TESTS_ENVIRONMENT") != "" {
 		tagsFile = os.Getenv("D8_TAGS_TMP_FILE")
 		externalModulesDir = "testdata/modules-images-tags/external-modules"
-	}
-
-	tagsObj, err := parseImagesTagsFile(tagsFile)
-	if err != nil {
-		return err
 	}
 
 	if externalModulesDir == "" {

--- a/global-hooks/discovery/modules_images_tags.go
+++ b/global-hooks/discovery/modules_images_tags.go
@@ -37,12 +37,6 @@ func discoveryModulesImagesTags(input *go_hook.HookInput) error {
 
 	tagsFile := "/deckhouse/modules/images_tags.json"
 
-	tagsObj, err := parseImagesTagsFile(tagsFile)
-	if err != nil {
-		return err
-	}
-
-	// external modules
 	if env := os.Getenv("EXTERNAL_MODULES_DIR"); env != "" {
 		externalModulesDir = filepath.Join(env, "modules")
 	}
@@ -50,6 +44,11 @@ func discoveryModulesImagesTags(input *go_hook.HookInput) error {
 	if os.Getenv("D8_IS_TESTS_ENVIRONMENT") != "" {
 		tagsFile = os.Getenv("D8_TAGS_TMP_FILE")
 		externalModulesDir = "testdata/modules-images-tags/external-modules"
+	}
+
+	tagsObj, err := parseImagesTagsFile(tagsFile)
+	if err != nil {
+		return err
 	}
 
 	if externalModulesDir == "" {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.13.0
-	github.com/flant/addon-operator v1.1.2
+	github.com/flant/addon-operator v1.1.3-0.20230208094144-e823034182fa
 	github.com/flant/kube-client v0.25.0
 	github.com/flant/shell-operator v1.1.3
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckhouse/deckhouse/dhctl v0.0.0 // use non-existent version for replace
 	github.com/fatih/color v1.13.0
-	github.com/flant/addon-operator v1.1.3-0.20230208094144-e823034182fa
+	github.com/flant/addon-operator v1.1.3-0.20230209101344-0aaa96dbf974
 	github.com/flant/kube-client v0.25.0
 	github.com/flant/shell-operator v1.1.3
 	github.com/gammazero/deque v0.0.0-20190521012701-46e4ffb7a622

--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,8 @@ github.com/flant/addon-operator v1.1.2 h1:pZv/v0AHNtyyf9xqjquitSOn8SL3B9BZnvaQcM
 github.com/flant/addon-operator v1.1.2/go.mod h1:wz9v/YGGom/FyjWF8Ga3T6R4oa93uMoMk4lMBoTXehQ=
 github.com/flant/addon-operator v1.1.3-0.20230208094144-e823034182fa h1:mSS4yv3bqEg4c1eScC1gWt7HZ0wQXVd1NJ/ZRyRRJZw=
 github.com/flant/addon-operator v1.1.3-0.20230208094144-e823034182fa/go.mod h1:wz9v/YGGom/FyjWF8Ga3T6R4oa93uMoMk4lMBoTXehQ=
+github.com/flant/addon-operator v1.1.3-0.20230209101344-0aaa96dbf974 h1:F1r5blw6uMXnE49GCNtqFUPsgpZzYpaK1i9vVLUpM6E=
+github.com/flant/addon-operator v1.1.3-0.20230209101344-0aaa96dbf974/go.mod h1:wz9v/YGGom/FyjWF8Ga3T6R4oa93uMoMk4lMBoTXehQ=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v0.25.0 h1:7uwwbvGNl3d7jNk0nHM4VxNbTnhESXLTiv/gQaUb9A0=

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/flant/addon-operator v1.1.2 h1:pZv/v0AHNtyyf9xqjquitSOn8SL3B9BZnvaQcMkWbIM=
 github.com/flant/addon-operator v1.1.2/go.mod h1:wz9v/YGGom/FyjWF8Ga3T6R4oa93uMoMk4lMBoTXehQ=
+github.com/flant/addon-operator v1.1.3-0.20230208094144-e823034182fa h1:mSS4yv3bqEg4c1eScC1gWt7HZ0wQXVd1NJ/ZRyRRJZw=
+github.com/flant/addon-operator v1.1.3-0.20230208094144-e823034182fa/go.mod h1:wz9v/YGGom/FyjWF8Ga3T6R4oa93uMoMk4lMBoTXehQ=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v0.25.0 h1:7uwwbvGNl3d7jNk0nHM4VxNbTnhESXLTiv/gQaUb9A0=

--- a/go_lib/deckhouse-config/service.go
+++ b/go_lib/deckhouse-config/service.go
@@ -88,6 +88,13 @@ func (srv *ConfigService) SetExternalNames(allExternalNamesToRepos map[string]st
 	srv.externalNames = allExternalNamesToRepos
 }
 
+func (srv *ConfigService) AddExternalModuleName(moduleName, moduleSource string) {
+	srv.externalNamesLock.Lock()
+	defer srv.externalNamesLock.Unlock()
+
+	srv.externalNames[moduleName] = moduleSource
+}
+
 func (srv *ConfigService) ExternalNames() map[string]string {
 	srv.externalNamesLock.RLock()
 	defer srv.externalNamesLock.RUnlock()

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -196,4 +196,7 @@ spec:
         hostPath:
           path: /var/lib/deckhouse/external-modules
           type: DirectoryOrCreate
-
+      - name: module-links
+        hostPath:
+          path: /var/lib/deckhouse/external-modules/modules
+          type: DirectoryOrCreate

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -196,7 +196,3 @@ spec:
         hostPath:
           path: /var/lib/deckhouse/external-modules
           type: DirectoryOrCreate
-      - name: module-links
-        hostPath:
-          path: /var/lib/deckhouse/external-modules/modules
-          type: DirectoryOrCreate

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -195,5 +195,5 @@ spec:
       - name: external-modules
         hostPath:
           path: /var/lib/deckhouse/external-modules
-          type: Directory
+          type: DirectoryOrCreate
 

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -142,6 +142,8 @@ spec:
               value: "yes"
             - name: HELM_HISTORY_MAX
               value: "3"
+            - name: EXTERNAL_MODULES_DIR
+              value: "/deckhouse/external-modules/"
             - name: DEBUG_UNIX_SOCKET
               value: /tmp/shell-operator-debug.socket
             - name: HISTFILE
@@ -172,6 +174,8 @@ spec:
             name: tmp
           - mountPath: /.kube
             name: kube
+          - mountPath: /deckhouse/external-modules
+            name: external-modules
       hostNetwork: true
 {{- if .Values.global.clusterIsBootstrapped }}
       dnsPolicy: ClusterFirstWithHostNet
@@ -186,4 +190,8 @@ spec:
       - emptyDir:
           medium: Memory
         name: kube
+      - name: external-modules
+        hostPath:
+          path: /var/lib/deckhouse/external-modules
+          type: Directory
 

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -142,6 +142,8 @@ spec:
               value: "yes"
             - name: HELM_HISTORY_MAX
               value: "3"
+            - name: MODULES_DIR
+              value: "/deckhouse/modules:/deckhouse/external-modules/modules"
             - name: EXTERNAL_MODULES_DIR
               value: "/deckhouse/external-modules/"
             - name: DEBUG_UNIX_SOCKET

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
       initContainers:
         - name: init-external-modules
           image: {{ include "helm_lib_module_common_image" (list . "alpine") }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command: ['sh', '-c', 'mkdir -p /deckhouse/external-modules/modules && chmod -R 0777 /deckhouse/external-modules']
           securityContext:
             runAsUser: 0

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -94,6 +94,9 @@ spec:
         - name: init-external-modules
           image: {{ include "helm_lib_module_common_image" (list . "alpine") }}
           command: ['sh', '-c', 'mkdir -p /deckhouse/external-modules/modules && chmod -R 0777 /deckhouse/external-modules']
+          securityContext:
+            runAsUser: 0
+            runAsNonRoot: false
           volumeMounts:
             - mountPath: /deckhouse/external-modules
               name: external-modules

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
       initContainers:
         - name: init-external-modules
           image: {{ include "helm_lib_module_common_image" (list . "alpine") }}
-          command: ['sh', '-c', 'mkdir /deckhouse/external-modules/modules && chmod -R 0777 /deckhouse/external-modules']
+          command: ['sh', '-c', 'mkdir -p /deckhouse/external-modules/modules && chmod -R 0777 /deckhouse/external-modules']
           volumeMounts:
             - mountPath: /deckhouse/external-modules
               name: external-modules

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -90,6 +90,13 @@ spec:
       {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
 {{- end }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      initContainers:
+        - name: init-external-modules
+          image: {{ include "helm_lib_module_common_image" (list . "alpine") }}
+          command: ['sh', '-c', 'mkdir /deckhouse/external-modules/modules && chmod -R 0777 /deckhouse/external-modules']
+          volumeMounts:
+            - mountPath: /deckhouse/external-modules
+              name: external-modules
       containers:
         - name: deckhouse
           {{- include "helm_lib_module_container_security_context_not_allow_privilege_escalation" . | nindent 10 }}

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -93,10 +93,14 @@ spec:
       initContainers:
         - name: init-external-modules
           image: {{ include "helm_lib_module_common_image" (list . "alpine") }}
+          imagePullPolicy: IfNotPresent
           command: ['sh', '-c', 'mkdir -p /deckhouse/external-modules/modules && chmod -R 0777 /deckhouse/external-modules']
           securityContext:
             runAsUser: 0
             runAsNonRoot: false
+          resources:
+            requests:
+              {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 100 | nindent 14 }}
           volumeMounts:
             - mountPath: /deckhouse/external-modules
               name: external-modules

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
         - name: init-external-modules
           image: {{ include "helm_lib_module_common_image" (list . "alpine") }}
           imagePullPolicy: Always
-          command: ['sh', '-c', 'mkdir -p /deckhouse/external-modules/modules && chmod -R 0777 /deckhouse/external-modules']
+          command: ['sh', '-c', 'mkdir -p /deckhouse/external-modules/modules && chown -hR 65534 /deckhouse/external-modules && chmod -R 0700 /deckhouse/external-modules']
           securityContext:
             runAsUser: 0
             runAsNonRoot: false

--- a/modules/003-deckhouse-config/images/deckhouse-config-webhook/go.mod
+++ b/modules/003-deckhouse-config/images/deckhouse-config-webhook/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/color v1.13.0 // indirect
-	github.com/flant/addon-operator v1.1.3-0.20230208094144-e823034182fa // indirect
+	github.com/flant/addon-operator v1.1.3-0.20230209101344-0aaa96dbf974 // indirect
 	github.com/flant/kube-client v0.25.0 // indirect
 	github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a // indirect
 	github.com/flant/shell-operator v1.1.3 // indirect

--- a/modules/003-deckhouse-config/images/deckhouse-config-webhook/go.mod
+++ b/modules/003-deckhouse-config/images/deckhouse-config-webhook/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/color v1.13.0 // indirect
-	github.com/flant/addon-operator v1.1.2 // indirect
+	github.com/flant/addon-operator v1.1.3-0.20230208094144-e823034182fa // indirect
 	github.com/flant/kube-client v0.25.0 // indirect
 	github.com/flant/libjq-go v1.6.2-0.20200616114952-907039e8a02a // indirect
 	github.com/flant/shell-operator v1.1.3 // indirect

--- a/modules/003-deckhouse-config/images/deckhouse-config-webhook/go.sum
+++ b/modules/003-deckhouse-config/images/deckhouse-config-webhook/go.sum
@@ -179,8 +179,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
-github.com/flant/addon-operator v1.1.3-0.20230208094144-e823034182fa h1:mSS4yv3bqEg4c1eScC1gWt7HZ0wQXVd1NJ/ZRyRRJZw=
-github.com/flant/addon-operator v1.1.3-0.20230208094144-e823034182fa/go.mod h1:wz9v/YGGom/FyjWF8Ga3T6R4oa93uMoMk4lMBoTXehQ=
+github.com/flant/addon-operator v1.1.3-0.20230209101344-0aaa96dbf974 h1:F1r5blw6uMXnE49GCNtqFUPsgpZzYpaK1i9vVLUpM6E=
+github.com/flant/addon-operator v1.1.3-0.20230209101344-0aaa96dbf974/go.mod h1:wz9v/YGGom/FyjWF8Ga3T6R4oa93uMoMk4lMBoTXehQ=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v0.25.0 h1:7uwwbvGNl3d7jNk0nHM4VxNbTnhESXLTiv/gQaUb9A0=

--- a/modules/003-deckhouse-config/images/deckhouse-config-webhook/go.sum
+++ b/modules/003-deckhouse-config/images/deckhouse-config-webhook/go.sum
@@ -179,8 +179,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
-github.com/flant/addon-operator v1.1.2 h1:pZv/v0AHNtyyf9xqjquitSOn8SL3B9BZnvaQcMkWbIM=
-github.com/flant/addon-operator v1.1.2/go.mod h1:wz9v/YGGom/FyjWF8Ga3T6R4oa93uMoMk4lMBoTXehQ=
+github.com/flant/addon-operator v1.1.3-0.20230208094144-e823034182fa h1:mSS4yv3bqEg4c1eScC1gWt7HZ0wQXVd1NJ/ZRyRRJZw=
+github.com/flant/addon-operator v1.1.3-0.20230208094144-e823034182fa/go.mod h1:wz9v/YGGom/FyjWF8Ga3T6R4oa93uMoMk4lMBoTXehQ=
 github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbLR5vJOUzKAK8p3nrD7mDk=
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v0.25.0 h1:7uwwbvGNl3d7jNk0nHM4VxNbTnhESXLTiv/gQaUb9A0=

--- a/modules/003-deckhouse-config/templates/deckhouse-config-webhook/deployment.yaml
+++ b/modules/003-deckhouse-config/templates/deckhouse-config-webhook/deployment.yaml
@@ -73,7 +73,9 @@ spec:
         - name: ALLOWED_USERS
           value: "system:serviceaccount:d8-system:deckhouse"
         - name: MODULES_DIR
-          value: "/deckhouse/modules"
+          value: "/deckhouse/modules:/deckhouse/external-modules/modules"
+        - name: EXTERNAL_MODULES_DIR
+          value: "/deckhouse/external-modules/"
         - name: GLOBAL_HOOKS_DIR
           value: "/deckhouse/global-hooks"
         ports:

--- a/modules/003-deckhouse-config/templates/deckhouse-config-webhook/deployment.yaml
+++ b/modules/003-deckhouse-config/templates/deckhouse-config-webhook/deployment.yaml
@@ -94,6 +94,9 @@ spec:
           - name: webhook-certs
             mountPath: /etc/webhook/certs
             readOnly: true
+          - mountPath: /deckhouse/external-modules
+            name: external-modules
+            readOnly: true
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
@@ -104,3 +107,7 @@ spec:
       - name: webhook-certs
         secret:
           secretName: deckhouse-config-webhook-tls
+      - name: external-modules
+        hostPath:
+          path: /var/lib/deckhouse/external-modules
+          type: Directory

--- a/modules/005-external-module-manager/.helmignore
+++ b/modules/005-external-module-manager/.helmignore
@@ -1,0 +1,8 @@
+crds
+docs
+enabled
+hooks
+images
+openapi
+template_tests
+README.md

--- a/modules/005-external-module-manager/.namespace
+++ b/modules/005-external-module-manager/.namespace
@@ -1,0 +1,1 @@
+d8-system

--- a/modules/005-external-module-manager/Chart.yaml
+++ b/modules/005-external-module-manager/Chart.yaml
@@ -1,0 +1,2 @@
+name: external-module-manager
+version: 0.1.0

--- a/modules/005-external-module-manager/charts/helm_lib
+++ b/modules/005-external-module-manager/charts/helm_lib
@@ -1,0 +1,1 @@
+/deckhouse/helm_lib

--- a/modules/005-external-module-manager/charts/helm_lib
+++ b/modules/005-external-module-manager/charts/helm_lib
@@ -1,1 +1,1 @@
-/deckhouse/helm_lib
+/deckhouse/helm_lib/charts/deckhouse_lib_helm

--- a/modules/005-external-module-manager/crds/doc-ru-external-module-release.yaml
+++ b/modules/005-external-module-manager/crds/doc-ru-external-module-release.yaml
@@ -1,0 +1,42 @@
+spec:
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: |
+            Определяет конфигурацию релизов сторонних модулей Deckhouse.
+          properties:
+            spec:
+              properties:
+                moduleName:
+                  description: Название стороннего модуля.
+                version:
+                  description: Версия модуля в данном релизе.
+            status:
+              properties:
+                phase:
+                  description: Текущий статус релиза.
+                message:
+                  type: string
+                  description: Детальное сообщение об ошибки или статусе релиза.
+                transitionTime:
+                  description: Время изменения статуса релиза.
+                approved:
+                  description: |
+                    Статус готовности релиза к обновлению. Используется только для режима обновления Manual (`update.mode: Manual`).
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: phase
+          jsonPath: .status.phase
+          type: string
+          description: 'Показывает текущий статус релиза.'
+        - name: transitionTime
+          jsonPath: .status.transitionTime
+          type: date
+          description: 'Показывает, когда статус релиза изменился.'
+        - name: message
+          jsonPath: .status.message
+          type: string
+          description: 'Детали статуса релиза.'

--- a/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
@@ -1,0 +1,39 @@
+spec:
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: |
+            Определяет конфигурацию источника сторонних модулей Deckhouse.
+          properties:
+            spec:
+              properties:
+                registry:
+                  properties:
+                    repo:
+                      type: string
+                      description: Адрес docker репозитория.
+                    dockerCfg:
+                      description: Строка Base64 с вашим токеном для доступа к реестру Docker.
+            status:
+              properties:
+                syncTime:
+                  description: 'Время, когда репозиторий последний раз был синхронизирован.'
+                availableModules:
+                  type: array
+                  description: Список доступных для установки модулей в данном репозитории.
+                message:
+                  type: string
+                  description: Сообщение с детальной ошибкой.
+                moduleErrors:
+                  type: array
+                  description: Сообщения с ошибками установки модулей.
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: syncTime
+          jsonPath: .status.syncTime
+          type: date
+          format: date-time
+          description: 'Время последней синхронизации docker репозитория.'

--- a/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
@@ -37,3 +37,7 @@ spec:
           type: date
           format: date-time
           description: 'Время последней синхронизации с container registry.'
+        - name: msg
+          jsonPath: .status.message
+          type: string
+          description: 'Сообщение об ошибке.'

--- a/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
@@ -15,7 +15,7 @@ spec:
                       type: string
                       description: Адрес репозитория образов контейнеров.
                     dockerCfg:
-                      description: Строка Base64 с вашим токеном для доступа к реестру Docker.
+                      description: Строка с токеном доступа к container registry в Base64.
             status:
               properties:
                 syncTime:

--- a/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
@@ -13,7 +13,7 @@ spec:
                   properties:
                     repo:
                       type: string
-                      description: Адрес docker репозитория.
+                      description: Адрес репозитория образов контейнеров.
                     dockerCfg:
                       description: Строка Base64 с вашим токеном для доступа к реестру Docker.
             status:

--- a/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
@@ -19,7 +19,7 @@ spec:
             status:
               properties:
                 syncTime:
-                  description: 'Время, когда репозиторий последний раз был синхронизирован.'
+                  description: 'Время последней синхронизации с container registry.'
                 availableModules:
                   type: array
                   description: Список доступных для установки модулей в данном репозитории.

--- a/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
@@ -36,4 +36,4 @@ spec:
           jsonPath: .status.syncTime
           type: date
           format: date-time
-          description: 'Время последней синхронизации docker репозитория.'
+          description: 'Время последней синхронизации с container registry.'

--- a/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
@@ -9,6 +9,8 @@ spec:
           properties:
             spec:
               properties:
+                releaseChannel:
+                  description: Желаемый канал обновлений для модулей данного container registry.
                 registry:
                   properties:
                     repo:

--- a/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
@@ -37,6 +37,10 @@ spec:
           type: date
           format: date-time
           description: 'Время последней синхронизации с container registry.'
+        - name: count
+          type: integer
+          jsonPath: .status.modulesCount
+          description: "Количество доступных модулей в данном репозитории."
         - name: msg
           jsonPath: .status.message
           type: string

--- a/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
@@ -10,7 +10,7 @@ spec:
             spec:
               properties:
                 releaseChannel:
-                  description: Желаемый канал обновлений для модулей данного container registry.
+                  description: Желаемый канал обновлений по-умолчанию для модулей данного container registry.
                 registry:
                   properties:
                     repo:

--- a/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/doc-ru-external-module-source.yaml
@@ -34,15 +34,19 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-        - name: syncTime
-          jsonPath: .status.syncTime
-          type: date
-          format: date-time
-          description: 'Время последней синхронизации с container registry.'
+        - name: "release channel"
+          type: string
+          jsonPath: .spec.releaseChannel
+          description: "Канал обновлений по-умолчанию для модулей в данном репоизтории."
         - name: count
           type: integer
           jsonPath: .status.modulesCount
           description: "Количество доступных модулей в данном репозитории."
+        - name: sync
+          jsonPath: .status.syncTime
+          type: date
+          format: date-time
+          description: 'Время последней синхронизации с container registry.'
         - name: msg
           jsonPath: .status.message
           type: string

--- a/modules/005-external-module-manager/crds/external-module-release.yaml
+++ b/modules/005-external-module-manager/crds/external-module-release.yaml
@@ -1,0 +1,85 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: externalmodulereleases.deckhouse.io
+  labels:
+    heritage: deckhouse
+    module: external-module-manager
+spec:
+  group: deckhouse.io
+  scope: Cluster
+  names:
+    plural: externalmodulereleases
+    singular: externalmodulerelease
+    kind: ExternalModuleRelease
+  preserveUnknownFields: false
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: |
+            Defines the configuration for Deckhouse release.
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              required:
+                - moduleName
+                - version
+              properties:
+                moduleName:
+                  type: string
+                  description: Module name.
+                version:
+                  type: string
+                  description: Module version.
+                  example: 'v1.0.0'
+                applyAfter:
+                  type: string
+                  description: Marks release as a part of canary release. This release will be delayed until this time.
+                requirements:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: Deckhouse release requirements.
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum:
+                    - Pending
+                    - Deployed
+                    - Outdated
+                    - Suspended
+                  description: Current status of the release.
+                message:
+                  type: string
+                  description: Detailed status or error message.
+                transitionTime:
+                  type: string
+                  description: Time of release status change.
+                approved:
+                  type: boolean
+                  description: |
+                    The status of the release's readiness for deployment. It makes sense only for Manual updates (`update.mode: Manual`).
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: phase
+          jsonPath: .status.phase
+          type: string
+          description: 'Current release status.'
+        - name: transitionTime
+          jsonPath: .status.transitionTime
+          type: date
+          format: date-time
+          description: 'When the release status was changed.'
+        - name: message
+          jsonPath: .status.message
+          type: string
+          description: 'Release status details.'

--- a/modules/005-external-module-manager/crds/external-module-release.yaml
+++ b/modules/005-external-module-manager/crds/external-module-release.yaml
@@ -54,7 +54,7 @@ spec:
                   enum:
                     - Pending
                     - Deployed
-                    - Outdated
+                    - Superseded
                     - Suspended
                   description: Current status of the release.
                 message:

--- a/modules/005-external-module-manager/crds/external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/external-module-source.yaml
@@ -1,0 +1,74 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: externalmodulesources.deckhouse.io
+  labels:
+    heritage: deckhouse
+    module: external-module-manager
+spec:
+  group: deckhouse.io
+  scope: Cluster
+  names:
+    plural: externalmodulesources
+    singular: externalmodulesource
+    kind: ExternalModuleSource
+  preserveUnknownFields: false
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: |
+            Defines the configuration.
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              required:
+                - registry
+              properties:
+                registry:
+                  type: object
+                  required:
+                    - repo
+                  properties:
+                    repo:
+                      type: string
+                      description: Repository address.
+                      x-examples:
+                        - registry.deckhouse.io/deckhouse/external-modules
+                    dockerCfg:
+                      type: string
+                      description: Base64 string with your token to access Docker registry.
+            status:
+              type: object
+              properties:
+                syncTime:
+                  type: string
+                  description: 'When the repository was synchronized.'
+                availableModules:
+                  type: array
+                  items:
+                    type: string
+                message:
+                  type: string
+                moduleErrors:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      error:
+                        type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: syncTime
+          jsonPath: .status.syncTime
+          type: date
+          format: date-time
+          description: 'When the repository was synchronized.'

--- a/modules/005-external-module-manager/crds/external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/external-module-source.yaml
@@ -72,3 +72,7 @@ spec:
           type: date
           format: date-time
           description: 'When the repository was synchronized.'
+        - name: msg
+          jsonPath: .status.message
+          type: string
+          description: 'Error message if exists.'

--- a/modules/005-external-module-manager/crds/external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/external-module-source.yaml
@@ -37,7 +37,7 @@ spec:
                   properties:
                     repo:
                       type: string
-                      description: Repository address.
+                      description: URL of the container registry.
                       x-examples:
                         - registry.deckhouse.io/deckhouse/external-modules
                     dockerCfg:

--- a/modules/005-external-module-manager/crds/external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/external-module-source.yaml
@@ -42,7 +42,7 @@ spec:
                         - registry.deckhouse.io/deckhouse/external-modules
                     dockerCfg:
                       type: string
-                      description: Base64 string with your token to access Docker registry.
+                      description: Container registry access token in Base64.
             status:
               type: object
               properties:

--- a/modules/005-external-module-manager/crds/external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/external-module-source.yaml
@@ -49,6 +49,9 @@ spec:
                 syncTime:
                   type: string
                   description: 'When the repository was synchronized.'
+                modulesCount:
+                  type: integer
+                  description: "Number of modules available."
                 availableModules:
                   type: array
                   items:
@@ -68,11 +71,15 @@ spec:
         status: {}
       additionalPrinterColumns:
         - name: syncTime
-          jsonPath: .status.syncTime
           type: date
+          jsonPath: .status.syncTime
           format: date-time
           description: 'When the repository was synchronized.'
+        - name: count
+          type: integer
+          jsonPath: .status.modulesCount
+          description: "Number of modules available."
         - name: msg
-          jsonPath: .status.message
           type: string
+          jsonPath: .status.message
           description: 'Error message if exists.'

--- a/modules/005-external-module-manager/crds/external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/external-module-source.yaml
@@ -30,6 +30,10 @@ spec:
               required:
                 - registry
               properties:
+                releaseChannel:
+                  type: string
+                  description: Desirable release channel for the current modules source.
+                  default: "alpha"
                 registry:
                   type: object
                   required:

--- a/modules/005-external-module-manager/crds/external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/external-module-source.yaml
@@ -32,7 +32,7 @@ spec:
               properties:
                 releaseChannel:
                   type: string
-                  description: Desirable release channel for the current modules source.
+                  description: Desirable default release channel for modules in the current source.
                   default: "alpha"
                 registry:
                   type: object

--- a/modules/005-external-module-manager/crds/external-module-source.yaml
+++ b/modules/005-external-module-manager/crds/external-module-source.yaml
@@ -74,15 +74,19 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-        - name: syncTime
-          type: date
-          jsonPath: .status.syncTime
-          format: date-time
-          description: 'When the repository was synchronized.'
+        - name: "release channel"
+          type: string
+          jsonPath: .spec.releaseChannel
+          description: "Default release channel for modules inside this source."
         - name: count
           type: integer
           jsonPath: .status.modulesCount
           description: "Number of modules available."
+        - name: sync
+          type: date
+          jsonPath: .status.syncTime
+          format: date-time
+          description: 'When the repository was synchronized.'
         - name: msg
           type: string
           jsonPath: .status.message

--- a/modules/005-external-module-manager/hooks/apply_release.go
+++ b/modules/005-external-module-manager/hooks/apply_release.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/utils/pointer"
 
 	deckhouse_config "github.com/deckhouse/deckhouse/go_lib/deckhouse-config"
-
 	"github.com/deckhouse/deckhouse/modules/005-external-module-manager/hooks/internal/apis/v1alpha1"
 )
 

--- a/modules/005-external-module-manager/hooks/apply_release.go
+++ b/modules/005-external-module-manager/hooks/apply_release.go
@@ -86,6 +86,8 @@ func applyModuleRelease(input *go_hook.HookInput) error {
 
 		if pred.currentReleaseIndex == len(pred.releases)-1 {
 			// latest release deployed
+			deployedRelease := pred.releases[pred.currentReleaseIndex]
+			deckhouse_config.Service().AddExternalModuleName(deployedRelease.ModuleName, deployedRelease.ModuleSource)
 			continue
 		}
 

--- a/modules/005-external-module-manager/hooks/apply_release.go
+++ b/modules/005-external-module-manager/hooks/apply_release.go
@@ -128,7 +128,6 @@ func applyModuleRelease(input *go_hook.HookInput) error {
 				continue
 			}
 			modulesChanged = true
-			deckhouse_config.Service().AddExternalModuleName(release.ModuleName, release.ModuleSource)
 
 			status := map[string]v1alpha1.ExternalModuleReleaseStatus{
 				"status": {

--- a/modules/005-external-module-manager/hooks/apply_release.go
+++ b/modules/005-external-module-manager/hooks/apply_release.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"os"
+	"path"
+	"sort"
+	"syscall"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+
+	"github.com/deckhouse/deckhouse/modules/005-external-module-manager/hooks/internal/apis/v1alpha1"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/external-module-source/apply-release",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                         "releases",
+			ApiVersion:                   "deckhouse.io/v1alpha1",
+			Kind:                         "ExternalModuleRelease",
+			ExecuteHookOnEvents:          pointer.Bool(true),
+			ExecuteHookOnSynchronization: pointer.Bool(true),
+			FilterFunc:                   filterRelease,
+		},
+	},
+}, applyModuleRelease)
+
+func applyModuleRelease(input *go_hook.HookInput) error {
+	var modulesChanged bool
+
+	snap := input.Snapshots["releases"]
+
+	externalModulesDir := os.Getenv("EXTERNAL_MODULES_DIR")
+
+	moduleReleases := make(map[string][]enqueueRelease, 0)
+
+	for _, sn := range snap {
+		if sn == nil {
+			continue
+		}
+		rel := sn.(enqueueRelease)
+		if rel.Status == "" {
+			rel.Status = v1alpha1.PhasePending
+			status := map[string]v1alpha1.ExternalModuleReleaseStatus{
+				"status": {
+					Phase:          v1alpha1.PhasePending,
+					TransitionTime: time.Now().UTC(),
+					Message:        "",
+				},
+			}
+			input.PatchCollector.MergePatch(status, "deckhouse.io/v1alpha1", "ExternalModuleRelease", "", rel.Name, object_patch.WithSubresource("/status"))
+		}
+
+		moduleReleases[rel.Module] = append(moduleReleases[rel.Module], rel)
+	}
+
+	for module, releases := range moduleReleases {
+		sort.Sort(byVersion[enqueueRelease](releases))
+
+		pred := NewReleasePredictor(releases)
+
+		pred.calculateRelease()
+
+		if pred.currentReleaseIndex == len(pred.releases)-1 {
+			// latest release deployed
+			continue
+		}
+
+		if len(pred.skippedPatchesIndexes) > 0 {
+			for _, index := range pred.skippedPatchesIndexes {
+				release := pred.releases[index]
+				status := map[string]v1alpha1.ExternalModuleReleaseStatus{
+					"status": {
+						Phase:          v1alpha1.PhaseOutdated,
+						TransitionTime: pred.ts,
+						Message:        "",
+					},
+				}
+				input.PatchCollector.MergePatch(status, "deckhouse.io/v1alpha1", "ExternalModuleRelease", "", release.Name, object_patch.WithSubresource("/status"))
+			}
+		}
+
+		if pred.currentReleaseIndex >= 0 {
+			release := pred.releases[pred.currentReleaseIndex]
+			status := map[string]v1alpha1.ExternalModuleReleaseStatus{
+				"status": {
+					Phase:          v1alpha1.PhaseOutdated,
+					TransitionTime: pred.ts,
+					Message:        "",
+				},
+			}
+			input.PatchCollector.MergePatch(status, "deckhouse.io/v1alpha1", "ExternalModuleRelease", "", release.Name, object_patch.WithSubresource("/status"))
+		}
+
+		if pred.desiredReleaseIndex >= 0 {
+			release := pred.releases[pred.desiredReleaseIndex]
+
+			symlinkName := path.Join(externalModulesDir, "modules", module)
+			modulePath := path.Join(externalModulesDir, module, "v"+release.Version.String())
+			err := enableModule(symlinkName, modulePath)
+			if err != nil {
+				input.LogEntry.Errorf("Module release failed: %v", err)
+				continue
+			}
+			modulesChanged = true
+
+			status := map[string]v1alpha1.ExternalModuleReleaseStatus{
+				"status": {
+					Phase:          v1alpha1.PhaseDeployed,
+					TransitionTime: pred.ts,
+					Message:        "",
+				},
+			}
+			input.PatchCollector.MergePatch(status, "deckhouse.io/v1alpha1", "ExternalModuleRelease", "", release.Name, object_patch.WithSubresource("/status"))
+		}
+	}
+
+	if modulesChanged {
+		err := syscall.Kill(1, syscall.SIGUSR2)
+		if err != nil {
+			input.LogEntry.Errorf("Send SIGUSR2 signal failed: %s", err)
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func enableModule(symlinkPath, modulePath string) error {
+	if _, err := os.Lstat(symlinkPath); err == nil {
+		err = os.Remove(symlinkPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	return os.Symlink(modulePath, symlinkPath)
+}
+
+func filterRelease(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var release v1alpha1.ExternalModuleRelease
+
+	err := sdk.FromUnstructured(obj, &release)
+	if err != nil {
+		return nil, err
+	}
+
+	var releaseApproved bool
+	if v, ok := release.Annotations["release.deckhouse.io/approved"]; ok {
+		if v == "true" {
+			releaseApproved = true
+		}
+	}
+
+	return enqueueRelease{
+		Name:     release.Name,
+		Version:  release.Spec.Version,
+		Module:   release.Spec.ModuleName,
+		Status:   release.Status.Phase,
+		Approved: releaseApproved,
+	}, nil
+}
+
+type enqueueRelease struct {
+	Name     string
+	Version  *semver.Version
+	Module   string
+	Status   string
+	Approved bool
+}
+
+func (er enqueueRelease) GetVersion() *semver.Version {
+	return er.Version
+}
+
+type releasePredictor struct {
+	ts time.Time
+
+	releases              []enqueueRelease
+	currentReleaseIndex   int
+	desiredReleaseIndex   int
+	skippedPatchesIndexes []int
+}
+
+func NewReleasePredictor(releases []enqueueRelease) *releasePredictor {
+	return &releasePredictor{
+		ts:       time.Now().UTC(),
+		releases: releases,
+
+		currentReleaseIndex:   -1,
+		desiredReleaseIndex:   -1,
+		skippedPatchesIndexes: make([]int, 0),
+	}
+}
+
+func (rp *releasePredictor) calculateRelease() {
+	for index, rl := range rp.releases {
+		switch rl.Status {
+		case v1alpha1.PhaseDeployed:
+			rp.currentReleaseIndex = index
+
+		case v1alpha1.PhasePending:
+			if rp.desiredReleaseIndex >= 0 {
+				previousPredictedRelease := rp.releases[rp.desiredReleaseIndex]
+				if previousPredictedRelease.Version.Major() != rl.Version.Major() {
+					continue
+				}
+
+				if previousPredictedRelease.Version.Minor() != rl.Version.Minor() {
+					continue
+				}
+				// it's a patch for predicted release, continue
+				rp.skippedPatchesIndexes = append(rp.skippedPatchesIndexes, rp.desiredReleaseIndex)
+			}
+
+			// release is predicted to be Deployed
+			rp.desiredReleaseIndex = index
+		}
+	}
+}

--- a/modules/005-external-module-manager/hooks/apply_release.go
+++ b/modules/005-external-module-manager/hooks/apply_release.go
@@ -88,7 +88,7 @@ func applyModuleRelease(input *go_hook.HookInput) error {
 
 		pred.calculateRelease()
 
-		symlinkName := path.Join(externalModulesDir, "modules", "900-"+module) // TODO: calculate index somehow
+		symlinkName := path.Join(externalModulesDir, "modules", "900-"+module)
 
 		if pred.currentReleaseIndex == len(pred.releases)-1 {
 			// latest release deployed

--- a/modules/005-external-module-manager/hooks/apply_release.go
+++ b/modules/005-external-module-manager/hooks/apply_release.go
@@ -113,7 +113,7 @@ func applyModuleRelease(input *go_hook.HookInput) error {
 				release := pred.releases[index]
 				status := map[string]v1alpha1.ExternalModuleReleaseStatus{
 					"status": {
-						Phase:          v1alpha1.PhaseOutdated,
+						Phase:          v1alpha1.PhaseSuperseded,
 						TransitionTime: pred.ts,
 						Message:        "",
 					},
@@ -126,7 +126,7 @@ func applyModuleRelease(input *go_hook.HookInput) error {
 			release := pred.releases[pred.currentReleaseIndex]
 			status := map[string]v1alpha1.ExternalModuleReleaseStatus{
 				"status": {
-					Phase:          v1alpha1.PhaseOutdated,
+					Phase:          v1alpha1.PhaseSuperseded,
 					TransitionTime: pred.ts,
 					Message:        "",
 				},

--- a/modules/005-external-module-manager/hooks/cleanup_releases.go
+++ b/modules/005-external-module-manager/hooks/cleanup_releases.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"os"
+	"path"
+	"sort"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+
+	"github.com/deckhouse/deckhouse/modules/005-external-module-manager/hooks/internal/apis/v1alpha1"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/external-module-source/cleanup",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                         "releases",
+			ApiVersion:                   "deckhouse.io/v1alpha1",
+			Kind:                         "ExternalModuleRelease",
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			FilterFunc:                   filterDeprecatedRelease,
+		},
+	},
+	Schedule: []go_hook.ScheduleConfig{
+		{
+			Name:    "check_deckhouse_release",
+			Crontab: "13 3 * * *",
+		},
+	},
+}, cleanupReleases)
+
+const (
+	keepReleaseCount = 3
+)
+
+func cleanupReleases(input *go_hook.HookInput) error {
+	snap := input.Snapshots["releases"]
+
+	externalModulesDir := os.Getenv("EXTERNAL_MODULES_DIR")
+
+	moduleRelease := make(map[string][]deprecatedRelease, 0)
+
+	for _, sn := range snap {
+		if sn == nil {
+			continue
+		}
+		rel := sn.(deprecatedRelease)
+		moduleRelease[rel.Module] = append(moduleRelease[rel.Module], rel)
+	}
+
+	for _, releases := range moduleRelease {
+		sort.Sort(sort.Reverse(byVersion[deprecatedRelease](releases)))
+
+		if len(releases) > keepReleaseCount {
+			for i := keepReleaseCount; i < len(releases); i++ {
+				release := releases[i]
+
+				modulePath := path.Join(externalModulesDir, release.Module, "v"+release.Version.String())
+				err := deleteFromFS(modulePath)
+				if err != nil {
+					input.LogEntry.Errorf("unable to remove module: %v", err)
+					continue
+				}
+
+				input.PatchCollector.Delete("deckhouse.io/v1alpha1", "ExternalModuleRelease", "", release.Name, object_patch.InBackground())
+			}
+		}
+	}
+
+	return nil
+}
+
+func deleteFromFS(dir string) error {
+	return os.RemoveAll(dir)
+}
+
+func filterDeprecatedRelease(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var release v1alpha1.ExternalModuleRelease
+
+	err := sdk.FromUnstructured(obj, &release)
+	if err != nil {
+		return nil, err
+	}
+
+	if !(release.Status.Phase == v1alpha1.PhaseOutdated || release.Status.Phase == v1alpha1.PhaseSuspended) {
+		return nil, err
+	}
+
+	return deprecatedRelease{
+		Name:    release.Name,
+		Module:  release.Spec.ModuleName,
+		Version: release.Spec.Version,
+	}, nil
+}
+
+type deprecatedRelease struct {
+	Name    string
+	Module  string
+	Version *semver.Version
+}
+
+func (dr deprecatedRelease) GetVersion() *semver.Version {
+	return dr.Version
+}
+
+type versionGetter interface {
+	GetVersion() *semver.Version
+}
+
+type byVersion[T versionGetter] []T
+
+func (b byVersion[T]) Len() int {
+	return len(b)
+}
+
+func (b byVersion[T]) Swap(i, j int) {
+	b[i], b[j] = b[j], b[i]
+}
+
+func (b byVersion[T]) Less(i, j int) bool {
+	return b[i].GetVersion().LessThan(b[j].GetVersion())
+}

--- a/modules/005-external-module-manager/hooks/cleanup_releases.go
+++ b/modules/005-external-module-manager/hooks/cleanup_releases.go
@@ -78,7 +78,7 @@ func cleanupReleases(input *go_hook.HookInput) error {
 				release := releases[i]
 
 				modulePath := path.Join(externalModulesDir, release.Module, "v"+release.Version.String())
-				err := deleteFromFS(modulePath)
+				err := os.RemoveAll(modulePath)
 				if err != nil {
 					input.LogEntry.Errorf("unable to remove module: %v", err)
 					continue
@@ -90,10 +90,6 @@ func cleanupReleases(input *go_hook.HookInput) error {
 	}
 
 	return nil
-}
-
-func deleteFromFS(dir string) error {
-	return os.RemoveAll(dir)
 }
 
 func filterDeprecatedRelease(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {

--- a/modules/005-external-module-manager/hooks/cleanup_releases.go
+++ b/modules/005-external-module-manager/hooks/cleanup_releases.go
@@ -100,7 +100,7 @@ func filterDeprecatedRelease(obj *unstructured.Unstructured) (go_hook.FilterResu
 		return nil, err
 	}
 
-	if !(release.Status.Phase == v1alpha1.PhaseOutdated || release.Status.Phase == v1alpha1.PhaseSuspended) {
+	if !(release.Status.Phase == v1alpha1.PhaseSuperseded || release.Status.Phase == v1alpha1.PhaseSuspended) {
 		return nil, err
 	}
 

--- a/modules/005-external-module-manager/hooks/cleanup_releases_test.go
+++ b/modules/005-external-module-manager/hooks/cleanup_releases_test.go
@@ -59,7 +59,7 @@ metadata:
   name: echoserver-v0.0.6
 spec:
   moduleName: echoserver
-  version: 0.0.5
+  version: 0.0.6
 status:
   phase: Deployed
 ---

--- a/modules/005-external-module-manager/hooks/cleanup_releases_test.go
+++ b/modules/005-external-module-manager/hooks/cleanup_releases_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"fmt"
+	"strconv"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: external module manager :: hooks :: cleanup::", func() {
+
+	f := HookExecutionConfigInit(`
+global:
+  deckhouseVersion: "12345"
+  modulesImages:
+    registry:
+      base: registry.deckhouse.io/deckhouse/fe
+external-module-manager:
+  internal: {}
+`, `{}`)
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "ExternalModuleRelease", false)
+
+	Context("Cluster has releases which should be cleaned up", func() {
+		BeforeEach(func() {
+			var echoserverState string
+			for i := 1; i < 5; i++ {
+				echoserverState += "\n" + generateOutdated("echoserver", "v0.0."+strconv.Itoa(i))
+			}
+
+			var helloState string
+			for i := 1; i < 3; i++ {
+				helloState += "\n" + generateOutdated("hellow", "v0.0."+strconv.Itoa(i))
+			}
+
+			f.KubeStateSet(echoserverState + `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ExternalModuleRelease
+metadata:
+  name: echoserver-v0.0.6
+spec:
+  moduleName: echoserver
+  version: 0.0.5
+status:
+  phase: Deployed
+---
+` + helloState + `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ExternalModuleRelease
+metadata:
+  name: hellow-v0.0.3
+spec:
+  moduleName: hellow
+  version: 0.0.3
+status:
+  phase: Deployed
+`)
+
+			f.BindingContexts.Set(f.GenerateScheduleContext("13 3 * * *"))
+			f.RunHook()
+		})
+
+		It("Should delete outdated releases", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			rele1 := f.KubernetesGlobalResource("ExternalModuleRelease", "echoserver-v0.0.1")
+			Expect(rele1.Exists()).To(BeFalse())
+			rele2 := f.KubernetesGlobalResource("ExternalModuleRelease", "echoserver-v0.0.2")
+			Expect(rele2.Exists()).To(BeTrue())
+
+			hel1 := f.KubernetesGlobalResource("ExternalModuleRelease", "hellow-v0.0.1")
+			Expect(hel1.Exists()).To(BeTrue())
+		})
+	})
+})
+
+const outdatedTemplate = `
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ExternalModuleRelease
+metadata:
+  name: %[1]s-%[2]s
+spec:
+  moduleName: %[1]s
+  version: %[2]s
+status:
+  phase: Outdated
+`
+
+func generateOutdated(moduleName, moduleVersion string) string {
+	return fmt.Sprintf(outdatedTemplate, moduleName, moduleVersion)
+}

--- a/modules/005-external-module-manager/hooks/cleanup_releases_test.go
+++ b/modules/005-external-module-manager/hooks/cleanup_releases_test.go
@@ -103,7 +103,7 @@ spec:
   moduleName: %[1]s
   version: %[2]s
 status:
-  phase: Outdated
+  phase: Superseded
 `
 
 func generateOutdated(moduleName, moduleVersion string) string {

--- a/modules/005-external-module-manager/hooks/common_test.go
+++ b/modules/005-external-module-manager/hooks/common_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}

--- a/modules/005-external-module-manager/hooks/ensure_crds.go
+++ b/modules/005-external-module-manager/hooks/ensure_crds.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"github.com/deckhouse/deckhouse/go_lib/hooks/ensure_crds"
+)
+
+var _ = ensure_crds.RegisterEnsureCRDsHook("/deckhouse/modules/005-external-module-manager/crds/*.yaml")

--- a/modules/005-external-module-manager/hooks/handle_sources.go
+++ b/modules/005-external-module-manager/hooks/handle_sources.go
@@ -66,6 +66,9 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			Crontab: "*/3 * * * *",
 		},
 	},
+	Settings: &go_hook.HookConfigSettings{
+		EnableSchedulesOnStartup: true,
+	},
 }, dependency.WithExternalDependencies(handleSource))
 
 func filterSource(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {

--- a/modules/005-external-module-manager/hooks/handle_sources.go
+++ b/modules/005-external-module-manager/hooks/handle_sources.go
@@ -82,7 +82,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "check_deckhouse_release",
-			Crontab: "*/3 * * * *",
+			Crontab: "*/1 * * * *",
 		},
 	},
 }, dependency.WithExternalDependencies(handleSource))
@@ -249,7 +249,6 @@ func fetchModuleVersion(logger *logrus.Entry, dc dependency.Container, moduleSou
 	}
 
 	return "v" + moduleMetadata.Version.String(), nil
-
 }
 
 func fetchAndCopyModuleVersion(dc dependency.Container, externalModulesDir string, moduleSource v1alpha1.ExternalModuleSource, moduleName, moduleVersion string, registryOptions []cr.Option) error {

--- a/modules/005-external-module-manager/hooks/handle_sources.go
+++ b/modules/005-external-module-manager/hooks/handle_sources.go
@@ -1,0 +1,436 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"archive/tar"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube/object_patch"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/deckhouse/deckhouse/go_lib/dependency/cr"
+	"github.com/deckhouse/deckhouse/modules/005-external-module-manager/hooks/internal/apis/v1alpha1"
+)
+
+const (
+	// TODO: get release channel from somewhere
+	releaseChannel = "alpha"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/external-module-source/sources",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                "sources",
+			ApiVersion:          "deckhouse.io/v1alpha1",
+			Kind:                "ExternalModuleSource",
+			ExecuteHookOnEvents: pointer.Bool(true),
+			FilterFunc:          filterSource,
+		},
+		{
+			// d8-external-modules-checksums
+			Name:                         "checksum",
+			ApiVersion:                   "v1",
+			Kind:                         "ConfigMap",
+			ExecuteHookOnSynchronization: pointer.Bool(false),
+			ExecuteHookOnEvents:          pointer.Bool(false),
+			NameSelector: &types.NameSelector{
+				MatchNames: []string{"d8-external-modules-checksum"},
+			},
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-system"},
+				},
+			},
+			FilterFunc: filterChecksumCM,
+		},
+	},
+	Schedule: []go_hook.ScheduleConfig{
+		{
+			Name:    "check_deckhouse_release",
+			Crontab: "*/3 * * * *",
+		},
+	},
+}, dependency.WithExternalDependencies(handleSource))
+
+func filterSource(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var ex v1alpha1.ExternalModuleSource
+
+	err := sdk.FromUnstructured(obj, &ex)
+
+	// remove unused fields
+	newex := v1alpha1.ExternalModuleSource{
+		TypeMeta: ex.TypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ex.Name,
+		},
+		Spec: ex.Spec,
+	}
+
+	return newex, err
+}
+
+func filterChecksumCM(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var cm corev1.ConfigMap
+
+	err := sdk.FromUnstructured(obj, &cm)
+	if err != nil {
+		return nil, err
+	}
+
+	return cm.BinaryData, nil
+}
+
+func handleSource(input *go_hook.HookInput, dc dependency.Container) error {
+	ts := time.Now().UTC()
+
+	checksumCM := input.Snapshots["checksum"]
+	var sourcesChecksum map[string][]byte
+	if len(checksumCM) > 0 {
+		sourcesChecksum = checksumCM[0].(map[string][]byte)
+		if len(sourcesChecksum) == 0 {
+			sourcesChecksum = make(map[string][]byte, 0)
+		}
+	}
+
+	snap := input.Snapshots["sources"]
+
+	externalModulesDir := os.Getenv("EXTERNAL_MODULES_DIR")
+
+	for _, sn := range snap {
+		ex := sn.(v1alpha1.ExternalModuleSource)
+		sc := v1alpha1.ExternalModuleSourceStatus{
+			SyncTime: ts,
+		}
+
+		opts := make([]cr.Option, 0)
+		if ex.Spec.Registry.DockerCFG != "" {
+			opts = append(opts, cr.WithAuth(ex.Spec.Registry.DockerCFG))
+		} else {
+			opts = append(opts, cr.WithDisabledAuth())
+		}
+
+		regCli, err := dc.GetRegistryClient(ex.Spec.Registry.Repo, opts...)
+		if err != nil {
+			sc.Msg = err.Error()
+			updateSourceStatus(input, ex.Name, sc)
+			continue
+		}
+
+		tags, err := regCli.ListTags()
+		if err != nil {
+			sc.Msg = err.Error()
+			updateSourceStatus(input, ex.Name, sc)
+			continue
+		}
+
+		sort.Strings(tags)
+
+		sc.Msg = ""
+		sc.AvailableModules = tags
+		moduleErrors := make([]v1alpha1.ModuleError, 0)
+
+		// fetch release image
+		modulesChecksum := make(map[string]string)
+
+		if data, ok := sourcesChecksum[ex.Name]; ok {
+			_ = json.Unmarshal(data, &modulesChecksum)
+		}
+
+		for _, moduleName := range tags {
+			moduleVersion, err := fetchModuleVersion(input.LogEntry, dc, ex, moduleName, modulesChecksum, opts)
+			if err != nil {
+				moduleErrors = append(moduleErrors, v1alpha1.ModuleError{
+					Name:  moduleName,
+					Error: err.Error(),
+				})
+				continue
+			}
+
+			if moduleVersion == "" {
+				// checksum has not been changed
+				continue
+			}
+
+			err = fetchAndCopyModuleVersion(dc, externalModulesDir, ex, moduleName, moduleVersion, opts)
+			if err != nil {
+				moduleErrors = append(moduleErrors, v1alpha1.ModuleError{
+					Name:  moduleName,
+					Error: err.Error(),
+				})
+				continue
+			}
+
+			createRelease(input, ex.Name, moduleName, moduleVersion)
+		}
+
+		sc.ModuleErrors = moduleErrors
+		if len(sc.ModuleErrors) > 0 {
+			sc.Msg = "Some errors occurred. Inspect status for details"
+		} else {
+			data, _ := json.Marshal(modulesChecksum)
+			sourcesChecksum[ex.Name] = data
+		}
+		updateSourceStatus(input, ex.Name, sc)
+	}
+
+	// update checksum configmap
+	patch := map[string]map[string][]byte{
+		"binaryData": sourcesChecksum,
+	}
+
+	input.PatchCollector.MergePatch(patch, "v1", "ConfigMap", "d8-system", "d8-external-modules-checksum", object_patch.IgnoreMissingObject())
+
+	return nil
+}
+
+func fetchModuleVersion(logger *logrus.Entry, dc dependency.Container, moduleSource v1alpha1.ExternalModuleSource, moduleName string, modulesChecksum map[string]string, registryOptions []cr.Option) ( /* moduleVersion */ string, error) {
+	regCli, err := dc.GetRegistryClient(path.Join(moduleSource.Spec.Registry.Repo, moduleName, "release"), registryOptions...)
+	if err != nil {
+		return "", fmt.Errorf("fetch release image error: %v", err)
+	}
+
+	img, err := regCli.Image(releaseChannel)
+	if err != nil {
+		return "", fmt.Errorf("fetch image error: %v", err)
+	}
+
+	digest, err := img.Digest()
+	if err != nil {
+		return "", fmt.Errorf("fetch digest error: %v", err)
+	}
+
+	if prev, ok := modulesChecksum[moduleName]; ok {
+		if prev == digest.String() {
+			logger.Infof("Module %s checksum has not been changed. Ignoring.", moduleName)
+			return "", nil
+		}
+	}
+
+	modulesChecksum[moduleName] = digest.String()
+
+	moduleMetadata, err := fetchModuleReleaseMetadata(img)
+	if err != nil {
+		return "", fmt.Errorf("fetch release metadata error: %v", err)
+	}
+
+	return "v" + moduleMetadata.Version.String(), nil
+
+}
+
+func fetchAndCopyModuleVersion(dc dependency.Container, externalModulesDir string, moduleSource v1alpha1.ExternalModuleSource, moduleName, moduleVersion string, registryOptions []cr.Option) error {
+	regCli, err := dc.GetRegistryClient(path.Join(moduleSource.Spec.Registry.Repo, moduleName), registryOptions...)
+	if err != nil {
+		return fmt.Errorf("fetch module error: %v", err)
+	}
+
+	img, err := regCli.Image(moduleVersion)
+	if err != nil {
+		return fmt.Errorf("fetch module version error: %v", err)
+	}
+
+	moduleVersionPath := path.Join(externalModulesDir, moduleName, moduleVersion)
+	_ = os.RemoveAll(moduleVersionPath)
+
+	err = copyModuleToFS(moduleVersionPath, img)
+	if err != nil {
+		return fmt.Errorf("copy module error: %v", err)
+	}
+
+	return nil
+}
+
+func createRelease(input *go_hook.HookInput, sourceName, moduleName, moduleVersion string) {
+	rl := &v1alpha1.ExternalModuleRelease{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ExternalModuleRelease",
+			APIVersion: "deckhouse.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        fmt.Sprintf("%s-%s", moduleName, moduleVersion),
+			Annotations: make(map[string]string),
+			Labels:      map[string]string{"module": moduleName, "source": sourceName},
+		},
+		Spec: v1alpha1.ExternalModuleReleaseSpec{
+			ModuleName: moduleName,
+			Version:    semver.MustParse(moduleVersion),
+		},
+	}
+
+	input.PatchCollector.Create(rl, object_patch.UpdateIfExists())
+}
+
+func copyModuleToFS(rootPath string, img v1.Image) error {
+	layers, err := img.Layers()
+	if err != nil {
+		return err
+	}
+
+	for _, layer := range layers {
+		rc, err := layer.Uncompressed()
+		if err != nil {
+			return err
+		}
+		err = copyLayerToFS(rootPath, rc)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func copyLayerToFS(rootPath string, rc io.ReadCloser) error {
+	tr := tar.NewReader(rc)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			// end of archive
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if strings.HasSuffix(hdr.Name, ".wh..wh..opq") {
+			continue
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(path.Join(rootPath, hdr.Name), 0755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			outFile, err := os.Create(path.Join(rootPath, hdr.Name))
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(outFile, tr); err != nil {
+				outFile.Close()
+				return err
+			}
+			outFile.Close()
+
+			err = os.Chmod(outFile.Name(), os.FileMode(hdr.Mode))
+			if err != nil {
+				return err
+			}
+
+		default:
+			return errors.New("unknown tar type")
+		}
+	}
+}
+
+func untarVersionLayer(rc io.ReadCloser, rw io.Writer) error {
+	tr := tar.NewReader(rc)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			// end of archive
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if strings.HasPrefix(hdr.Name, ".werf") {
+			continue
+		}
+
+		switch hdr.Name {
+		case "version.json":
+			_, err = io.Copy(rw, tr)
+			if err != nil {
+				return err
+			}
+			return nil
+
+		default:
+			continue
+		}
+	}
+}
+
+func fetchModuleReleaseMetadata(img v1.Image) (moduleReleaseMetadata, error) {
+	buf := bytes.NewBuffer(nil)
+	var meta moduleReleaseMetadata
+
+	layers, err := img.Layers()
+	if err != nil {
+		return meta, err
+	}
+
+	for _, layer := range layers {
+		size, err := layer.Size()
+		if err != nil {
+			// dcr.logger.Warnf("couldn't calculate layer size")
+			return meta, err
+		}
+		if size == 0 {
+			// skip some empty werf layers
+			continue
+		}
+		rc, err := layer.Uncompressed()
+		if err != nil {
+			return meta, err
+		}
+
+		err = untarVersionLayer(rc, buf)
+		if err != nil {
+			return meta, err
+		}
+
+		rc.Close()
+	}
+
+	err = json.Unmarshal(buf.Bytes(), &meta)
+
+	return meta, err
+}
+
+type moduleReleaseMetadata struct {
+	Version *semver.Version `json:"version"`
+}
+
+func updateSourceStatus(input *go_hook.HookInput, name string, sc v1alpha1.ExternalModuleSourceStatus) {
+	st := map[string]v1alpha1.ExternalModuleSourceStatus{
+		"status": sc,
+	}
+
+	input.PatchCollector.MergePatch(st, "deckhouse.io/v1alpha1", "ExternalModuleSource", "", name, object_patch.WithSubresource("/status"))
+}

--- a/modules/005-external-module-manager/hooks/handle_sources.go
+++ b/modules/005-external-module-manager/hooks/handle_sources.go
@@ -82,7 +82,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Schedule: []go_hook.ScheduleConfig{
 		{
 			Name:    "check_deckhouse_release",
-			Crontab: "*/1 * * * *",
+			Crontab: "*/3 * * * *",
 		},
 	},
 }, dependency.WithExternalDependencies(handleSource))

--- a/modules/005-external-module-manager/hooks/handle_sources.go
+++ b/modules/005-external-module-manager/hooks/handle_sources.go
@@ -286,7 +286,7 @@ func injectRegistryToModuleValues(moduleVersionPath string, moduleSource v1alpha
 
 	valuesFile := path.Join(moduleVersionPath, "values.yaml")
 
-	f, err := os.OpenFile(valuesFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 666)
+	f, err := os.OpenFile(valuesFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
 		return err
 	}

--- a/modules/005-external-module-manager/hooks/handle_sources.go
+++ b/modules/005-external-module-manager/hooks/handle_sources.go
@@ -291,7 +291,7 @@ func injectRegistryToModuleValues(moduleVersionPath string, moduleSource v1alpha
 		return err
 	}
 
-	yamlData.Registry = reg
+	yamlData.Properties.Registry = reg
 
 	valuesData, err = yaml.Marshal(yamlData)
 	if err != nil {
@@ -502,6 +502,9 @@ func (rsv *registrySchemaForValues) SetDockercfg(dockercfg string) {
 }
 
 type injectedValues struct {
-	XXX      map[string]interface{}   `json:",inline" yaml:",inline"`
-	Registry *registrySchemaForValues `json:"registry" yaml:"registry"`
+	XXX        map[string]interface{} `json:",inline" yaml:",inline"`
+	Properties struct {
+		YYY      map[string]interface{}   `json:",inline" yaml:",inline"`
+		Registry *registrySchemaForValues `json:"registry" yaml:"registry"`
+	} `json:"properties" yaml:"properties"`
 }

--- a/modules/005-external-module-manager/hooks/handle_sources.go
+++ b/modules/005-external-module-manager/hooks/handle_sources.go
@@ -34,6 +34,7 @@ import (
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube/object_patch"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/iancoleman/strcase"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,11 +44,6 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/cr"
 	"github.com/deckhouse/deckhouse/modules/005-external-module-manager/hooks/internal/apis/v1alpha1"
-)
-
-const (
-	// TODO: get release channel from somewhere
-	releaseChannel = "alpha"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -84,6 +80,10 @@ func filterSource(obj *unstructured.Unstructured) (go_hook.FilterResult, error) 
 			Name: ex.Name,
 		},
 		Spec: ex.Spec,
+	}
+
+	if newex.Spec.ReleaseChannel == "" {
+		newex.Spec.ReleaseChannel = "alpha"
 	}
 
 	return newex, err
@@ -218,7 +218,7 @@ func fetchModuleVersion(logger *logrus.Entry, dc dependency.Container, moduleSou
 		return "", fmt.Errorf("fetch release image error: %v", err)
 	}
 
-	img, err := regCli.Image(releaseChannel)
+	img, err := regCli.Image(strcase.ToKebab(moduleSource.Spec.ReleaseChannel))
 	if err != nil {
 		return "", fmt.Errorf("fetch image error: %v", err)
 	}

--- a/modules/005-external-module-manager/hooks/handle_sources.go
+++ b/modules/005-external-module-manager/hooks/handle_sources.go
@@ -131,6 +131,7 @@ func handleSource(input *go_hook.HookInput, dc dependency.Container) error {
 
 		sc.Msg = ""
 		sc.AvailableModules = tags
+		sc.ModulesCount = len(tags)
 		moduleErrors := make([]v1alpha1.ModuleError, 0)
 
 		mChecksum := make(moduleChecksum)

--- a/modules/005-external-module-manager/hooks/handle_sources.go
+++ b/modules/005-external-module-manager/hooks/handle_sources.go
@@ -478,7 +478,8 @@ type sourceChecksum map[string]moduleChecksum
 
 // part of openapi schema for injecting registry values
 type registrySchemaForValues struct {
-	Type       string `yaml:"type"`
+	Type       string   `yaml:"type"`
+	Default    struct{} `yaml:"default"`
 	Properties struct {
 		Base struct {
 			Type    string `yaml:"type"`

--- a/modules/005-external-module-manager/hooks/handle_sources.go
+++ b/modules/005-external-module-manager/hooks/handle_sources.go
@@ -83,7 +83,7 @@ func filterSource(obj *unstructured.Unstructured) (go_hook.FilterResult, error) 
 	}
 
 	if newex.Spec.ReleaseChannel == "" {
-		newex.Spec.ReleaseChannel = "alpha"
+		newex.Spec.ReleaseChannel = "stable"
 	}
 
 	return newex, err

--- a/modules/005-external-module-manager/hooks/handle_sources_test.go
+++ b/modules/005-external-module-manager/hooks/handle_sources_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package hooks
 
 import (

--- a/modules/005-external-module-manager/hooks/handle_sources_test.go
+++ b/modules/005-external-module-manager/hooks/handle_sources_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package hooks
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,8 +51,6 @@ properties:
 
 	data, err := mutateOpenapiSchema([]byte(source), sourceModule)
 	require.NoError(t, err)
-
-	fmt.Println(string(data))
 
 	assert.YAMLEq(t, `
 type: object

--- a/modules/005-external-module-manager/hooks/handle_sources_test.go
+++ b/modules/005-external-module-manager/hooks/handle_sources_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package hooks
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,6 +53,8 @@ properties:
 	data, err := mutateOpenapiSchema([]byte(source), sourceModule)
 	require.NoError(t, err)
 
+	fmt.Println(string(data))
+
 	assert.YAMLEq(t, `
 type: object
 x-extend:
@@ -59,6 +62,7 @@ x-extend:
 properties:
   registry:
     type: object
+    default: {}
     properties:
       base:
         type: string

--- a/modules/005-external-module-manager/hooks/handle_sources_test.go
+++ b/modules/005-external-module-manager/hooks/handle_sources_test.go
@@ -1,0 +1,63 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/modules/005-external-module-manager/hooks/internal/apis/v1alpha1"
+)
+
+func TestOpenapiInjection(t *testing.T) {
+	source := `
+x-extend:
+  schema: config-values.yaml
+type: object
+properties:
+  internal:
+    type: object
+    default: {}
+    properties:
+      pythonVersions:
+        type: array
+        default: []
+        items:
+          type: string
+  registry:
+    type: object
+    description: "System field, overwritten by Deckhouse. Don't use"
+`
+
+	sourceModule := v1alpha1.ExternalModuleSource{}
+	sourceModule.Spec.Registry.Repo = "test.deckhouse.io/foo/bar"
+	sourceModule.Spec.Registry.DockerCFG = "dGVzdG1lCg=="
+
+	data, err := mutateOpenapiSchema([]byte(source), sourceModule)
+	require.NoError(t, err)
+
+	assert.YAMLEq(t, `
+type: object
+x-extend:
+  schema: config-values.yaml
+properties:
+  registry:
+    type: object
+    properties:
+      base:
+        type: string
+        default: test.deckhouse.io/foo/bar
+      dockercfg:
+        type: string
+        default: dGVzdG1lCg==
+  internal:
+    default: {}
+    properties:
+      pythonVersions:
+        default: []
+        items:
+          type: string
+        type: array
+    type: object
+`, string(data))
+}

--- a/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/release.go
+++ b/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/release.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// +genclient
+// +genclient:nonNamespaced
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+const (
+	PhasePending   = "Pending"
+	PhaseDeployed  = "Deployed"
+	PhaseOutdated  = "Outdated"
+	PhaseSuspended = "Suspended"
+)
+
+// ExternalModuleRelease is a ExternalModule release object.
+type ExternalModuleRelease struct {
+	metav1.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec ExternalModuleReleaseSpec `json:"spec"`
+
+	Status ExternalModuleReleaseStatus `json:"status,omitempty"`
+}
+
+type ExternalModuleReleaseSpec struct {
+	ModuleName   string            `json:"moduleName"`
+	Version      *semver.Version   `json:"version,omitempty"`
+	ApplyAfter   *time.Time        `json:"applyAfter,omitempty"`
+	Requirements map[string]string `json:"requirements,omitempty"`
+}
+
+type ExternalModuleReleaseStatus struct {
+	Phase          string    `json:"phase,omitempty"`
+	Approved       bool      `json:"approved"`
+	TransitionTime time.Time `json:"transitionTime,omitempty"`
+	Message        string    `json:"message"`
+}
+
+type ExternalModuleReleaseKind struct{}
+
+func (in *ExternalModuleReleaseStatus) GetObjectKind() schema.ObjectKind {
+	return &ExternalModuleReleaseKind{}
+}
+
+func (f *ExternalModuleReleaseKind) SetGroupVersionKind(_ schema.GroupVersionKind) {}
+func (f *ExternalModuleReleaseKind) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: "deckhouse.io", Version: "v1alpha1", Kind: "ExternalModuleRelease"}
+}
+
+// Duration custom type for appropriate json marshalling / unmarshalling (like "15m")
+type Duration struct {
+	time.Duration
+}
+
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	switch value := v.(type) {
+	case float64:
+		d.Duration = time.Duration(value)
+		return nil
+	case string:
+		var err error
+		d.Duration, err = time.ParseDuration(value)
+		if err != nil {
+			return err
+		}
+		return nil
+	default:
+		return errors.New("invalid duration")
+	}
+}

--- a/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/release.go
+++ b/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/release.go
@@ -31,10 +31,10 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 const (
-	PhasePending   = "Pending"
-	PhaseDeployed  = "Deployed"
-	PhaseOutdated  = "Outdated"
-	PhaseSuspended = "Suspended"
+	PhasePending    = "Pending"
+	PhaseDeployed   = "Deployed"
+	PhaseSuperseded = "Superseded"
+	PhaseSuspended  = "Suspended"
 )
 
 // ExternalModuleRelease is a ExternalModule release object.

--- a/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/source.go
+++ b/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/source.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2023 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ExternalModuleSource struct {
+	metav1.TypeMeta `json:",inline"`
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+	// +optional
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// Spec defines the behavior of an ExternalModuleSource.
+	Spec ExternalModuleSourceSpec `json:"spec"`
+
+	// Status of an ExternalModuleSource.
+	Status ExternalModuleSourceStatus `json:"status,omitempty"`
+}
+
+type ExternalModuleSourceSpec struct {
+	Registry struct {
+		Repo      string `json:"repo"`
+		DockerCFG string `json:"dockerCfg"`
+	} `json:"registry"`
+}
+
+type ExternalModuleSourceStatus struct {
+	SyncTime         time.Time     `json:"syncTime,omitempty"`
+	AvailableModules []string      `json:"availableModules,omitempty"`
+	Msg              string        `json:"message,omitempty"`
+	ModuleErrors     []ModuleError `json:"moduleErrors,omitempty"`
+}
+
+type ModuleError struct {
+	Name  string `json:"name"`
+	Error string `json:"error"`
+}

--- a/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/source.go
+++ b/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/source.go
@@ -44,10 +44,10 @@ type ExternalModuleSourceSpec struct {
 }
 
 type ExternalModuleSourceStatus struct {
-	SyncTime         time.Time     `json:"syncTime,omitempty"`
-	AvailableModules []string      `json:"availableModules,omitempty"`
-	Msg              string        `json:"message,omitempty"`
-	ModuleErrors     []ModuleError `json:"moduleErrors,omitempty"`
+	SyncTime         time.Time     `json:"syncTime"`
+	AvailableModules []string      `json:"availableModules"`
+	Msg              string        `json:"message"`
+	ModuleErrors     []ModuleError `json:"moduleErrors"`
 }
 
 type ModuleError struct {

--- a/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/source.go
+++ b/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/source.go
@@ -41,6 +41,7 @@ type ExternalModuleSourceSpec struct {
 		Repo      string `json:"repo"`
 		DockerCFG string `json:"dockerCfg"`
 	} `json:"registry"`
+	ReleaseChannel string `json:"releaseChannel"`
 }
 
 type ExternalModuleSourceStatus struct {

--- a/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/source.go
+++ b/modules/005-external-module-manager/hooks/internal/apis/v1alpha1/source.go
@@ -45,6 +45,7 @@ type ExternalModuleSourceSpec struct {
 
 type ExternalModuleSourceStatus struct {
 	SyncTime         time.Time     `json:"syncTime"`
+	ModulesCount     int           `json:"modulesCount"`
 	AvailableModules []string      `json:"availableModules"`
 	Msg              string        `json:"message"`
 	ModuleErrors     []ModuleError `json:"moduleErrors"`

--- a/modules/005-external-module-manager/openapi/config-values.yaml
+++ b/modules/005-external-module-manager/openapi/config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/modules/005-external-module-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/005-external-module-manager/openapi/doc-ru-config-values.yaml
@@ -1,0 +1,2 @@
+type: object
+properties: {}

--- a/modules/005-external-module-manager/openapi/openapi-case-tests.yaml
+++ b/modules/005-external-module-manager/openapi/openapi-case-tests.yaml
@@ -1,0 +1,10 @@
+positive:
+  configValues:
+  - {}
+  values:
+  - { internal: {} }
+negative:
+  configValues:
+  - { somethingInConfig: yes }
+  values:
+  - { somethingInConfig: yes }

--- a/modules/005-external-module-manager/openapi/values.yaml
+++ b/modules/005-external-module-manager/openapi/values.yaml
@@ -1,0 +1,8 @@
+x-extend:
+  schema: config-values.yaml
+type: object
+properties:
+  internal:
+    type: object
+    default: {}
+

--- a/modules/005-external-module-manager/templates/configmap.yaml
+++ b/modules/005-external-module-manager/templates/configmap.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: d8-external-modules-checksum
+  namespace: d8-system
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+data: {}

--- a/modules/005-external-module-manager/templates/configmap.yaml
+++ b/modules/005-external-module-manager/templates/configmap.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: d8-external-modules-checksum
-  namespace: d8-system
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-data: {}

--- a/modules/040-node-manager/hooks/machineclass_checksum_assign.go
+++ b/modules/040-node-manager/hooks/machineclass_checksum_assign.go
@@ -167,6 +167,6 @@ func readChecksumTemplate(cloudType string) ([]byte, error) {
 func getChecksumTemplatePath(cloudType string) string {
 	// Memorize: we can not use MODULES_DIR env variable anymore
 	// because MODULES_DIR could contain multiple paths, joined with colon (:) in the unpredictable order
-	path := filepath.Join("deckhouse", "modules", "040-node-manager", "cloud-providers", cloudType, "machine-class.checksum")
+	path := filepath.Join("/deckhouse", "modules", "040-node-manager", "cloud-providers", cloudType, "machine-class.checksum")
 	return path
 }

--- a/modules/040-node-manager/hooks/machineclass_checksum_assign.go
+++ b/modules/040-node-manager/hooks/machineclass_checksum_assign.go
@@ -165,10 +165,8 @@ func readChecksumTemplate(cloudType string) ([]byte, error) {
 }
 
 func getChecksumTemplatePath(cloudType string) string {
-	modulesDir, ok := os.LookupEnv("MODULES_DIR")
-	if !ok {
-		modulesDir = "../.."
-	}
-	path := filepath.Join(modulesDir, "040-node-manager", "cloud-providers", cloudType, "machine-class.checksum")
+	// Memorize: we can not use MODULES_DIR env variable anymore
+	// because MODULES_DIR could contain multiple paths, joined with colon (:) in the unpredictable order
+	path := filepath.Join("deckhouse", "modules", "040-node-manager", "cloud-providers", cloudType, "machine-class.checksum")
 	return path
 }

--- a/modules/040-node-manager/hooks/machineclass_checksum_assign_test.go
+++ b/modules/040-node-manager/hooks/machineclass_checksum_assign_test.go
@@ -943,7 +943,7 @@ func newCloudProviderAvailabilityChecker() func(tYpE string) {
 func getAvailableCloudProviderTypes() set.Set {
 	ptypes := set.New()
 
-	dir := filepath.Join("deckhouse", "modules", "040-node-manager", "cloud-providers")
+	dir := filepath.Join("/deckhouse", "modules", "040-node-manager", "cloud-providers")
 
 	files, err := os.ReadDir(dir)
 	if err != nil {

--- a/modules/040-node-manager/hooks/machineclass_checksum_assign_test.go
+++ b/modules/040-node-manager/hooks/machineclass_checksum_assign_test.go
@@ -943,11 +943,7 @@ func newCloudProviderAvailabilityChecker() func(tYpE string) {
 func getAvailableCloudProviderTypes() set.Set {
 	ptypes := set.New()
 
-	modulesDir, ok := os.LookupEnv("MODULES_DIR")
-	if !ok {
-		modulesDir = "../.."
-	}
-	dir := filepath.Join(modulesDir, "040-node-manager", "cloud-providers")
+	dir := filepath.Join("deckhouse", "modules", "040-node-manager", "cloud-providers")
 
 	files, err := os.ReadDir(dir)
 	if err != nil {

--- a/modules/values-default.yaml
+++ b/modules/values-default.yaml
@@ -7,6 +7,7 @@ containerizedDataImporterEnabled: true
 controlPlaneManagerEnabled: true
 dashboardEnabled: true
 deckhouseConfigEnabled: true
+externalModuleManagerEnabled: true
 deckhouseEnabled: true
 deckhouseWebEnabled: true
 deschedulerEnabled: true

--- a/modules/values-managed.yaml
+++ b/modules/values-managed.yaml
@@ -4,6 +4,7 @@ certManagerEnabled: true
 containerizedDataImporterEnabled: true
 dashboardEnabled: true
 deckhouseConfigEnabled: true
+externalModuleManagerEnabled: true
 deckhouseEnabled: true
 deckhouseWebEnabled: true
 deschedulerEnabled: true

--- a/modules/values-minimal.yaml
+++ b/modules/values-minimal.yaml
@@ -1,3 +1,4 @@
 # CE Bundle "Minimal"
 deckhouseConfigEnabled: true
 deckhouseEnabled: true
+externalModuleManagerEnabled: true

--- a/modules/values-minimal.yaml
+++ b/modules/values-minimal.yaml
@@ -1,4 +1,3 @@
 # CE Bundle "Minimal"
 deckhouseConfigEnabled: true
 deckhouseEnabled: true
-externalModuleManagerEnabled: true

--- a/testing/matrix/linter/rules/modules/modules.go
+++ b/testing/matrix/linter/rules/modules/modules.go
@@ -153,7 +153,7 @@ func GetDeckhouseModulesWithValuesMatrixTests(focusNames set.Set) (modules []uti
 			"/deckhouse/ee/fe/modules",
 		}
 	} else {
-		possibleModulesPaths = []string{modulesDir}
+		possibleModulesPaths = strings.Split(modulesDir, ":")
 	}
 
 	var modulesPaths []string

--- a/testing/matrix/linter/rules/modules/oss.go
+++ b/testing/matrix/linter/rules/modules/oss.go
@@ -151,6 +151,7 @@ var skipOssChecks = map[string]struct{}{
 	// module name
 	"001-priority-class":                      {},
 	"003-deckhouse-config":                    {},
+	"005-external-module-manager":             {},
 	"011-flow-schema":                         {},
 	"013-helm":                                {}, // helm in 002-deckhouse
 	"021-kube-proxy":                          {},


### PR DESCRIPTION
## Description
Add new module for having and ability to load external modules

## Why do we need it, and what problem does it solve?
We want to support external modules, load them and add to the Deckhouse
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: external-module-manager
type: feature
summary: Add new module for loading external modules in runtime
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
