### PR TITLE
[ci] Fix save test results step

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -404,7 +404,7 @@ check_e2e_labels:
           ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
     - name: Save test results
-      if: always()
+      if: ${{ steps.setup.outputs.dhctl-log-file }}
       uses: {!{ index (ds "actions") "actions/upload-artifact" }!}
       with:
         name: test_output_{!{ printf "%s_%s_%s" $ctx.provider $ctx.cri $ctx.kubernetesVersionSlug }!}

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -573,7 +573,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_aws_docker_1_21
@@ -1002,7 +1002,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_aws_docker_1_22
@@ -1431,7 +1431,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_aws_docker_1_23
@@ -1860,7 +1860,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_aws_docker_1_24
@@ -2289,7 +2289,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_aws_docker_1_25
@@ -2718,7 +2718,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_aws_containerd_1_21
@@ -3147,7 +3147,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_aws_containerd_1_22
@@ -3576,7 +3576,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_aws_containerd_1_23
@@ -4005,7 +4005,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_aws_containerd_1_24
@@ -4434,7 +4434,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_aws_containerd_1_25

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -581,7 +581,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_azure_docker_1_21
@@ -1018,7 +1018,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_azure_docker_1_22
@@ -1455,7 +1455,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_azure_docker_1_23
@@ -1892,7 +1892,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_azure_docker_1_24
@@ -2329,7 +2329,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_azure_docker_1_25
@@ -2766,7 +2766,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_azure_containerd_1_21
@@ -3203,7 +3203,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_azure_containerd_1_22
@@ -3640,7 +3640,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_azure_containerd_1_23
@@ -4077,7 +4077,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_azure_containerd_1_24
@@ -4514,7 +4514,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_azure_containerd_1_25

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -461,7 +461,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_aws_containerd_1_23
@@ -879,7 +879,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_azure_containerd_1_23
@@ -1285,7 +1285,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_gcp_containerd_1_23
@@ -1699,7 +1699,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_yandex-cloud_containerd_1_23
@@ -2105,7 +2105,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_openstack_containerd_1_23
@@ -2515,7 +2515,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_vsphere_containerd_1_23
@@ -2921,7 +2921,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_static_containerd_1_23

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -569,7 +569,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_gcp_docker_1_21
@@ -994,7 +994,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_gcp_docker_1_22
@@ -1419,7 +1419,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_gcp_docker_1_23
@@ -1844,7 +1844,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_gcp_docker_1_24
@@ -2269,7 +2269,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_gcp_docker_1_25
@@ -2694,7 +2694,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_gcp_containerd_1_21
@@ -3119,7 +3119,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_gcp_containerd_1_22
@@ -3544,7 +3544,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_gcp_containerd_1_23
@@ -3969,7 +3969,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_gcp_containerd_1_24
@@ -4394,7 +4394,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_gcp_containerd_1_25

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -569,7 +569,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_openstack_docker_1_21
@@ -994,7 +994,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_openstack_docker_1_22
@@ -1419,7 +1419,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_openstack_docker_1_23
@@ -1844,7 +1844,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_openstack_docker_1_24
@@ -2269,7 +2269,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_openstack_docker_1_25
@@ -2694,7 +2694,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_openstack_containerd_1_21
@@ -3119,7 +3119,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_openstack_containerd_1_22
@@ -3544,7 +3544,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_openstack_containerd_1_23
@@ -3969,7 +3969,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_openstack_containerd_1_24
@@ -4394,7 +4394,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_openstack_containerd_1_25

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -569,7 +569,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_static_docker_1_21
@@ -994,7 +994,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_static_docker_1_22
@@ -1419,7 +1419,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_static_docker_1_23
@@ -1844,7 +1844,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_static_docker_1_24
@@ -2269,7 +2269,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_static_docker_1_25
@@ -2694,7 +2694,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_static_containerd_1_21
@@ -3119,7 +3119,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_static_containerd_1_22
@@ -3544,7 +3544,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_static_containerd_1_23
@@ -3969,7 +3969,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_static_containerd_1_24
@@ -4394,7 +4394,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_static_containerd_1_25

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -573,7 +573,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_vsphere_docker_1_21
@@ -1002,7 +1002,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_vsphere_docker_1_22
@@ -1431,7 +1431,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_vsphere_docker_1_23
@@ -1860,7 +1860,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_vsphere_docker_1_24
@@ -2289,7 +2289,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_vsphere_docker_1_25
@@ -2718,7 +2718,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_vsphere_containerd_1_21
@@ -3147,7 +3147,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_vsphere_containerd_1_22
@@ -3576,7 +3576,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_vsphere_containerd_1_23
@@ -4005,7 +4005,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_vsphere_containerd_1_24
@@ -4434,7 +4434,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_vsphere_containerd_1_25

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -577,7 +577,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_yandex-cloud_docker_1_21
@@ -1010,7 +1010,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_yandex-cloud_docker_1_22
@@ -1443,7 +1443,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_yandex-cloud_docker_1_23
@@ -1876,7 +1876,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_yandex-cloud_docker_1_24
@@ -2309,7 +2309,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_yandex-cloud_docker_1_25
@@ -2742,7 +2742,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_yandex-cloud_containerd_1_21
@@ -3175,7 +3175,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_yandex-cloud_containerd_1_22
@@ -3608,7 +3608,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_yandex-cloud_containerd_1_23
@@ -4041,7 +4041,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_yandex-cloud_containerd_1_24
@@ -4474,7 +4474,7 @@ jobs:
             ${{ steps.setup.outputs.tmp-dir-path}}/*.tfstate
 
       - name: Save test results
-        if: always()
+        if: ${{ steps.setup.outputs.dhctl-log-file }}
         uses: actions/upload-artifact@v2
         with:
           name: test_output_yandex-cloud_containerd_1_25


### PR DESCRIPTION
Signed-off-by: Nikolay Mitrofanov <nikolay.mitrofanov@flant.com>

## Description
Do not try to save e2e test results (dhctl, deckhouse logs) if dhctl log path variable does not set

## Why do we need it, and what problem does it solve?
If e2e test was failed before finish setup step then `save test result` step tried to load all directory in artifacts (because we use specified regexp)

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: fix 
summary: Fix save test results step
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
