### PR TITLE
[linstor] fix rollingUpdate with two system nodes

### DIFF
--- a/modules/041-linstor/crds/piraeus.linbit.com_linstorcsidrivers.yaml
+++ b/modules/041-linstor/crds/piraeus.linbit.com_linstorcsidrivers.yaml
@@ -869,6 +869,55 @@ spec:
                   for the CSI controller deployment.
                 format: int32
                 type: integer
+              controllerStrategy:
+                description: controllerStrategy describes how to replace existing
+                  pods with new ones.
+                nullable: true
+                properties:
+                  rollingUpdate:
+                    description: 'Rolling update config params. Present only if DeploymentStrategyType
+                      = RollingUpdate. --- TODO: Update this to follow our convention
+                      for oneOf, whatever we decide it to be.'
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of pods that can be scheduled
+                          above the desired number of pods. Value can be an absolute
+                          number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0. Absolute number
+                          is calculated from percentage by rounding up. Defaults to
+                          25%. Example: when this is set to 30%, the new ReplicaSet
+                          can be scaled up immediately when the rolling update starts,
+                          such that the total number of old and new pods do not exceed
+                          130% of desired pods. Once old pods have been killed, new
+                          ReplicaSet can be scaled up further, ensuring that total
+                          number of pods running at any time during the update is
+                          at most 130% of desired pods.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of pods that can be unavailable
+                          during the update. Value can be an absolute number (ex:
+                          5) or a percentage of desired pods (ex: 10%). Absolute number
+                          is calculated from percentage by rounding down. This can
+                          not be 0 if MaxSurge is 0. Defaults to 25%. Example: when
+                          this is set to 30%, the old ReplicaSet can be scaled down
+                          to 70% of desired pods immediately when the rolling update
+                          starts. Once new pods are ready, old ReplicaSet can be scaled
+                          down further, followed by scaling up the new ReplicaSet,
+                          ensuring that the total number of pods available at all
+                          times during the update is at least 70% of desired pods.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                      Default is RollingUpdate.
+                    type: string
+                type: object
               controllerTolerations:
                 description: Tolerations for schedluing CSI controller pods
                 items:

--- a/modules/041-linstor/images/piraeus-operator/patches/README.md
+++ b/modules/041-linstor/images/piraeus-operator/patches/README.md
@@ -5,3 +5,12 @@
 This is our internal patch to disable finalizers logic for piraeus-operator custom resources.
 It was the simpliest way to avoid dependency problem while deleting operator and custom resources at one time.
 It makes no sense for us since all the resources are deployed in single namespace and managed together as one.
+
+### CSI-controller strategy
+
+This PR allows to specify deployment strategy for linstor-csi-controller
+linstor-csi-controller with podAntiAffinity and default strategy will stuck update in case of two nodes.
+
+The linstor-controller deployment is not affected due to hardcoded `strategy: Recreate`
+
+- https://github.com/piraeusdatastore/piraeus-operator/pull/395

--- a/modules/041-linstor/images/piraeus-operator/patches/csi-controller-strategy.patch
+++ b/modules/041-linstor/images/piraeus-operator/patches/csi-controller-strategy.patch
@@ -1,0 +1,48 @@
+diff --git a/pkg/apis/piraeus/v1/linstorcsidriver_types.go b/pkg/apis/piraeus/v1/linstorcsidriver_types.go
+index 6008500..9e80aa1 100644
+--- a/pkg/apis/piraeus/v1/linstorcsidriver_types.go
++++ b/pkg/apis/piraeus/v1/linstorcsidriver_types.go
+@@ -19,6 +19,7 @@ package v1
+ 
+ import (
+ 	"github.com/piraeusdatastore/piraeus-operator/pkg/apis/piraeus/shared"
++	appsv1 "k8s.io/api/apps/v1"
+ 	corev1 "k8s.io/api/core/v1"
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ )
+@@ -89,6 +90,11 @@ type LinstorCSIDriverSpec struct {
+ 	// +optional
+ 	ControllerReplicas *int32 `json:"controllerReplicas"`
+ 
++	// controllerStrategy describes how to replace existing pods with new ones.
++	// +optional
++	// +nullable
++	ControllerStrategy appsv1.DeploymentStrategy `json:"controllerStrategy,omitempty"`
++
+ 	// Cluster URL of the linstor controller.
+ 	// If not set, will be determined from the current resource name.
+ 	// +optional
+diff --git a/pkg/apis/piraeus/v1/zz_generated.deepcopy.go b/pkg/apis/piraeus/v1/zz_generated.deepcopy.go
+index 2f1b224..51f1467 100644
+--- a/pkg/apis/piraeus/v1/zz_generated.deepcopy.go
++++ b/pkg/apis/piraeus/v1/zz_generated.deepcopy.go
+@@ -95,6 +95,7 @@ func (in *LinstorCSIDriverSpec) DeepCopyInto(out *LinstorCSIDriverSpec) {
+ 		*out = new(int32)
+ 		**out = **in
+ 	}
++	in.ControllerStrategy.DeepCopyInto(&out.ControllerStrategy)
+ 	in.Resources.DeepCopyInto(&out.Resources)
+ 	if in.NodeAffinity != nil {
+ 		in, out := &in.NodeAffinity, &out.NodeAffinity
+diff --git a/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go b/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
+index 3b7a0bb..0d3980f 100644
+--- a/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
++++ b/pkg/controller/linstorcsidriver/linstorcsidriver_controller.go
+@@ -993,6 +993,7 @@ func newCSIControllerDeployment(csiResource *piraeusv1.LinstorCSIDriver) *appsv1
+ 				MatchLabels: meta.Labels,
+ 			},
+ 			Replicas: csiResource.Spec.ControllerReplicas,
++			Strategy: csiResource.Spec.ControllerStrategy,
+ 			Template: template,
+ 		},
+ 	}

