### PR TITLE
[extended-monitoring] Fixed keychain panic in IAE

### DIFF
--- a/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_GOLANG_17_ALPINE
 FROM $BASE_GOLANG_17_ALPINE as artifact
 WORKDIR /src
 ENV GOARCH=amd64
-RUN wget --no-check-certificate https://github.com/deckhouse/k8s-image-availability-exporter/tarball/v0.3.3 -O - | tar -xz --strip-components=1 && \
+RUN wget --no-check-certificate https://github.com/deckhouse/k8s-image-availability-exporter/tarball/v0.3.4 -O - | tar -xz --strip-components=1 && \
     go get -d -v ./... && \
     CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o /k8s-image-availability-exporter main.go
 

--- a/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_GOLANG_17_ALPINE
 FROM $BASE_GOLANG_17_ALPINE as artifact
 WORKDIR /src
 ENV GOARCH=amd64
-RUN wget --no-check-certificate https://github.com/deckhouse/k8s-image-availability-exporter/tarball/v0.3.2 -O - | tar -xz --strip-components=1 && \
+RUN wget --no-check-certificate https://github.com/deckhouse/k8s-image-availability-exporter/tarball/v0.3.3 -O - | tar -xz --strip-components=1 && \
     go get -d -v ./... && \
     CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o /k8s-image-availability-exporter main.go
 

--- a/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
+++ b/modules/340-extended-monitoring/images/image-availability-exporter/Dockerfile
@@ -5,7 +5,7 @@ ARG BASE_GOLANG_17_ALPINE
 FROM $BASE_GOLANG_17_ALPINE as artifact
 WORKDIR /src
 ENV GOARCH=amd64
-RUN wget --no-check-certificate https://github.com/deckhouse/k8s-image-availability-exporter/tarball/v0.3.4 -O - | tar -xz --strip-components=1 && \
+RUN wget https://github.com/deckhouse/k8s-image-availability-exporter/tarball/v0.3.4 -O - | tar -xz --strip-components=1 && \
     go get -d -v ./... && \
     CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' -o /k8s-image-availability-exporter main.go
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixed panic upstream. Still needs some work to streamline Keychain interface usage, but it should suffice for now.

https://github.com/deckhouse/k8s-image-availability-exporter/releases/tag/v0.3.4

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

It panicked on some specific pullSecrets compositions.

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

It does not panic anymore.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: extended-monitoring
type: fix
summary: Fixed keychain access panic in image-availability-exporter
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
