### PR TITLE
[cni-cilium] bump cilium version to v1.11.14

### DIFF
--- a/modules/021-cni-cilium/images/cilium/Dockerfile
+++ b/modules/021-cni-cilium/images/cilium/Dockerfile
@@ -3,16 +3,16 @@
 # Copyright 2020-2021 Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-# https://github.com/cilium/cilium/blob/v1.11.13/images/runtime/Dockerfile#L7-L12
+# https://github.com/cilium/cilium/blob/v1.11.14/images/runtime/Dockerfile#L7-L12
 ARG GOLANG_IMAGE=docker.io/library/golang:1.17.13@sha256:87262e4a4c7db56158a80a18fefdc4fee5accc41b59cde821e691d05541bbb18
-ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:0e0402cd13f68137edb0266e1d2c682f217814420f2d43d300ed8f65479b14fb
+ARG UBUNTU_IMAGE=docker.io/library/ubuntu:20.04@sha256:4a45212e9518f35983a976eead0de5eecc555a2f047134e9dd2cfc589076a00d
 
 ARG CILIUM_LLVM_IMAGE=quay.io/cilium/cilium-llvm:0147a23fdada32bd51b4f313c645bcb5fbe188d6@sha256:24fd3ad32471d0e45844c856c38f1b2d4ac8bd0a2d4edf64cffaaa3fd0b21202
 ARG CILIUM_BPFTOOL_IMAGE=quay.io/cilium/cilium-bpftool:7a5420acb4a0fa276a549eb4674515eadb2821d7@sha256:3e204885a1b9ec2a5b593584608664721ef0bd221d3920c091c2e77eb259090c
 ARG CILIUM_IPROUTE2_IMAGE=quay.io/cilium/cilium-iproute2:824df0c341c724f4b12cc48762f80aa3d698b589@sha256:0af5e059b2a43c6383a3daa293182b50cb88f7761f543dacf43c1c3f8f79030c
 
-# https://github.com/cilium/cilium/blob/v1.11.13/images/cilium/Dockerfile#L6
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:fa81c6a1224623533eb3d63753f9527f1fe3b5cd@sha256:01cbcfdc1416d8aeb0fac9cfd1c40e506a86054d5e789dbda78697ef354301fe
+# https://github.com/cilium/cilium/blob/v1.11.14/images/cilium/Dockerfile#L6
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:a453bffcfd267482d51a71cd3b9a969c5dcfb596@sha256:57067753e56813d481da260cd2b592e1368f35fdff51a1259f0bb0818fd7dc49
 ARG CILIUM_RUNTIME_IMAGE=cilium-runtime
 
 FROM ${CILIUM_LLVM_IMAGE} as llvm-dist
@@ -62,26 +62,26 @@ COPY --from=rootfs / /
 
 # cilium-envoy from github.com/cilium/proxy
 #
-# https://github.com/cilium/cilium/blob/v1.11.13/images/cilium/Dockerfile#L11
-FROM quay.io/cilium/cilium-envoy:3b70fad0b9514720f33db82841907821202c1f02@sha256:8cca16ce66a0960a207cbf518ee2e0d923ae2a49207b154cdc37c2d95f583180 as cilium-envoy
+# https://github.com/cilium/cilium/blob/v1.11.14/images/cilium/Dockerfile#L11
+FROM quay.io/cilium/cilium-envoy:d59b7f950565d4ccad5c9e30f725740271b7f1c2@sha256:a9c20ee37fe8b280606b096f34f074fed02a347381ded71f1853a214a324a9ef as cilium-envoy
 
 #
 # Cilium builder image with tools and source code
 #
 FROM ${CILIUM_BUILDER_IMAGE} as cilium_builder
 RUN apt-get update && apt-get install patch curl -y
-RUN mkdir /tmp/cilium-repo && curl -sSL https://github.com/cilium/cilium/archive/refs/tags/v1.11.13.tar.gz | tar xvz -C /tmp/cilium-repo
+RUN mkdir /tmp/cilium-repo && curl -sSL https://github.com/cilium/cilium/archive/refs/tags/v1.11.14.tar.gz | tar xvz -C /tmp/cilium-repo
 
 #
 # Hubble CLI
 #
 FROM cilium_builder as hubble
-RUN bash /tmp/cilium-repo/cilium-1.11.13/images/cilium/download-hubble.sh
+RUN bash /tmp/cilium-repo/cilium-1.11.14/images/cilium/download-hubble.sh
 RUN /out/linux/amd64/bin/hubble completion bash > /out/linux/bash_completion
 
 FROM cilium_builder as builder
 
-WORKDIR /tmp/cilium-repo/cilium-1.11.13
+WORKDIR /tmp/cilium-repo/cilium-1.11.14
 
 COPY patches/001-customer-annotations.patch /
 COPY patches/002-mtu.patch /

--- a/modules/021-cni-cilium/images/operator/Dockerfile
+++ b/modules/021-cni-cilium/images/operator/Dockerfile
@@ -1,7 +1,7 @@
 # Based on https://github.com/cilium/cilium/blob/956c4d670fd75eb9f2a5a44406bc02aeab820cd7/images/operator/Dockerfile
 ARG BASE_ALPINE
-# https://github.com/cilium/cilium/releases/tag/v1.11.12
-FROM quay.io/cilium/operator:v1.11.13@sha256:859ff723b1b6c03f7f0126383e619fcff9fb78648eca6f4c6a4412989047f9da as artifact
+# https://github.com/cilium/cilium/releases/tag/v1.11.14
+FROM quay.io/cilium/operator:v1.11.14@sha256:5e3da0ece8520c95f252b904de6fd670bba72ef7b0c8eba2cfba992dcc18cb97 as artifact
 
 FROM $BASE_ALPINE
 COPY --from=artifact /usr/bin/cilium-operator /usr/bin/cilium-operator


### PR DESCRIPTION
## Description
Bump cilium to v1.11.13.

## Why do we need it, and what problem does it solve?
Cilium bug fixes and security patches.

## What is the expected result?
Update cilium agents and operator are deployed.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: cni-cilium
type: chore
summary: Bump cilium to v1.11.14
impact: All cilium Pods will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
