### PR TITLE
[snapshot-controller][containerized-data-importer] fix trace output in enabled scripts

### DIFF
--- a/modules/045-snapshot-controller/enabled
+++ b/modules/045-snapshot-controller/enabled
@@ -33,7 +33,7 @@ function __main__() {
   done
   if [ "$enabled" = "false" ]; then
     # workaround: allow explicit enabling of the module
-    case "$(kubectl get moduleconfig snapshot-controller -o jsonpath={.spec.enabled} 2>/dev/null)" in
+    case "$(kubectl get moduleconfig snapshot-controller -o jsonpath={.spec.enabled} 2>/dev/null || true)" in
       # match all cases of true|y|yes|1
       [Tt][Rr][Uu][Ee]|[Yy]|[Yy][Ee][Ss]|1)
         enabled=true

--- a/modules/491-containerized-data-importer/enabled
+++ b/modules/491-containerized-data-importer/enabled
@@ -24,7 +24,7 @@ function __main__() {
   fi
   if [ "$enabled" = "false" ]; then
     # workaround: allow explicit enabling of the module
-    case "$(kubectl get moduleconfig containerized-data-importer -o jsonpath={.spec.enabled} 2>/dev/null)" in
+    case "$(kubectl get moduleconfig containerized-data-importer -o jsonpath={.spec.enabled} 2>/dev/null || true)" in
       # match all cases of true|y|yes|1
       [Tt][Rr][Uu][Ee]|[Yy]|[Yy][Ee][Ss]|1)
         enabled=true


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

## Description

Fix trace output in enabled scripts

## Why do we need it, and what problem does it solve?

```
│ │ Running pod found! Checking logs...
│ │ 	containerized-data-importer/: Traceback (most recent call last):
│ │ 	containerized-data-importer/:   File "/deckhouse/modules/491-containerized-data-importer/enabled", line 37, in main
│ │ 	containerized-data-importer/:     enabled::run "$@"
│ │ 	containerized-data-importer/:   File "/deckhouse/shell_lib/enabled.sh", line 18, in enabled::run
│ │ 	containerized-data-importer/:     __main__
│ │ 	containerized-data-importer/:   File "/deckhouse/modules/491-containerized-data-importer/enabled", line 27, in __main__
│ │ 	containerized-data-importer/:     case "$(kubectl get moduleconfig containerized-data-importer -o jsonpath={.spec.enabled}            ↵
│ │ 2>/dev/null)" in
│ │ 	containerized-data-importer/: Exiting with status 1
```

## What is the expected result?

no error messages ^^

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: containerized-data-importer
type: fix
summary: Fix trace output in the enabled script.
impact_level: low
---
section: snapshot-controller
type: fix
summary: Fix trace output in the enabled script.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
