### PR TITLE
[candi] Fixes for centos 9 based bundles and force apparmor install in ubuntu

### DIFF
--- a/candi/bashible/bundles/centos/all/001_install_mandatory_packages.sh.tpl
+++ b/candi/bashible/bundles/centos/all/001_install_mandatory_packages.sh.tpl
@@ -13,7 +13,7 @@
 # limitations under the License.
 # policycoreutils-python libseccomp - containerd.io dependencies
 SYSTEM_PACKAGES="curl wget virt-what bash-completion lvm2 parted sudo yum-utils nfs-utils tar xz device-mapper-persistent-data net-tools libseccomp checkpolicy"
-KUBERNETES_DEPENDENCIES="conntrack ebtables ethtool iproute iptables socat util-linux"
+KUBERNETES_DEPENDENCIES="conntrack-tools ebtables ethtool iproute iptables socat util-linux"
 if bb-is-centos-version? 7; then
   SYSTEM_PACKAGES="${SYSTEM_PACKAGES} policycoreutils-python"
 fi

--- a/candi/bashible/bundles/debian/all/001_install_mandatory_packages.sh.tpl
+++ b/candi/bashible/bundles/debian/all/001_install_mandatory_packages.sh.tpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SYSTEM_PACKAGES="curl wget inotify-tools bash-completion lvm2 parted apt-transport-https sudo nfs-common vim"
+SYSTEM_PACKAGES="curl wget inotify-tools bash-completion lvm2 parted apt-transport-https sudo nfs-common vim apparmor apparmor-utils"
 KUBERNETES_DEPENDENCIES="iptables iproute2 socat util-linux mount ebtables ethtool"
 
 if bb-is-debian-version? 9 || bb-is-debian-version? 10 || bb-is-debian-version? 11; then

--- a/candi/bashible/bundles/ubuntu-lts/all/001_install_mandatory_packages.sh.tpl
+++ b/candi/bashible/bundles/ubuntu-lts/all/001_install_mandatory_packages.sh.tpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SYSTEM_PACKAGES="curl wget virt-what inotify-tools bash-completion lvm2 parted apt-transport-https sudo nfs-common"
+SYSTEM_PACKAGES="curl wget virt-what inotify-tools bash-completion lvm2 parted apt-transport-https sudo nfs-common apparmor apparmor-utils"
 KUBERNETES_DEPENDENCIES="iptables iproute2 socat util-linux mount ebtables ethtool conntrack"
 
 bb-apt-install ${SYSTEM_PACKAGES} ${KUBERNETES_DEPENDENCIES}

--- a/ee/candi/bashible/bundles/redos/all/001_install_mandatory_packages.sh.tpl
+++ b/ee/candi/bashible/bundles/redos/all/001_install_mandatory_packages.sh.tpl
@@ -2,7 +2,7 @@
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE.
 # policycoreutils-python libseccomp - containerd.io dependencies
 SYSTEM_PACKAGES="curl wget virt-what bash-completion lvm2 parted sudo yum-utils nfs-utils tar xz device-mapper-persistent-data net-tools libseccomp checkpolicy"
-KUBERNETES_DEPENDENCIES="conntrack ebtables ethtool iproute iptables socat util-linux"
+KUBERNETES_DEPENDENCIES="conntrack-tools ebtables ethtool iproute iptables socat util-linux"
 if bb-is-redos-version? 7.3; then
   SYSTEM_PACKAGES="${SYSTEM_PACKAGES} policycoreutils-python"
 fi

--- a/modules/007-registrypackages/images/containerd-centos/scripts/install
+++ b/modules/007-registrypackages/images/containerd-centos/scripts/install
@@ -15,27 +15,18 @@
 
 set -Eeo pipefail
 packages_to_install=""
-package_container_selinux="container-selinux"
-package_file_container_selinux="${package_container_selinux}.x86_64.rpm"
-rpm_name_container_selinux="$(rpm -qip ${package_file_container_selinux} 2>/dev/null | grep Name | awk '{print $3}')"
-rpm_version_container_selinux="$(rpm -qip ${package_file_container_selinux} 2>/dev/null | grep Version | awk '{print $3}')"
+# We need a cycle because different versions of centos need to install a different number of packages
+for package_file in *.rpm
+do
+  rpm_name="$(rpm -qip ${package_file} 2>/dev/null | grep Name | awk '{print $3}')"
+  rpm_version="$(rpm -qip ${package_file} 2>/dev/null | grep Version | awk '{print $3}')"
 
-if ! rpm --quiet -q "${rpm_name_container_selinux}-${rpm_version_container_selinux}"; then
-  packages_to_install="${packages_to_install} ${package_file_container_selinux}"
-else
-  echo "RPM ${package_file_container_selinux} already installed."
-fi
-
-package_containerd_io="containerd.io"
-package_file_containerd_io="${package_containerd_io}.x86_64.rpm"
-rpm_name_containerd_io="$(rpm -qip ${package_file_containerd_io} 2>/dev/null | grep Name | awk '{print $3}')"
-rpm_version_containerd_io="$(rpm -qip ${package_file_containerd_io} 2>/dev/null | grep Version | awk '{print $3}')"
-
-if ! rpm --quiet -q "${rpm_name_containerd_io}-${rpm_version_containerd_io}"; then
-  packages_to_install="${packages_to_install} ${package_file_containerd_io}"
-else
-  echo "RPM ${package_file_containerd_io} already installed."
-fi
+  if ! rpm --quiet -q "${rpm_name}-${rpm_version}"; then
+    packages_to_install="${packages_to_install} ${package_file}"
+  else
+    echo "RPM ${package_file} already installed."
+  fi
+done
 
 if [[ -n "${packages_to_install}" ]]; then
   rpm -U --oldpackage ${packages_to_install}

--- a/modules/007-registrypackages/images/containerd-centos/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd-centos/werf.inc.yaml
@@ -23,6 +23,10 @@ import:
   includePaths:
   - containerd.io.x86_64.rpm
   - container-selinux.x86_64.rpm
+  {{- if contains "el9" $image_version }}
+  - selinux-policy.x86_64.rpm
+  - selinux-policy-targeted.x86_64.rpm
+  {{- end }}
   - install
   - uninstall
   before: setup
@@ -62,5 +66,7 @@ shell:
   {{- else if contains "el9" $image_version }}
   - curl -sfL https://download.docker.com/linux/centos/9/x86_64/stable/Packages/{{ $version }}.rpm --output /containerd.io.x86_64.rpm
   - curl -sfL {{ index $selinux_version "9" }} --output /container-selinux.x86_64.rpm
+  - curl -sfL https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/selinux-policy-38.1.4-1.el9.noarch.rpm  --output /selinux-policy.x86_64.rpm
+  - curl -sfL https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/selinux-policy-targeted-38.1.4-1.el9.noarch.rpm  --output /selinux-policy-targeted.x86_64.rpm
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixes in CentOS and Ubuntu based distros for normal node bootstrap.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
There is 3 problems:
- Centos 9 based distributives wants selinux-policy 38.1.2-1 or higher, but in base last version is 34.1.2-1.
- With Ubuntu, there is possibility of missed apparmor package.
- Centos based distributives wants to install conntrack, which is replaced with conntrack-tools. In case of AWS AMI thereis is version lock on conntrack-tools, and bashible can't proceed mandatory packages installation

All cases can lead to node bootstrap failure

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->
Successful node bootstrap

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: candi
type: fix
summary: Fixes in CentOS and Ubuntu based distros for normal node bootstrap.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
