### PR TITLE
[docs] Update Alpine Linux logo URL

### DIFF
--- a/modules/000-common/oss.yaml
+++ b/modules/000-common/oss.yaml
@@ -3,7 +3,7 @@
 - name: Alpine Linux
   description: A Linux distribution built around musl libc and BusyBox.
   link: https://alpinelinux.org/
-  logo: https://wiki.alpinelinux.org/images/alogo.png
+  logo: https://alpinelinux.org/alpinelinux-logo-icon.svg
   licence: Apache License 2.0
 
 - name: Kubernetes CSI


### PR DESCRIPTION
## Description
The previous Alpine Logo URL is no longer available, so it has been updated to the new one.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Update Alpine Linux logo URL
impact_level: low
```
