### PR TITLE
[openvpn] Setup HA for openvpn module

### DIFF
--- a/modules/500-openvpn/openapi/config-values.yaml
+++ b/modules/500-openvpn/openapi/config-values.yaml
@@ -189,6 +189,13 @@ properties:
               The name of the Secret in the `d8-system` namespace to use with the OpenVPN admin panel (this Secret must have the [kubernetes.io/tls](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#tls-secrets) format).
 
             x-doc-default: 'false'
+  highAvailability:
+    type: boolean
+    x-examples: [true, false]
+    description: |
+      Manually enable the high availability mode.
+
+      By default, Deckhouse automatically decides whether to enable the HA mode. Click [here](../../deckhouse-configure-global.html#parameters) to learn more about the HA mode for modules.
   nodeSelector:
     type: object
     description: |

--- a/modules/500-openvpn/openapi/doc-ru-config-values.yaml
+++ b/modules/500-openvpn/openapi/doc-ru-config-values.yaml
@@ -121,6 +121,11 @@ properties:
           secretName:
             description: |
               Имя Secret'а в пространстве имен `d8-system`, который будет использоваться для панели администратора OpenVPN (данный Secret должен быть в формате [kubernetes.io/tls](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#tls-secrets)).
+  highAvailability:
+    description: |
+      Ручное управление режимом отказоустойчивости.
+
+      По умолчанию режим отказоустойчивости определяется автоматически. [Подробнее](../../deckhouse-configure-global.html#параметры) про режим отказоустойчивости.
   nodeSelector:
     description: |
       Структура, аналогичная `spec.nodeSelector` Kubernetes Pod.

--- a/modules/500-openvpn/templates/openvpn/statefulset.yaml
+++ b/modules/500-openvpn/templates/openvpn/statefulset.yaml
@@ -78,9 +78,7 @@ metadata:
   {{- end }}
   {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
 spec:
-  updateStrategy:
-    type: RollingUpdate
-  {{- include "helm_lib_deployment_strategy_and_replicas_for_ha" . | nindent 2 }}
+  replicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
   serviceName: openvpn
   selector:
     matchLabels:

--- a/modules/500-openvpn/templates/openvpn/statefulset.yaml
+++ b/modules/500-openvpn/templates/openvpn/statefulset.yaml
@@ -90,15 +90,6 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/openvpn/configmap.yaml") . | sha256sum }}
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values: {{ .Chart.Name }}
-            topologyKey: kubernetes.io/hostname
       imagePullSecrets:
       - name: deckhouse-registry
       terminationGracePeriodSeconds: 5
@@ -321,6 +312,16 @@ spec:
         volumeMounts:
         - name: kube-rbac-proxy-ca
           mountPath: /etc/kube-rbac-proxy
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - openvpn
+            topologyKey: kubernetes.io/hostname
       volumes:
       - name: kube-rbac-proxy-ca
         configMap:

--- a/modules/500-openvpn/templates/openvpn/statefulset.yaml
+++ b/modules/500-openvpn/templates/openvpn/statefulset.yaml
@@ -78,6 +78,8 @@ metadata:
   {{- end }}
   {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
 spec:
+  updateStrategy:
+    type: RollingUpdate
   {{- include "helm_lib_deployment_strategy_and_replicas_for_ha" . | nindent 2 }}
   serviceName: openvpn
   selector:

--- a/modules/500-openvpn/templates/openvpn/statefulset.yaml
+++ b/modules/500-openvpn/templates/openvpn/statefulset.yaml
@@ -90,6 +90,15 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/openvpn/configmap.yaml") . | sha256sum }}
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values: {{ .Chart.Name }}
+            topologyKey: kubernetes.io/hostname
       imagePullSecrets:
       - name: deckhouse-registry
       terminationGracePeriodSeconds: 5

--- a/modules/500-openvpn/templates/openvpn/statefulset.yaml
+++ b/modules/500-openvpn/templates/openvpn/statefulset.yaml
@@ -78,7 +78,7 @@ metadata:
   {{- end }}
   {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
 spec:
-  replicas: 1
+  {{- include "helm_lib_deployment_strategy_and_replicas_for_ha" . | nindent 2 }}
   serviceName: openvpn
   selector:
     matchLabels:


### PR DESCRIPTION
Signed-off-by: Konstantin Maltsev <konstantin.maltsev@flant.com>

## Description
There is a configuration of **highAvailability** flag for openvpn module.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
There is horizontal scaling of openvpn server for high availability.
It refers to this issue: #1622 
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
In case of specifying 'false' or non-specified - there would be only 1 replica of server.
In case of specifying 'true' - there would be 2 replicas of server.
Also it controls by global **highAvailability** parameter.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: openvpn
type: feature
summary: configuration HA for openvpn server
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
