### PR TITLE
[user-authn] discover_dex_ca loops the list of secrets

### DIFF
--- a/modules/150-user-authn/hooks/discover_dex_ca.go
+++ b/modules/150-user-authn/hooks/discover_dex_ca.go
@@ -18,13 +18,14 @@ package hooks
 
 import (
 	"fmt"
-	"github.com/deckhouse/deckhouse/go_lib/module"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/deckhouse/deckhouse/go_lib/module"
 )
 
 const (

--- a/modules/150-user-authn/hooks/discover_dex_ca_test.go
+++ b/modules/150-user-authn/hooks/discover_dex_ca_test.go
@@ -118,26 +118,5 @@ data:
 				Expect(f.ValuesGet("userAuthn.internal.discoveredDexCA").String()).To(Equal("testca"))
 			})
 		})
-
-		Context("Adding ingress-tls-customcertificate secret with empty ca.crt", func() {
-			BeforeEach(func() {
-				f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(`
-apiVersion: v1
-kind: Secret
-metadata:
-  name: ingress-tls-customcertificate
-  namespace: d8-user-authn
-data:
-  ca.crt: ""
-  tls.crt: dGVzdGNh
-`, 2))
-				f.RunHook()
-			})
-
-			It("Should add tls.crt for OIDC provider", func() {
-				Expect(f).To(ExecuteSuccessfully())
-				Expect(f.ValuesGet("userAuthn.internal.discoveredDexCA").String()).To(Equal("testca"))
-			})
-		})
 	})
 })

--- a/modules/150-user-authn/hooks/discover_dex_ca_test.go
+++ b/modules/150-user-authn/hooks/discover_dex_ca_test.go
@@ -15,9 +15,10 @@ package hooks
 
 import (
 	"fmt"
-	. "github.com/deckhouse/deckhouse/testing/hooks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
 var _ = Describe("User Authn hooks :: discover dex ca ::", func() {

--- a/modules/150-user-authn/hooks/discover_dex_ca_test.go
+++ b/modules/150-user-authn/hooks/discover_dex_ca_test.go
@@ -15,6 +15,7 @@ package hooks
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 


### PR DESCRIPTION
Signed-off-by: Konstantin Maltsev <konstantin.maltsev@flant.com>

## Description
There is a fix for **discover_dex_ca** hook for proper secrets loop.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
It must loops over the list of secrets instead of catching first one.
It refers to this issue: #2173
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
Depending on mode (_CertManager_ or _CustomCertificate_) it subcribes to the secret (_ingress-tls_ or _ingress-tls-customcertificate_) accordingly.
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: user-authn
type: fix
summary: 'The `discover_dex_ca` hook subscribes secret according to the used mode.'
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
