### PR TITLE
[docs] Update example in the InitConfigration OpenAPI spec

### DIFF
--- a/candi/openapi/init_configuration.yaml
+++ b/candi/openapi/init_configuration.yaml
@@ -22,10 +22,6 @@ apiVersions:
         global:
           modules:
             publicDomainTemplate: "%s.kube.company.my"
-            proxy:
-              httpProxy: http://proxy.company.my
-              httpsProxy: https://proxy.company.my
-              noProxy: ["192.168.0.0/24", "company.my", ".company.my"]
         cniFlannelEnabled: true
         cniFlannel:
           podNetworkMode: VXLAN


### PR DESCRIPTION
## Description
Remove the deprecated `global.modules.proxy` parameter from the example.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [X] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: [docs] Update example in the InitConfigration OpenAPI spec.
impact_level: low
```
