### PR TITLE
[docs][gs] Use the Standard layout in the Yandex Cloud provider

### DIFF
--- a/docs/site/_data/getting_started/data.yaml
+++ b/docs/site/_data/getting_started/data.yaml
@@ -226,8 +226,8 @@ installTypes:
   yandex:
     iconPath: images/icons/platforms/yandex_cloud.png
     layout:
-      code: without_nat
-      name: WithoutNAT
+      code: standard
+      name: Standard
     pages_title:
       en: "Deckhouse Platform in Yandex Cloud"
       ru: "Deckhouse Platform в Yandex Cloud"

--- a/docs/site/_includes/getting_started/yandex/layouts/STANDARD.md
+++ b/docs/site/_includes/getting_started/yandex/layouts/STANDARD.md
@@ -1,0 +1,4 @@
+![resources](https://docs.google.com/drawings/d/e/2PACX-1vTSpvzjcEBpD1qad9u_UgvsOrYT_Xtnxwg6Pzb64HQHLqQWcZi6hhCNRPKVUdYKX32nXEVJeCzACVRG/pub?w=812&h=655)
+<!--- Source: https://docs.google.com/drawings/d/1WI8tu-QZYcz3DvYBNlZG4s5OKQ9JKyna7ESHjnjuCVQ/edit --->
+
+Under this placement strategy, virtual machines access the Internet using a NAT gateway service in Yandex Cloud with a public (and single) source IP.

--- a/docs/site/_includes/getting_started/yandex/layouts/STANDARD_RU.md
+++ b/docs/site/_includes/getting_started/yandex/layouts/STANDARD_RU.md
@@ -1,0 +1,4 @@
+![resources](https://docs.google.com/drawings/d/e/2PACX-1vTSpvzjcEBpD1qad9u_UgvsOrYT_Xtnxwg6Pzb64HQHLqQWcZi6hhCNRPKVUdYKX32nXEVJeCzACVRG/pub?w=812&h=655)
+<!--- Исходник: https://docs.google.com/drawings/d/1WI8tu-QZYcz3DvYBNlZG4s5OKQ9JKyna7ESHjnjuCVQ/edit --->
+
+В данной схеме размещения узлы не будут иметь публичных адресов, а будут выходить в интернет через NAT-шлюз (NAT Gateway) Yandex Cloud.

--- a/docs/site/_includes/getting_started/yandex/layouts/WITHOUT_NAT.md
+++ b/docs/site/_includes/getting_started/yandex/layouts/WITHOUT_NAT.md
@@ -1,6 +1,0 @@
-![resources](https://docs.google.com/drawings/d/e/2PACX-1vTgwXWsNX6CKCRaMf5t6rl3kpKQQFHK6T8Dsg1jAwAwYaN1MRbxKFsSFQHeo1N3Qec4etPpeA0guB6-/pub?w=812&h=655)
-<!--- Source: https://docs.google.com/drawings/d/1I7M9DquzLNu-aTjqLx1_6ZexPckL__-501Mt393W1fw/edit --->
-
-This deployment scheme does not use NAT and gives each node a public IP.
-
-> **Caution!** Deckhouse does not yet support Yandex Security Groups, so all nodes in the cluster will be publicly accessible.

--- a/docs/site/_includes/getting_started/yandex/layouts/WITHOUT_NAT_RU.md
+++ b/docs/site/_includes/getting_started/yandex/layouts/WITHOUT_NAT_RU.md
@@ -1,6 +1,0 @@
-![resources](https://docs.google.com/drawings/d/e/2PACX-1vTgwXWsNX6CKCRaMf5t6rl3kpKQQFHK6T8Dsg1jAwAwYaN1MRbxKFsSFQHeo1N3Qec4etPpeA0guB6-/pub?w=812&h=655)
-<!--- Исходник: https://docs.google.com/drawings/d/1I7M9DquzLNu-aTjqLx1_6ZexPckL__-501Mt393W1fw/edit --->
-
-В данной схеме размещения NAT (любого вида) не используется, а каждому узлу выдаётся публичный IP.
-
-> **Внимание!** В модуле cloud-provider-yandex пока нет поддержки Security Groups, поэтому все узлы кластера будут доступны публично.

--- a/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ce.inc
@@ -11,7 +11,7 @@ cloud:
   # [<en>] You might consider changing this.
   # [<ru>] Префикс объектов, создаваемых в облаке при установке.
   # [<ru>] Возможно, захотите изменить.
-  prefix: cloud-demo
+  prefix: "cloud-demo"
 # [<en>] Address space of the cluster's Pods.
 # [<ru>] Адресное пространство Pod’ов кластера.
 podSubnetCIDR: 10.111.0.0/16
@@ -53,7 +53,7 @@ deckhouse:
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-yandex/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: YandexClusterConfiguration
-layout: WithoutNAT
+layout: Standard
 # [<en>] Yandex Cloud account parameters.
 # [<ru>] Параметры доступа к облаку Yandex Cloud.
 provider:
@@ -77,7 +77,6 @@ provider:
   #      "private_key": "-----BEGIN PRIVATE KEY-----...-----END PRIVATE KEY-----\n"
   #    }
   serviceAccountJSON: *!CHANGE_ServiceAccountJSON*
-masterNodeGroup:
   replicas: 1
   instanceClass:
     cores: 4

--- a/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ee.inc
+++ b/docs/site/_includes/getting_started/yandex/partials/config.yml.standard.ee.inc
@@ -57,9 +57,9 @@ deckhouse:
 # [<ru>] https://deckhouse.io/documentation/v1/modules/030-cloud-provider-yandex/cluster_configuration.html
 apiVersion: deckhouse.io/v1
 kind: YandexClusterConfiguration
-layout: WithoutNAT
-# [<en>] Yandex Cloud account parameters.
-# [<ru>] Параметры доступа к облаку Yandex Cloud.
+layout: Standard
+# [<en>] Yandex account parameters
+# [<ru>] параметры доступа к облаку Yandex
 provider:
   # [<en>] The cloud ID.
   # [<ru>] ID облака.


### PR DESCRIPTION
## Description
Use the Standard layout in the Yandex Cloud provider.

Ref: https://github.com/deckhouse/deckhouse/pull/3411

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Use the Standard layout in the Yandex Cloud provider.
impact_level: low
```
