### PR TITLE
[cni-cilium] reuse route mtu for interfaces

### DIFF
--- a/modules/021-cni-cilium/images/cilium/Dockerfile
+++ b/modules/021-cni-cilium/images/cilium/Dockerfile
@@ -86,8 +86,10 @@ WORKDIR /tmp/cilium-repo/cilium-1.11.12
 
 COPY patches/001-netfilter-compatibility-mode.patch /
 COPY patches/002-customer-annotations.patch /
+COPY patches/003-mtu.patch /
 RUN patch -p1 < /001-netfilter-compatibility-mode.patch && \
-    patch -p1 < /002-customer-annotations.patch
+    patch -p1 < /002-customer-annotations.patch && \
+    patch -p1 < /003-mtu.patch
 
 RUN make PKG_BUILD=1 \
     SKIP_DOCS=true DESTDIR=/tmp/install build-container install-container-binary

--- a/modules/021-cni-cilium/images/cilium/patches/003-mtu.patch
+++ b/modules/021-cni-cilium/images/cilium/patches/003-mtu.patch
@@ -1,0 +1,13 @@
+diff --git a/plugins/cilium-cni/cilium-cni.go b/plugins/cilium-cni/cilium-cni.go
+index 0bbde3be7b..b327bc16f1 100644
+--- a/plugins/cilium-cni/cilium-cni.go
++++ b/plugins/cilium-cni/cilium-cni.go
+@@ -411,7 +411,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
+ 			peer      *netlink.Link
+ 			tmpIfName string
+ 		)
+-		veth, peer, tmpIfName, err = connector.SetupVeth(ep.ContainerID, int(conf.DeviceMTU), ep)
++		veth, peer, tmpIfName, err = connector.SetupVeth(ep.ContainerID, int(conf.RouteMTU), ep)
+ 		if err != nil {
+ 			err = fmt.Errorf("unable to set up veth on host side: %s", err)
+ 			return err

--- a/modules/021-cni-cilium/images/cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/cilium/patches/README.md
@@ -14,3 +14,9 @@ Add the oportunity to request specific MAC- and IP-address using annotations:
     cni.cilium.io/macAddress: f6:e1:74:94:b8:1d
 
 Upstream <https://github.com/cilium/cilium/pull/19789>
+
+## 003-mtu.patch
+
+Set correct MTU value for veth interfaces
+
+Upstream issue <https://github.com/deckhouse/deckhouse/pull/3836>


### PR DESCRIPTION
## Description

Here is an upstream issue https://github.com/cilium/cilium/issues/23711
By default cilium inherits MTU values from phiscal dev, this is not working for tunneled mode. 

## Why do we need it, and what problem does it solve?

While containers are not affected, the virtual machines are very sensitive for provided MTU value. 
Setting correct number will fix problems with communication between VMs in tunneled mode.

## What is the expected result?

If cilium tunnel mode enabled, then all veth-interfaces will be created with correct MTU settings

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [X] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cilium-cni
type: fix
summary: set correct mtu values in tunnel mode
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
