### PR TITLE
[bashible] refactor start_kubelet step

### DIFF
--- a/candi/bashible/common-steps/all/091_set_virtualization_type.sh.tpl
+++ b/candi/bashible/common-steps/all/091_set_virtualization_type.sh.tpl
@@ -19,6 +19,10 @@ if [ ! -f "$kubeconfig" ]; then
   exit 0
 fi
 
+if [[ "${FIRST_BASHIBLE_RUN}" == "yes" ]]; then
+  exit 0
+fi
+
 # if reboot flag set due to disruption update (for example, in case of CRI change) we pass this step.
 # this step runs normally after node reboot.
 if bb-flag? disruption && bb-flag? reboot; then

--- a/candi/bashible/common-steps/node-group/069_start_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/069_start_kubelet.sh.tpl
@@ -12,59 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- /* CSI socket migration. fox MR !2179 */}}
-{{- if ne .nodeGroup.nodeType "Static" }}
-if [[ -d /var/lib/kubelet/plugins/ebs.csi.aws.com ]]; then
-  if [[ -d /var/lib/kubelet/csi-plugins/ebs.csi.aws.com ]]; then
-    rm -rf /var/lib/kubelet/plugins/ebs.csi.aws.com
-    bb-flag-set kubelet-need-restart
-  else
-    bb-log-error '"/var/lib/kubelet/csi-plugins/ebs.csi.aws.com" is not created yet'
-    exit 1
-  fi
-fi
-
-if [[ -d /var/lib/kubelet/plugins/pd.csi.storage.gke.io ]]; then
-  if [[ -d /var/lib/kubelet/csi-plugins/pd.csi.storage.gke.io ]]; then
-    rm -rf /var/lib/kubelet/plugins/pd.csi.storage.gke.io
-    bb-flag-set kubelet-need-restart
-  else
-    bb-log-error '"/var/lib/kubelet/csi-plugins/pd.csi.storage.gke.io" is not created yet'
-    exit 1
-  fi
-fi
-
-if [[ -d /var/lib/kubelet/plugins/cinder.csi.openstack.org ]]; then
-  if [[ -d /var/lib/kubelet/csi-plugins/cinder.csi.openstack.org ]]; then
-    rm -rf /var/lib/kubelet/plugins/cinder.csi.openstack.org
-    bb-flag-set kubelet-need-restart
-  else
-    bb-log-error '"/var/lib/kubelet/csi-plugins/cinder.csi.openstack.org" is not created yet'
-    exit 1
-  fi
-fi
-
-if [[ -d /var/lib/kubelet/plugins/vsphere.csi.vmware.com ]]; then
-  if [[ -d /var/lib/kubelet/csi-plugins/vsphere.csi.vmware.com ]]; then
-    rm -rf /var/lib/kubelet/plugins/vsphere.csi.vmware.com
-    bb-flag-set kubelet-need-restart
-  else
-    bb-log-error '"/var/lib/kubelet/csi-plugins/vsphere.csi.vmware.com" is not created yet'
-    exit 1
-  fi
-fi
-
-if [[ -d /var/lib/kubelet/plugins/yandex.csi.flant.com ]]; then
-  if [[ -d /var/lib/kubelet/csi-plugins/yandex.csi.flant.com ]]; then
-    rm -rf /var/lib/kubelet/plugins/yandex.csi.flant.com
-    bb-flag-set kubelet-need-restart
-  else
-    bb-log-error '"/var/lib/kubelet/csi-plugins/yandex.csi.flant.com" is not created yet'
-    exit 1
-  fi
-fi
-{{- end }}
-
 if bb-flag? kubelet-need-restart; then
 
 {{- if ne .runType "ImageBuilding" }}
@@ -77,9 +24,6 @@ if bb-flag? kubelet-need-restart; then
     # https://github.com/kubernetes/kubernetes/issues/102367
     # Remove the sleep once a solution is devised.
     sleep 60
-  else
-     bb-log-info "Skip restarting kubelet because node will be rebooted."
-  fi
   {{- end }}
 {{- end }}
 

--- a/candi/bashible/common-steps/node-group/069_start_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/069_start_kubelet.sh.tpl
@@ -24,6 +24,7 @@ if bb-flag? kubelet-need-restart; then
     # https://github.com/kubernetes/kubernetes/issues/102367
     # Remove the sleep once a solution is devised.
     sleep 60
+  fi
   {{- end }}
 {{- end }}
 

--- a/candi/bashible/common-steps/node-group/069_start_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/069_start_kubelet.sh.tpl
@@ -95,7 +95,7 @@ if systemctl is-active --quiet "kubelet.service"; then
   exit 0
 fi
 
-bb-log-warning "Kubelet service is not running. Start it..."
+bb-log-warning "Kubelet service is not running. Starting it..."
 if systemctl start "kubelet.service"; then
   bb-log-info "Kubelet has started."
 else

--- a/candi/bashible/common-steps/node-group/069_start_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/node-group/069_start_kubelet.sh.tpl
@@ -15,7 +15,7 @@
 if bb-flag? kubelet-need-restart; then
 
 {{- if ne .runType "ImageBuilding" }}
-  bb-log-warning "'kubelet-need-restart' flag was set. Restart kubelet."
+  bb-log-warning "'kubelet-need-restart' flag was set, restarting kubelet."
   systemctl restart "kubelet.service"
   {{ if ne .runType "ClusterBootstrap" }}
   if [[ "${FIRST_BASHIBLE_RUN}" != "yes" ]] && ! bb-flag? reboot; then


### PR DESCRIPTION
Signed-off-by: Denis Romanenko <denis.romanenko@flant.com>

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
 Refactor start_kubelet step to avoid 60 sec pause on cloud node bootstrap.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When we bootstrap cloud nodes, on the first bashible run we got 60 sec pause on kubelet restart.
## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: refactor start_kubelet step
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
