### PR TITLE
[cloud-providers][docs] Add description and examples to OpenAPI specs

### DIFF
--- a/candi/cloud-providers/aws/docs/LAYOUTS.md
+++ b/candi/cloud-providers/aws/docs/LAYOUTS.md
@@ -19,9 +19,12 @@ Example of the layout configuration:
 apiVersion: deckhouse.io/v1
 kind: AWSClusterConfiguration
 layout: WithoutNAT
+vpcNetworkCIDR: "10.241.0.0/16"
+nodeNetworkCIDR: "10.241.32.0/20"
+sshPublicKey: <SSH_PUBLIC_KEY>
 provider:
-  providerAccessKeyId: MYACCESSKEY
-  providerSecretAccessKey: mYsEcReTkEy
+  providerAccessKeyId: '<AWS_ACCESS_KEY>'
+  providerSecretAccessKey: '<AWS_SECRET_ACCESS_KEY>'
   region: eu-central-1
 masterNodeGroup:
   replicas: 1
@@ -45,10 +48,7 @@ nodeGroups:
       instanceType: t2.medium
       ami: ami-0caef02b518350c8b
     additionalTags:
-      backup: me
-vpcNetworkCIDR: "10.241.0.0/16"
-nodeNetworkCIDR: "10.241.32.0/20"
-sshPublicKey: <SSH_PUBLIC_KEY>
+      backup: srv1
 tags:
   team: rangers
 ```

--- a/candi/cloud-providers/aws/docs/LAYOUTS_RU.md
+++ b/candi/cloud-providers/aws/docs/LAYOUTS_RU.md
@@ -19,9 +19,12 @@ title: "Cloud provider — AWS: схемы размещения"
 apiVersion: deckhouse.io/v1
 kind: AWSClusterConfiguration
 layout: WithoutNAT
+vpcNetworkCIDR: "10.241.0.0/16"
+nodeNetworkCIDR: "10.241.32.0/20"
+sshPublicKey: <SSH_PUBLIC_KEY>
 provider:
-  providerAccessKeyId: MYACCESSKEY
-  providerSecretAccessKey: mYsEcReTkEy
+  providerAccessKeyId: '<AWS_ACCESS_KEY>'
+  providerSecretAccessKey: '<AWS_SECRET_ACCESS_KEY>'
   region: eu-central-1
 masterNodeGroup:
   # Количество master-узлов.
@@ -47,10 +50,7 @@ nodeGroups:
       instanceType: t2.medium
       ami: ami-0caef02b518350c8b
     additionalTags:
-      backup: me
-vpcNetworkCIDR: "10.241.0.0/16"
-nodeNetworkCIDR: "10.241.32.0/20"
-sshPublicKey: "<SSH_PUBLIC_KEY>"
+      backup: srv1
 tags:
   team: torpedo
 ```

--- a/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/cluster_configuration.yaml
@@ -3,6 +3,46 @@ apiVersions:
 - apiVersion: deckhouse.io/v1
   openAPISpec:
     type: object
+    description: |
+      Describes the configuration of a cloud cluster in AWS.
+
+      Used by the cloud provider if a cluster's control plane is hosted in the cloud.
+
+      Run the following command to change the configuration in a running cluster:
+
+      ```shell
+      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      ```
+    x-examples:
+      - apiVersion: deckhouse.io/v1
+        kind: AWSClusterConfiguration
+        layout: WithoutNAT
+        sshPublicKey: "<SSH_PUBLIC_KEY>"
+        nodeNetworkCIDR: "172.16.0.0/22"
+        vpcNetworkCIDR: "172.16.0.0/16"
+        masterNodeGroup:
+          replicas: 1
+          instanceClass:
+            instanceType: m5.xlarge
+            ami: ami-08b6d44b4f6f7b279
+            diskType: gp3
+        nodeGroups:
+          - name: worker
+            nodeTemplate:
+              labels:
+                node-role.kubernetes.io/worker: ""
+            replicas: 2
+            instanceClass:
+              instanceType: t2.medium
+              ami: ami-0caef02b518350c8b
+            additionalTags:
+              backup: srv1
+        provider:
+          providerAccessKeyId: '<AWS_ACCESS_KEY>'
+          providerSecretAccessKey: '<AWS_SECRET_ACCESS_KEY>'
+          region: eu-central-1
+        tags:
+          team: rangers
     additionalProperties: false
     required: [apiVersion, kind, layout, provider, masterNodeGroup, sshPublicKey]
     properties:

