### PR TITLE
[docs] Add the link to the global storageClass

### DIFF
--- a/ee/modules/450-network-gateway/openapi/config-values.yaml
+++ b/ee/modules/450-network-gateway/openapi/config-values.yaml
@@ -72,6 +72,6 @@ properties:
     description: |
       The name of the StorageClass to use for storing the DHCP lease.
 
-      If omitted, the StorageClass of the existing PVC is used. If there is no PVC yet, either `global.StorageClass` or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.
+      If omitted, the StorageClass of the existing PVC is used. If there is no PVC yet, either the global [StorageClass](../../deckhouse-configure-global.html#parameters-storageclass) or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.
 
       Dnsmasq (underlies our DHCP server) has its own mechanisms for protecting against the duplication of IP addresses if the lease database is lost (but it is better not to lose it).

--- a/ee/modules/450-network-gateway/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/450-network-gateway/openapi/doc-ru-config-values.yaml
@@ -31,6 +31,6 @@ properties:
     description: |
       Имя storageClass'а, который использовать для хранения DHCP lease.
 
-      Если не указано — используется StorageClass существующей PVC, а если PVC пока нет — используется или `global.storageClass`, или `global.discovery.defaultStorageClass`, а если и их нет — данные сохраняются в emptyDir.
+      Если не указано — используется StorageClass существующей PVC, а если PVC пока нет — используется или глобальный [StorageClass](../../deckhouse-configure-global.html#parameters-storageclass), или `global.discovery.defaultStorageClass`, а если и их нет — данные сохраняются в emptyDir.
 
       Dnsmasq, на котором основан наш DHCP-сервер имеет свои механизмы защиты от дублирования IP-адресов в случае утери базы с lease-ами, но лучше её не терять.

--- a/ee/modules/502-delivery/openapi/config-values.yaml
+++ b/ee/modules/502-delivery/openapi/config-values.yaml
@@ -27,7 +27,7 @@ properties:
     description: |
       The name of the StorageClass to use.
 
-      If omitted, the StorageClass of the existing PVC is used. If there is no PVC yet, either `global.StorageClass` or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.
+      If omitted, the StorageClass of the existing PVC is used. If there is no PVC yet, either the global [StorageClass](../../deckhouse-configure-global.html#parameters-storageclass) or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.
 
       **CAUTION!** Setting this value to one that differs from the current one (in the existing PVC) will result in disk reprovisioning and data loss.
 

--- a/ee/modules/502-delivery/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/502-delivery/openapi/doc-ru-config-values.yaml
@@ -19,7 +19,7 @@ properties:
     description: |
       Имя storageClass'а, который использовать.
 
-      Если не указано — используется StorageClass существующей PVC, а если PVC пока нет — используется или `global.storageClass`, или `global.discovery.defaultStorageClass`, а если и их нет — данные сохраняются в emptyDir.
+      Если не указано — используется StorageClass существующей PVC, а если PVC пока нет — используется или [глобальный StorageClass](../../deckhouse-configure-global.html#parameters-storageclass), или `global.discovery.defaultStorageClass`, а если и их нет — данные сохраняются в emptyDir.
 
       **ОСТОРОЖНО!** При указании этой опции в значение, отличное от текущего (из существующей PVC), диск будет перезаказан, а все данные удалены.
 

--- a/modules/300-prometheus/openapi/config-values.yaml
+++ b/modules/300-prometheus/openapi/config-values.yaml
@@ -11,7 +11,7 @@ properties:
     description: |
       The name of the StorageClass to use.
 
-      If omitted, the StorageClass of the existing Prometheus PVC is used. If there is no PVC yet, either `global.StorageClass` or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.
+      If omitted, the StorageClass of the existing Prometheus PVC is used. If there is no PVC yet, either the global [StorageClass](../../deckhouse-configure-global.html#parameters-storageclass) or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.
 
       `storageClass: false` — forces the `emptyDir` usage. You will need to delete the old PVC and restart the Pod manually.
 
@@ -22,7 +22,7 @@ properties:
     description: |
       The name of the storageClass to use for Longterm Prometheus.
 
-      If omitted, the StorageClass of the existing Longterm Prometheus PVC is used. If there is no PVC yet, either `global.StorageClass` or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data;
+      If omitted, the StorageClass of the existing Longterm Prometheus PVC is used. If there is no PVC yet, either the global [StorageClass](../../deckhouse-configure-global.html#parameters-storageclass) or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data;
 
       **CAUTION!** Setting this value to one that differs from the current one (in the existing PVC) will result in Longterm Prometheus volume reprovisioning and data loss.
   longtermRetentionDays:

--- a/modules/300-prometheus/openapi/doc-ru-config-values.yaml
+++ b/modules/300-prometheus/openapi/doc-ru-config-values.yaml
@@ -5,7 +5,7 @@ properties:
     description: |
       Имя storageClass'а, который использовать.
 
-      Если не указано — используется StorageClass существующей PVC Prometheus, а если PVC пока нет — используется или `global.storageClass`, или `global.discovery.defaultStorageClass`, а если и их нет — данные сохраняются в `emptyDir`.
+      Если не указано — используется StorageClass существующей PVC Prometheus, а если PVC пока нет — используется или [глобальный StorageClass](../../deckhouse-configure-global.html#parameters-storageclass), или `global.discovery.defaultStorageClass`, а если и их нет — данные сохраняются в `emptyDir`.
 
       `false` — принудительное использование `emptyDir`. Удалить старый PVC и рестартануть Pod придется руками
 
@@ -14,7 +14,7 @@ properties:
     description: |
       Имя storageClass'а, который использовать для Longterm Prometheus.
 
-      Если не указано — используется StorageClass существующей PVC Longterm Prometheus, а если PVC пока нет — используется или `global.storageClass`, или `global.discovery.defaultStorageClass`, а если и их нет — данные сохраняются в `emptyDir`.
+      Если не указано — используется StorageClass существующей PVC Longterm Prometheus, а если PVC пока нет — используется или [глобальный StorageClass](../../deckhouse-configure-global.html#parameters-storageclass), или `global.discovery.defaultStorageClass`, а если и их нет — данные сохраняются в `emptyDir`.
 
       **ОСТОРОЖНО!** При указании этой опции в значение, отличное от текущего (из существующей PVC), диск Longterm Prometheus будет перезаказан, а все данные удалены.
   longtermRetentionDays:

--- a/modules/500-upmeter/openapi/config-values.yaml
+++ b/modules/500-upmeter/openapi/config-values.yaml
@@ -10,7 +10,7 @@ properties:
         enum: [false]
     x-examples: [false, "default"]
     description: |
-      The name of the StorageClass to use. If omitted, the StorageClass of the existing PVC is used. If there is no PVC yet, either `global.StorageClass` or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.
+      The name of the StorageClass to use. If omitted, the StorageClass of the existing PVC is used. If there is no PVC yet, either the global [StorageClass](../../deckhouse-configure-global.html#parameters-storageclass) or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.
 
       **CAUTION!** Setting this value to one that differs from the current one (in the existing PVC) will result in disk reprovisioning and data loss.
 
@@ -164,7 +164,7 @@ properties:
         description: |
           A storageClass to use when checking the health of disks.
 
-          If omitted, the StorageClass of the existing PVC is used. If there is no PVC yet, either `global.StorageClass` or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.
+          If omitted, the StorageClass of the existing PVC is used. If there is no PVC yet, either the global [StorageClass](../../deckhouse-configure-global.html#parameters-storageclass) or `global.discovery.defaultStorageClass` is used, and if those are undefined, the emptyDir volume is used to store the data.
 
           Setting it to `false` forces the use of an emptyDir volume.
       ingressClass:

--- a/modules/500-upmeter/openapi/doc-ru-config-values.yaml
+++ b/modules/500-upmeter/openapi/doc-ru-config-values.yaml
@@ -3,7 +3,7 @@ properties:
     description: |
       Имя storageClass'а, который использовать.
 
-      * Если не указано — используется StorageClass существующей PVC, а если PVC пока нет — используется или `global.storageClass`, или `global.discovery.defaultStorageClass`, а если и их нет — данные сохраняются в emptyDir.
+      * Если не указано — используется StorageClass существующей PVC, а если PVC пока нет — используется или [глобальный StorageClass](../../deckhouse-configure-global.html#parameters-storageclass), или `global.discovery.defaultStorageClass`, а если и их нет — данные сохраняются в emptyDir.
       * **ОСТОРОЖНО!** При указании этой опции в значение, отличное от текущего (из существующей PVC), диск будет перезаказан, а все данные удалены.
       * Если указать `false` — будет форсироваться использование emptyDir'а.
   auth:
@@ -94,7 +94,7 @@ properties:
         description: |
           storageClass для использования при проверке работоспособности дисков.
 
-          * Если не указано — используется StorageClass существующей PVC, а если PVC пока нет — используется или `global.storageClass`, или `global.discovery.defaultStorageClass`, а если и их нет — данные сохраняются в emptyDir.
+          * Если не указано — используется StorageClass существующей PVC, а если PVC пока нет — используется или [глобальный StorageClass](../../deckhouse-configure-global.html#parameters-storageclass), или `global.discovery.defaultStorageClass`, а если и их нет — данные сохраняются в emptyDir.
           * Если указать `false` — будет форсироваться использование emptyDir'а.
       ingressClass:
         description: |


### PR DESCRIPTION
## Description
Add the link to the global storageClass.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [X] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add the link to the global `storageClass`.
impact_level: low
```
