### PR TITLE
[docs] Update docs to use the module configuration method everywhere

### DIFF
--- a/docs/documentation/pages/DECKHOUSE-FAQ.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ.md
@@ -31,11 +31,17 @@ Change (set) the `releaseChannel` parameter in the `deckhouse` module [configura
 
 It will activate the mechanism of [automatic stabilization of the release channel](#how-does-automatic-deckhouse-update-work).
 
-Here is an example of the module configuration:
+Here is an example of the `deckhouse` module configuration with the `Stable` release channel:
 
 ```yaml
-deckhouse: |
-  releaseChannel: Stable
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    releaseChannel: Stable
 ```
 
 ## How do I disable automatic updates?
@@ -80,9 +86,15 @@ You should also avoid using **CloudEphemeral** nodes. Otherwise, a situation may
 Here is an example of the module configuration:
 
 ```yaml
-deckhouse: |
-  nodeSelector:
-    node-role.deckhouse.io/deckhouse: ""
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    nodeSelector:
+      node-role.deckhouse.io/deckhouse: ""
 ```
 
 ## How do I configure Deckhouse to use a third-party registry?

--- a/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
+++ b/docs/documentation/pages/DECKHOUSE-FAQ_RU.md
@@ -33,11 +33,17 @@ kubectl get mc global -o yaml
 
 В этом случае включится механизм [автоматической стабилизации релизного канала](#как-работает-автоматическое-обновление-deckhouse).
 
-Пример конфигурации модуля:
+Пример конфигурации модуля `deckhouse` с установленным каналом обновлений `Stable`:
 
 ```yaml
-deckhouse: |
-  releaseChannel: Stable
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    releaseChannel: Stable
 ```
 
 ## Как отключить автоматическое обновление?
@@ -82,9 +88,15 @@ kubectl get deckhousereleases
 Пример конфигурации модуля:
 
 ```yaml
-deckhouse: |
-  nodeSelector:
-    node-role.deckhouse.io/deckhouse: ""
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    nodeSelector:
+      node-role.deckhouse.io/deckhouse: ""
 ```
 
 ## Как установить Deckhouse из стороннего registry?

--- a/ee/modules/030-cloud-provider-openstack/docs/EXAMPLES.md
+++ b/ee/modules/030-cloud-provider-openstack/docs/EXAMPLES.md
@@ -18,27 +18,34 @@ spec:
 ## Example 2
 
 ```yaml
-cloudProviderOpenstack: |
-  connection:
-    authURL: https://test.tests.com:5000/v3/
-    domainName: default
-    tenantName: default
-    username: jamie
-    password: nein
-    region: HetznerFinland
-  externalNetworkNames:
-  - public
-  internalNetworkNames:
-  - kube
-  instances:
-    sshKeyPairName: my-ssh-keypair
-    securityGroups:
-    - default
-    - allow-ssh-and-icmp
-  zones:
-  - zone-a
-  - zone-b
-  tags:
-    project: cms
-    owner: default
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cloud-provider-openstack
+spec:
+  version: 1
+  enabled: true
+  settings:
+    connection:
+      authURL: https://test.tests.com:5000/v3/
+      domainName: default
+      tenantName: default
+      username: jamie
+      password: nein
+      region: HetznerFinland
+    externalNetworkNames:
+    - public
+    internalNetworkNames:
+    - kube
+    instances:
+      sshKeyPairName: my-ssh-keypair
+      securityGroups:
+      - default
+      - allow-ssh-and-icmp
+    zones:
+    - zone-a
+    - zone-b
+    tags:
+      project: cms
+      owner: default
 ```

--- a/ee/modules/030-cloud-provider-openstack/docs/EXAMPLES_RU.md
+++ b/ee/modules/030-cloud-provider-openstack/docs/EXAMPLES_RU.md
@@ -18,27 +18,34 @@ spec:
 ## Пример 2
 
 ```yaml
-cloudProviderOpenstack: |
-  connection:
-    authURL: https://test.tests.com:5000/v3/
-    domainName: default
-    tenantName: default
-    username: jamie
-    password: nein
-    region: HetznerFinland
-  externalNetworkNames:
-  - public
-  internalNetworkNames:
-  - kube
-  instances:
-    sshKeyPairName: my-ssh-keypair
-    securityGroups:
-    - default
-    - allow-ssh-and-icmp
-  zones:
-  - zone-a
-  - zone-b
-  tags:
-    project: cms
-    owner: default
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cloud-provider-openstack
+spec:
+  version: 1
+  enabled: true
+  settings:
+    connection:
+      authURL: https://test.tests.com:5000/v3/
+      domainName: default
+      tenantName: default
+      username: jamie
+      password: nein
+      region: HetznerFinland
+    externalNetworkNames:
+    - public
+    internalNetworkNames:
+    - kube
+    instances:
+      sshKeyPairName: my-ssh-keypair
+      securityGroups:
+      - default
+      - allow-ssh-and-icmp
+    zones:
+    - zone-a
+    - zone-b
+    tags:
+      project: cms
+      owner: default
 ```

--- a/ee/modules/030-cloud-provider-vsphere/docs/EXAMPLES.md
+++ b/ee/modules/030-cloud-provider-vsphere/docs/EXAMPLES.md
@@ -7,30 +7,36 @@ Below is an example configuration for a VMware vSphere cloud provider.
 ## An example of the configuration
 
 ```yaml
-cloudProviderVsphereEnabled: "true"
-cloudProviderVsphere: |
-  host: vc-3.internal
-  username: user
-  password: password
-  vmFolderPath: dev/test
-  insecure: true
-  region: moscow-x001
-  sshKeys:
-  - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD5sAcceTHeT6ZnU+PUF1rhkIHG8/B36VWy/j7iwqqimC9CxgFTEi8MPPGNjf+vwZIepJU8cWGB/By1z1wLZW3H0HMRBhv83FhtRzOaXVVHw38ysYdQvYxPC0jrQlcsJmLi7Vm44KwA+LxdFbkj+oa9eT08nQaQD6n3Ll4+/8eipthZCDFmFgcL/IWy6DjumN0r4B+NKHVEdLVJ2uAlTtmiqJwN38OMWVGa4QbvY1qgwcyeCmEzZdNCT6s4NJJpzVsucjJ0ZqbFqC7luv41tNuTS3Moe7d8TwIrHCEU54+W4PIQ5Z4njrOzze9/NlM935IzpHYw+we+YR+Nz6xHJwwj i@my-PC"
-  externalNetworkNames:
-  - KUBE-3
-  - devops-internal
-  internalNetworkNames:
-  - KUBE-3
-  - devops-internal
-  nsxt:
-    defaultIpPoolName: "External IP Pool"
-    tier1GatewayPath: flant_tier1
-    user: guestuser1
-    password: pass
-    host: 1.2.3.4
-    insecureFlag: true
-    size: SMALL
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cloud-provider-vsphere
+spec:
+  version: 1
+  enabled: true
+  settings:
+    host: vc-3.internal
+    username: user
+    password: password
+    vmFolderPath: dev/test
+    insecure: true
+    region: moscow-x001
+    sshKeys:
+    - "ssh-rsa AAAAB3N....6xHJwwj"
+    externalNetworkNames:
+    - KUBE-3
+    - devops-internal
+    internalNetworkNames:
+    - KUBE-3
+    - devops-internal
+    nsxt:
+      defaultIpPoolName: "External IP Pool"
+      tier1GatewayPath: flant_tier1
+      user: guestuser1
+      password: pass
+      host: 1.2.3.4
+      insecureFlag: true
+      size: SMALL
 ```
 
 ## An example of the `VsphereInstanceClass` custom resource

--- a/ee/modules/030-cloud-provider-vsphere/docs/EXAMPLES_RU.md
+++ b/ee/modules/030-cloud-provider-vsphere/docs/EXAMPLES_RU.md
@@ -7,30 +7,36 @@ title: "Cloud provider — VMware vSphere: Примеры"
 ## Пример конфигурации
 
 ```yaml
-cloudProviderVsphereEnabled: "true"
-cloudProviderVsphere: |
-  host: vc-3.internal
-  username: user
-  password: password
-  vmFolderPath: dev/test
-  insecure: true
-  region: moscow-x001
-  sshKeys:
-  - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD5sAcceTHeT6ZnU+PUF1rhkIHG8/B36VWy/j7iwqqimC9CxgFTEi8MPPGNjf+vwZIepJU8cWGB/By1z1wLZW3H0HMRBhv83FhtRzOaXVVHw38ysYdQvYxPC0jrQlcsJmLi7Vm44KwA+LxdFbkj+oa9eT08nQaQD6n3Ll4+/8eipthZCDFmFgcL/IWy6DjumN0r4B+NKHVEdLVJ2uAlTtmiqJwN38OMWVGa4QbvY1qgwcyeCmEzZdNCT6s4NJJpzVsucjJ0ZqbFqC7luv41tNuTS3Moe7d8TwIrHCEU54+W4PIQ5Z4njrOzze9/NlM935IzpHYw+we+YR+Nz6xHJwwj i@my-PC"
-  externalNetworkNames:
-  - KUBE-3
-  - devops-internal
-  internalNetworkNames:
-  - KUBE-3
-  - devops-internal
-  nsxt:
-    defaultIpPoolName: "External IP Pool"
-    tier1GatewayPath: flant_tier1
-    user: guestuser1
-    password: pass
-    host: 1.2.3.4
-    insecureFlag: true
-    size: SMALL
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cloud-provider-vsphere
+spec:
+  version: 1
+  enabled: true
+  settings:
+    host: vc-3.internal
+    username: user
+    password: password
+    vmFolderPath: dev/test
+    insecure: true
+    region: moscow-x001
+    sshKeys:
+    - "ssh-rsa AAAAB3N....6xHJwwj"
+    externalNetworkNames:
+    - KUBE-3
+    - devops-internal
+    internalNetworkNames:
+    - KUBE-3
+    - devops-internal
+    nsxt:
+      defaultIpPoolName: "External IP Pool"
+      tier1GatewayPath: flant_tier1
+      user: guestuser1
+      password: pass
+      host: 1.2.3.4
+      insecureFlag: true
+      size: SMALL
 ```
 
 ## Пример custom resource `VsphereInstanceClass`

--- a/ee/modules/380-metallb/docs/EXAMPLES.md
+++ b/ee/modules/380-metallb/docs/EXAMPLES.md
@@ -54,22 +54,30 @@ demo-worker-0     Ready    worker     61d   v1.21.14
 
 Module `metallb` is disabled by default, so you have to explicitly enable it. You also have to set the correct `nodeSelector` and `tolerations` for Metallb speakers.
 
+An example of the module configuration:
+
 ```yaml
-metallb: |
-  addressPools:
-  - addresses:
-    - 192.168.199.100-192.168.199.102
-    name: frontend-pool
-    protocol: layer2
-  speaker:
-    nodeSelector:
-      node-role/metallb: ""
-    tolerations:
-    - effect: NoExecute
-      key: dedicated.deckhouse.io
-      operator: Equal
-      value: frontend
-metallbEnabled: "true"
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: metallb
+spec:
+  version: 1
+  enabled: true
+  settings:
+    addressPools:
+    - addresses:
+      - 192.168.199.100-192.168.199.102
+      name: frontend-pool
+      protocol: layer2
+    speaker:
+      nodeSelector:
+        node-role/metallb: ""
+      tolerations:
+      - effect: NoExecute
+        key: dedicated.deckhouse.io
+        operator: Equal
+        value: frontend
 ```
 
 Create `IngressNginxController`.

--- a/ee/modules/380-metallb/docs/EXAMPLES_RU.md
+++ b/ee/modules/380-metallb/docs/EXAMPLES_RU.md
@@ -55,22 +55,30 @@ demo-worker-0     Ready    worker     61d   v1.21.14
 
 Модуль `metallb` отключен по умолчанию, поэтому его необходимо включить явно. Также необходимо задать корректные `nodeSelector` и `tolerations` для Metallb speaker'ов.
 
+Пример конфигурации модуля:
+
 ```yaml
-metallb: |
-  addressPools:
-  - addresses:
-    - 192.168.199.100-192.168.199.102
-    name: frontend-pool
-    protocol: layer2
-  speaker:
-    nodeSelector:
-      node-role/metallb: ""
-    tolerations:
-    - effect: NoExecute
-      key: dedicated.deckhouse.io
-      operator: Equal
-      value: frontend
-metallbEnabled: "true"
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: metallb
+spec:
+  version: 1
+  enabled: true
+  settings:
+    addressPools:
+    - addresses:
+      - 192.168.199.100-192.168.199.102
+      name: frontend-pool
+      protocol: layer2
+    speaker:
+      nodeSelector:
+        node-role/metallb: ""
+      tolerations:
+      - effect: NoExecute
+        key: dedicated.deckhouse.io
+        operator: Equal
+        value: frontend
 ```
 
 Создайте `IngressNginxController`.

--- a/ee/modules/600-flant-integration/docs/CONFIGURATION.md
+++ b/ee/modules/600-flant-integration/docs/CONFIGURATION.md
@@ -7,10 +7,17 @@ title: "The flant-integration module: configuration"
 ## Example of configuration
 
 ```yaml
-flantIntegration: |
-  licenseKey: s6f8766314a9426faa2b3
-  madisonAuthKey: abc9ydhshy32plkj
-  kubeall:
-    host: myproject.kube-master-0
-    kubeconfig: /etc/kubernetes/admin.conf
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: flant-integration
+spec:
+  version: 1
+  enabled: true
+  settings:
+    licenseKey: s6f8766314a9426faa2b3
+    madisonAuthKey: abc9ydhshy32plkj
+    kubeall:
+      host: myproject.kube-master-0
+      kubeconfig: /etc/kubernetes/admin.conf
 ```

--- a/ee/modules/600-flant-integration/docs/CONFIGURATION_RU.md
+++ b/ee/modules/600-flant-integration/docs/CONFIGURATION_RU.md
@@ -7,10 +7,17 @@ title: "Модуль flant-integration: настройки"
 ## Пример конфигурации
 
 ```yaml
-flantIntegration: |
-  licenseKey: s6f8766314a9426faa2b3
-  madisonAuthKey: abc9ydhshy32plkj
-  kubeall:
-    host: myproject.kube-master-0
-    kubeconfig: /etc/kubernetes/admin.conf
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: flant-integration
+spec:
+  version: 1
+  enabled: true
+  settings:
+    licenseKey: s6f8766314a9426faa2b3
+    madisonAuthKey: abc9ydhshy32plkj
+    kubeall:
+      host: myproject.kube-master-0
+      kubeconfig: /etc/kubernetes/admin.conf
 ```

--- a/modules/002-deckhouse/docs/USAGE.md
+++ b/modules/002-deckhouse/docs/USAGE.md
@@ -7,10 +7,16 @@ title: "The deckhouse module: usage"
 Below is a simple example of the module configuration:
 
 ```yaml
-deckhouse: |
-  logLevel: Debug
-  bundle: Minimal
-  releaseChannel: RockSolid
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    logLevel: Debug
+    bundle: Minimal
+    releaseChannel: EarlyAccess
 ```
 
 You can also configure additional parameters.
@@ -25,35 +31,45 @@ Patch versions (e.g. updates from `1.26.1` to `1.26.2`) are installed without co
 
 ### Update windows configuration
 
-You can configure the time when Deckhouse will install updates by specifying the following parameters in the module configuration:
+You can configure the time when Deckhouse will install updates by using the [update.windows](configuration.html#parameters-update-windows) module configuration parameter.
+
+An example of setting up two daily update windows — from 8 a.m. to 10 a.m. and from 8 p.m. to 10 p.m. (UTC):
 
 ```yaml
-deckhouse: |
-  ...
-  releaseChannel: Stable
-  update:
-    windows: 
-      - from: "8:00"
-        to: "15:00"
-      - from: "20:00"
-        to: "23:00"
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    releaseChannel: EarlyAccess
+    update:
+      windows: 
+        - from: "8:00"
+          to: "10:00"
+        - from: "20:00"
+          to: "22:00"
 ```
 
-Here updates will be installed every day from 8:00 to 15:00 and from 20:00 to 23:00.
-
-You can also set up updates on certain days, for example, on Tuesdays and Saturdays from 13:00 to 18:30:
+You can also set up updates on certain days, for example, on Tuesdays and Saturdays from 18:00 to 19:30 (UTC):
 
 ```yaml
-deckhouse: |
-  ...
-  releaseChannel: Stable
-  update:
-    windows: 
-      - from: "8:00"
-        to: "15:00"
-        days:
-          - Tue
-          - Sat
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    releaseChannel: Stable
+    update:
+      windows: 
+        - from: "18:00"
+          to: "19:30"
+          days:
+            - Tue
+            - Sat
 ```
 
 ### Manual update confirmation
@@ -61,19 +77,24 @@ deckhouse: |
 If necessary, it is possible to enable manual confirmation of updates. This can be done as follows:
 
 ```yaml
-deckhouse: |
-  ...
-  releaseChannel: Stable
-  update:
-    mode: Manual
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    releaseChannel: Stable
+    update:
+      mode: Manual
 ```
 
 In this mode, it will be necessary to confirm each minor Deckhouse updates (excluding patch versions).
 
-Manual confirmation of the update to the version `v1.26.0`:
+Manual confirmation of the update to the version `v1.43.2`:
 
 ```shell
-kubectl patch DeckhouseRelease v1-26-0 --type=merge -p='{"approved": true}'
+kubectl patch DeckhouseRelease v1-43-2 --type=merge -p='{"approved": true}'
 ```
 
 ### Manual disruption update confirmation
@@ -81,48 +102,67 @@ kubectl patch DeckhouseRelease v1-26-0 --type=merge -p='{"approved": true}'
 If necessary, it is possible to enable manual confirmation of disruptive updates (updates that change the default values or behavior). This can be done as follows:
 
 ```yaml
-deckhouse: |
-  ...
-  releaseChannel: Stable
-  update:
-    disruptionApprovalMode: Manual
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    releaseChannel: Stable
+    update:
+      disruptionApprovalMode: Manual
 ```
 
-In this mode, it will be necessary to confirm each minor disruptive update with an annotation:
+In this mode, it will be necessary to confirm each minor disruptive update with the `release.deckhouse.io/disruption-approved=true` annotation on the `DeckhouseRelease` resource.
+
+An example of confirmation of a potentially dangerous Deckhouse minor update `v1.36.4`:
 
 ```shell
-kubectl annotate DeckhouseRelease v1-36-0 release.deckhouse.io/disruption-approved=true
+kubectl annotate DeckhouseRelease v1-36-4 release.deckhouse.io/disruption-approved=true
 ```
 
 ### Deckhouse update notification
 
 In the `Auto` update mode, you can [set up](configuration.html#parameters-update-notification) a webhook call, to be notified of an upcoming Deckhouse minor version update.
 
-Example:
+An example:
 
 ```yaml
-deckhouse: |
-  ...
-  update:
-    mode: Auto
-    notification:
-      webhook: https://release-webhook.mydomain.com
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    update:
+      releaseChannel: Stable
+      mode: Auto
+      notification:
+        webhook: https://release-webhook.mydomain.com
 ```
 
 After a new Deckhouse minor version appears on the update channel, a [POST request](configuration.html#parameters-update-notification-webhook) will be executed to the webhook's URL before it is applied in the cluster.
 
 Set the [minimalNotificationTime](configuration.html#parameters-update-notification-minimalnotificationtime) parameter to have enough time to react to a Deckhouse update notification. In this case, the update will happen after the specified time, considering the update windows.
 
-Example:
+An example:
 
 ```yaml
-deckhouse: |
-  ...
-  update:
-    mode: Auto
-    notification:
-      webhook: https://release-webhook.mydomain.com
-      minimalNotificationTime: 8h
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    update:
+      releaseChannel: Stable
+      mode: Auto
+      notification:
+        webhook: https://release-webhook.mydomain.com
+        minimalNotificationTime: 8h
 ```
 
 ## Collect debug info

--- a/modules/002-deckhouse/docs/USAGE_RU.md
+++ b/modules/002-deckhouse/docs/USAGE_RU.md
@@ -7,10 +7,16 @@ title: "Модуль deckhouse: примеры конфигурации"
 Ниже представлен простой пример конфигурации модуля:
 
 ```yaml
-deckhouse: |
-  logLevel: Debug
-  bundle: Minimal
-  releaseChannel: RockSolid
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    logLevel: Debug
+    bundle: Minimal
+    releaseChannel: EarlyAccess
 ```
 
 Также можно настроить дополнительные параметры.
@@ -25,35 +31,45 @@ Patch-версии (например, обновления с `1.26.1` до `1.2
 
 ### Конфигурация окон обновлений
 
-Сконфигурировать время, когда Deckhouse будет устанавливать обновления, можно, указав следующие параметры в конфигурации модуля:
+Настроить время, когда Deckhouse будет устанавливать обновления, можно в параметре [update.windows](configuration.html#parameters-update-windows) конфигурации модуля.
+
+Пример настройки двух ежедневных окон обновлений: с 8 до 10 и c 20 до 22 (UTC):
 
 ```yaml
-deckhouse: |
-  ...
-  releaseChannel: Stable
-  update:
-    windows: 
-      - from: "8:00"
-        to: "15:00"
-      - from: "20:00"
-        to: "23:00"
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    releaseChannel: EarlyAccess
+    update:
+      windows: 
+        - from: "8:00"
+          to: "10:00"
+        - from: "20:00"
+          to: "22:00"
 ```
 
-Здесь обновления будут устанавливаться каждый день с 8:00 до 15:00 и с 20:00 до 23:00.
-
-Также можно настроить обновления в определенные дни, например, по вторникам и субботам с 13:00 до 18:30:
+Также можно настроить обновления в определенные дни, например, по вторникам и субботам с 13:00 до 18:30 (UTC):
 
 ```yaml
-deckhouse: |
-  ...
-  releaseChannel: Stable
-  update:
-    windows: 
-      - from: "13:00"
-        to: "18:30"
-        days:
-          - Tue
-          - Sat
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    releaseChannel: Stable
+    update:
+      windows: 
+        - from: "18:00"
+          to: "19:30"
+          days:
+            - Tue
+            - Sat
 ```
 
 ### Ручное подтверждение обновлений
@@ -61,19 +77,24 @@ deckhouse: |
 При необходимости возможно включить ручное подтверждение обновлений. Сделать это можно следующим образом:
 
 ```yaml
-deckhouse: |
-  ...
-  releaseChannel: Stable
-  update:
-    mode: Manual
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    releaseChannel: Stable
+    update:
+      mode: Manual
 ```
 
 В этом режиме необходимо подтверждать каждое минорное обновление Deckhouse (без учёта patch-версий).
 
-Пример подтверждения обновления на версию `v1.26.0`:
+Пример подтверждения обновления на версию `v1.43.2`:
 
 ```shell
-kubectl patch DeckhouseRelease v1-26-0 --type=merge -p='{"approved": true}'
+kubectl patch DeckhouseRelease v1-43-2 --type=merge -p='{"approved": true}'
 ```
 
 ### Ручное подтверждение потенциально опасных (disruptive) обновлений
@@ -81,17 +102,24 @@ kubectl patch DeckhouseRelease v1-26-0 --type=merge -p='{"approved": true}'
 При необходимости возможно включить ручное подтверждение потенциально опасных (disruptive) обновлений (которые меняют значения по-умолчанию или поведение некоторых модулей). Сделать это можно следующим образом:
 
 ```yaml
-deckhouse: |
-  ...
-  releaseChannel: Stable
-  update:
-    disruptionApprovalMode: Manual
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    releaseChannel: Stable
+    update:
+      disruptionApprovalMode: Manual
 ```
 
-В этом режиме необходимо подтверждать каждое минорное потенциально опасное(disruptive) обновление Deckhouse (без учёта patch-версий) с помощью аннотации:
+В этом режиме необходимо подтверждать каждое минорное потенциально опасное (disruptive) обновление Deckhouse (без учёта patch-версий) с помощью аннотации `release.deckhouse.io/disruption-approved=true` на соответствующем ресурсе `DeckhouseRelease`.
+
+Пример подтверждения минорного потенциально опасного обновления Deckhouse `v1.36.4`:
 
 ```shell
-kubectl annotate DeckhouseRelease v1-36-0 release.deckhouse.io/disruption-approved=true
+kubectl annotate DeckhouseRelease v1-36-4 release.deckhouse.io/disruption-approved=true
 ```
 
 ### Оповещение об обновлении Deckhouse
@@ -101,12 +129,18 @@ kubectl annotate DeckhouseRelease v1-36-0 release.deckhouse.io/disruption-approv
 Пример настройки оповещения:
 
 ```yaml
-deckhouse: |
-  ...
-  update:
-    mode: Auto
-    notification:
-      webhook: https://release-webhook.mydomain.com
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    update:
+      releaseChannel: Stable
+      mode: Auto
+      notification:
+        webhook: https://release-webhook.mydomain.com
 ```
 
 После появления новой минорной версии Deckhouse на используемом канале обновлений, но до момента применения ее в кластере, на адрес webhook'а будет выполнен [POST-запрос](configuration.html#parameters-update-notification-webhook).
@@ -116,13 +150,19 @@ deckhouse: |
 Пример:
 
 ```yaml
-deckhouse: |
-  ...
-  update:
-    mode: Auto
-    notification:
-      webhook: https://release-webhook.mydomain.com
-      minimalNotificationTime: 8h
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  settings:
+    update:
+      releaseChannel: Stable
+      mode: Auto
+      notification:
+        webhook: https://release-webhook.mydomain.com
+        minimalNotificationTime: 8h
 ```
 
 ## Сбор информации для отладки

--- a/modules/030-cloud-provider-azure/docs/CONFIGURATION.md
+++ b/modules/030-cloud-provider-azure/docs/CONFIGURATION.md
@@ -20,16 +20,23 @@ It allows you to configure additional StorageClasses for volumes with configurab
 An example of Storage Class configuration:
 
 ```yaml
-cloudProviderAzure: |
-  storageClass:
-    provision:
-    - name: managed-ultra-ssd
-      diskIOPSReadWrite: 600
-      diskMBpsReadWrite: 150
-    exclude:
-    - managed-standard.*
-    - managed-premium
-    default: managed-ultra-ssd
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cloud-provider-azure
+spec:
+  version: 1
+  enabled: true
+  settings:
+    storageClass:
+      provision:
+      - name: managed-ultra-ssd
+        diskIOPSReadWrite: 600
+        diskMBpsReadWrite: 150
+      exclude:
+      - managed-standard.*
+      - managed-premium
+      default: managed-ultra-ssd
 ```
 
 {% include module-settings.liquid %}

--- a/modules/030-cloud-provider-azure/docs/CONFIGURATION_RU.md
+++ b/modules/030-cloud-provider-azure/docs/CONFIGURATION_RU.md
@@ -20,18 +20,23 @@ title: "Cloud provider — Azure: настройки"
 Пример конфигурации StorageClass:
 
 ```yaml
-cloudProviderAzure: |
-  storageClass:
-    provision:
-    - name: managed-ultra-ssd
-      type: UltraSSD_LRS
-      cachingMode: None
-      diskIOPSReadWrite: 600
-      diskMBpsReadWrite: 150
-    exclude:
-    - managed-standard.*
-    - managed-premium
-    default: managed-ultra-ssd
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cloud-provider-azure
+spec:
+  version: 1
+  enabled: true
+  settings:
+    storageClass:
+      provision:
+      - name: managed-ultra-ssd
+        diskIOPSReadWrite: 600
+        diskMBpsReadWrite: 150
+      exclude:
+      - managed-standard.*
+      - managed-premium
+      default: managed-ultra-ssd
 ```
 
 {% include module-settings.liquid %}

--- a/modules/030-cloud-provider-yandex/docs/EXAMPLES.md
+++ b/modules/030-cloud-provider-yandex/docs/EXAMPLES.md
@@ -7,10 +7,16 @@ Below is an example of the Yandex Cloud cloud provider configuration.
 ## An example of the module configuration
 
 ```yaml
-cloudProviderYandexEnabled: "true"
-cloudProviderYandex: |
-  additionalExternalNetworkIDs:
-  - enp6t4snovl2ko4p15em
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cloud-provider-yandex
+spec:
+  version: 1
+  enabled: true
+  settings:
+    additionalExternalNetworkIDs:
+    - enp6t4snovl2ko4p15em
 ```
 
 ## An example of the `YandexInstanceClass` custom resource

--- a/modules/030-cloud-provider-yandex/docs/EXAMPLES_RU.md
+++ b/modules/030-cloud-provider-yandex/docs/EXAMPLES_RU.md
@@ -7,10 +7,16 @@ title: "Cloud provider — Yandex Cloud: примеры"
 ## Пример конфигурации модуля
 
 ```yaml
-cloudProviderYandexEnabled: "true"
-cloudProviderYandex: |
-  additionalExternalNetworkIDs:
-  - enp6t4snovl2ko4p15em
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cloud-provider-yandex
+spec:
+  version: 1
+  enabled: true
+  settings:
+    additionalExternalNetworkIDs:
+    - enp6t4snovl2ko4p15em
 ```
 
 ## Пример custom resource `YandexInstanceClass`

--- a/modules/041-linstor/docs/FAQ.md
+++ b/modules/041-linstor/docs/FAQ.md
@@ -98,9 +98,16 @@ To configure Prometheus to use LINSTOR for storing data:
   Example:
 
   ```yaml
-  prometheus: |
-    longtermStorageClass: linstor-data-r2
-    storageClass: linstor-data-r2
+  apiVersion: deckhouse.io/v1alpha1
+  kind: ModuleConfig
+  metadata:
+    name: prometheus
+  spec:
+    version: 2
+    enabled: true
+    settings:
+      longtermStorageClass: linstor-data-r2
+      storageClass: linstor-data-r2
   ```
 
 - Wait for the restart of Prometheus Pods.

--- a/modules/041-linstor/docs/FAQ_RU.md
+++ b/modules/041-linstor/docs/FAQ_RU.md
@@ -98,9 +98,16 @@ linstor storage-pool create lvmthin node01 lvmthin linstor_data/data
   Пример:
 
   ```yaml
-  prometheus: |
-    longtermStorageClass: linstor-data-r2
-    storageClass: linstor-data-r2
+  apiVersion: deckhouse.io/v1alpha1
+  kind: ModuleConfig
+  metadata:
+    name: prometheus
+  spec:
+    version: 2
+    enabled: true
+    settings:
+      longtermStorageClass: linstor-data-r2
+      storageClass: linstor-data-r2
   ```
 
 - Дождаться перезапуска Pod'ов Prometheus.

--- a/modules/042-kube-dns/docs/EXAMPLES.md
+++ b/modules/042-kube-dns/docs/EXAMPLES.md
@@ -5,21 +5,28 @@ title: "The kube-dns module: examples"
 ## Configuration example
 
 ```yaml
-kubeDns: |
-  upstreamNameservers:
-  - 8.8.8.8
-  - 8.8.4.4
-  hosts:
-  - domain: one.example.com
-    ip: 192.168.0.1
-  - domain: two.another.example.com
-    ip: 10.10.0.128
-  stubZones:
-  - zone: consul.local
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: kube-dns
+spec:
+  version: 1
+  enabled: true
+  settings:
     upstreamNameservers:
-    - 10.150.0.1
-  enableLogs: true
-  clusterDomainAliases:
-  - foo.bar
-  - baz.qux
+    - 8.8.8.8
+    - 8.8.4.4
+    hosts:
+    - domain: one.example.com
+      ip: 192.168.0.1
+    - domain: two.another.example.com
+      ip: 10.10.0.128
+    stubZones:
+    - zone: consul.local
+      upstreamNameservers:
+      - 10.150.0.1
+    enableLogs: true
+    clusterDomainAliases:
+    - foo.bar
+    - baz.qux
 ```

--- a/modules/042-kube-dns/docs/EXAMPLES_RU.md
+++ b/modules/042-kube-dns/docs/EXAMPLES_RU.md
@@ -5,21 +5,28 @@ title: "Модуль kube-dns: примеры"
 ## Пример конфигурации
 
 ```yaml
-kubeDns: |
-  upstreamNameservers:
-  - 8.8.8.8
-  - 8.8.4.4
-  hosts:
-  - domain: one.example.com
-    ip: 192.168.0.1
-  - domain: two.another.example.com
-    ip: 10.10.0.128
-  stubZones:
-  - zone: consul.local
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: kube-dns
+spec:
+  version: 1
+  enabled: true
+  settings:
     upstreamNameservers:
-    - 10.150.0.1
-  enableLogs: true
-  clusterDomainAliases:
-  - foo.bar
-  - baz.qux
+    - 8.8.8.8
+    - 8.8.4.4
+    hosts:
+    - domain: one.example.com
+      ip: 192.168.0.1
+    - domain: two.another.example.com
+      ip: 10.10.0.128
+    stubZones:
+    - zone: consul.local
+      upstreamNameservers:
+      - 10.150.0.1
+    enableLogs: true
+    clusterDomainAliases:
+    - foo.bar
+    - baz.qux
 ```

--- a/modules/150-user-authn/docs/USAGE.md
+++ b/modules/150-user-authn/docs/USAGE.md
@@ -7,7 +7,14 @@ title: "The user-authn module: usage"
 {% raw %}
 
 ```yaml
-  userAuthn: |
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
     kubeconfigGenerator:
     - id: direct
       masterURI: https://159.89.5.247:6443

--- a/modules/150-user-authn/docs/USAGE_RU.md
+++ b/modules/150-user-authn/docs/USAGE_RU.md
@@ -7,7 +7,14 @@ title: "Модуль user-authn: примеры конфигурации"
 {% raw %}
 
 ```yaml
-  userAuthn: |
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 1
+  enabled: true
+  settings:
     kubeconfigGenerator:
     - id: direct
       masterURI: https://159.89.5.247:6443

--- a/modules/300-prometheus/docs/USAGE.md
+++ b/modules/300-prometheus/docs/USAGE.md
@@ -8,17 +8,24 @@ search: prometheus remote write, how to connect to Prometheus, custom Grafana, p
 ## An example of the module configuration
 
 ```yaml
-prometheus: |
-  auth:
-    password: xxxxxx
-  retentionDays: 7
-  storageClass: rbd
-  nodeSelector:
-    node-role/example: ""
-  tolerations:
-  - key: dedicated
-    operator: Equal
-    value: example
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: prometheus
+spec:
+  version: 2
+  enabled: true
+  settings:
+    auth:
+      password: xxxxxx
+    retentionDays: 7
+    storageClass: rbd
+    nodeSelector:
+      node-role/example: ""
+    tolerations:
+    - key: dedicated
+      operator: Equal
+      value: example
 ```
 
 ## Writing Prometheus data to the longterm storage

--- a/modules/300-prometheus/docs/USAGE_RU.md
+++ b/modules/300-prometheus/docs/USAGE_RU.md
@@ -8,17 +8,24 @@ search: prometheus remote write, как подключится к Prometheus, п
 ## Пример конфигурации модуля
 
 ```yaml
-prometheus: |
-  auth:
-    password: xxxxxx
-  retentionDays: 7
-  storageClass: rbd
-  nodeSelector:
-    node-role/example: ""
-  tolerations:
-  - key: dedicated
-    operator: Equal
-    value: example
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: prometheus
+spec:
+  version: 2
+  enabled: true
+  settings:
+    auth:
+      password: xxxxxx
+    retentionDays: 7
+    storageClass: rbd
+    nodeSelector:
+      node-role/example: ""
+    tolerations:
+    - key: dedicated
+      operator: Equal
+      value: example
 ```
 
 ## Запись данных Prometheus в longterm storage

--- a/modules/302-vertical-pod-autoscaler/docs/EXAMPLES.md
+++ b/modules/302-vertical-pod-autoscaler/docs/EXAMPLES.md
@@ -5,13 +5,20 @@ title: "The vertical-pod-autoscaler module: examples"
 ## The module configuration
 
 ```yaml
-verticalPodAutoscaler: |
-  nodeSelector:
-    node-role/example: ""
-  tolerations:
-  - key: dedicated
-    operator: Equal
-    value: example
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: vertical-pod-autoscaler
+spec:
+  version: 1
+  enabled: true
+  settings:
+    nodeSelector:
+      node-role/example: ""
+    tolerations:
+    - key: dedicated
+      operator: Equal
+      value: example
 ```
 
 ## The basic `VerticalPodAutoscaler` CR example

--- a/modules/302-vertical-pod-autoscaler/docs/EXAMPLES_RU.md
+++ b/modules/302-vertical-pod-autoscaler/docs/EXAMPLES_RU.md
@@ -5,13 +5,20 @@ title: "Модуль vertical-pod-autoscaler: примеры"
 ## Настройка модуля
 
 ```yaml
-verticalPodAutoscaler: |
-  nodeSelector:
-    node-role/example: ""
-  tolerations:
-  - key: dedicated
-    operator: Equal
-    value: example
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: vertical-pod-autoscaler
+spec:
+  version: 1
+  enabled: true
+  settings:
+    nodeSelector:
+      node-role/example: ""
+    tolerations:
+    - key: dedicated
+      operator: Equal
+      value: example
 ```
 
 ## Пример минимального CR `VerticalPodAutoscaler`

--- a/modules/303-prometheus-pushgateway/docs/EXAMPLES.md
+++ b/modules/303-prometheus-pushgateway/docs/EXAMPLES.md
@@ -5,12 +5,18 @@ title: "THe Prometheus Pushgateway module: examples"
 ## Example of the module configuration
 
 ```yaml
-prometheusPushgatewayEnabled: "true"
-prometheusPushgateway: |
-  instances:
-  - first
-  - second
-  - another
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: prometheus-pushgateway
+spec:
+  version: 1
+  enabled: true
+  settings:
+    instances:
+    - first
+    - second
+    - another
 ```
 
 {% raw %}

--- a/modules/303-prometheus-pushgateway/docs/EXAMPLES_RU.md
+++ b/modules/303-prometheus-pushgateway/docs/EXAMPLES_RU.md
@@ -5,12 +5,18 @@ title: "Модуль Prometheus Pushgateway: примеры"
 ## Пример настройки модуля
 
 ```yaml
-prometheusPushgatewayEnabled: "true"
-prometheusPushgateway: |
-  instances:
-  - first
-  - second
-  - another
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: prometheus-pushgateway
+spec:
+  version: 1
+  enabled: true
+  settings:
+    instances:
+    - first
+    - second
+    - another
 ```
 
 {% raw %}

--- a/modules/400-descheduler/docs/EXAMPLES.md
+++ b/modules/400-descheduler/docs/EXAMPLES.md
@@ -3,14 +3,21 @@ title: "The descheduler module: examples"
 ---
 
 ```yaml
-descheduler: |
-  removePodsViolatingNodeAffinity: false
-  removeDuplicates: true
-  lowNodeUtilization: true
-  nodeSelector:
-    node-role/example: ""
-  tolerations:
-  - key: dedicated
-    operator: Equal
-    value: example
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: descheduler
+spec:
+  version: 1
+  enabled: true
+  settings:
+    removePodsViolatingNodeAffinity: false
+    removeDuplicates: true
+    lowNodeUtilization: true
+    nodeSelector:
+      node-role/example: ""
+    tolerations:
+    - key: dedicated
+      operator: Equal
+      value: example
 ```

--- a/modules/400-descheduler/docs/EXAMPLES_RU.md
+++ b/modules/400-descheduler/docs/EXAMPLES_RU.md
@@ -3,14 +3,21 @@ title: "Модуль descheduler: примеры"
 ---
 
 ```yaml
-descheduler: |
-  removePodsViolatingNodeAffinity: false
-  removeDuplicates: true
-  lowNodeUtilization: true
-  nodeSelector:
-    node-role/example: ""
-  tolerations:
-  - key: dedicated
-    operator: Equal
-    value: example
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: descheduler
+spec:
+  version: 1
+  enabled: true
+  settings:
+    removePodsViolatingNodeAffinity: false
+    removeDuplicates: true
+    lowNodeUtilization: true
+    nodeSelector:
+      node-role/example: ""
+    tolerations:
+    - key: dedicated
+      operator: Equal
+      value: example
 ```

--- a/modules/500-dashboard/docs/EXAMPLES.md
+++ b/modules/500-dashboard/docs/EXAMPLES.md
@@ -5,15 +5,22 @@ title: "The dashboard module: examples"
 ## An example of the module configuration
 
 ```yaml
-dashboard: |
-  nodeSelector:
-    node-role/example: ""
-  tolerations:
-  - key: dedicated
-    operator: Equal
-    value: example
-  externalAuthentication:
-    authURL: "https://<applicationDomain>/auth"
-    authSignInURL: "https://<applicationDomain>/sign-in"
-    authResponseHeaders: "Authorization"
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: dashboard
+spec:
+  version: 1
+  enabled: true
+  settings:
+    nodeSelector:
+      node-role/example: ""
+    tolerations:
+    - key: dedicated
+      operator: Equal
+      value: example
+    externalAuthentication:
+      authURL: "https://<applicationDomain>/auth"
+      authSignInURL: "https://<applicationDomain>/sign-in"
+      authResponseHeaders: "Authorization"
 ```

--- a/modules/500-dashboard/docs/EXAMPLES_RU.md
+++ b/modules/500-dashboard/docs/EXAMPLES_RU.md
@@ -5,15 +5,22 @@ title: "Модуль dashboard: примеры"
 ## Пример конфигурации модуля
 
 ```yaml
-dashboard: |
-  nodeSelector:
-    node-role/example: ""
-  tolerations:
-  - key: dedicated
-    operator: Equal
-    value: example
-  externalAuthentication:
-    authURL: "https://<applicationDomain>/auth"
-    authSignInURL: "https://<applicationDomain>/sign-in"
-    authResponseHeaders: "Authorization"
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: dashboard
+spec:
+  version: 1
+  enabled: true
+  settings:
+    nodeSelector:
+      node-role/example: ""
+    tolerations:
+    - key: dedicated
+      operator: Equal
+      value: example
+    externalAuthentication:
+      authURL: "https://<applicationDomain>/auth"
+      authSignInURL: "https://<applicationDomain>/sign-in"
+      authResponseHeaders: "Authorization"
 ```

--- a/modules/500-okmeter/docs/EXAMPLES.md
+++ b/modules/500-okmeter/docs/EXAMPLES.md
@@ -5,7 +5,13 @@ title: "The okmeter module: examples"
 ## Example
 
 ```yaml
-okmeterEnabled: "true"
-okmeter: |
-  apiKey: 5ff9z2a3-9127-1sh4-2192-06a3fc6e13e3
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: okmeter
+spec:
+  version: 1
+  enabled: true
+  settings: 
+    apiKey: 5ff9z2a3-9127-1sh4-2192-06a3fc6e13e3
 ```

--- a/modules/500-okmeter/docs/EXAMPLES_RU.md
+++ b/modules/500-okmeter/docs/EXAMPLES_RU.md
@@ -5,7 +5,13 @@ title: "Модуль okmeter: примеры"
 ## Пример
 
 ```yaml
-okmeterEnabled: "true"
-okmeter: |
-  apiKey: 5ff9z2a3-9127-1sh4-2192-06a3fc6e13e3
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: okmeter
+spec:
+  version: 1
+  enabled: true
+  settings: 
+    apiKey: 5ff9z2a3-9127-1sh4-2192-06a3fc6e13e3
 ```

--- a/modules/500-openvpn/docs/EXAMPLES.md
+++ b/modules/500-openvpn/docs/EXAMPLES.md
@@ -5,28 +5,46 @@ title: "The openvpn module: examples"
 ## An example for bare metal clusters
 
 ```yaml
-openvpnEnabled: "true"
-openvpn: |
-  inlet: ExternalIP
-  externalIP: 5.4.54.4
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: openvpn
+spec:
+  version: 2
+  enabled: true
+  settings:
+   inlet: ExternalIP
+   externalIP: 5.4.54.4
 ```
 
 ## An example for AWS & Google Cloud
 
 ```yaml
-openvpnEnabled: "true"
-openvpn: |
-  inlet: LoadBalancer
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: openvpn
+spec:
+  version: 2
+  enabled: true
+  settings:
+    inlet: LoadBalancer
 ```
 
 ## An example for an external load balancer with a public IP address
 
 ```yaml
-openvpnEnabled: "true"
-openvpn: |
-  externalHost: 5.4.54.4
-  externalIP: 192.168.0.30 # The internal IP address to forward the external LB's traffic to.
-  inlet: ExternalIP
-  nodeSelector:
-    kubernetes.io/hostname: node
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: openvpn
+spec:
+  version: 2
+  enabled: true
+  settings:
+    externalHost: 5.4.54.4
+    externalIP: 192.168.0.30 # The internal IP address to forward the external LB's traffic to.
+    inlet: ExternalIP
+    nodeSelector:
+      kubernetes.io/hostname: node
 ```

--- a/modules/500-openvpn/docs/EXAMPLES_RU.md
+++ b/modules/500-openvpn/docs/EXAMPLES_RU.md
@@ -5,28 +5,46 @@ title: "Модуль openvpn: примеры"
 ## Пример для кластеров bare metal
 
 ```yaml
-openvpnEnabled: "true"
-openvpn: |
-  inlet: ExternalIP
-  externalIP: 5.4.54.4
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: openvpn
+spec:
+  version: 2
+  enabled: true
+  settings:
+    inlet: ExternalIP
+    externalIP: 5.4.54.4
 ```
 
 ## Пример для AWS и Google Cloud
 
 ```yaml
-openvpnEnabled: "true"
-openvpn: |
-  inlet: LoadBalancer
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: openvpn
+spec:
+  version: 2
+  enabled: true
+  settings:
+    inlet: LoadBalancer
 ```
 
 ## Пример для публичного IP-адреса на внешнем балансировщике
 
 ```yaml
-openvpnEnabled: "true"
-openvpn: |
-  externalHost: 5.4.54.4
-  externalIP: 192.168.0.30 # Внутренний IP-адрес, который примет трафик от внешнего балансировщика.
-  inlet: ExternalIP
-  nodeSelector:
-    kubernetes.io/hostname: node
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: openvpn
+spec:
+  version: 2
+  enabled: true
+  settings:
+    externalHost: 5.4.54.4
+    externalIP: 192.168.0.30 # Внутренний IP-адрес, который примет трафик от внешнего балансировщика.
+    inlet: ExternalIP
+    nodeSelector:
+      kubernetes.io/hostname: node
 ```

--- a/modules/600-namespace-configurator/docs/EXAMPLES.md
+++ b/modules/600-namespace-configurator/docs/EXAMPLES.md
@@ -7,16 +7,22 @@ title: "The namespace-configurator module: examples"
 This example will add `extended-monitoring.flant.com/enabled=true` annotation and `foo=bar` label to every namespace starting with `prod-` and `infra-`, except `infra-test`.
 
 ```yaml
-namespaceConfiguratorEnabled: "true"
-namespaceConfigurator: |
-  configurations:
-  - annotations:
-      extended-monitoring.flant.com/enabled: "true"
-    labels:
-      foo: bar
-    includeNames:
-    - "prod-.*"
-    - "infra-.*"
-    excludeNames:
-    - "infra-test"
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: namespace-configurator
+spec:
+  version: 1
+  enabled: true
+  settings:
+    configurations:
+    - annotations:
+        extended-monitoring.flant.com/enabled: "true"
+      labels:
+        foo: bar
+      includeNames:
+      - "prod-.*"
+      - "infra-.*"
+      excludeNames:
+      - "infra-test"
 ```

--- a/modules/600-namespace-configurator/docs/EXAMPLES_RU.md
+++ b/modules/600-namespace-configurator/docs/EXAMPLES_RU.md
@@ -7,16 +7,22 @@ title: "Модуль namespace-configurator: примеры"
 Этот пример добавит аннотацию `extended-monitoring.flant.com/enabled=true` и label `foo=bar` к каждому Namespace, начинающемуся с `prod-` или `infra-`, за исключением `infra-test`.
 
 ```yaml
-namespaceConfiguratorEnabled: "true"
-namespaceConfigurator: |
-  configurations:
-  - annotations:
-      extended-monitoring.flant.com/enabled: "true"
-    labels:
-      foo: bar
-    includeNames:
-    - "prod-.*"
-    - "infra-.*"
-    excludeNames:
-    - "infra-test"
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: namespace-configurator
+spec:
+  version: 1
+  enabled: true
+  settings:
+    configurations:
+    - annotations:
+        extended-monitoring.flant.com/enabled: "true"
+      labels:
+        foo: bar
+      includeNames:
+      - "prod-.*"
+      - "infra-.*"
+      excludeNames:
+      - "infra-test"
 ```

--- a/modules/810-deckhouse-web/docs/EXAMPLES.md
+++ b/modules/810-deckhouse-web/docs/EXAMPLES.md
@@ -7,15 +7,22 @@ title: "The deckhouse-web module: examples"
 Below is a simple example of the module configuration:
 
 ```yaml
-deckhouseWeb: |
-  nodeSelector:
-    node-role/example: ""
-  tolerations:
-  - key: dedicated
-    operator: Equal
-    value: example
-  externalAuthentication:
-    authURL: "https://<applicationDomain>/auth"
-    authSignInURL: "https://<applicationDomain>/sign-in"
-    authResponseHeaders: "Authorization"
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse-web
+spec:
+  version: 2
+  enabled: true
+  settings:
+    nodeSelector:
+      node-role/example: ""
+    tolerations:
+    - key: dedicated
+      operator: Equal
+      value: example
+    externalAuthentication:
+      authURL: "https://<applicationDomain>/auth"
+      authSignInURL: "https://<applicationDomain>/sign-in"
+      authResponseHeaders: "Authorization"
 ```

--- a/modules/810-deckhouse-web/docs/EXAMPLES_RU.md
+++ b/modules/810-deckhouse-web/docs/EXAMPLES_RU.md
@@ -7,15 +7,22 @@ title: "Модуль deckhouse-web: примеры"
 Ниже представлен простой пример конфигурации модуля:
 
 ```yaml
-deckhouseWeb: |
-  nodeSelector:
-    node-role/example: ""
-  tolerations:
-  - key: dedicated
-    operator: Equal
-    value: example
-  externalAuthentication:
-    authURL: "https://<applicationDomain>/auth"
-    authSignInURL: "https://<applicationDomain>/sign-in"
-    authResponseHeaders: "Authorization"
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse-web
+spec:
+  version: 2
+  enabled: true
+  settings:
+    nodeSelector:
+      node-role/example: ""
+    tolerations:
+    - key: dedicated
+      operator: Equal
+      value: example
+    externalAuthentication:
+      authURL: "https://<applicationDomain>/auth"
+      authSignInURL: "https://<applicationDomain>/sign-in"
+      authResponseHeaders: "Authorization"
 ```


### PR DESCRIPTION
## Description
Update docs to use the module configuration method everywhere and get rid of the old configuration method (in the deckhouse ConfigMap).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [X] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: 
impact: Update docs to use the module configuration method everywhere.
impact_level: low
```