--- a/candi/cloud-providers/aws/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/aws/openapi/doc-ru-cluster_configuration.yaml
@@ -1,6 +1,16 @@
 apiVersions:
 - apiVersion: deckhouse.io/v1
   openAPISpec:
+    description: |
+      Описывает конфигурацию облачного кластера в AWS.
+
+      Используется cloud-провайдером если control plane кластера размещен в облаке.
+
+      Выполните следующую команду, чтобы изменить конфигурацию в работающем кластере:
+
+      ```shell
+      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      ```
     properties:
       peeredVPCs:
         description: |

--- a/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/cluster_configuration.yaml
@@ -3,11 +3,21 @@ apiVersions:
 - apiVersion: deckhouse.io/v1
   openAPISpec:
     type: object
+    description: |
+      Describes the configuration of a cloud cluster in Azure.
+
+      Used by the cloud provider if a cluster's control plane is hosted in the cloud.
+
+      Run the following command to change the configuration in a running cluster:
+
+      ```shell
+      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      ```
     x-examples:
-      - layout: Standard
-        apiVersion: deckhouse.io/v1
+      - apiVersion: deckhouse.io/v1
         kind: AzureClusterConfiguration
-        sshPublicKey: ssh-rsa <SSH_PUBLIC_KEY>
+        layout: Standard
+        sshPublicKey: "<SSH_PUBLIC_KEY>"
         vNetCIDR: 10.0.0.0/16
         subnetCIDR: 10.0.0.0/24
         masterNodeGroup:
@@ -15,9 +25,10 @@ apiVersions:
           instanceClass:
             machineSize: Standard_D4ds_v4
             urn: Canonical:UbuntuServer:18.04-LTS:18.04.202207120
+            enableExternalIP: false
         provider:
-          location: "westeurope"
           subscriptionId: "<SUBSCRIPTION_ID>"
+          location: "westeurope"
           clientId: "<CLIENT_ID>"
           clientSecret: "<CLIENT_SECRET>"
           tenantId: "<TENANT_ID>"

--- a/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/azure/openapi/doc-ru-cluster_configuration.yaml
@@ -1,6 +1,16 @@
 apiVersions:
 - apiVersion: deckhouse.io/v1
   openAPISpec:
+    description: |
+      Описывает конфигурацию облачного кластера в Azure.
+
+      Используется cloud-провайдером если control plane кластера размещен в облаке.
+
+      Выполните следующую команду, чтобы изменить конфигурацию в работающем кластере:
+
+      ```shell
+      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      ```
     properties:
       layout:
         description: |

--- a/candi/cloud-providers/gcp/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/gcp/openapi/cluster_configuration.yaml
@@ -3,6 +3,46 @@ apiVersions:
 - apiVersion: deckhouse.io/v1
   openAPISpec:
     type: object
+    description: |
+      Describes the configuration of a cloud cluster in GCP.
+
+      Used by the cloud provider if a cluster's control plane is hosted in the cloud.
+
+      Run the following command to change the configuration in a running cluster:
+
+      ```shell
+      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      ```
+    x-examples:
+      - apiVersion: deckhouse.io/v1
+        kind: GCPClusterConfiguration
+        layout: WithoutNAT
+        sshKey: "<SSH_PUBLIC_KEY>"
+        subnetworkCIDR: 10.36.0.0/24
+        masterNodeGroup:
+          replicas: 1
+          zones:
+            - europe-west3-b
+          instanceClass:
+            machineType: n1-standard-4
+            image: projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20220831
+            diskSizeGb: 20
+        nodeGroups:
+          - name: static
+            replicas: 1
+            zones:
+              - europe-west3-b
+            instanceClass:
+              machineType: n1-standard-4
+              image: projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20220831
+              diskSizeGb: 20
+              additionalNetworkTags:
+                - tag1
+              additionalLabels:
+                kube-node: static
+        provider:
+          region: europe-west3
+          serviceAccountJSON: "<SERVICE_ACCOUNT_JSON>"
     additionalProperties: false
     required: [apiVersion, kind, layout, provider, masterNodeGroup, sshKey]
     properties:

--- a/candi/cloud-providers/gcp/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/gcp/openapi/doc-ru-cluster_configuration.yaml
@@ -1,6 +1,16 @@
 apiVersions:
 - apiVersion: deckhouse.io/v1
   openAPISpec:
