### PR TITLE
[virtualization] Fix panic when creating empty disks

### DIFF
--- a/modules/490-virtualization/hooks/disk_handler.go
+++ b/modules/490-virtualization/hooks/disk_handler.go
@@ -237,16 +237,21 @@ func handleVirtualMachineDisks(input *go_hook.HookInput) error {
 		}
 
 		// DataVolume not found, needs to create a new one
-
-		source := &v1alpha1.TypedObjectReference{}
-		source.APIGroup = disk.Source.APIGroup
-		source.Kind = disk.Source.Kind
-		source.Name = disk.Source.Name
+		var source *v1alpha1.TypedObjectReference
+		if disk.Source != nil {
+			source = &v1alpha1.TypedObjectReference{
+				TypedLocalObjectReference: corev1.TypedLocalObjectReference{
+					APIGroup: disk.Source.APIGroup,
+					Kind:     disk.Source.Kind,
+					Name:     disk.Source.Name,
+				},
+			}
+		}
 
 		dataVolumeSource, err := resolveDataVolumeSource(&diskSnap, &clusterImageSnap, source)
 		if err != nil {
 			input.LogEntry.Warnf("%s. Skip", err)
-			return nil
+			continue
 		}
 
 		storage := &cdiv1.StorageSpec{

--- a/modules/490-virtualization/hooks/disk_handler_test.go
+++ b/modules/490-virtualization/hooks/disk_handler_test.go
@@ -191,6 +191,16 @@ spec:
     name: foo
   storageClassName: linstor-thindata-r2
   size: 12Gi
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: VirtualMachineDisk
+metadata:
+  name: mydata5
+  namespace: ns1
+spec:
+  storageClassName: linstor-thindata-r2
+  size: 10Gi
+
 `),
 			)
 			f.RunHook()
@@ -216,6 +226,11 @@ spec:
 			By("Should not create DataVolume with missing ClusterVirtualMachineImage")
 			dataVolume = f.KubernetesResource("DataVolume", "ns1", "disk-mydata4")
 			Expect(dataVolume).To(BeEmpty())
+
+			By("Should create DataVolume with empty source")
+			dataVolume = f.KubernetesResource("DataVolume", "ns1", "disk-mydata5")
+			Expect(dataVolume).To(Not(BeEmpty()))
+			Expect(dataVolume.Field(`spec.source.blank`).String()).To(Equal("{}"))
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

## Description

Some fixes regarding queue and panic when creating empty disks

## Why do we need it, and what problem does it solve?
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x369b120]

goroutine 78218 [running]:
github.com/deckhouse/deckhouse/modules/490-virtualization/hooks.handleVirtualMachineDisks(0xc003fed700)
	/deckhouse/modules/490-virtualization/hooks/disk_handler.go:242 +0x520
github.com/flant/addon-operator/sdk.(*commonGoHook).Run(0xc004d14038?, 0xc00588cde0?)
	/go/pkg/mod/github.com/flant/addon-operator@v1.1.2/sdk/sdk.go:27 +0x22
github.com/flant/addon-operator/pkg/module_manager.(*HookExecutor).RunGoHook(0xc004d14908)
	/go/pkg/mod/github.com/flant/addon-operator@v1.1.2/pkg/module_manager/hook_executor.go:183 +0x544
github.com/flant/addon-operator/pkg/module_manager.(*HookExecutor).Run(0xc004d14908)
	/go/pkg/mod/github.com/flant/addon-operator@v1.1.2/pkg/module_manager/hook_executor.go:66 +0x42f
github.com/flant/addon-operator/pkg/module_manager.(*ModuleHook).Run(0xc00180e0f0, {0x404d967, 0xa}, {0xc005abac40, 0x1, 0x1}, 0xc0049c0a80, 0x5f5d620?)
	/go/pkg/mod/github.com/flant/addon-operator@v1.1.2/pkg/module_manager/module_hook.go:166 +0x58b
github.com/flant/addon-operator/pkg/module_manager.(*moduleManager).RunModuleHook(0x3fc1ee0?, {0x4de0abe?, 0xc0045f7520?}, {0x404d967, 0xa}, {0xc005aba700?, 0x1, 0x1}, 0x404d967?)
	/go/pkg/mod/github.com/flant/addon-operator@v1.1.2/pkg/module_manager/module_manager.go:926 +0x395
github.com/flant/addon-operator/pkg/addon-operator.(*AddonOperator).HandleModuleHookRun(0xc00040fab0, {0x4564c98, 0xc00388a600}, 0xc0049c0a80)
	/go/pkg/mod/github.com/flant/addon-operator@v1.1.2/pkg/addon-operator/operator.go:1498 +0xc2b
github.com/flant/addon-operator/pkg/addon-operator.(*AddonOperator).TaskHandler(0xc00040fab0, {0x4564c98, 0xc00388a600})
	/go/pkg/mod/github.com/flant/addon-operator@v1.1.2/pkg/addon-operator/operator.go:899 +0x40b
github.com/flant/shell-operator/pkg/task/queue.(*TaskQueue).Start.func1()
	/go/pkg/mod/github.com/flant/shell-operator@v1.1.3/pkg/task/queue/task_queue.go:406 +0x35e
created by github.com/flant/shell-operator/pkg/task/queue.(*TaskQueue).Start
	/go/pkg/mod/github.com/flant/shell-operator@v1.1.3/pkg/task/queue/task_queue.go:387 +0x6f
```

## What is the expected result?
vm disks are operational

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: virtualization
type: fix
summary: Some fixes regarding queue and panic when creating empty disks
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
