### PR TITLE
[log-shipper] Send metadata to Kafka

### DIFF
--- a/modules/460-log-shipper/hooks/internal/vector/destination/kafka.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/kafka.go
@@ -74,9 +74,8 @@ func NewKafka(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Kafka {
 		TLS:   tls,
 		Topic: spec.Topic,
 		Encoding: Encoding{
-			Codec:           "text",
+			Codec:           "json",
 			TimestampFormat: "rfc3339",
-			OnlyFields:      []string{"message"},
 		},
 		Compression:      "gzip",
 		BootstrapServers: strings.Join(spec.BootstrapServers, ","),

--- a/modules/460-log-shipper/hooks/internal/vector/destination/vector.go
+++ b/modules/460-log-shipper/hooks/internal/vector/destination/vector.go
@@ -74,7 +74,7 @@ func NewVector(name string, cspec v1alpha1.ClusterLogDestinationSpec) *Vector {
 		TLS:     tls,
 		Version: "2",
 		Address: spec.Endpoint,
-		// TODO(nabokikhms): Only available for vector the first version sink, consider different load balancing solution
+		// TODO(nabokihms): Only available for vector the first version sink, consider different load balancing solution
 		//
 		// Keepalive: VectorKeepalive{
 		//	TimeSecs: 7200,

--- a/modules/460-log-shipper/hooks/internal/vector/transform/extra_fields.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/extra_fields.go
@@ -40,6 +40,9 @@ var (
 //	It definitely deserves refactoring. My assumption is that it generates VRL rules from extra labels.
 //	Example:
 //	  label_name: {{ values.app }} -> .label_name = .values.app
+//
+// NOTE: it seems like this function does not escape variable names with a minus sign
+// Example: {{ screw-driver }} leads to .parsed_data.screw-driver, which is invalid for vector.
 func ExtraFieldTransform(extraFields map[string]string) *DynamicTransform {
 	var dataField string
 

--- a/modules/460-log-shipper/hooks/internal/vrl/elasticsearch.go
+++ b/modules/460-log-shipper/hooks/internal/vrl/elasticsearch.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package vrl
 
-// TODO(nabokihms): figure out why do we need this rule
+// TODO(nabokihms): figure out why do we need this rule.
+//   The assumption is that it is required to send logs to datastream indexes in which logs were previously send
+//   by logstash. Elasticsearch can only show logs with either timestamp or @timestamp field.
+//   Thus, without this rule appending to logstash datastream indexes is not possible.
+//   Now it seems more like a weird kludge.
 
 // StreamRule puts the vector timestamp to the label recognized by Elasticsearch.
 const StreamRule Rule = `

--- a/modules/460-log-shipper/hooks/testdata/file-to-kafka-tls/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-kafka-tls/result.json
@@ -28,10 +28,7 @@
       },
       "bootstrap_servers": "192.168.1.1:9200",
       "encoding": {
-        "only_fields": [
-          "message"
-        ],
-        "codec": "text",
+        "codec": "json",
         "timestamp_format": "rfc3339"
       },
       "topic": "logs",

--- a/modules/460-log-shipper/hooks/testdata/file-to-kafka/result.json
+++ b/modules/460-log-shipper/hooks/testdata/file-to-kafka/result.json
@@ -28,10 +28,7 @@
       },
       "bootstrap_servers": "192.168.1.1:9200",
       "encoding": {
-        "only_fields": [
-          "message"
-        ],
-        "codec": "text",
+        "codec": "json",
         "timestamp_format": "rfc3339"
       },
       "topic": "logs",


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
* Make log-shipper sending whole json message with metadata to Kafka destination
* Fix some TODO messages

## Why do we need it, and what problem does it solve?
Closes https://github.com/deckhouse/deckhouse/issues/3623

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: log-shipper
type: fix
summary: Make log-shipper-agents sending whole JSON message with metadata to Kafka destination.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