+    description: |
+      Описывает конфигурацию облачного кластера в GCP.
+
+      Используется cloud-провайдером если control plane кластера размещен в облаке.
+
+      Выполните следующую команду, чтобы изменить конфигурацию в работающем кластере:
+
+      ```shell
+      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      ```
     properties:
       subnetworkCIDR:
         description: Подсеть, в которой будут работать узлы кластера.

--- a/candi/cloud-providers/yandex/docs/LAYOUTS_RU.md
+++ b/candi/cloud-providers/yandex/docs/LAYOUTS_RU.md
@@ -17,6 +17,9 @@ title: "Cloud provider — Yandex Cloud: схемы размещения"
 apiVersion: deckhouse.io/v1
 kind: YandexClusterConfiguration
 layout: Standard
+sshPublicKey: "<SSH_PUBLIC_KEY>"
+nodeNetworkCIDR: 192.168.12.13/24
+existingNetworkID: <EXISTING_NETWORK_ID>
 provider:
   cloudID: <CLOUD_ID>
   folderID: <FOLDER_ID>
@@ -55,9 +58,6 @@ nodeGroups:
       toy: example
 labels:
   billing: prod
-sshPublicKey: "<SSH_PUBLIC_KEY>"
-nodeNetworkCIDR: 192.168.12.13/24
-existingNetworkID: <EXISTING_NETWORK_ID>
 dhcpOptions:
   domainName: test.local
   domainNameServers:

--- a/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/cluster_configuration.yaml
@@ -3,23 +3,53 @@ apiVersions:
 - apiVersion: deckhouse.io/v1
   openAPISpec:
     type: object
+    description: |
+      Describes the configuration of a cloud cluster in Yandex Cloud.
+
+      Used by the cloud provider if a cluster's control plane is hosted in the cloud.
+
+      Run the following command to change the configuration in a running cluster:
+
+      ```shell
+      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      ```
     x-examples:
-    - sshPublicKey: "ssh-rsa AAAAAAA"
-      apiVersion: deckhouse.io/v1
-      kind: YandexClusterConfiguration
-      masterNodeGroup:
-        replicas: 1
-        instanceClass:
-          cores: 1
-          memory: 1024
-          imageID: fd8nb7ecsbvj76dfaa8b
-      provider:
-        cloudID: clnb7ecsbvj76dfaa8b
-        folderID: fldrb7ecsbvj76dfaa8b
-        serviceAccountJSON: '{"account": "a"}'
-      nodeNetworkCIDR: '127.0.0.1/8'
-      labels: { "label-2": "b" }
-      layout: Standard
+      - apiVersion: deckhouse.io/v1
+        kind: YandexClusterConfiguration
+        layout: Standard
+        nodeNetworkCIDR: '127.0.0.1/8'
+        labels: { "label-2": "b" }
+        sshPublicKey: "<SSH_PUBLIC_KEY>"
+        masterNodeGroup:
+          replicas: 1
+          instanceClass:
+            cores: 4
+            memory: 8192
+            imageID: fd8nb7ecsbvj76dfaa8b
+        nodeGroups:
+          - name: worker
+            replicas: 1
+            zones:
+              - ru-central1-a
+            instanceClass:
+              cores: 4
+              memory: 8192
+              imageID: fd8nb7ecsbvj76dfaa8b
+              coreFraction: 50
+              externalIPAddresses:
+                - "198.51.100.5"
+                - "Auto"
+        provider:
+          cloudID: "<CLOUD_ID>"
+          folderID: "<FOLDER_ID>"
+          serviceAccountJSON: |
+            {
+            "id": "id",
+            "service_account_id": "service_account_id",
+            "key_algorithm": "RSA_2048",
+            "public_key": "-----BEGIN PUBLIC KEY-----\nMIIwID....AQAB\n-----END PUBLIC KEY-----\n",
+            "private_key": "-----BEGIN PRIVATE KEY-----\nMIIE....1ZPJeBLt+\n-----END PRIVATE KEY-----\n"
+            }
     additionalProperties: false
     required: [apiVersion, kind, masterNodeGroup, nodeNetworkCIDR, sshPublicKey, layout, provider]
     properties:

--- a/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
+++ b/candi/cloud-providers/yandex/openapi/doc-ru-cluster_configuration.yaml
@@ -1,6 +1,16 @@
 apiVersions:
 - apiVersion: deckhouse.io/v1
   openAPISpec:
+    description: |
+      Описывает конфигурацию облачного кластера в Yandex Cloud.
+
+      Используется cloud-провайдером если control plane кластера размещен в облаке.
+
+      Выполните следующую команду, чтобы изменить конфигурацию в работающем кластере:
+
+      ```shell
+      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      ```
     properties:
       sshPublicKey:
         description: |

