### PR TITLE
[deckhouse] add bash wrapper for handling USR signals

### DIFF
--- a/deckhouse-controller/entrypoint.sh
+++ b/deckhouse-controller/entrypoint.sh
@@ -40,12 +40,8 @@ set +e
 PID=0
 EXITCODE=0
 
-for SIG in SIGUSR1 SIGUSR2 SIGINT SIGTERM SIGHUP SIGQUIT; do
-  trap "signal_handler ${SIG}" "${SIG}"
-done
-
 signal_handler() {
-  echo "{\"msg\": \"Catch signal ${1}\"}"
+  echo "{\"level\":\"warning\", \"msg\": \"Catch signal ${1}\"}"
   case "${1}" in
   "SIGUSR1" | "SIGUSR2")
     kill "${PID}"
@@ -59,12 +55,16 @@ signal_handler() {
 }
 
 run_deckhouse() {
-  /usr/bin/deckhouse-controller start &
+  /sbin/tini -s -- /usr/bin/deckhouse-controller start &
   PID="${!}"
-  echo "{\"msg\": \" New deckhouse PID ${PID}\"}"
+  echo "{\"level\":\"info\", \"msg\": \"New deckhouse PID ${PID}\"}"
   wait "${PID}"
   EXITCODE="${?}"
 }
+
+for SIG in SIGUSR1 SIGUSR2 SIGINT SIGTERM SIGHUP SIGQUIT; do
+  trap "signal_handler ${SIG}" "${SIG}"
+done
 
 run_deckhouse
 exit "${EXITCODE}"

--- a/deckhouse-controller/entrypoint.sh
+++ b/deckhouse-controller/entrypoint.sh
@@ -17,6 +17,31 @@
 set -o pipefail
 set -e
 
+PID=0
+EXITCODE=0
+
+signal_handler() {
+  echo "{\"level\":\"warning\", \"msg\": \"Catch signal ${1}\"}"
+  case "${1}" in
+  "SIGUSR1" | "SIGUSR2")
+    kill "${PID}"
+    wait "${PID}"
+    run_deckhouse
+    ;;
+  *)
+    kill -"${1}" "${PID}"
+    ;;
+  esac
+}
+
+run_deckhouse() {
+  /usr/bin/deckhouse-controller start &
+  PID="${!}"
+  echo "{\"level\":\"info\", \"msg\": \"New deckhouse PID ${PID}\"}"
+  wait "${PID}"
+  EXITCODE="${?}"
+}
+
 declare -A bundles_map; bundles_map=( ["Default"]="default" ["Minimal"]="minimal" ["Managed"]="managed" )
 
 bundle=${DECKHOUSE_BUNDLE:-Default}
@@ -36,31 +61,6 @@ cat ${MODULES_DIR}/values-${bundles_map[$bundle]}.yaml >> ${MODULES_DIR}/values.
 
 set +o pipefail
 set +e
-
-PID=0
-EXITCODE=0
-
-signal_handler() {
-  echo "{\"level\":\"warning\", \"msg\": \"Catch signal ${1}\"}"
-  case "${1}" in
-  "SIGUSR1" | "SIGUSR2")
-    kill "${PID}"
-    wait "${PID}"
-    run_deckhouse
-    ;;
-  *)
-    kill -"${1}" "${PID}"
-    ;;
-  esac
-}
-
-run_deckhouse() {
-  /sbin/tini -s -- /usr/bin/deckhouse-controller start &
-  PID="${!}"
-  echo "{\"level\":\"info\", \"msg\": \"New deckhouse PID ${PID}\"}"
-  wait "${PID}"
-  EXITCODE="${?}"
-}
 
 for SIG in SIGUSR1 SIGUSR2 SIGINT SIGTERM SIGHUP SIGQUIT; do
   trap "signal_handler ${SIG}" "${SIG}"

--- a/deckhouse-controller/entrypoint.sh
+++ b/deckhouse-controller/entrypoint.sh
@@ -34,6 +34,9 @@ EOF
 
 cat ${MODULES_DIR}/values-${bundles_map[$bundle]}.yaml >> ${MODULES_DIR}/values.yaml
 
+set +o pipefail
+set +e
+
 PID=0
 EXITCODE=0
 

--- a/deckhouse-controller/entrypoint.sh
+++ b/deckhouse-controller/entrypoint.sh
@@ -42,6 +42,7 @@ for SIG in SIGUSR1 SIGUSR2 SIGINT SIGTERM SIGHUP SIGQUIT; do
 done
 
 signal_handler() {
+  echo "{\"msg\": \"Catch signal ${1}\"}"
   case "${1}" in
   "SIGUSR1" | "SIGUSR2")
     kill "${PID}"
@@ -57,6 +58,7 @@ signal_handler() {
 run_deckhouse() {
   /usr/bin/deckhouse-controller start &
   PID="${!}"
+  echo "{\"msg\": \" New deckhouse PID ${PID}\"}"
   wait "${PID}"
   EXITCODE="${?}"
 }

--- a/werf.yaml
+++ b/werf.yaml
@@ -255,9 +255,10 @@ ansible:
         {{- .Env | default "unknown" | nindent 8 }}
       dest: /deckhouse/edition
 
-  # Because of https://github.com/flant/werf/issues/1741 just make symlink for the entry point
-  - name: "Make symlink for deckhouse entrypoint in the right location"
-    shell: ln -s /deckhouse/deckhouse-controller/entrypoint.sh /deckhouse/deckhouse
+  - name: "Override deckhouse entrypoint to use tini as supervisor"
+    shell: |
+      echo -e "#!/bin/bash\nexec tini -- /deckhouse/deckhouse-controller/entrypoint.sh" > /deckhouse/deckhouse
+      chmod +x /deckhouse/deckhouse
 
   - name: "Run deckhouse from nobody"
     file:


### PR DESCRIPTION
## Description
Added bash wrapper, allowing processing of USR1, USR2 signals, which is used to restart the deckhouse child process.

## Why do we need it, and what problem does it solve?
This supervisor is required for the use of 3rd party modules.

## What is the expected result?
By receiving USR1, USR2 the deckhouse child process will receive a TERM signal and be restarted.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: deckhouse
type: feature
summary: Added bash wrapper for handling USR signals.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
