### PR TITLE
[python_lib] Fix external module path discovery: rely on Chart.yaml

### DIFF
--- a/python_lib/sitecustomize.py
+++ b/python_lib/sitecustomize.py
@@ -33,6 +33,10 @@ def find_module_root(path):
         (str): hook 'module' root
     """
     while True:
+        # We are in the module root if we found Chart.yaml file.
+        if os.path.exists(os.path.join(path, "Chart.yaml")):
+            return path
+
         parent, _ = os.path.split(path)
         # Discover module root for deckhouse, or module webhooks root for webhook handler.
         if os.path.split(parent)[1] == "modules" or path == "/":


### PR DESCRIPTION
## Description

Fix failing discovery of external module hooks, that are not in modules/

## Why do we need it, and what problem does it solve?

Make python hooks in external modules work

## What is the expected result?

External module hooks work

## Changelog entries

```changes
section: python_lib
type: fix
summary: Fixed the discovery of external module hooks
impact_level: low
```
