### PR TITLE
[delivery] Fix werf sidecar user permissions in Argo CD repo server

### DIFF
--- a/ee/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-deployment.yaml
+++ b/ee/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-deployment.yaml
@@ -78,7 +78,7 @@ spec:
         - image:  {{ include "helm_lib_module_image" (list . "werfArgocdCmpSidecar") }}
           imagePullPolicy: IfNotPresent
           name: werf-argocd-cmp-sidecar
-          {{- include "helm_lib_module_pod_security_context_run_as_user_custom" (list . 999 999) | nindent 10 }}
+          {{- include "helm_lib_module_container_security_context_capabilities_drop_all_and_run_as_user_custom" (list . 999 999) | nindent 10 }}
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 1024 | nindent 14 }}

--- a/ee/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-deployment.yaml
+++ b/ee/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-deployment.yaml
@@ -78,7 +78,7 @@ spec:
         - image:  {{ include "helm_lib_module_image" (list . "werfArgocdCmpSidecar") }}
           imagePullPolicy: IfNotPresent
           name: werf-argocd-cmp-sidecar
-          {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 10 }}
+          {{- include "helm_lib_module_pod_security_context_run_as_user_custom" . 999 999 | nindent 10 }}
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 1024 | nindent 14 }}

--- a/ee/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-deployment.yaml
+++ b/ee/modules/502-delivery/templates/argocd/repo-server/argocd-repo-server-deployment.yaml
@@ -78,7 +78,7 @@ spec:
         - image:  {{ include "helm_lib_module_image" (list . "werfArgocdCmpSidecar") }}
           imagePullPolicy: IfNotPresent
           name: werf-argocd-cmp-sidecar
-          {{- include "helm_lib_module_pod_security_context_run_as_user_custom" . 999 999 | nindent 10 }}
+          {{- include "helm_lib_module_pod_security_context_run_as_user_custom" (list . 999 999) | nindent 10 }}
           resources:
             requests:
               {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 1024 | nindent 14 }}

--- a/helm_lib/templates/_module_security_context.tpl
+++ b/helm_lib/templates/_module_security_context.tpl
@@ -98,3 +98,17 @@ securityContext:
     - ALL
     add: {{ index . 1 | toJson }}
 {{- end }}
+
+{{- /* Usage: {{ include "helm_lib_module_container_security_context_capabilities_drop_all_and_run_as_user_custom" (list . 1000 1000) }} */ -}}
+{{- /* returns SecurityContext parameters for Container with read only root filesystem, all dropped, and custom user ID */ -}}
+{{- define "helm_lib_module_container_security_context_capabilities_drop_all_and_run_as_user_custom" }}
+securityContext:
+  runAsUser: {{ index . 1 }}
+  runAsGroup: {{ index . 2 }}
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+{{- end }}


### PR DESCRIPTION
## Description

Fixes non-working delivery module due to excessive restrictions in werf-sidecar. This sidecar is meant to run on behalf of `argocd` user with id 999, but is run as nobody for now. 

## Why do we need it, and what problem does it solve?

Apps are not deployed because werf sidecar fails to write a lock file on FS.  

## What is the expected result?

Apps are able to be deployed 

## Checklist

- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: delivery
type: fix
summary: Fixed non-working delivery module due to wrong user ID in werf-sidecar.
```
