### PR TITLE
[extended-monitoring] Add tip to figure out problematic nodes in KubernetesDaemonSetReplicasUnavailable alert

### DIFF
--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
@@ -75,6 +75,15 @@
 
         List of unavailable Pod(s): {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_ready{namespace=\"%s\", condition!=\"true\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"DaemonSet\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.daemonset | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
 
+        This command might help figuring out problematic nodes given you are aware where the DaemonSet should be scheduled in the first place:
+
+        ```
+        comm -13 \
+          <(kubectl -n {{$labels.namespace}} get po -l app={{$labels.label_app}} -o'custom-columns=NODE:.spec.nodeName' --no-headers --sort-by=.spec.nodeName) \
+          <(kubectl get no -o'custom-columns=NAME:.metadata.name' --no-headers)
+        ```
+
+
   - alert: KubernetesDaemonSetReplicasUnavailable
     expr: |
       (

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
@@ -70,9 +70,9 @@
       plk_create_group_if_not_exists__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,namespace={{ $labels.namespace }},kubernetes=~kubernetes"
       plk_grouped_by__controllers_malfunctioning: "KubernetesControllersMalfunctioningInNamespace,prometheus=deckhouse,namespace={{ $labels.namespace }},kubernetes=~kubernetes"
       summary: |-
-        Count of unavailable replicas in DaemonSet {{$labels.namespace}}/{{$labels.daemonset}} above threshold.
+        Count of unavailable replicas in DaemonSet {{$labels.namespace}}/{{$labels.daemonset}} is above threshold.
       description: |-
-        Count of unavailable replicas in DaemonSet {{$labels.namespace}}/{{$labels.daemonset}} above threshold.
+        Count of unavailable replicas in DaemonSet {{$labels.namespace}}/{{$labels.daemonset}} is above threshold.
         Currently at: {{ .Value }} unavailable replica(s)
         Threshold at: {{ printf "extended_monitoring_daemonset_threshold{threshold=\"replicas-not-ready\", namespace=\"%s\", daemonset=\"%s\"}" $labels.namespace $labels.daemonset | query | first | value }} unavailable replica(s)
 

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
@@ -53,11 +53,14 @@
 
   - alert: KubernetesDaemonSetReplicasUnavailable
     expr: |
-      kube_daemonset_status_number_unavailable
-      > on (namespace, daemonset)
       (
-        max by (namespace, daemonset) (extended_monitoring_daemonset_threshold{threshold="replicas-not-ready"})
-      )
+        kube_daemonset_status_number_unavailable
+        >
+        on (namespace, daemonset)
+        (
+          max by (namespace, daemonset) (extended_monitoring_daemonset_threshold{threshold="replicas-not-ready"})
+        )
+      ) + on (namespace, daemonset) group_left(label_app) kube_daemonset_labels * 0
     for: 5m
     labels:
       severity_level: "6"

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/application-controllers.yaml
@@ -53,14 +53,11 @@
 
   - alert: KubernetesDaemonSetReplicasUnavailable
     expr: |
+      kube_daemonset_status_number_unavailable
+      > on (namespace, daemonset)
       (
-        kube_daemonset_status_number_unavailable
-        >
-        on (namespace, daemonset)
-        (
-          max by (namespace, daemonset) (extended_monitoring_daemonset_threshold{threshold="replicas-not-ready"})
-        )
-      ) + on (namespace, daemonset) group_left(label_app) kube_daemonset_labels * 0
+        max by (namespace, daemonset) (extended_monitoring_daemonset_threshold{threshold="replicas-not-ready"})
+      )
     for: 5m
     labels:
       severity_level: "6"
@@ -78,11 +75,11 @@
 
         List of unavailable Pod(s): {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_ready{namespace=\"%s\", condition!=\"true\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"DaemonSet\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.daemonset | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
 
-        This command might help figuring out problematic nodes given you are aware where the DaemonSet should be scheduled in the first place:
+        This command might help figuring out problematic nodes given you are aware where the DaemonSet should be scheduled in the first place (using label selector for pods might be of help, too):
 
         ```
         comm -13 \
-          <(kubectl -n {{$labels.namespace}} get po -l app={{$labels.label_app}} -o'custom-columns=NODE:.spec.nodeName' --no-headers --sort-by=.spec.nodeName) \
+          <(kubectl -n {{$labels.namespace}} get po -o'custom-columns=NODE:.spec.nodeName' --no-headers --sort-by=.spec.nodeName) \
           <(kubectl get no -o'custom-columns=NAME:.metadata.name' --no-headers)
         ```
 

--- a/modules/340-monitoring-ping/templates/daemon-set.yaml
+++ b/modules/340-monitoring-ping/templates/daemon-set.yaml
@@ -44,6 +44,7 @@ spec:
     metadata:
       labels:
         name: monitoring-ping
+        app: monitoring-ping
     spec:
       terminationGracePeriodSeconds: 0
       hostNetwork: true


### PR DESCRIPTION
Signed-off-by: Eugene Shevchenko <evgeny.shevchenko@flant.com>

## Description

Added a tip about how to find problem nodes unscheduled DaemonSet replicas

## Why do we need it, and what problem does it solve?

In big clusters, unscheduled DaemonSet replicas usually mean there is a problem with a node. This
tip helps to find the problem node.

## What is the expected result?

The alert renders useful shell command.

## Checklist
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: extended-monitoring
type: feature
summary: Added a tip about how to find problem nodes for unscheduled DaemonSet replicas.
```
