### PR TITLE
[istio] iptables-wrapper fix

### DIFF
--- a/ee/modules/110-istio/images/proxyv2-v1x12x6/iptables-wrapper-installer.sh
+++ b/ee/modules/110-istio/images/proxyv2-v1x12x6/iptables-wrapper-installer.sh
@@ -124,7 +124,17 @@ else
         if [ "\${num_legacy_lines}" -gt "\${num_nft_lines}" ]; then
             mode=legacy
         else
-            mode=nft
+            iptables-nft-restore 2>/dev/null << EOF_RESTORE
+* filter
+-N IPTABLES_WRAPPER
+-A IPTABLES_WRAPPER -m comment --comment "the dummy rule to detect iptables api (nft or legacy)" -j RETURN
+COMMIT
+EOF_RESTORE;
+           if [ $? -eq 0 ]; then
+               mode=nft
+           else
+               mode=legacy
+           fi
         fi
     fi
 fi

--- a/ee/modules/110-istio/images/proxyv2-v1x12x6/iptables-wrapper-installer.sh
+++ b/ee/modules/110-istio/images/proxyv2-v1x12x6/iptables-wrapper-installer.sh
@@ -124,13 +124,12 @@ else
         if [ "\${num_legacy_lines}" -gt "\${num_nft_lines}" ]; then
             mode=legacy
         else
-            iptables-nft-restore 2>/dev/null << EOF_RESTORE
+            if iptables-nft-restore >/dev/null 2>&1 << EOF_RESTORE
 * filter
 -N IPTABLES_WRAPPER
 -A IPTABLES_WRAPPER -m comment --comment "the dummy rule to detect iptables api (nft or legacy)" -j RETURN
 COMMIT
-EOF_RESTORE;
-           if [ $? -eq 0 ]; then
+EOF_RESTORE; then
                mode=nft
            else
                mode=legacy

--- a/ee/modules/110-istio/images/proxyv2-v1x12x6/iptables-wrapper-installer.sh
+++ b/ee/modules/110-istio/images/proxyv2-v1x12x6/iptables-wrapper-installer.sh
@@ -129,11 +129,12 @@ else
 -N IPTABLES_WRAPPER
 -A IPTABLES_WRAPPER -m comment --comment "the dummy rule to detect iptables api (nft or legacy)" -j RETURN
 COMMIT
-EOF_RESTORE; then
-               mode=nft
-           else
-               mode=legacy
-           fi
+EOF_RESTORE
+            then
+                mode=nft
+            else
+                mode=legacy
+            fi
         fi
     fi
 fi

--- a/ee/modules/110-istio/images/proxyv2-v1x13x7/Dockerfile
+++ b/ee/modules/110-istio/images/proxyv2-v1x13x7/Dockerfile
@@ -1,5 +1,4 @@
-# Based on https://github.com/istio/istio/blob/1.13.7/docker/Dockerfile.base
-#      and https://github.com/istio/istio/blob/1.13.7/pilot/docker/Dockerfile.proxyv2
+# Based on https://github.com/istio/istio/blob/1.13.7/pilot/docker/Dockerfile.proxyv2
 ARG BASE_UBUNTU
 FROM docker.io/istio/proxyv2:1.13.7@sha256:fdf6fc9eb3336dbc8f77f45ff02530c032eb9260123d7117e2f608c0a1078b2e as artifact
 

--- a/ee/modules/110-istio/images/proxyv2-v1x13x7/Dockerfile
+++ b/ee/modules/110-istio/images/proxyv2-v1x13x7/Dockerfile
@@ -1,4 +1,5 @@
-# Based on https://github.com/istio/istio/blob/1.13.7/pilot/docker/Dockerfile.proxyv2
+# Based on https://github.com/istio/istio/blob/1.13.7/docker/Dockerfile.base
+#      and https://github.com/istio/istio/blob/1.13.7/pilot/docker/Dockerfile.proxyv2
 ARG BASE_UBUNTU
 FROM docker.io/istio/proxyv2:1.13.7@sha256:fdf6fc9eb3336dbc8f77f45ff02530c032eb9260123d7117e2f608c0a1078b2e as artifact
 

--- a/ee/modules/110-istio/images/proxyv2-v1x13x7/iptables-wrapper-installer.sh
+++ b/ee/modules/110-istio/images/proxyv2-v1x13x7/iptables-wrapper-installer.sh
@@ -124,7 +124,17 @@ else
         if [ "\${num_legacy_lines}" -gt "\${num_nft_lines}" ]; then
             mode=legacy
         else
-            mode=nft
+            iptables-nft-restore 2>/dev/null << EOF_RESTORE
+* filter
+-N IPTABLES_WRAPPER
+-A IPTABLES_WRAPPER -m comment --comment "the dummy rule to detect iptables api (nft or legacy)" -j RETURN
+COMMIT
+EOF_RESTORE;
+           if [ $? -eq 0 ]; then
+               mode=nft
+           else
+               mode=legacy
+           fi
         fi
     fi
 fi

--- a/ee/modules/110-istio/images/proxyv2-v1x13x7/iptables-wrapper-installer.sh
+++ b/ee/modules/110-istio/images/proxyv2-v1x13x7/iptables-wrapper-installer.sh
@@ -124,13 +124,12 @@ else
         if [ "\${num_legacy_lines}" -gt "\${num_nft_lines}" ]; then
             mode=legacy
         else
-            iptables-nft-restore 2>/dev/null << EOF_RESTORE
+            if iptables-nft-restore >/dev/null 2>&1 << EOF_RESTORE
 * filter
 -N IPTABLES_WRAPPER
 -A IPTABLES_WRAPPER -m comment --comment "the dummy rule to detect iptables api (nft or legacy)" -j RETURN
 COMMIT
-EOF_RESTORE;
-           if [ $? -eq 0 ]; then
+EOF_RESTORE; then
                mode=nft
            else
                mode=legacy

--- a/ee/modules/110-istio/images/proxyv2-v1x13x7/iptables-wrapper-installer.sh
+++ b/ee/modules/110-istio/images/proxyv2-v1x13x7/iptables-wrapper-installer.sh
@@ -129,11 +129,12 @@ else
 -N IPTABLES_WRAPPER
 -A IPTABLES_WRAPPER -m comment --comment "the dummy rule to detect iptables api (nft or legacy)" -j RETURN
 COMMIT
-EOF_RESTORE; then
-               mode=nft
-           else
-               mode=legacy
-           fi
+EOF_RESTORE
+            then
+                mode=nft
+            else
+                mode=legacy
+            fi
         fi
     fi
 fi


### PR DESCRIPTION
## Description
iptables-wrapper fix for istio sidecar.

## Why do we need it, and what problem does it solve?
Previous one didn't detect the legacy mode.

## What is the expected result?
Pods with istio sidecar start without problems.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: istio
type: fix
summary: iptables-wrapper fix for istio sidecar.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