--- a/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/cluster_configuration.yaml
@@ -3,6 +3,61 @@ apiVersions:
 - apiVersion: deckhouse.io/v1
   openAPISpec:
     type: object
+    description: |
+      Describes the configuration of a cloud cluster in OpenStack.
+
+      Used by the cloud provider if a cluster's control plane is hosted in the cloud.
+
+      Run the following command to change the configuration in a running cluster:
+
+      ```shell
+      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      ```
+    x-examples:
+      - apiVersion: deckhouse.io/v1
+        kind: OpenStackClusterConfiguration
+        layout: Standard
+        sshPublicKey: "<SSH_PUBLIC_KEY>"
+        zones:
+          - ru-3a
+        standard:
+          internalNetworkDNSServers:
+            - 8.8.8.8
+          internalNetworkCIDR: 192.168.195.0/24
+          internalNetworkSecurity: false
+          externalNetworkName: "external-network"
+        provider:
+          authURL: '<AUTH_URL>'
+          domainName: '<DOMAIN_NAME>'
+          tenantID: '<TENANT_ID>'
+          username: '<USERNAME>'
+          password: '<PASSWORD>'
+          region: 'ru-3'
+        masterNodeGroup:
+          replicas: 1
+          instanceClass:
+            rootDiskSize: 20
+            flavorName: m1.large
+            imageName: "debian-11-genericcloud-amd64-20220911-1135"
+          volumeTypeMap:
+            ru-3a: "fast.ru-3a"
+        nodeGroups:
+          - name: front
+            replicas: 2
+            instanceClass:
+              flavorName: m1.large
+              imageName: "debian-11-genericcloud-amd64-20220911-1135"
+              rootDiskSize: 20
+              configDrive: false
+              floatingIPPools:
+                - public
+                - shared
+              additionalSecurityGroups:
+                - sec_group_1
+                - sec_group_2
+            zones:
+              - ru-1a
+              - ru-1b
     additionalProperties: false
     required: [apiVersion, kind, layout, provider, sshPublicKey, masterNodeGroup]
     properties:

--- a/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/openstack/openapi/doc-ru-cluster_configuration.yaml
@@ -2,6 +2,16 @@ kind: OpenStackClusterConfiguration
 apiVersions:
 - apiVersion: deckhouse.io/v1
   openAPISpec:
+    description: |
+      Описывает конфигурацию облачного кластера в OpenStack.
+
+      Используется cloud-провайдером если control plane кластера размещен в облаке.
+
+      Выполните следующую команду, чтобы изменить конфигурацию в работающем кластере:
+
+      ```shell
+      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      ```
     properties:
       sshPublicKey:
         description: |

--- a/ee/candi/cloud-providers/vsphere/docs/LAYOUTS.md
+++ b/ee/candi/cloud-providers/vsphere/docs/LAYOUTS.md
@@ -14,9 +14,9 @@ apiVersion: deckhouse.io/v1
 kind: VsphereClusterConfiguration
 layout: Standard
 provider:
-  server: test.local.org
-  username: test@dvdv.org
-  password: testtest
+  server: '<SERVER>'
+  username: '<USERNAME>'
+  password: '<PASSWORD>'
   insecure: true
 vmFolderPath: dev
 regionTagCategory: k8s-region
@@ -33,7 +33,7 @@ masterNodeGroup:
     memory: 8192
     template: dev/golden_image
     datastore: dev/lun_1
-    mainNetwork: k8s-msk/test_187
+    mainNetwork: net3-k8s
 nodeGroups:
 - name: khm
   replicas: 1
@@ -44,7 +44,7 @@ nodeGroups:
     memory: 8192
     template: dev/golden_image
     datastore: dev/lun_1
-    mainNetwork: k8s-msk/test_187
+    mainNetwork: net3-k8s
 sshPublicKey: "<SSH_PUBLIC_KEY>"
 zones:
 - ru-central1-a

--- a/ee/candi/cloud-providers/vsphere/docs/LAYOUTS_RU.md
+++ b/ee/candi/cloud-providers/vsphere/docs/LAYOUTS_RU.md
@@ -14,9 +14,9 @@ apiVersion: deckhouse.io/v1
 kind: VsphereClusterConfiguration
 layout: Standard
 provider:
