### PR TITLE
[upmeter] Fix smoke-mini StatefulSet rendering when nodes are named as numbers

### DIFF
--- a/modules/500-upmeter/openapi/openapi-case-tests.yaml
+++ b/modules/500-upmeter/openapi/openapi-case-tests.yaml
@@ -40,7 +40,7 @@ positive:
             d:
               effectiveStorageClass: default
               image: dev-registry.deckhouse.io/sys/deckhouse-oss:7ae695a87e999c762df8011581f23b2fa7f8ed980476913eea00d121-1630074529969
-              node: dev2-worker-small-391f2ede-79fcd-f64bd
+              node: "12345" # number, intentionally
               zone: nova
             e:
               effectiveStorageClass: default

--- a/modules/500-upmeter/templates/smoke-mini/statefulsets.yaml
+++ b/modules/500-upmeter/templates/smoke-mini/statefulsets.yaml
@@ -41,7 +41,7 @@ metadata:
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" "smoke-mini")) | nindent 2 }}
   annotations:
-    node: {{ $sts.node }}
+    node: {{ $sts.node | quote }}
     {{- if ne ($sts.zone) "NONE" }}
     zone: {{ $sts.zone | quote }}
     {{- end }}


### PR DESCRIPTION
## Description

Fixing rendering error.

## Why do we need it, and what problem does it solve?

Smoke mini statefulsets cannot render when nodes are named as numbers. Unquoted numbers in
annotations are interpreted as numbers when unmarshalling in kube client.

## What is the expected result?

Nodes with names like "12345" don't cause rendering problems.

## Checklist
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: upmeter
type: fix
summary: Fixed rendering error when nodes are named as numbers.
```