--- a/modules/041-linstor/templates/linstor-affinity-controller/deployment.yaml
+++ b/modules/041-linstor/templates/linstor-affinity-controller/deployment.yaml
@@ -51,7 +51,7 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "linstor-affinity-controller" )) | nindent 2 }}
 spec:
-  replicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
+  {{- include "helm_lib_deployment_strategy_and_replicas_for_ha" . | nindent 2 }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/modules/041-linstor/templates/linstor-csi/linstorcsidriver.yaml
+++ b/modules/041-linstor/templates/linstor-csi/linstorcsidriver.yaml
@@ -134,28 +134,10 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "linstor-csi-controller")) | nindent 2 }}
 spec:
-  minAvailable: 0
+  minAvailable: {{ include "helm_lib_is_ha_to_value" (list . 1 0) }}
   selector:
     matchLabels:
       app.kubernetes.io/component: csi-controller
-      app.kubernetes.io/instance: linstor
-      app.kubernetes.io/managed-by: piraeus-operator
-      app.kubernetes.io/name: piraeus-csi
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    helm.sh/hook: post-upgrade, post-install
-    helm.sh/hook-delete-policy: before-hook-creation
-  name: linstor-csi-node
-  namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "linstor-csi-node")) | nindent 2 }}
-spec:
-  minAvailable: 0
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: csi-node
       app.kubernetes.io/instance: linstor
       app.kubernetes.io/managed-by: piraeus-operator
       app.kubernetes.io/name: piraeus-csi
@@ -183,6 +165,13 @@ spec:
   linstorHttpsClientSecret: linstor-client-https-cert
   priorityClassName: ""
   controllerReplicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
+  controllerStrategy:
+    type: RollingUpdate
+    {{- if (include "helm_lib_ha_enabled" .) }}
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    {{- end }}
   controllerEndpoint: https://linstor.d8-{{ .Chart.Name }}.svc:3371
   nodeAffinity: {}
   nodeTolerations:

--- a/modules/041-linstor/templates/linstor-scheduler/deployment.yaml
+++ b/modules/041-linstor/templates/linstor-scheduler/deployment.yaml
@@ -63,7 +63,7 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "linstor-scheduler" )) | nindent 2 }}
 spec:
-  replicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
+  {{- include "helm_lib_deployment_strategy_and_replicas_for_ha" . | nindent 2 }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/modules/041-linstor/templates/piraeus-operator/deployment.yaml
+++ b/modules/041-linstor/templates/piraeus-operator/deployment.yaml
@@ -57,7 +57,7 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "piraeus-operator" )) | nindent 2 }}
 spec:
-  replicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
+  {{- include "helm_lib_deployment_strategy_and_replicas_for_ha" . | nindent 2 }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/modules/041-linstor/templates/spaas/deployment.yaml
+++ b/modules/041-linstor/templates/spaas/deployment.yaml
@@ -50,7 +50,7 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "spaas" )) | nindent 2 }}
 spec:
-  replicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
+  {{- include "helm_lib_deployment_strategy_and_replicas_for_ha" . | nindent 2 }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:


### PR DESCRIPTION
## Description

This PR specifies deployment strategy for linstor components 
Includes upstream fix:
-   https://github.com/piraeusdatastore/piraeus-operator/pull/395

## Why do we need it, and what problem does it solve?
fixes https://github.com/deckhouse/deckhouse/issues/3074

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: linstor
type: fix
summary: fix rollingUpdate with two system nodes
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
