### PR TITLE
[monitoring-kubernetes] Switching on the DeprecatedDockerContainerRuntime alert

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/cri-version.tpl
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/cri-version.tpl
@@ -47,7 +47,7 @@
       )
     labels:
       tier: cluster
-      severity_level: "6"
+      severity_level: "4"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: markdown

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/cri-version.tpl
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/cri-version.tpl
@@ -34,26 +34,26 @@
       summary: >
         Unsupported version of CRI {{`{{$labels.container_runtime_version}}`}} installed for Kubernetes version: {{`{{$labels.kubelet_version}}`}}
 
-  # - alert: DeprecatedDockerContainerRuntime
-  #   expr: |
-  #     sum by (container_runtime_version, node) (
-  #       kube_node_info{container_runtime_version=~"docker://.*"}
-  #       * on (node) group_left(label_node_deckhouse_io_group) kube_node_labels
-  #       * on (label_node_deckhouse_io_group) group_left(cri_type)
-  #       label_replace(
-  #         node_group_info{cri_type!="NotManaged"},
-  #         "label_node_deckhouse_io_group", "$0", "name", ".*"
-  #       )
-  #     )
-  #   labels:
-  #     tier: cluster
-  #     severity_level: "9"
-  #   annotations:
-  #     plk_protocol_version: "1"
-  #     plk_markup_format: markdown
-  #     description: |-
-  #       Found docker CRI installed on {{`{{$labels.node}}`}} node.
-  #       Docker runtime is deprecated and will be removed in the nearest future.
-  #       You should migrate to Containerd CRI.
-  #     summary: >
-  #       Deprecated version of CRI {{`{{$labels.container_runtime_version}}`}} installed on {{`{{$labels.node}}`}} node.
+  - alert: DeprecatedDockerContainerRuntime
+    expr: |
+      sum by (container_runtime_version, node) (
+        kube_node_info{container_runtime_version=~"docker://.*"}
+        * on (node) group_left(label_node_deckhouse_io_group) kube_node_labels
+        * on (label_node_deckhouse_io_group) group_left(cri_type)
+        label_replace(
+          node_group_info{cri_type!="NotManaged"},
+          "label_node_deckhouse_io_group", "$0", "name", ".*"
+        )
+      )
+    labels:
+      tier: cluster
+      severity_level: "6"
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: markdown
+      description: |-
+        Found docker CRI installed on {{`{{$labels.node}}`}} node.
+        Docker runtime is deprecated and will be removed in the nearest future.
+        You should [migrate](https://deckhouse.io/documentation/v1/modules/040-node-manager/faq.html#how-to-change-cri-for-the-whole-cluster) to Containerd CRI.
+      summary: >
+        Deprecated version of CRI {{`{{$labels.container_runtime_version}}`}} installed on {{`{{$labels.node}}`}} node.


### PR DESCRIPTION
## Description
Switching on the DeprecatedDockerContainerRuntime alert.

## Why do we need it, and what problem does it solve?
It was switched off earlier and now we are ready to migrate.

## What is the expected result?
The alert fires if there are nodes with Docker cri.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: monitoring-kubernetes
type: chore
summary: DeprecatedDockerContainerRuntime alert is switched on — it is time to use containerd now.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