-  server: test.local.org
-  username: test@dvdv.org
-  password: testtest
+  server: '<SERVER>'
+  username: '<USERNAME>'
+  password: '<PASSWORD>'
   insecure: true
 vmFolderPath: dev
 regionTagCategory: k8s-region
@@ -33,7 +33,7 @@ masterNodeGroup:
     memory: 8192
     template: dev/golden_image
     datastore: dev/lun_1
-    mainNetwork: k8s-msk/test_187
+    mainNetwork: net3-k8s
 nodeGroups:
 - name: khm
   replicas: 1
@@ -44,7 +44,7 @@ nodeGroups:
     memory: 8192
     template: dev/golden_image
     datastore: dev/lun_1
-    mainNetwork: k8s-msk/test_187
+    mainNetwork: net3-k8s
 sshPublicKey: "<SSH_PUBLIC_KEY>"
 zones:
 - ru-central1-a

--- a/ee/candi/cloud-providers/vsphere/openapi/cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vsphere/openapi/cluster_configuration.yaml
@@ -5,11 +5,61 @@ apiVersions:
     type: object
     additionalProperties: false
     description: |
-      A structure describing the configuration of a cloud cluster in vSphere.
+      Describes the configuration of a cloud cluster in vSphere.
 
-      The cloud provider uses this structure for its configuration if a cluster's control plane is hosted in the cloud.
+      Used by the cloud provider if a cluster's control plane is hosted in the cloud.
 
-      It is located in the `d8-provider-cluster-configuration` Secret in the `kube-system` namespace.
+      Run the following command to change the configuration in a running cluster:
+
+      ```shell
+      kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+      ```
+    x-examples:
+      - apiVersion: deckhouse.io/v1
+        kind: VsphereClusterConfiguration
+        sshPublicKey: "<SSH_PUBLIC_KEY>"
+        layout: Standard
+        vmFolderPath: 'folder/prefix'
+        regionTagCategory: k8s-region
+        zoneTagCategory: k8s-zone
+        region: region2
+        zones:
+          - region2-a
+        externalNetworkNames:
+          - net3-k8s
+        internalNetworkNames:
+          - K8S_3
+        internalNetworkCIDR: 172.16.2.0/24
+        baseResourcePool: kubernetes/cloud
+        masterNodeGroup:
+          replicas: 1
+          instanceClass:
+            numCPUs: 4
+            memory: 8192
+            template: Templates/ubuntu-focal-20.04
+            mainNetwork: net3-k8s
+            additionalNetworks:
+              - K8S_3
+            datastore: lun10
+            rootDiskSize: 20
+            runtimeOptions:
+              nestedHardwareVirtualization: false
+        nodeGroups:
+          - name: worker
+            replicas: 1
+            zones:
+              - ru-central1-a
+            instanceClass:
+              numCPUs: 4
+              memory: 8192
+              template: Templates/ubuntu-focal-20.04
+              datastore: lun10
+              mainNetwork: net3-k8s
+        provider:
+          server: '<SERVER>'
+          username: '<USERNAME>'
+          password: '<PASSWORD>'
+          insecure: true
     required: [apiVersion, kind, masterNodeGroup, regionTagCategory, zoneTagCategory, sshPublicKey, vmFolderPath, region, zones, layout, provider]
     properties:
       apiVersion:

--- a/ee/candi/cloud-providers/vsphere/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/candi/cloud-providers/vsphere/openapi/doc-ru-cluster_configuration.yaml
@@ -3,11 +3,15 @@ apiVersions:
   - apiVersion: deckhouse.io/v1
     openAPISpec:
       description: |
-        Структура, описывающая конфигурацию облачного кластера в vSphere.
+        Описывает конфигурацию облачного кластера в vSphere.
 
-        Cloud-провайдер использует эту структуру для настройки, если control plane кластера размещен в облаке.
+        Используется cloud-провайдером если control plane кластера размещен в облаке.
 
-        Находится в Secret'е `d8-provider-cluster-configuration` пространства имен `kube-system`.
+        Выполните следующую команду, чтобы изменить конфигурацию в работающем кластере:
+
+        ```shell
+        kubectl -n d8-system exec -ti deploy/deckhouse -- deckhouse-controller edit provider-cluster-configuration
+        ```
       properties:
         masterNodeGroup:
           description: |


### PR DESCRIPTION
## Description
Added description and examples to <PROVIDER>ClusterConfiguration OpenAPI specs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Added description and examples to <PROVIDER>ClusterConfiguration OpenAPI specs.
impact_level: low
```
