### PR TITLE
[virtualization] vmi-router: disable metrics by default

### DIFF
--- a/modules/490-virtualization/images/vmi-router/main.go
+++ b/modules/490-virtualization/images/vmi-router/main.go
@@ -66,8 +66,8 @@ func main() {
 	var probeAddr string
 	flag.Var(&cidrs, "cidr", "CIDRs enabled to route (multiple flags allowed)")
 	flag.BoolVar(&dryRun, "dry-run", false, "Don't perform any changes on the node.")
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":0", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":0", "The address the probe endpoint binds to.")
 	opts := zap.Options{
 		Development: true,
 	}


### PR DESCRIPTION
## Description

vmi-router: disable metrics by default

## Why do we need it, and what problem does it solve?

VMI-router runs in host-network and binding on `:8080` and `:8081` ports, which are conflicting with nginx-ingress
We're not collecting metrics and do not run probes for vmi-router right now, so it's better to disable them by default

## What is the expected result?

vmi-router stops listening on tcp ports

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the instruction page on the repo wiki
  https://github.com/deckhouse/deckhouse/wiki/How-to-add-to-changelog
-->

```changes
section: virtualization
type: fix
summary: vmi-router: disable metrics by default
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
