### PR TITLE
[prometheus-metrics-adapter] Relative CPU metrics query interval

### DIFF
--- a/modules/301-prometheus-metrics-adapter/templates/config-map.yaml
+++ b/modules/301-prometheus-metrics-adapter/templates/config-map.yaml
@@ -17,8 +17,8 @@ data:
       metricsQuery: 'label_replace(<<.Series>>{<<.LabelMatchers>>}, "__name__", "$1", "__name__", "^kube_adapter_metric_(.*)$")'
     resourceRules:
       cpu:
-        containerQuery: sum(irate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, container!="POD"}[5m])) by (<<.GroupBy>>)
-        nodeQuery: sum(irate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)
+        containerQuery: sum(irate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, container!="POD"}[{{ mul (.Values.global.discovery.prometheusScrapeInterval | default 30) 4 }}s])) by (<<.GroupBy>>)
+        nodeQuery: sum(irate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[{{ mul (.Values.global.discovery.prometheusScrapeInterval | default 30) 4 }}s])) by (<<.GroupBy>>)
         resources:
           overrides:
             node:
@@ -40,7 +40,7 @@ data:
             pod:
               resource: pod
         containerLabel: container
-      window: 30s
+      window: 0s
     rules:
     - seriesQuery: 'ingress_nginx_detail_requests_total{namespace!="",ingress!=""}'
       resources:


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

## Description
* Switch from the hardcoded 5m interval to the x4 scrape interval


## Why do we need it, and what problem does it solve?
Otherwise, users can experience problems with CPU metrics with the following error for all pods (this is important because, for a small number of pods, this error can happen for different reasons).

```
E0213 15:05:01.429761       1 provider.go:191] unable to fetch CPU metrics for pod d8-cni-flannel/flannel-jd692, skipping
E0213 15:05:01.429765       1 provider.go:191] unable to fetch CPU metrics for pod d8-cni-flannel/flannel-jfv86, skipping
E0213 15:05:01.429769       1 provider.go:191] unable to fetch CPU metrics for pod d8-cni-flannel/flannel-jkpvx, skipping
E0213 15:05:01.429774       1 provider.go:191] unable to fetch CPU metrics for pod d8-cni-flannel/flannel-jks8j, skipping
```


## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: prometheus-metrics-adapter
type: fix
summary: Use relative CPU metrics query interval to fix an issue with flaky CPU metrics if a scrape interval is higher than 30s.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
